### PR TITLE
feat(capability-core): 能力核外露——CLI/MCP 让 Claude Code 在本地驱动 Nomi

### DIFF
--- a/docs/plan/2026-06-20-capability-core-headless-exposure.md
+++ b/docs/plan/2026-06-20-capability-core-headless-exposure.md
@@ -181,14 +181,16 @@ infinite-canvas 被迫用 MCP+SSE 桥，**因为它是浏览器**。Nomi 是 Ele
 
 ### ✅ 真机端到端已验证（2026-06-21，隔离 worktree + 真 catalog 真 key 真调）
 - **B 模式 headless host spawn 往返**：CLI → spawn 真 Electron host → 建项目 / 加节点 / 连线 / 读画布 → `project.json` 真落盘（2 节点、kind/prompt 正确、自动错开不重叠）。
-- **真实生成 E2E**：headless host 直读真 catalog → 真调 `modelscope/Qwen3-8B`（text）→ status `succeeded`、文本返回 + 落节点。**接通**（接入即验证铁律达成，文本链路）。
-- **真机测试挖出并修 2 个真 bug**（单测全绿照不出）：
+- **真实文本生成 E2E**：headless host 直读真 catalog → 真调 `modelscope/Qwen3-8B`（text）→ `succeeded`、文本返回 + 落节点。
+- **真实图片生成 E2E**：真调 `modelscope/Z-Image-Turbo`（text_to_image，异步）→ 轮询 15s → `succeeded` → 1.16MB / 760×1280 PNG 本地化落盘，**人眼确认图像与 prompt 一致**（柴犬戴墨镜赛博朋克街，R13）。**接通**（接入即验证铁律达成，图/文链路）。
+- **真机测试挖出并修 3 个真 bug**（单测全绿照不出）：
   1. **headless 解密身份不匹配**：dev `electron host.js` spawn 时 getName 默认 "Electron"，与主 app 加密 safeStorage key 的身份（"nomi"）不符 → 解不开 key（"API key missing"）。修：spawner 经 `NOMI_APP_NAME` 传主 app 身份（package.json name），host `setName` 对齐 + 默认 userData 指真数据。实测三身份对照确认 `nomi` 能解、`Nomi`/`Electron` 不能。（生产 host 在打包 app 内、身份天然正确，不受影响。）
   2. **文本结果没捕获**：textTaskRunner 返回 `assets:[]`，文本在 `raw`；core 只读 assets → 丢文本。修：`extractTextFromRaw` best-effort 抽取。
-  - 修复 commit `863c417`，五门复跑全过。
+  3. **异步任务没轮询**：modelscope 图/视频首调返 `queued`，core 只调一次 runTask 就返回 → 永远拿不到图。修：generateOnProject 注入 fetchTaskResultFn，**在同一 host 进程内**轮询到终态（taskCache 进程内、host 退出即丢，不能跨调用轮询）。
+  - 修复 commit `863c417` + `c32f407`，五门各自复跑全过。
 
 ### ⚠️ 仍未验证 / 后续（按 P3 诚实标注）
-- **真实图/视频生成 E2E**：本机带 key 的 vendor（apimart/modelscope/dm-fox…）当前**只 enable 了文本模型**；图/视频模型（kie/*）无 key → 没法在本机真跑图/视频生成。待用户 enable 一个带 key 的图模型再补验（文本链路已证明 archetype→runTask 通路对，图/视频同路）。
+- **真实视频生成 E2E**：图/文已验，视频同路（image_to_video mapping 在、轮询超时已给 5min）但没真跑一次（更慢更贵）。
 - **A 模式实时桥接**：app 开着时图变更目前是 RPC **409 拒绝**（防覆盖，honest），**没做**「转发 ops 给 renderer 实时反映到 UI」——A 模式真正的活，需 renderer applier + 真机走查。
 - **MCP 在真 Claude Code 内**：握手/tools.list standalone 验过（含本机 tools/call 经 host 真跑），没在真实 Claude Code 客户端里挂载连过。
 - **单实例锁真为**：代码已加，没真起两个实例验证让出行为。

--- a/docs/plan/2026-06-20-capability-core-headless-exposure.md
+++ b/docs/plan/2026-06-20-capability-core-headless-exposure.md
@@ -1,0 +1,191 @@
+# Nomi 能力核外露：让内部 agent 与 Claude Code/Codex 共用一套可调用能力
+
+> 2026-06-20。起点：用户看了 `basketikun/infinite-canvas` 的「本地 Canvas Agent（MCP）」——它让电脑上的 Claude Code/Codex 通过 MCP 操作浏览器画布。用户想：**把 Nomi 自己的能力（带正确参数的生成 / 操作工程 / 角色一致性）也接出去，让外部 agent 能在本地驱动 Nomi 生成、操作本地文件。**
+>
+> 决策已拍（AskUserQuestion，2026-06-20）：
+> - **目的 = 两者并重**：内部 agent 和外部 agent 同为一等消费者。
+> - **开/不开都要、且自动**：Nomi 开着 → 实时看节点冒出来；关着 → 无头跑完落盘。不是手动开关，是传输自动探测。
+
+---
+
+## 0. 一句话战略定位（为什么做这件事）
+
+Nomi 的护城河是**「创作意图 → 正确模型调用」之间那层正确性 + 一致性**：archetype 参数全覆盖、角色一致性（定妆/角色卡）、参考图可达性（providerUrl/relay）。**这层现在锁死在 GUI 里，外面够不着。** 把它抽成可调用的能力核，Nomi 就从「一个你打开来用的 app」变成「别的 agent 会依赖的能力源」——黏性高一个量级。
+
+**但有个歪点必须钉死（solo 战略）**：目标 WHO 是创作者，不是开发者。所以本方案的主线**不是**「给开发者做 MCP server」，而是：
+
+> **抽一层我自己的 agent 本来就缺的 capability 层**（06-20 审计根因「AI 只产文本不产配置」，根子就是没有这层可调用能力面），**外部 CLI/MCP 只是这层之上几乎白送的薄传输**。
+
+这样「两者并重」不是两份工作——内部 agent、外部 CLI/MCP、开着的 UI 都是同一个核的消费者。
+
+---
+
+## 1. 现状勘查结论（Explore agent，全部带 file:line）
+
+### 1.1 生成核——已无头就绪 ✅
+- 总入口 `runTask(payload)`：`electron/runtime.ts:552`。四条分路（音频/profile 图视频/文本/fallback 图视频）全在主进程。
+- vendor HTTP 实际发出点：`electron/runtime.ts:486` / `:627`（`requestJson` → `electron/vendor/vendorHttp.ts` → `electron/hardenedFetch.ts`），**全在主进程**。
+- 请求体组装（archetype→body）：`electron/ai/requestPipeline.ts`（electron-free 纯模块）+ `electron/catalog/taskParams.ts` + `electron/catalog/archetypeInput.ts:24`。
+- IPC 之后整条 main 链路**零 React / 零 DOM / 零 Zustand**。IPC 入口 `main.ts:305` 的 handler 连 `_event` 都没用。
+- **唯一 Electron 硬依赖**：`electron/runtimePaths.ts:4` `import { app }`（仅 `app.getPath()` 取默认路径），且已有 `NOMI_PROJECTS_DIR` / `NOMI_SETTINGS_DIR` env 逃生口（`runtimePaths.ts:17,22`）。**evals 已靠这个在无头跑真实生成**——这是「已可无头」最强佐证。
+
+### 1.2 工程数据与持久化
+- 磁盘格式：每个 project 一个文件夹，清单 `project.json`（`electron/runtimePaths.ts:9`）；workspace 模式写 `<root>/.nomi/project.json`（`electron/workspace/workspacePaths.ts:99`）。
+- 读写模块：`electron/projects/repository.ts`（`readProject:188` / `saveProject:198` / `createProject:178`），原子写 `electron/jsonFile.ts`。
+- 真相源模型：**内存 store 为真相 + 偶尔落盘**（生成成功后 `generationRunController.ts:132` 立即落 + 防抖服务 `projectPersistenceService.ts` + 事件日志做尾部对齐）。磁盘快照在 `project.json` 的 `payload.generationCanvas` 等字段（`workbenchProjectSession.ts:10-17`）。
+
+### 1.3 缺口一——工程操作原语绑死 renderer store ⚠️
+- 实际执行层 `src/workbench/generationCanvas/agent/generationCanvasTools.ts`：`create_nodes:66` / `connect_nodes:77` / `update_node_prompt` / `send_to_timeline:125` / `generate_image|video:196` 全部**直接调 Zustand store action**，无中间领域层（store 巨壳即领域逻辑）。
+- 主进程 LLM 工具 schema `electron/ai/canvasTools.ts:108`（`read_canvas_state` / `propose_storyboard_plan` / `create_canvas_nodes` / `connect_canvas_edges` / `set_node_prompt` / `delete_canvas_nodes` / `run_generation_batch` / `arrange_storyboard_to_timeline`）**故意没有 execute**（`canvasTools.ts:16`）——只 emit 给 renderer 等用户确认，执行发生在 renderer。
+- 含义：「建节点/连线/排时间轴」目前**没有主进程等价物**。但真相是 `project.json` 快照，`repository.ts` 已能完整读写——可在主进程实现「读 payload → 改节点图 JSON → 写回」，复用 renderer 现成纯逻辑。
+
+### 1.4 缺口二——archetype 关键投影在 renderer ⚠️
+- 权威定义 `src/config/modelArchetypes/`（19 档案，纯 TS、无 React），解析 `resolveArchetypeForModel`（供应商无关）。
+- **关键投影 `buildArchetypeInputParams`**（`src/workbench/generationCanvas/nodes/controls/archetypeMeta.ts:376`）在 renderer：据当前 mode/variant 打出完整 snake input → `request.extras.archetypeInput`（`catalogTaskActions.ts:66-86`）。主进程 `archetypeInput.ts:24` 只「原样采用 or fallback 现场映射」。
+- 含义：要让主进程无头自己从 archetype 推完整请求体，需把 `modelArchetypes/` + `archetypeMeta` 这套下沉到共享层（纯 TS，下沉成本低）。
+
+### 1.5 缺口三——单实例锁/探测从零搭 🆕
+- 全仓**无** `requestSingleInstanceLock` / socket / lockfile（grep 零命中）。
+- main 入口 `electron/main.ts`，启动 `app.whenReady().then(...)`（`main.ts:341`）。
+- 「Nomi 是否开着」探测需新建：建议 `app.requestSingleInstanceLock()` + 固定路径 lockfile/socket，放 `getSettingsRoot()`（userData）。
+
+---
+
+## 2. 目标架构
+
+```
+            ┌─────────── 能力核 (headless, 无 React) ───────────┐
+            │  工程 store(真相)  +  生成引擎  +  能力函数         │
+            │  createShot / generateNode / defineCharacter /     │
+            │  connectNodes / arrangeTimeline / readCanvas …     │
+            │  （带正确 archetype 参数，单一真相源）              │
+            └───────────────────────────────────────────────────┘
+                 ▲           ▲              ▲              ▲
+        Nomi 内置 agent   CLI 传输      MCP 传输      Electron UI
+        (你自己的脑)    (无头/脚本)   (实时交互)   (渲染+实时订阅)
+```
+
+### 2.1 一条铁律（P1，决定成败）
+**所有写入必须经同一个能力核、写同一份工程真相。** 绝不能有「无头一条写文件的路 + 实时一条改 UI 的路」——分叉即并行版灾难。运行中的 UI 只是工程真相的**实时订阅者/投影**，不是第二个写入口。
+
+### 2.2 开/不开自动适配（满足「可选且自动」）
+传输调用时探测有没有运行中的 Nomi 实例（lockfile/socket）：
+
+| 探测到 | 行为 | 用户体验 |
+|---|---|---|
+| Nomi 开着 | 操作交给运行中实例（经新增 main RPC 端点）→ 改内存 store → UI 实时重渲 | 实时看节点冒出来（A 模式） |
+| Nomi 关着 | 临时拉起无头核（设 `NOMI_PROJECTS_DIR`/`NOMI_SETTINGS_DIR`）→ 改 `project.json` → 落盘 | 无头跑完，下次打开就在那（B 模式） |
+
+**同一条命令、同一个结果，区别只是你在不在场看。** 用户不用选模式。
+
+### 2.3 传输优先级：CLI > MCP
+infinite-canvas 被迫用 MCP+SSE 桥，**因为它是浏览器**。Nomi 是 Electron，自带主进程，多一张牌：
+
+| 传输 | 适合 | 优先级 |
+|---|---|---|
+| **CLI**（`nomi generate…` / `nomi shot add…`）| 无头、脚本化、Claude Code 用 Bash 直接调 | **先做**——最快验证价值、最像 CC 工作方式 |
+| **MCP server**（主进程内置 host，不用另起桥进程）| 实时交互态 | 后补 |
+
+---
+
+## 3. 范围（做什么）
+
+按依赖顺序切片，每片可独立验证、独立价值：
+
+- **S1 能力核骨架（去 Electron 依赖）**：把 `runtimePaths.ts:4` 的 `import { app }` 抽象成 paths provider（注入式），彻底去 Electron 硬依赖。生成核（runtime/catalog/vendor/requestPipeline）原地暴露统一入口。**验收**：纯 Node 脚本 `import` 能力核 + 设两个 env → 跑通一次真实生成（复用 evals 的无头模式）。
+- **S2 archetype 投影下沉**：`modelArchetypes/` + `archetypeMeta.buildArchetypeInputParams` 下沉到主进程/共享层（`electron/catalog/` 或新 `shared/`），让主进程能独立从 archetype 推完整请求体，不再依赖 renderer 预计算。**P1：renderer 改为 import 下沉后的同一份，删除并行逻辑。** **验收**：design-fidelity 不回归 + 一次带 archetype 变体（如 Seedance 全能参考）的无头生成参数正确。
+- **S3 工程图操作原语（主进程）**：在主进程实现 `createNode/connectNodes/updateNodePrompt/setReferences/arrangeTimeline` 等，操作 `project.json` 的 `payload` 快照，复用 renderer 可下沉的纯函数（`canvasGraphActions` 里相当一部分）+ 现有校验（`referenceEdgeCapability.ts` / `proposalTxn.ts`）。**验收**：无头建一条「提示词节点→生图配置节点→连线」并落盘，重开 Nomi 能看到。
+- **S4 单实例锁 + 探测 + RPC 端点**：加 `requestSingleInstanceLock` + lockfile/socket（放 userData）；开着时外部调用走新增 main RPC（非现有 renderer↔main IPC）→ 改内存 store（经 S3 同一原语）→ UI 实时投影。**验收**：开着调用→真机看到节点实时冒出；关着调用→落盘，重开可见。
+- **S5 CLI 传输**：`nomi` 命令行（`generate` / `project` / `shot` / `canvas` 子命令）调能力核，内含 S4 探测。**验收**：Claude Code 用 Bash 调 `nomi` 跑通建工程+生成。
+- **S6 安全门**：外部调用（CLI/MCP）触发生成 = 花用户额度，必须 token + 确认门（参考 infinite-canvas 的 token + `127.0.0.1` only）。**验收**：无 token 调用被拒；生成类操作有确认/审计。
+- **S7 MCP server（主进程内置）**：薄传输，工具 schema 复用 S3 原语 + 生成原语。对照 infinite-canvas 的 23 工具补齐缺的原语。**验收**：Claude Code 配上 Nomi MCP，实时驱动跑通 J1 主链路。
+
+> 切片可停：S1–S3 做完，内部 agent 就拿到了「能产配置/能无头跑」的能力核（解 06-20 审计根因），**外部暴露（S4–S7）是这之上的增量**，可按反馈节奏推。
+
+---
+
+## 4. 不动什么
+
+- 不改现有 renderer 内 agent 的用户体验链路（确认/进度 UI 照旧；S2/S3 只换底层 import，行为等价）。
+- 不引入新 vendor / 不改 archetype 能力定义本身（只搬位置）。
+- 不做「让外部 agent 拿任意 FS 权限」——Claude Code 本就有 Read/Write/Bash，能力核**只暴露语义化的 Nomi 领域操作**，不做冗余文件代理。
+- 不做云端/多人——纯本地，socket 只监听 `127.0.0.1`。
+- 不碰时间轴/导出引擎的既有实现（S3 的 arrangeTimeline 复用 `sendStoryboardToTimeline.ts` 逻辑，不重写）。
+
+---
+
+## 5. 回滚策略
+
+- S1/S2/S3 是「移动 + 抽象 + 删并行版」，每片独立 commit，回滚 = revert 单 commit（行为等价，无功能开关）。
+- S4–S7 是纯增量新文件（CLI/MCP/RPC/锁），未接入主链路前不影响现有功能；出问题直接不启用该传输即可，能力核与现有 app 无回归。
+- 铁律 2.1 保证：即使外部传输全删，内部 app 走的还是同一个核，不存在「外部专用的第二真相源」需要清理。
+
+---
+
+## 6. 验收门
+
+- **每片**：相应 `验收` 项 + 五门全过（filesize→tokens→lint→typecheck→test→build）。
+- **无头生成真实性**：复用 `接入即验证` 纪律——一次真实 E2E 生成跑通才算接通（不是 mock）。
+- **P1 检查**：S2/S3 下沉后 grep 确认 renderer 不再有并行实现（旧逻辑物理删除）。
+- **真机走查（R13）**：S4 开着模式必须真机看到节点实时冒出（截图人眼判断，不只断言）。
+- **安全（S6）**：无 token 调用被拒的回归断言。
+
+---
+
+## 7. 实现前还要补的功课（R5/R6）
+
+- **R5 Context7**：S7 动手前查 `@modelcontextprotocol/sdk` 官方文档（server 怎么在已有 Node 进程内 host、stdio vs SSE transport）；CLI 若用框架先查。
+- **R6 顶尖开源**：再细读 infinite-canvas `canvas-agent/`（`mcp-server.ts` / `http-server.ts` / `tools.ts`）的 token 鉴权 + SSE 回环 + 23 工具 schema，作为 S6/S7 的直接对照样本。
+- **R7 六角色评审**：S4（进程探测/RPC 架构岔路）落地前过一遍。
+
+---
+
+## 附：对照 infinite-canvas（差异化锚点）
+
+| 维度 | infinite-canvas | Nomi 本方案 |
+|---|---|---|
+| 形态 | 浏览器，被迫 MCP+SSE 桥 | Electron，多 CLI 这张牌 |
+| 外露的能力 | 操作**运行中的画布 UI**（远程遥控 GUI）| 操作**能力核**（生成正确性+一致性+工程图），开/关都行 |
+| 能力归类 | 关键字猜（seedance→video）| archetype 全覆盖（差异化护城河） |
+| 生成参数 | 全局一刀切 | per-model archetype 变体（全能参考/首尾帧） |
+| 角色一致性 | 无 | 定妆/角色卡（外部 agent 也能调） |
+| 开/不开 | 必须开着 | 自动探测，开着实时/关着无头 |
+
+---
+
+## 回填 · 执行结果（2026-06-21）
+
+一次性实现了 S1–S7 的可验证主干。新增子系统 `electron/capabilityCore/`（全主进程、复用 `repository`+`runtime.runTask`，零并行逻辑）+ 两个纯 node 传输脚本。
+
+### 交付清单（文件）
+- `electron/capabilityCore/canvasGraph.ts` — 纯图操作领域层（add/connect/setPrompt/delete/read，零 electron，可单测）
+- `electron/capabilityCore/core.ts` — 编排层（图操作 ↔ project.json 持久化 + `generateOnProject` 复用 runTask）
+- `electron/capabilityCore/dispatcher.ts` — method→core 路由**单一真相源**（RPC 与 host 共用，P1）
+- `electron/capabilityCore/security.ts` — token（`~/.nomi/capability-core/token`，常数时间校验，0600）
+- `electron/capabilityCore/lockfile.ts` — 实例广告 + pid 存活探测（开/不开自动判定）
+- `electron/capabilityCore/rpcServer.ts` — 127.0.0.1 HTTP + token 鉴权 + A/B 守卫
+- `electron/capabilityCore/appIntegration.ts` — 接进 app（启动 RPC/写广告/退出清理/追踪打开项目）
+- `electron/capabilityCore/host.ts` — 无窗口 Electron headless host（B 模式，app 关着的执行体）
+- `scripts/lib/nomiClient.mjs` — CLI/MCP 共用传输客户端（探测→RPC 或 spawn host）
+- `scripts/nomi.mjs` — CLI 传输（`node scripts/nomi.mjs <cmd>`）
+- `scripts/nomi-mcp.mjs` — MCP server（stdio JSON-RPC，手搓不引 SDK，协议经 Context7 核对）
+- `electron/main.ts` / `preload.ts` / `src/desktop/bridge.ts` / `src/workbench/project/workbenchProjectSession.ts` — 接线（单实例锁 + 上报打开项目供 A/B 守卫）
+
+### 已验证（headless，无额度）
+- 单测 20/20 绿：`canvasGraph`(9) + `core`(5，含建项目→加节点→连线→改词→删→读往返 + generate 请求体构造 + 结果落节点) + `rpcServer`(6，含 401 鉴权/全链路/A-B 守卫 409/未知方法 404)
+- MCP 握手 + tools/list（9 工具）实跑通过；CLI `status` 实跑通过
+- Renderer typecheck 干净；electron typecheck 我的代码 0 错；lint 我的文件 0 错
+
+### S2 处理（不复制 renderer 投影，不违 P1）
+`generateOnProject` 不重建 archetype→body：构造高层 `TaskRequest`（kind + prompt + extras{modelKey/projectId/nodeId/referenceImages/params}）→ `runTask` 主进程内部据 catalog mapping 自己组装请求体。**没把 renderer 的 `buildArchetypeInputParams` 搬过来**（那需跨 tsconfig 且易造并行版）。代价：archetype **变体特化**参数（如 Seedance 全能参考的 per-mode 投影）目前要调用方显式传 params，不自动从档案推——列为后续切片。
+
+### ⚠️ 未验证 / 后续（需真机 + 额度，按 P3 诚实标注，不谎称完成）
+1. **真实生成 E2E**：generate 请求体构造已测（注入 runTask），但**真 vendor 调用（花额度）没跑** → 按「接入即验证」铁律，generate 尚未算「真接通」。
+2. **A 模式实时桥接**：app 开着时图变更目前是 RPC **409 拒绝**（防覆盖，honest），**没做**「转发 ops 给 renderer 实时反映到 UI」——这是 A 模式真正的活，需 renderer applier + 真机走查。
+3. **headless host spawn 往返**：host.ts 逻辑复用已测 dispatch，但 `electron host.js` 真 spawn 往返没跑（需 dist-electron 构建 + 真机；沙箱 GPU 限制）。
+4. **MCP 在真 Claude Code 内**：握手/tools.list standalone 验过，没在真实 Claude Code 客户端里连过。
+5. **单实例锁真为**：代码已加，没真起两个实例验证让出行为。
+6. **付费守卫集成**：仓库里有并行会话在做的 `nomi:tasks:grant-spend`（铸一次性令牌绑 nodeIds）。外部 generate 目前只过 token 门，**没接** in-app 付费令牌 → 防止外部静默烧钱的最终形态应接这套，列为集成点。
+
+### 🚧 五门 / 提交阻塞（非本 slice 问题）
+electron typecheck/build 当前**红**，唯一错是并行会话半成品 `electron/main.ts:36 import './spendGrant'`（文件未建）。我的代码独立 typecheck 干净。**未提交**——等并行会话的 spendGrant 落地、build 转绿后再走五门 + 提交（避免推他们的半成品 / 用 `git add -p` 拆我的 hunk）。

--- a/docs/plan/2026-06-20-capability-core-headless-exposure.md
+++ b/docs/plan/2026-06-20-capability-core-headless-exposure.md
@@ -179,13 +179,20 @@ infinite-canvas 被迫用 MCP+SSE 桥，**因为它是浏览器**。Nomi 是 Ele
 ### S2 处理（不复制 renderer 投影，不违 P1）
 `generateOnProject` 不重建 archetype→body：构造高层 `TaskRequest`（kind + prompt + extras{modelKey/projectId/nodeId/referenceImages/params}）→ `runTask` 主进程内部据 catalog mapping 自己组装请求体。**没把 renderer 的 `buildArchetypeInputParams` 搬过来**（那需跨 tsconfig 且易造并行版）。代价：archetype **变体特化**参数（如 Seedance 全能参考的 per-mode 投影）目前要调用方显式传 params，不自动从档案推——列为后续切片。
 
-### ⚠️ 未验证 / 后续（需真机 + 额度，按 P3 诚实标注，不谎称完成）
-1. **真实生成 E2E**：generate 请求体构造已测（注入 runTask），但**真 vendor 调用（花额度）没跑** → 按「接入即验证」铁律，generate 尚未算「真接通」。
-2. **A 模式实时桥接**：app 开着时图变更目前是 RPC **409 拒绝**（防覆盖，honest），**没做**「转发 ops 给 renderer 实时反映到 UI」——这是 A 模式真正的活，需 renderer applier + 真机走查。
-3. **headless host spawn 往返**：host.ts 逻辑复用已测 dispatch，但 `electron host.js` 真 spawn 往返没跑（需 dist-electron 构建 + 真机；沙箱 GPU 限制）。
-4. **MCP 在真 Claude Code 内**：握手/tools.list standalone 验过，没在真实 Claude Code 客户端里连过。
-5. **单实例锁真为**：代码已加，没真起两个实例验证让出行为。
-6. **付费守卫集成**：仓库里有并行会话在做的 `nomi:tasks:grant-spend`（铸一次性令牌绑 nodeIds）。外部 generate 目前只过 token 门，**没接** in-app 付费令牌 → 防止外部静默烧钱的最终形态应接这套，列为集成点。
+### ✅ 真机端到端已验证（2026-06-21，隔离 worktree + 真 catalog 真 key 真调）
+- **B 模式 headless host spawn 往返**：CLI → spawn 真 Electron host → 建项目 / 加节点 / 连线 / 读画布 → `project.json` 真落盘（2 节点、kind/prompt 正确、自动错开不重叠）。
+- **真实生成 E2E**：headless host 直读真 catalog → 真调 `modelscope/Qwen3-8B`（text）→ status `succeeded`、文本返回 + 落节点。**接通**（接入即验证铁律达成，文本链路）。
+- **真机测试挖出并修 2 个真 bug**（单测全绿照不出）：
+  1. **headless 解密身份不匹配**：dev `electron host.js` spawn 时 getName 默认 "Electron"，与主 app 加密 safeStorage key 的身份（"nomi"）不符 → 解不开 key（"API key missing"）。修：spawner 经 `NOMI_APP_NAME` 传主 app 身份（package.json name），host `setName` 对齐 + 默认 userData 指真数据。实测三身份对照确认 `nomi` 能解、`Nomi`/`Electron` 不能。（生产 host 在打包 app 内、身份天然正确，不受影响。）
+  2. **文本结果没捕获**：textTaskRunner 返回 `assets:[]`，文本在 `raw`；core 只读 assets → 丢文本。修：`extractTextFromRaw` best-effort 抽取。
+  - 修复 commit `863c417`，五门复跑全过。
 
-### 🚧 五门 / 提交阻塞（非本 slice 问题）
-electron typecheck/build 当前**红**，唯一错是并行会话半成品 `electron/main.ts:36 import './spendGrant'`（文件未建）。我的代码独立 typecheck 干净。**未提交**——等并行会话的 spendGrant 落地、build 转绿后再走五门 + 提交（避免推他们的半成品 / 用 `git add -p` 拆我的 hunk）。
+### ⚠️ 仍未验证 / 后续（按 P3 诚实标注）
+- **真实图/视频生成 E2E**：本机带 key 的 vendor（apimart/modelscope/dm-fox…）当前**只 enable 了文本模型**；图/视频模型（kie/*）无 key → 没法在本机真跑图/视频生成。待用户 enable 一个带 key 的图模型再补验（文本链路已证明 archetype→runTask 通路对，图/视频同路）。
+- **A 模式实时桥接**：app 开着时图变更目前是 RPC **409 拒绝**（防覆盖，honest），**没做**「转发 ops 给 renderer 实时反映到 UI」——A 模式真正的活，需 renderer applier + 真机走查。
+- **MCP 在真 Claude Code 内**：握手/tools.list standalone 验过（含本机 tools/call 经 host 真跑），没在真实 Claude Code 客户端里挂载连过。
+- **单实例锁真为**：代码已加，没真起两个实例验证让出行为。
+- **付费守卫集成**：并行会话在做 `nomi:tasks:grant-spend`（铸令牌绑 nodeIds）。外部 generate 目前只过 token 门，**没接** in-app 付费令牌——列为集成点。
+
+### 交付：隔离 worktree 绕开并行会话缠绕
+主工作树被并行会话半成品 `electron/spendGrant.ts`（未建）卡死 build。故起 sibling worktree `/Users/aoqimin/Desktop/Nomi-capability-core`（分支 `feat/capability-core-headless`）从干净 main 重应用我的接线 → **五门全过** → commit `f344d4c`+`863c417` → push → PR https://github.com/aqm857886159/Nomi/pull/10。

--- a/electron/capabilityCore/appIntegration.ts
+++ b/electron/capabilityCore/appIntegration.ts
@@ -10,7 +10,7 @@ import { app } from 'electron'
 import { startRpcServer, type RpcServerHandle } from './rpcServer'
 import { ensureToken } from './security'
 import { clearInstanceAdvertisement, writeInstanceAdvertisement } from './lockfile'
-import type { RunTaskFn } from './core'
+import type { FetchTaskResultFn, RunTaskFn } from './core'
 
 let handle: RpcServerHandle | null = null
 let openProjectId = ''
@@ -23,11 +23,12 @@ export function setOpenProjectId(projectId: string): void {
 /**
  * 启动能力核对外口。绝不拖垮 app 启动：任何失败只记日志、不抛（fail-open，与 applySystemProxy 同纪律）。
  */
-export async function startCapabilityCore(runTask: RunTaskFn): Promise<void> {
+export async function startCapabilityCore(runTask: RunTaskFn, fetchTaskResult: FetchTaskResultFn): Promise<void> {
   try {
     const token = ensureToken()
     handle = await startRpcServer({
       runTask,
+      fetchTaskResult,
       isProjectOpen: (id) => Boolean(openProjectId) && id === openProjectId,
     })
     writeInstanceAdvertisement({

--- a/electron/capabilityCore/appIntegration.ts
+++ b/electron/capabilityCore/appIntegration.ts
@@ -1,0 +1,53 @@
+// 能力核 · app 集成（见 docs/plan/2026-06-20-capability-core-headless-exposure.md §S4）。
+//
+// 把 RPC server + token + 实例广告接到运行中的 Nomi app：启动时拉起 RPC（127.0.0.1）、ensureToken、
+// 写 instance.json 让外部 CLI/MCP 探测得到「app 开着」；退出时清广告 + 关 server。
+// 还维护「当前哪个项目正在窗口里打开」（renderer 经 IPC 上报）供 A/B 守卫用——避免外部直写正在
+// 编辑的工程被内存 store 覆盖（rpcServer 注释详述）。
+//
+// 这里只做接线，不碰 main.ts 的其它职责（保持 main.ts 精简、单一关注点）。
+import { app } from 'electron'
+import { startRpcServer, type RpcServerHandle } from './rpcServer'
+import { ensureToken } from './security'
+import { clearInstanceAdvertisement, writeInstanceAdvertisement } from './lockfile'
+import type { RunTaskFn } from './core'
+
+let handle: RpcServerHandle | null = null
+let openProjectId = ''
+
+/** renderer 上报当前打开的项目（打开/切换=id，关闭=''）。A/B 守卫据此拒绝直写打开中的工程。 */
+export function setOpenProjectId(projectId: string): void {
+  openProjectId = String(projectId || '').trim()
+}
+
+/**
+ * 启动能力核对外口。绝不拖垮 app 启动：任何失败只记日志、不抛（fail-open，与 applySystemProxy 同纪律）。
+ */
+export async function startCapabilityCore(runTask: RunTaskFn): Promise<void> {
+  try {
+    const token = ensureToken()
+    handle = await startRpcServer({
+      runTask,
+      isProjectOpen: (id) => Boolean(openProjectId) && id === openProjectId,
+    })
+    writeInstanceAdvertisement({
+      pid: process.pid,
+      port: handle.port,
+      token,
+      startedAt: Date.now(),
+      version: app.getVersion(),
+    })
+    console.log(`[nomi:capability-core] RPC 监听 127.0.0.1:${handle.port}`)
+  } catch (error) {
+    console.error('[nomi:capability-core] 启动失败（不影响 app）:', error)
+  }
+}
+
+/** 退出清理：清广告 + 关 server。同步触发、不抛，绝不卡退出。 */
+export function stopCapabilityCore(): void {
+  clearInstanceAdvertisement()
+  if (handle) {
+    void handle.close()
+    handle = null
+  }
+}

--- a/electron/capabilityCore/canvasGraph.test.ts
+++ b/electron/capabilityCore/canvasGraph.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  addNodes,
+  connectNodes,
+  deleteNodes,
+  emptyCanvasSnapshot,
+  normalizeSnapshot,
+  readCanvas,
+  setNodePrompt,
+} from './canvasGraph'
+
+describe('capabilityCore/canvasGraph', () => {
+  it('addNodes 给每个节点稳定唯一 id 且不重叠堆原点', () => {
+    const { snapshot, ids } = addNodes(emptyCanvasSnapshot(), [
+      { kind: 'text', prompt: '一句脚本' },
+      { kind: 'image', title: '镜头 1' },
+    ])
+    expect(ids).toHaveLength(2)
+    expect(new Set(ids).size).toBe(2)
+    expect(snapshot.nodes).toHaveLength(2)
+    expect(snapshot.nodes[0].kind).toBe('text')
+    expect(snapshot.nodes[0].prompt).toBe('一句脚本')
+    expect(snapshot.nodes[1].title).toBe('镜头 1')
+    // 不给坐标时纵向错开，y 严格递增（防「布局无避让」全堆原点）。
+    expect(snapshot.nodes[1].position.y).toBeGreaterThan(snapshot.nodes[0].position.y)
+  })
+
+  it('addNodes 不可变——原快照不被改写', () => {
+    const before = emptyCanvasSnapshot()
+    addNodes(before, [{ kind: 'text' }])
+    expect(before.nodes).toHaveLength(0)
+  })
+
+  it('connectNodes 按 target 入边数赋递增 order（保住 character1..N 顺序）', () => {
+    const built = addNodes(emptyCanvasSnapshot(), [{ kind: 'image' }, { kind: 'image' }, { kind: 'video' }])
+    const [a, b, target] = built.ids
+    const { snapshot, edgeIds } = connectNodes(built.snapshot, [
+      { source: a, target, mode: 'character_ref' },
+      { source: b, target, mode: 'character_ref' },
+    ])
+    expect(edgeIds).toHaveLength(2)
+    const edges = snapshot.edges.filter((edge) => edge.target === target)
+    expect(edges.map((edge) => edge.order)).toEqual([0, 1])
+  })
+
+  it('connectNodes 跳过不存在端点 / 自连 / 重复，并给出原因', () => {
+    const built = addNodes(emptyCanvasSnapshot(), [{ kind: 'image' }, { kind: 'video' }])
+    const [a, b] = built.ids
+    const first = connectNodes(built.snapshot, [{ source: a, target: b }])
+    const second = connectNodes(first.snapshot, [
+      { source: a, target: b }, // 重复
+      { source: a, target: 'ghost' }, // 端点不存在
+      { source: a, target: a }, // 自连
+    ])
+    expect(second.edgeIds).toHaveLength(0)
+    expect(second.skipped.map((item) => item.reason).sort()).toEqual(['不能自连', '端点节点不存在', '重复连线'])
+  })
+
+  it('connectNodes 非法 mode 落回 reference', () => {
+    const built = addNodes(emptyCanvasSnapshot(), [{ kind: 'image' }, { kind: 'video' }])
+    const { snapshot } = connectNodes(built.snapshot, [{ source: built.ids[0], target: built.ids[1], mode: 'bogus' }])
+    expect(snapshot.edges[0].mode).toBe('reference')
+  })
+
+  it('setNodePrompt 改提示词与标题；未知节点 changed=false', () => {
+    const built = addNodes(emptyCanvasSnapshot(), [{ kind: 'text' }])
+    const ok = setNodePrompt(built.snapshot, built.ids[0], '新提示', '新标题')
+    expect(ok.changed).toBe(true)
+    expect(ok.snapshot.nodes[0].prompt).toBe('新提示')
+    expect(ok.snapshot.nodes[0].title).toBe('新标题')
+    const miss = setNodePrompt(built.snapshot, 'ghost', 'x')
+    expect(miss.changed).toBe(false)
+  })
+
+  it('deleteNodes 同时清掉关联入边出边，无悬挂边', () => {
+    const built = addNodes(emptyCanvasSnapshot(), [{ kind: 'image' }, { kind: 'video' }, { kind: 'image' }])
+    const [a, b, c] = built.ids
+    const connected = connectNodes(built.snapshot, [
+      { source: a, target: b },
+      { source: c, target: b },
+    ])
+    const { snapshot, deleted } = deleteNodes(connected.snapshot, [b])
+    expect(deleted).toEqual([b])
+    expect(snapshot.nodes.map((node) => node.id).sort()).toEqual([a, c].sort())
+    expect(snapshot.edges).toHaveLength(0)
+  })
+
+  it('normalizeSnapshot 把坏数据降级为空，过滤无 id 的节点/边', () => {
+    expect(normalizeSnapshot(null).nodes).toHaveLength(0)
+    const dirty = normalizeSnapshot({
+      nodes: [{ id: 'n1', kind: 'text', title: 't', position: { x: 0, y: 0 } }, { kind: 'broken' }],
+      edges: [{ id: 'e1', source: 'n1', target: 'n2' }, { id: 'bad' }],
+    })
+    expect(dirty.nodes).toHaveLength(1)
+    expect(dirty.edges).toHaveLength(1)
+  })
+
+  it('readCanvas 只暴露决策所需精简字段，不灌 raw', () => {
+    const built = addNodes(emptyCanvasSnapshot(), [{ kind: 'text', prompt: 'p', title: 't' }])
+    const view = readCanvas(built.snapshot)
+    expect(view.nodes[0]).toMatchObject({ kind: 'text', prompt: 'p', title: 't', status: 'idle', hasResult: false })
+    expect(view.nodes[0]).not.toHaveProperty('raw')
+  })
+})

--- a/electron/capabilityCore/canvasGraph.ts
+++ b/electron/capabilityCore/canvasGraph.ts
@@ -1,0 +1,239 @@
+// 能力核 · 纯图操作领域层（见 docs/plan/2026-06-20-capability-core-headless-exposure.md）。
+//
+// 这是「外部 agent / CLI / MCP 驱动 Nomi 画布」的最底层：把对画布工程的语义操作
+// （建节点 / 连线 / 改提示词 / 删节点 / 读画布）实现成**纯函数**——输入一份
+// GenerationCanvasSnapshot（即 project.json 的 payload.generationCanvas，纯 JSON），
+// 输出新的 snapshot + 受影响的 id。零 electron、零 store、零副作用，故可在纯 Node 单测。
+//
+// 真相源铁律（P1）：节点/边的形状以 renderer 的 generationCanvasTypes 为准；这里**不复制
+// 任何业务逻辑**，只按那份形状增删改 JSON。建出的节点是「最小合法节点」——renderer 载入时
+// 走既有 normalize（categoryMigration / getNodeSize 等）补全，不在这里抢着算。
+import { randomUUID } from 'node:crypto'
+
+/** 画布快照（project.json payload.generationCanvas 的纯 JSON 形状）。 */
+export type CanvasSnapshot = {
+  nodes: CanvasNode[]
+  edges: CanvasEdge[]
+  groups?: unknown[]
+  selectedNodeIds?: string[]
+}
+
+export type CanvasNode = {
+  id: string
+  kind: string
+  title: string
+  position: { x: number; y: number }
+  size?: { width: number; height: number }
+  prompt?: string
+  references?: string[]
+  status?: string
+  categoryId?: string
+  meta?: Record<string, unknown>
+  [key: string]: unknown
+}
+
+export type CanvasEdge = {
+  id: string
+  source: string
+  target: string
+  mode?: string
+  order?: number
+}
+
+/** 建节点入参——只收语义字段，几何缺省由这里补最小值（renderer 会再归一）。 */
+export type NodeSpec = {
+  kind?: string
+  title?: string
+  prompt?: string
+  x?: number
+  y?: number
+  references?: string[]
+}
+
+export type ConnectionSpec = {
+  source: string
+  target: string
+  mode?: string
+}
+
+// 最小默认尺寸：仅供 headless 建节点占位，renderer 的 registry.defaultSize 是权威，
+// 节点带 size 时各几何子系统用 node.size（getNodeSize 单一真相源），缺省才回退。
+// 这里给一个保守通用值，不按 kind 细分——避免在主进程复制 registry（那才是并行版）。
+const DEFAULT_NODE_SIZE = { width: 340, height: 280 }
+
+const VALID_EDGE_MODES = new Set([
+  'reference',
+  'first_frame',
+  'last_frame',
+  'style_ref',
+  'character_ref',
+  'composition_ref',
+])
+
+let idCounter = 0
+
+/**
+ * 生成稳定且不撞的 id。不可用 Date.now()/Math.random() 之外的来源——这里用
+ * crypto.randomUUID 保证跨进程唯一（撞 id 是「文字 clip 撞 id」那类 P0 的根因，见
+ * clip-timeline-walkthrough 记忆），prefix 标明类型便于排错。
+ */
+function genId(prefix: string): string {
+  idCounter += 1
+  return `${prefix}-${randomUUID().slice(0, 8)}-${idCounter.toString(36)}`
+}
+
+function cloneSnapshot(snapshot: CanvasSnapshot): CanvasSnapshot {
+  return {
+    nodes: snapshot.nodes.map((node) => ({ ...node })),
+    edges: snapshot.edges.map((edge) => ({ ...edge })),
+    ...(snapshot.groups ? { groups: snapshot.groups } : {}),
+    ...(snapshot.selectedNodeIds ? { selectedNodeIds: [...snapshot.selectedNodeIds] } : {}),
+  }
+}
+
+/** 空快照（新工程 / payload 缺 generationCanvas 时的兜底）。 */
+export function emptyCanvasSnapshot(): CanvasSnapshot {
+  return { nodes: [], edges: [], groups: [], selectedNodeIds: [] }
+}
+
+/** 把任意 unknown（来自 project.json）规整成可操作的 CanvasSnapshot，坏数据降级为空。 */
+export function normalizeSnapshot(value: unknown): CanvasSnapshot {
+  if (!value || typeof value !== 'object') return emptyCanvasSnapshot()
+  const raw = value as Record<string, unknown>
+  const nodes = Array.isArray(raw.nodes) ? (raw.nodes as CanvasNode[]) : []
+  const edges = Array.isArray(raw.edges) ? (raw.edges as CanvasEdge[]) : []
+  return {
+    nodes: nodes.filter((node) => node && typeof node.id === 'string'),
+    edges: edges.filter((edge) => edge && typeof edge.id === 'string' && typeof edge.source === 'string' && typeof edge.target === 'string'),
+    groups: Array.isArray(raw.groups) ? (raw.groups as unknown[]) : [],
+    selectedNodeIds: Array.isArray(raw.selectedNodeIds) ? (raw.selectedNodeIds as string[]) : [],
+  }
+}
+
+/** 读画布：返回精简到「外部 agent 需要据此决策」的字段，不灌完整 raw（R2 极简）。 */
+export function readCanvas(snapshot: CanvasSnapshot): {
+  nodes: Array<{ id: string; kind: string; title: string; prompt: string; status: string; position: { x: number; y: number }; hasResult: boolean }>
+  edges: Array<{ id: string; source: string; target: string; mode: string }>
+} {
+  return {
+    nodes: snapshot.nodes.map((node) => ({
+      id: node.id,
+      kind: node.kind,
+      title: node.title || '',
+      prompt: typeof node.prompt === 'string' ? node.prompt : '',
+      status: typeof node.status === 'string' ? node.status : 'idle',
+      position: node.position || { x: 0, y: 0 },
+      hasResult: Boolean(node.result),
+    })),
+    edges: snapshot.edges.map((edge) => ({
+      id: edge.id,
+      source: edge.source,
+      target: edge.target,
+      mode: edge.mode || 'reference',
+    })),
+  }
+}
+
+/**
+ * 批量建节点。缺省纵向自动排布（避免外部调用方不给坐标时全堆原点重叠——那是
+ * 「布局无避让」类问题的入口）。返回新快照 + 新建 id（按入参顺序，供后续连线引用）。
+ */
+export function addNodes(
+  snapshot: CanvasSnapshot,
+  specs: NodeSpec[],
+): { snapshot: CanvasSnapshot; ids: string[] } {
+  const next = cloneSnapshot(snapshot)
+  const ids: string[] = []
+  // 起始落点：现有节点最大 y 之下，避免叠在已有内容上。
+  const baseY = next.nodes.reduce((max, node) => Math.max(max, (node.position?.y ?? 0) + (node.size?.height ?? DEFAULT_NODE_SIZE.height)), 0)
+  specs.forEach((spec, index) => {
+    const id = genId('node')
+    ids.push(id)
+    const kind = (spec.kind && spec.kind.trim()) || 'text'
+    next.nodes.push({
+      id,
+      kind,
+      title: (spec.title && spec.title.trim()) || '',
+      position: {
+        x: typeof spec.x === 'number' ? spec.x : 0,
+        y: typeof spec.y === 'number' ? spec.y : baseY + 40 + index * (DEFAULT_NODE_SIZE.height + 40),
+      },
+      size: { ...DEFAULT_NODE_SIZE },
+      ...(spec.prompt ? { prompt: spec.prompt } : {}),
+      ...(spec.references && spec.references.length ? { references: [...spec.references] } : {}),
+      status: 'idle',
+    })
+  })
+  return { snapshot: next, ids }
+}
+
+/**
+ * 批量连线。order 按「该 target 现有入边数」递增赋值（全模式单调、全局插入序）——
+ * 与 renderer connectNodes 同一口径（generationCanvasTypes 注释），保住「谁是 character1」。
+ * 跳过：端点不存在 / 自环 / 重复（同 source→target 同 mode）。返回新快照 + 新建边 id。
+ */
+export function connectNodes(
+  snapshot: CanvasSnapshot,
+  connections: ConnectionSpec[],
+): { snapshot: CanvasSnapshot; edgeIds: string[]; skipped: Array<{ connection: ConnectionSpec; reason: string }> } {
+  const next = cloneSnapshot(snapshot)
+  const nodeIds = new Set(next.nodes.map((node) => node.id))
+  const edgeIds: string[] = []
+  const skipped: Array<{ connection: ConnectionSpec; reason: string }> = []
+  for (const connection of connections) {
+    const mode = connection.mode && VALID_EDGE_MODES.has(connection.mode) ? connection.mode : 'reference'
+    if (!nodeIds.has(connection.source) || !nodeIds.has(connection.target)) {
+      skipped.push({ connection, reason: '端点节点不存在' })
+      continue
+    }
+    if (connection.source === connection.target) {
+      skipped.push({ connection, reason: '不能自连' })
+      continue
+    }
+    const duplicate = next.edges.some(
+      (edge) => edge.source === connection.source && edge.target === connection.target && (edge.mode || 'reference') === mode,
+    )
+    if (duplicate) {
+      skipped.push({ connection, reason: '重复连线' })
+      continue
+    }
+    const order = next.edges.filter((edge) => edge.target === connection.target).length
+    const id = genId('edge')
+    edgeIds.push(id)
+    next.edges.push({ id, source: connection.source, target: connection.target, mode, order })
+  }
+  return { snapshot: next, edgeIds, skipped }
+}
+
+/** 改节点提示词（可选改标题）。节点不存在则原样返回（changed=false）。 */
+export function setNodePrompt(
+  snapshot: CanvasSnapshot,
+  nodeId: string,
+  prompt: string,
+  title?: string,
+): { snapshot: CanvasSnapshot; changed: boolean } {
+  const index = snapshot.nodes.findIndex((node) => node.id === nodeId)
+  if (index < 0) return { snapshot, changed: false }
+  const next = cloneSnapshot(snapshot)
+  next.nodes[index] = {
+    ...next.nodes[index],
+    prompt,
+    ...(typeof title === 'string' && title.trim() ? { title: title.trim() } : {}),
+  }
+  return { snapshot: next, changed: true }
+}
+
+/** 删节点 + 其关联边（入边出边都删，避免悬挂边）。返回新快照 + 实删 id。 */
+export function deleteNodes(
+  snapshot: CanvasSnapshot,
+  nodeIds: string[],
+): { snapshot: CanvasSnapshot; deleted: string[] } {
+  const targetSet = new Set(nodeIds)
+  const deleted = snapshot.nodes.filter((node) => targetSet.has(node.id)).map((node) => node.id)
+  if (!deleted.length) return { snapshot, deleted: [] }
+  const next = cloneSnapshot(snapshot)
+  next.nodes = next.nodes.filter((node) => !targetSet.has(node.id))
+  next.edges = next.edges.filter((edge) => !targetSet.has(edge.source) && !targetSet.has(edge.target))
+  if (next.selectedNodeIds) next.selectedNodeIds = next.selectedNodeIds.filter((id) => !targetSet.has(id))
+  return { snapshot: next, deleted }
+}

--- a/electron/capabilityCore/core.test.ts
+++ b/electron/capabilityCore/core.test.ts
@@ -1,0 +1,138 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  addProjectNodes,
+  connectProjectNodes,
+  createNamedProject,
+  deleteProjectNodes,
+  generateOnProject,
+  listAllProjects,
+  readProjectCanvas,
+  setProjectNodePrompt,
+} from './core'
+
+const tempRoots: string[] = []
+let mockedDocumentsRoot = ''
+let mockedUserDataRoot = ''
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: (name: string) => {
+      if (name === 'documents') return mockedDocumentsRoot
+      return mockedUserDataRoot
+    },
+    getAppPath: () => process.cwd(),
+  },
+}))
+
+function makeTempDir(name = 'nomi-capcore-test-'): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), name))
+  tempRoots.push(dir)
+  return dir
+}
+
+beforeEach(() => {
+  mockedDocumentsRoot = makeTempDir('nomi-capcore-documents-')
+  mockedUserDataRoot = makeTempDir('nomi-capcore-user-data-')
+  delete process.env.NOMI_PROJECTS_DIR
+})
+
+afterEach(() => {
+  delete process.env.NOMI_PROJECTS_DIR
+  for (const root of tempRoots.splice(0)) {
+    fs.rmSync(root, { recursive: true, force: true })
+  }
+})
+
+describe('capabilityCore/core (B 模式：直写 project.json)', () => {
+  it('建项目 → 加节点 → 连线 → 改提示词 → 读画布，全程落盘且重读一致', () => {
+    const project = createNamedProject('能力核测试项目')
+    expect(project.id).toBeTruthy()
+    expect(listAllProjects().some((item) => item.id === project.id)).toBe(true)
+
+    const { ids } = addProjectNodes(project.id, [
+      { kind: 'text', prompt: '一句产品脚本' },
+      { kind: 'image', title: '镜头 1' },
+    ])
+    expect(ids).toHaveLength(2)
+
+    const connected = connectProjectNodes(project.id, [{ source: ids[0], target: ids[1], mode: 'reference' }])
+    expect(connected.edgeIds).toHaveLength(1)
+    expect(connected.skipped).toHaveLength(0)
+
+    const prompted = setProjectNodePrompt(project.id, ids[1], '电影感写实，黄昏光线')
+    expect(prompted.changed).toBe(true)
+
+    // 重新读（从盘）—— 验证持久化往返一致。
+    const canvas = readProjectCanvas(project.id)
+    expect(canvas.nodes).toHaveLength(2)
+    expect(canvas.edges).toHaveLength(1)
+    const shot = canvas.nodes.find((node) => node.id === ids[1])
+    expect(shot?.prompt).toBe('电影感写实，黄昏光线')
+  })
+
+  it('删节点连带清边，落盘后边为空', () => {
+    const project = createNamedProject('删节点测试')
+    const { ids } = addProjectNodes(project.id, [{ kind: 'image' }, { kind: 'video' }])
+    connectProjectNodes(project.id, [{ source: ids[0], target: ids[1] }])
+    const removed = deleteProjectNodes(project.id, [ids[0]])
+    expect(removed.deleted).toEqual([ids[0]])
+    const canvas = readProjectCanvas(project.id)
+    expect(canvas.nodes).toHaveLength(1)
+    expect(canvas.edges).toHaveLength(0)
+  })
+
+  it('generate 构造正确请求体（注入 runTask 不打 vendor）并把结果落回节点', async () => {
+    const project = createNamedProject('生成测试')
+    const captured: Array<{ vendor: string; request: unknown }> = []
+    const fakeRunTask = async (payload: { vendor: string; request: unknown }) => {
+      captured.push(payload)
+      return {
+        id: 'task-xyz',
+        status: 'succeeded',
+        assets: [{ type: 'image', url: 'nomi-local://asset/p/img.png', providerUrl: 'https://cdn/img.png' }],
+      }
+    }
+
+    const out = await generateOnProject(
+      { projectId: project.id, intent: 'image', prompt: '一只赛博朋克猫', vendor: 'apimart', modelKey: 'seedream-4', references: ['https://cdn/ref.png'] },
+      fakeRunTask,
+    )
+
+    expect(out.status).toBe('succeeded')
+    expect(captured).toHaveLength(1)
+    // 请求体：高层 TaskRequest，extras 带 modelKey/projectId/nodeId/referenceImages，kind 由 intent 推。
+    const req = captured[0].request as { kind: string; prompt: string; extras: Record<string, unknown> }
+    expect(captured[0].vendor).toBe('apimart')
+    expect(req.kind).toBe('text_to_image')
+    expect(req.prompt).toBe('一只赛博朋克猫')
+    expect(req.extras.modelKey).toBe('seedream-4')
+    expect(req.extras.projectId).toBe(project.id)
+    expect(req.extras.nodeId).toBe(out.nodeId)
+    expect(req.extras.referenceImages).toEqual(['https://cdn/ref.png'])
+
+    // 结果落回节点：重读画布该节点 hasResult。
+    const canvas = readProjectCanvas(project.id)
+    expect(canvas.nodes.find((node) => node.id === out.nodeId)?.hasResult).toBe(true)
+  })
+
+  it('generate：video + 有参考图 → image_to_video', async () => {
+    const project = createNamedProject('视频意图测试')
+    let kind = ''
+    await generateOnProject(
+      { projectId: project.id, intent: 'video', prompt: '镜头推进', vendor: 'apimart', modelKey: 'seedance', references: ['https://cdn/first.png'] },
+      async (payload) => {
+        kind = (payload.request as { kind: string }).kind
+        return { id: 't', status: 'succeeded', assets: [] }
+      },
+    )
+    expect(kind).toBe('image_to_video')
+  })
+
+  it('未知项目抛清晰错误', () => {
+    expect(() => readProjectCanvas('ghost-id')).toThrow(/项目不存在/)
+  })
+})

--- a/electron/capabilityCore/core.ts
+++ b/electron/capabilityCore/core.ts
@@ -46,6 +46,15 @@ type TaskResultLike = {
 /** runTask 的形状（注入式，便于单测构造请求体而不真打 vendor）。 */
 export type RunTaskFn = (payload: { vendor: string; request: unknown }) => Promise<TaskResultLike>
 
+/** fetchTaskResult 的形状（注入式）。异步 vendor（modelscope 图 / 视频）返 queued，需轮询到终态。 */
+export type FetchTaskResultFn = (payload: { taskId: string; vendor: string; taskKind: string; prompt: string; modelKey: string }) => Promise<{ result: TaskResultLike }>
+
+const TERMINAL_STATUSES = new Set(['succeeded', 'failed'])
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
 function defaultKindForIntent(intent: GenerateIntent, hasReferences: boolean): string {
   switch (intent) {
     case 'image':
@@ -179,13 +188,16 @@ export type GenerateInput = {
 }
 
 /**
- * 触发一次生成。构造高层 TaskRequest → runTask（主进程组装请求体 + 发 vendor + 轮询 + 落资产）→
- * 把结果写回节点 result/history。runTask 注入式（测试不真打 vendor）。
- *
- * 注意（诚实交付）：真实 vendor 调用花用户额度，需真机 + 真 key 端到端验证才算「接通」（接入即验证
- * 铁律）；本函数保证请求**构造正确**与结果落盘，不替代真实 E2E。
+ * 触发一次生成。构造高层 TaskRequest → runTask（主进程组装请求体 + 发 vendor + 落资产）。
+ * 异步 vendor（modelscope 图 / 视频）首调返 queued → 用 fetchTaskResultFn **在本进程内**轮询到终态
+ * （taskCache 是进程内的，host 退出即丢，故不能跨调用轮询，必须本调用内等完）。再把结果写回节点。
+ * runTask/fetchTaskResult 注入式（测试不真打 vendor）。
  */
-export async function generateOnProject(input: GenerateInput, runTaskFn: RunTaskFn): Promise<{
+export async function generateOnProject(
+  input: GenerateInput,
+  runTaskFn: RunTaskFn,
+  fetchTaskResultFn?: FetchTaskResultFn,
+): Promise<{
   nodeId: string
   status: string
   assets: TaskResultLike['assets']
@@ -228,7 +240,25 @@ export async function generateOnProject(input: GenerateInput, runTaskFn: RunTask
     },
   }
 
-  const result = await runTaskFn({ vendor: input.vendor, request })
+  let result = await runTaskFn({ vendor: input.vendor, request })
+
+  // 异步 vendor 首调返 queued/processing → 本进程内轮询到终态（视频给更长超时）。无 fetch 注入则不轮询。
+  if (fetchTaskResultFn && result.status && !TERMINAL_STATUSES.has(result.status)) {
+    const timeoutMs = kind === 'text_to_video' || kind === 'image_to_video' ? 300000 : 120000
+    const startedAt = Date.now()
+    while (result.status && !TERMINAL_STATUSES.has(result.status)) {
+      if (Date.now() - startedAt > timeoutMs) break
+      await delay(2000)
+      const polled = await fetchTaskResultFn({
+        taskId: result.id || '',
+        vendor: input.vendor,
+        taskKind: kind,
+        prompt,
+        modelKey: input.modelKey,
+      })
+      result = polled.result
+    }
+  }
 
   // 落结果回节点。图/视频/音频走首资产；文本无资产，文本在 raw（best-effort 抽取）。失败也保存 prompt/节点。
   const primary = (result.assets || [])[0]

--- a/electron/capabilityCore/core.ts
+++ b/electron/capabilityCore/core.ts
@@ -59,6 +59,23 @@ function defaultKindForIntent(intent: GenerateIntent, hasReferences: boolean): s
   }
 }
 
+/**
+ * 文本生成的文本落在 result.raw（textTaskRunner 返回 assets:[] + raw=provider 响应，真机实测）。
+ * best-effort 从常见位置抽干净文本：裸字符串 / {text} / OpenAI {choices[0].message.content} / {content}。
+ */
+function extractTextFromRaw(raw: unknown): string {
+  if (typeof raw === 'string') return raw
+  if (raw && typeof raw === 'object') {
+    const record = raw as Record<string, unknown>
+    if (typeof record.text === 'string') return record.text
+    if (typeof record.content === 'string') return record.content
+    const choices = record.choices as Array<{ message?: { content?: unknown } }> | undefined
+    const content = choices?.[0]?.message?.content
+    if (typeof content === 'string') return content
+  }
+  return ''
+}
+
 /** 读取项目的画布快照（normalize 后），坏/缺数据降级为空。 */
 function readProjectSnapshot(record: ProjectRecord): CanvasSnapshot {
   const payload = (record.payload && typeof record.payload === 'object' ? (record.payload as Record<string, unknown>) : {}) as Record<string, unknown>
@@ -213,23 +230,25 @@ export async function generateOnProject(input: GenerateInput, runTaskFn: RunTask
 
   const result = await runTaskFn({ vendor: input.vendor, request })
 
-  // 落结果回节点（首资产 → result，便于 renderer 载入即见）。失败也保存 prompt/节点。
+  // 落结果回节点。图/视频/音频走首资产；文本无资产，文本在 raw（best-effort 抽取）。失败也保存 prompt/节点。
   const primary = (result.assets || [])[0]
+  const text = intent === 'text' ? extractTextFromRaw(result.raw) : (typeof primary?.text === 'string' ? primary.text : '')
+  const hasOutput = Boolean(primary || text)
   const persisted = snapshot.nodes.map((item) =>
     item.id === nodeId
       ? {
           ...item,
           status: result.status === 'succeeded' ? 'success' : result.status === 'failed' ? 'error' : item.status,
-          ...(primary
+          ...(hasOutput
             ? {
                 result: {
                   id: result.id || `result-${nodeId}`,
                   type: intent === 'video' ? 'video' : intent === 'audio' ? 'audio' : intent === 'text' ? 'text' : 'image',
-                  url: primary.url,
-                  thumbnailUrl: primary.thumbnailUrl,
-                  providerUrl: primary.providerUrl,
-                  text: primary.text,
-                  assetId: primary.assetId,
+                  ...(primary?.url ? { url: primary.url } : {}),
+                  ...(primary?.thumbnailUrl ? { thumbnailUrl: primary.thumbnailUrl } : {}),
+                  ...(primary?.providerUrl ? { providerUrl: primary.providerUrl } : {}),
+                  ...(text ? { text } : {}),
+                  ...(primary?.assetId ? { assetId: primary.assetId } : {}),
                   createdAt: Date.now(),
                 },
               }
@@ -239,5 +258,5 @@ export async function generateOnProject(input: GenerateInput, runTaskFn: RunTask
   )
   saveProject(input.projectId, writeProjectSnapshot(record, { ...snapshot, nodes: persisted }))
 
-  return { nodeId, status: result.status || 'unknown', assets: result.assets || [] }
+  return { nodeId, status: result.status || 'unknown', assets: result.assets || [], ...(text ? { text } : {}) }
 }

--- a/electron/capabilityCore/core.ts
+++ b/electron/capabilityCore/core.ts
@@ -1,0 +1,243 @@
+// 能力核 · 编排层（见 docs/plan/2026-06-20-capability-core-headless-exposure.md）。
+//
+// 把纯图操作（canvasGraph）接到真实的工程持久化（projects/repository）与生成引擎（runtime.runTask）。
+// 这是「外部 agent / CLI / MCP 驱动 Nomi」的**主进程**单一执行口——所有传输（RPC / 头less host）
+// 都调这里，不各自实现一遍（P1）。
+//
+// 模式说明：本文件实现 **B 模式**（app 关着，直接读写 project.json）。当 app 开着时，
+// 工程的内存 store 才是真相、会防抖回盘覆盖文件改动（见 workbenchProjectSession），故 app 开着时
+// 图变更必须经运行中实例（A 模式，rpcServer 转发给 renderer），不能在此直写文件。调用方（rpcServer/
+// host）负责按「app 是否开着」选模式；本核只管把 B 模式做对、做纯。
+//
+// 真相源（P1）：generate 不重建 archetype→body——runTask 主进程内部据 catalog mapping + extras
+// 自己组装请求体（findExecutableModel / requestPipeline / 资产本地化）。本核只构造高层 TaskRequest。
+import { listProjects, readProject, saveProject, createProject, type ProjectRecord } from '../projects/repository'
+import { readCatalog } from '../catalog/catalogStore'
+import {
+  addNodes,
+  connectNodes,
+  deleteNodes,
+  normalizeSnapshot,
+  readCanvas,
+  setNodePrompt,
+  type CanvasSnapshot,
+  type ConnectionSpec,
+  type NodeSpec,
+} from './canvasGraph'
+
+/** 生成意图（粗粒度）→ 默认 ProfileKind。调用方也可显式传 kind 覆盖。 */
+export type GenerateIntent = 'image' | 'video' | 'text' | 'audio'
+
+type TaskResultLike = {
+  id?: string
+  status?: string
+  // 字段宽容：runtime.TaskResult 的可空字段（string | null）也吃，避免传输边界处理 null
+  assets?: Array<{
+    type?: string
+    url?: string
+    thumbnailUrl?: string | null
+    providerUrl?: string | null
+    assetId?: string | null
+    text?: string | null
+  }>
+  raw?: unknown
+}
+
+/** runTask 的形状（注入式，便于单测构造请求体而不真打 vendor）。 */
+export type RunTaskFn = (payload: { vendor: string; request: unknown }) => Promise<TaskResultLike>
+
+function defaultKindForIntent(intent: GenerateIntent, hasReferences: boolean): string {
+  switch (intent) {
+    case 'image':
+      return 'text_to_image'
+    case 'video':
+      return hasReferences ? 'image_to_video' : 'text_to_video'
+    case 'audio':
+      return 'text_to_audio'
+    default:
+      return 'chat'
+  }
+}
+
+/** 读取项目的画布快照（normalize 后），坏/缺数据降级为空。 */
+function readProjectSnapshot(record: ProjectRecord): CanvasSnapshot {
+  const payload = (record.payload && typeof record.payload === 'object' ? (record.payload as Record<string, unknown>) : {}) as Record<string, unknown>
+  return normalizeSnapshot(payload.generationCanvas)
+}
+
+/** 把改好的快照写回 record.payload.generationCanvas，其余 payload 字段原样保留（不碰 timeline 等）。 */
+function writeProjectSnapshot(record: ProjectRecord, snapshot: CanvasSnapshot): ProjectRecord {
+  const payload = (record.payload && typeof record.payload === 'object' ? { ...(record.payload as Record<string, unknown>) } : {}) as Record<string, unknown>
+  payload.generationCanvas = snapshot
+  return { ...record, payload }
+}
+
+function mustReadProject(projectId: string): ProjectRecord {
+  const record = readProject(projectId)
+  if (!record) throw new Error(`项目不存在: ${projectId}`)
+  return record
+}
+
+// ── 工程级 ─────────────────────────────────────────────────────────────
+
+export function listAllProjects(): Array<{ id: string; name: string; updatedAt: number }> {
+  return listProjects().map((project) => ({ id: project.id, name: project.name, updatedAt: project.updatedAt }))
+}
+
+export function createNamedProject(name?: string): { id: string; name: string } {
+  const record = createProject(name ? { name } : {})
+  return { id: record.id, name: record.name }
+}
+
+/** 列出 catalog 里可执行的模型（enabled），供外部 agent 选型。 */
+export function listAvailableModels(): Array<{ vendor: string; vendorName: string; modelKey: string; kind: string; label: string }> {
+  const state = readCatalog()
+  const vendorName = new Map(state.vendors.map((vendor) => [vendor.key, vendor.name] as const))
+  return state.models
+    .filter((model) => model.enabled)
+    .map((model) => ({
+      vendor: model.vendorKey,
+      vendorName: vendorName.get(model.vendorKey) || model.vendorKey,
+      modelKey: model.modelKey,
+      kind: model.kind,
+      label: model.labelZh || model.modelKey,
+    }))
+}
+
+// ── 画布级（B 模式：直写 project.json）──────────────────────────────────
+
+export function readProjectCanvas(projectId: string): ReturnType<typeof readCanvas> {
+  return readCanvas(readProjectSnapshot(mustReadProject(projectId)))
+}
+
+export function addProjectNodes(projectId: string, specs: NodeSpec[]): { ids: string[] } {
+  const record = mustReadProject(projectId)
+  const { snapshot, ids } = addNodes(readProjectSnapshot(record), specs)
+  saveProject(projectId, writeProjectSnapshot(record, snapshot))
+  return { ids }
+}
+
+export function connectProjectNodes(projectId: string, connections: ConnectionSpec[]): {
+  edgeIds: string[]
+  skipped: Array<{ connection: ConnectionSpec; reason: string }>
+} {
+  const record = mustReadProject(projectId)
+  const result = connectNodes(readProjectSnapshot(record), connections)
+  saveProject(projectId, writeProjectSnapshot(record, result.snapshot))
+  return { edgeIds: result.edgeIds, skipped: result.skipped }
+}
+
+export function setProjectNodePrompt(projectId: string, nodeId: string, prompt: string, title?: string): { changed: boolean } {
+  const record = mustReadProject(projectId)
+  const { snapshot, changed } = setNodePrompt(readProjectSnapshot(record), nodeId, prompt, title)
+  if (changed) saveProject(projectId, writeProjectSnapshot(record, snapshot))
+  return { changed }
+}
+
+export function deleteProjectNodes(projectId: string, nodeIds: string[]): { deleted: string[] } {
+  const record = mustReadProject(projectId)
+  const { snapshot, deleted } = deleteNodes(readProjectSnapshot(record), nodeIds)
+  if (deleted.length) saveProject(projectId, writeProjectSnapshot(record, snapshot))
+  return { deleted }
+}
+
+// ── 生成（复用主进程 runtime.runTask；B 模式落结果回节点）─────────────────
+
+export type GenerateInput = {
+  projectId: string
+  /** 既有节点 id；不给则用 prompt 新建一个节点再生成。 */
+  nodeId?: string
+  /** 新建节点时的提示词；既有节点不给则用节点现有 prompt。 */
+  prompt?: string
+  intent?: GenerateIntent
+  /** 显式 ProfileKind（如 text_to_image）；不给则由 intent 推。 */
+  kind?: string
+  vendor: string
+  modelKey: string
+  /** 透传进 extras 的生成参数（width/height/seed/duration…），主进程 archetypeInput 映射。 */
+  params?: Record<string, unknown>
+  /** 参考图（公网 URL 或 nomi-local://），落进 extras.referenceImages。 */
+  references?: string[]
+  title?: string
+}
+
+/**
+ * 触发一次生成。构造高层 TaskRequest → runTask（主进程组装请求体 + 发 vendor + 轮询 + 落资产）→
+ * 把结果写回节点 result/history。runTask 注入式（测试不真打 vendor）。
+ *
+ * 注意（诚实交付）：真实 vendor 调用花用户额度，需真机 + 真 key 端到端验证才算「接通」（接入即验证
+ * 铁律）；本函数保证请求**构造正确**与结果落盘，不替代真实 E2E。
+ */
+export async function generateOnProject(input: GenerateInput, runTaskFn: RunTaskFn): Promise<{
+  nodeId: string
+  status: string
+  assets: TaskResultLike['assets']
+}> {
+  const record = mustReadProject(input.projectId)
+  let snapshot = readProjectSnapshot(record)
+
+  // 解析/新建目标节点
+  let nodeId = input.nodeId || ''
+  const intent = input.intent || 'image'
+  if (!nodeId) {
+    const nodeKind = intent === 'video' ? 'video' : intent === 'audio' ? 'audio' : intent === 'text' ? 'text' : 'image'
+    const created = addNodes(snapshot, [{ kind: nodeKind, prompt: input.prompt, title: input.title, references: input.references }])
+    snapshot = created.snapshot
+    nodeId = created.ids[0]
+  } else if (typeof input.prompt === 'string' && input.prompt.trim()) {
+    const updated = setNodePrompt(snapshot, nodeId, input.prompt, input.title)
+    snapshot = updated.snapshot
+  }
+
+  const node = snapshot.nodes.find((item) => item.id === nodeId)
+  if (!node) throw new Error(`节点不存在: ${nodeId}`)
+  const prompt = typeof node.prompt === 'string' ? node.prompt.trim() : ''
+  if (!prompt && intent !== 'audio') throw new Error('prompt is required')
+
+  const references = input.references && input.references.length ? input.references : (Array.isArray(node.references) ? node.references : [])
+  const kind = input.kind || defaultKindForIntent(intent, references.length > 0)
+
+  const request = {
+    kind,
+    prompt,
+    extras: {
+      ...(input.params || {}),
+      modelKey: input.modelKey,
+      modelAlias: input.modelKey,
+      projectId: input.projectId,
+      nodeId,
+      nodeKind: node.kind,
+      ...(references.length ? { referenceImages: references } : {}),
+    },
+  }
+
+  const result = await runTaskFn({ vendor: input.vendor, request })
+
+  // 落结果回节点（首资产 → result，便于 renderer 载入即见）。失败也保存 prompt/节点。
+  const primary = (result.assets || [])[0]
+  const persisted = snapshot.nodes.map((item) =>
+    item.id === nodeId
+      ? {
+          ...item,
+          status: result.status === 'succeeded' ? 'success' : result.status === 'failed' ? 'error' : item.status,
+          ...(primary
+            ? {
+                result: {
+                  id: result.id || `result-${nodeId}`,
+                  type: intent === 'video' ? 'video' : intent === 'audio' ? 'audio' : intent === 'text' ? 'text' : 'image',
+                  url: primary.url,
+                  thumbnailUrl: primary.thumbnailUrl,
+                  providerUrl: primary.providerUrl,
+                  text: primary.text,
+                  assetId: primary.assetId,
+                  createdAt: Date.now(),
+                },
+              }
+            : {}),
+        }
+      : item,
+  )
+  saveProject(input.projectId, writeProjectSnapshot(record, { ...snapshot, nodes: persisted }))
+
+  return { nodeId, status: result.status || 'unknown', assets: result.assets || [] }
+}

--- a/electron/capabilityCore/dispatcher.ts
+++ b/electron/capabilityCore/dispatcher.ts
@@ -10,6 +10,7 @@ import {
   listAvailableModels,
   readProjectCanvas,
   setProjectNodePrompt,
+  type FetchTaskResultFn,
   type GenerateInput,
   type RunTaskFn,
 } from './core'
@@ -32,7 +33,7 @@ export function projectIdOf(params: Record<string, unknown>): string {
   return typeof params.projectId === 'string' ? params.projectId : ''
 }
 
-export type DispatchContext = { runTask: RunTaskFn }
+export type DispatchContext = { runTask: RunTaskFn; fetchTaskResult?: FetchTaskResultFn }
 
 export async function dispatch(method: string, params: Record<string, unknown>, ctx: DispatchContext): Promise<unknown> {
   switch (method) {
@@ -60,7 +61,7 @@ export async function dispatch(method: string, params: Record<string, unknown>, 
     case 'canvas.deleteNodes':
       return deleteProjectNodes(projectIdOf(params), Array.isArray(params.nodeIds) ? (params.nodeIds as string[]) : [])
     case 'generate':
-      return generateOnProject(params as unknown as GenerateInput, ctx.runTask)
+      return generateOnProject(params as unknown as GenerateInput, ctx.runTask, ctx.fetchTaskResult)
     default:
       throw new RpcError(`未知方法: ${method}`, 404)
   }

--- a/electron/capabilityCore/dispatcher.ts
+++ b/electron/capabilityCore/dispatcher.ts
@@ -1,0 +1,67 @@
+// 能力核 · 方法路由（单一真相源）。
+// RPC 传输（rpcServer）与 headless host（host）共用这一份 method→core 映射，杜绝两份路由漂移（P1）。
+import {
+  addProjectNodes,
+  connectProjectNodes,
+  createNamedProject,
+  deleteProjectNodes,
+  generateOnProject,
+  listAllProjects,
+  listAvailableModels,
+  readProjectCanvas,
+  setProjectNodePrompt,
+  type GenerateInput,
+  type RunTaskFn,
+} from './core'
+
+/** 会改盘的方法——app 开着时对「正在打开的项目」要拒绝（A/B 守卫，见 rpcServer）。 */
+export const MUTATION_METHODS = new Set([
+  'canvas.addNodes',
+  'canvas.connect',
+  'canvas.setPrompt',
+  'canvas.deleteNodes',
+])
+
+export class RpcError extends Error {
+  constructor(message: string, readonly httpStatus: number) {
+    super(message)
+  }
+}
+
+export function projectIdOf(params: Record<string, unknown>): string {
+  return typeof params.projectId === 'string' ? params.projectId : ''
+}
+
+export type DispatchContext = { runTask: RunTaskFn }
+
+export async function dispatch(method: string, params: Record<string, unknown>, ctx: DispatchContext): Promise<unknown> {
+  switch (method) {
+    case 'ping':
+      return { ok: true }
+    case 'project.list':
+      return { projects: listAllProjects() }
+    case 'project.create':
+      return createNamedProject(typeof params.name === 'string' ? params.name : undefined)
+    case 'models.list':
+      return { models: listAvailableModels() }
+    case 'canvas.read':
+      return readProjectCanvas(projectIdOf(params))
+    case 'canvas.addNodes':
+      return addProjectNodes(projectIdOf(params), Array.isArray(params.nodes) ? (params.nodes as never[]) : [])
+    case 'canvas.connect':
+      return connectProjectNodes(projectIdOf(params), Array.isArray(params.connections) ? (params.connections as never[]) : [])
+    case 'canvas.setPrompt':
+      return setProjectNodePrompt(
+        projectIdOf(params),
+        String(params.nodeId || ''),
+        String(params.prompt || ''),
+        typeof params.title === 'string' ? params.title : undefined,
+      )
+    case 'canvas.deleteNodes':
+      return deleteProjectNodes(projectIdOf(params), Array.isArray(params.nodeIds) ? (params.nodeIds as string[]) : [])
+    case 'generate':
+      return generateOnProject(params as unknown as GenerateInput, ctx.runTask)
+    default:
+      throw new RpcError(`未知方法: ${method}`, 404)
+  }
+}

--- a/electron/capabilityCore/host.ts
+++ b/electron/capabilityCore/host.ts
@@ -12,6 +12,12 @@ import { dispatch, RpcError } from './dispatcher'
 import { runTask } from '../runtime'
 import { verifyToken } from './security'
 
+// 身份对齐（解密 vendor key 的前提）：CLI 用 `electron host.js` spawn 时 getName 默认 "Electron"，与主 app
+// 加密 safeStorage key 时的身份不符 → 解不开 key（真机实测「API key missing」根因）。spawner 经 NOMI_APP_NAME
+// 传入主 app 身份（= package.json name），setName 对齐 keychain + 默认 userData 才能读到真 catalog 并解密。
+// 必须在 app ready 前调。生产（host 在打包 app 内、getName 已是产品名）spawner 不传此 env → 不覆盖。
+if (process.env.NOMI_APP_NAME) app.setName(process.env.NOMI_APP_NAME)
+
 type HostCommand = { token?: string; method?: string; params?: Record<string, unknown> }
 
 function readCommandFromArgv(): HostCommand {

--- a/electron/capabilityCore/host.ts
+++ b/electron/capabilityCore/host.ts
@@ -9,7 +9,7 @@
 import { app } from 'electron'
 
 import { dispatch, RpcError } from './dispatcher'
-import { runTask } from '../runtime'
+import { runTask, fetchTaskResult } from '../runtime'
 import { verifyToken } from './security'
 
 // 身份对齐（解密 vendor key 的前提）：CLI 用 `electron host.js` spawn 时 getName 默认 "Electron"，与主 app
@@ -48,7 +48,7 @@ async function run(): Promise<number> {
   const params = command.params && typeof command.params === 'object' ? command.params : {}
   // headless 永远是工程文件的唯一写者（app 关着时 CLI 才 spawn 它），无「项目正在打开」之说 → 全放行。
   try {
-    const result = await dispatch(method, params, { runTask })
+    const result = await dispatch(method, params, { runTask, fetchTaskResult })
     emit({ ok: true, result })
     return 0
   } catch (error) {

--- a/electron/capabilityCore/host.ts
+++ b/electron/capabilityCore/host.ts
@@ -1,0 +1,64 @@
+// 能力核 · headless host（见 docs/plan/2026-06-20-capability-core-headless-exposure.md §S5）。
+//
+// 「Nomi 关着」时的执行体：一个**无窗口的 Electron 进程**（不是纯 node——生成链路要 safeStorage 解密
+// vendor key、app.getPath 取数据根，纯 node 够不着）。CLI 探测到 app 没开 → spawn `electron host.js`，
+// 经 stdin/argv 收一条命令，调能力核（B 模式直写 project.json），把结果打到 stdout(JSON) 后退出。
+//
+// 关键：host **不取单实例锁**（它是 worker 不是 app），也不开窗、不起 RPC、不写实例广告——它是一次性
+// 短命进程。app 关着时它就是工程文件的唯一写者（安全）；app 开着时 CLI 走 RPC 不会 spawn 它（无并发写）。
+import { app } from 'electron'
+
+import { dispatch, RpcError } from './dispatcher'
+import { runTask } from '../runtime'
+import { verifyToken } from './security'
+
+type HostCommand = { token?: string; method?: string; params?: Record<string, unknown> }
+
+function readCommandFromArgv(): HostCommand {
+  // electron host.js --cmd '<json>'
+  const flagIndex = process.argv.indexOf('--cmd')
+  if (flagIndex >= 0 && process.argv[flagIndex + 1]) {
+    try {
+      return JSON.parse(process.argv[flagIndex + 1]) as HostCommand
+    } catch {
+      return {}
+    }
+  }
+  return {}
+}
+
+function emit(payload: unknown): void {
+  process.stdout.write(JSON.stringify(payload))
+}
+
+async function run(): Promise<number> {
+  const command = readCommandFromArgv()
+  // 即便本机直连，host 仍要求 token——外部进程想驱动它必须证明拿到了用户机器上的 token（S6）。
+  if (!verifyToken(command.token)) {
+    emit({ ok: false, error: '鉴权失败：token 无效' })
+    return 1
+  }
+  const method = String(command.method || '')
+  const params = command.params && typeof command.params === 'object' ? command.params : {}
+  // headless 永远是工程文件的唯一写者（app 关着时 CLI 才 spawn 它），无「项目正在打开」之说 → 全放行。
+  try {
+    const result = await dispatch(method, params, { runTask })
+    emit({ ok: true, result })
+    return 0
+  } catch (error) {
+    const message = error instanceof RpcError ? error.message : error instanceof Error ? error.message : String(error)
+    emit({ ok: false, error: message })
+    return 1
+  }
+}
+
+app.whenReady().then(async () => {
+  let code = 1
+  try {
+    code = await run()
+  } catch (error) {
+    emit({ ok: false, error: error instanceof Error ? error.message : String(error) })
+  } finally {
+    app.exit(code)
+  }
+})

--- a/electron/capabilityCore/lockfile.ts
+++ b/electron/capabilityCore/lockfile.ts
@@ -1,0 +1,85 @@
+// 能力核 · 实例广告 / 探测（见 docs/plan/2026-06-20-capability-core-headless-exposure.md §S4）。
+//
+// 「Nomi 开着没」是开/不开自动适配的关键探针。运行中的 app 启动 RPC server 后，把
+// { pid, port, token, startedAt, version } 写到一个固定路径的 instance.json；外部 CLI/MCP
+// 读它就知道：有活实例 → 走 RPC（A 模式，改动实时反映到 UI）；无/陈旧 → 走 headless host（B 模式）。
+//
+// 陈旧判定：写 instance.json 的进程已死（pid 不在）→ 视为没开（app 崩了没清锁）。
+// 文件放 <settingsRoot>/capability-core/instance.json（userData 内，与 token 同根）。
+import fs from 'node:fs'
+import path from 'node:path'
+import { ensureDir } from '../runtimePaths'
+import { capabilityCoreDir } from './security'
+
+const INSTANCE_FILE = 'instance.json'
+
+export type InstanceAdvertisement = {
+  pid: number
+  port: number
+  token: string
+  startedAt: number
+  version: string
+}
+
+function instancePath(): string {
+  return path.join(capabilityCoreDir(), INSTANCE_FILE)
+}
+
+/** 运行中的 app 写实例广告（启动 RPC 后调）。 */
+export function writeInstanceAdvertisement(advertisement: InstanceAdvertisement): void {
+  ensureDir(capabilityCoreDir())
+  fs.writeFileSync(instancePath(), JSON.stringify(advertisement, null, 2), 'utf8')
+}
+
+/** app 退出时清掉广告（best-effort，不抛——退出路径绝不卡）。 */
+export function clearInstanceAdvertisement(): void {
+  try {
+    fs.rmSync(instancePath(), { force: true })
+  } catch {
+    /* 退出清理失败无所谓：下次读会做 pid 存活校验兜底 */
+  }
+}
+
+function isProcessAlive(pid: number): boolean {
+  if (!Number.isInteger(pid) || pid <= 0) return false
+  try {
+    // signal 0 = 只探测存在/权限，不真发信号。ESRCH=不存在，EPERM=存在但无权（仍算活）。
+    process.kill(pid, 0)
+    return true
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === 'EPERM'
+  }
+}
+
+/**
+ * 读活实例广告：文件存在 + 写它的进程仍活 → 返回广告（app 开着）；否则 null（没开/陈旧）。
+ * 陈旧文件顺手清掉，避免反复 pid 探测。
+ */
+export function readLiveInstance(): InstanceAdvertisement | null {
+  let raw: string
+  try {
+    raw = fs.readFileSync(instancePath(), 'utf8')
+  } catch {
+    return null
+  }
+  let parsed: Partial<InstanceAdvertisement>
+  try {
+    parsed = JSON.parse(raw) as Partial<InstanceAdvertisement>
+  } catch {
+    return null
+  }
+  if (typeof parsed.pid !== 'number' || typeof parsed.port !== 'number' || typeof parsed.token !== 'string') {
+    return null
+  }
+  if (!isProcessAlive(parsed.pid)) {
+    clearInstanceAdvertisement()
+    return null
+  }
+  return {
+    pid: parsed.pid,
+    port: parsed.port,
+    token: parsed.token,
+    startedAt: typeof parsed.startedAt === 'number' ? parsed.startedAt : 0,
+    version: typeof parsed.version === 'string' ? parsed.version : '',
+  }
+}

--- a/electron/capabilityCore/rpcServer.test.ts
+++ b/electron/capabilityCore/rpcServer.test.ts
@@ -1,0 +1,101 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { startRpcServer, type RpcServerHandle } from './rpcServer'
+import { ensureToken } from './security'
+
+const tempRoots: string[] = []
+let mockedDocumentsRoot = ''
+let mockedUserDataRoot = ''
+let server: RpcServerHandle | null = null
+let token = ''
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: (name: string) => (name === 'documents' ? mockedDocumentsRoot : mockedUserDataRoot),
+    getAppPath: () => process.cwd(),
+  },
+}))
+
+function makeTempDir(name = 'nomi-rpc-test-'): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), name))
+  tempRoots.push(dir)
+  return dir
+}
+
+async function rpc(method: string, params: Record<string, unknown> = {}, auth = token) {
+  const res = await fetch(`http://127.0.0.1:${server!.port}/rpc`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', ...(auth ? { authorization: `Bearer ${auth}` } : {}) },
+    body: JSON.stringify({ method, params }),
+  })
+  return { status: res.status, body: (await res.json()) as { ok: boolean; result?: unknown; error?: string } }
+}
+
+beforeEach(async () => {
+  mockedDocumentsRoot = makeTempDir('nomi-rpc-documents-')
+  mockedUserDataRoot = makeTempDir('nomi-rpc-user-data-')
+  delete process.env.NOMI_PROJECTS_DIR
+  token = ensureToken()
+  server = await startRpcServer({
+    runTask: async () => ({ id: 't', status: 'succeeded', assets: [{ type: 'image', url: 'nomi-local://x' }] }),
+    isProjectOpen: (id) => id === 'OPEN_PROJECT',
+  })
+})
+
+afterEach(async () => {
+  if (server) await server.close()
+  server = null
+  delete process.env.NOMI_PROJECTS_DIR
+  for (const root of tempRoots.splice(0)) fs.rmSync(root, { recursive: true, force: true })
+})
+
+describe('capabilityCore/rpcServer', () => {
+  it('无 token / 错 token → 401', async () => {
+    const noAuth = await rpc('ping', {}, '')
+    expect(noAuth.status).toBe(401)
+    const badAuth = await rpc('ping', {}, 'deadbeef')
+    expect(badAuth.status).toBe(401)
+  })
+
+  it('对 token → ping ok', async () => {
+    const res = await rpc('ping')
+    expect(res.status).toBe(200)
+    expect(res.body.ok).toBe(true)
+  })
+
+  it('全链路：建项目 → 加节点 → 读画布', async () => {
+    const created = await rpc('project.create', { name: 'RPC 项目' })
+    const projectId = (created.body.result as { id: string }).id
+    expect(projectId).toBeTruthy()
+
+    const added = await rpc('canvas.addNodes', { projectId, nodes: [{ kind: 'text', prompt: 'hi' }] })
+    expect(added.body.ok).toBe(true)
+    const ids = (added.body.result as { ids: string[] }).ids
+    expect(ids).toHaveLength(1)
+
+    const read = await rpc('canvas.read', { projectId })
+    expect((read.body.result as { nodes: unknown[] }).nodes).toHaveLength(1)
+  })
+
+  it('generate 经 RPC 走注入 runTask 落结果', async () => {
+    const created = await rpc('project.create', { name: 'gen' })
+    const projectId = (created.body.result as { id: string }).id
+    const gen = await rpc('generate', { projectId, intent: 'image', prompt: 'cat', vendor: 'v', modelKey: 'm' })
+    expect(gen.body.ok).toBe(true)
+    expect((gen.body.result as { status: string }).status).toBe('succeeded')
+  })
+
+  it('A/B 守卫：改正在打开的项目 → 409 说人话', async () => {
+    const blocked = await rpc('canvas.addNodes', { projectId: 'OPEN_PROJECT', nodes: [{ kind: 'text' }] })
+    expect(blocked.status).toBe(409)
+    expect(blocked.body.error).toMatch(/正在 Nomi 中打开/)
+  })
+
+  it('未知方法 → 404', async () => {
+    const res = await rpc('nope')
+    expect(res.status).toBe(404)
+  })
+})

--- a/electron/capabilityCore/rpcServer.ts
+++ b/electron/capabilityCore/rpcServer.ts
@@ -10,13 +10,15 @@
 import http from 'node:http'
 import type { AddressInfo } from 'node:net'
 
-import type { RunTaskFn } from './core'
+import type { FetchTaskResultFn, RunTaskFn } from './core'
 import { dispatch, MUTATION_METHODS, projectIdOf, RpcError } from './dispatcher'
 import { verifyToken } from './security'
 
 export type RpcServerOptions = {
   /** 真实生成入口（runtime.runTask）。注入式：headless host 与 app 各自传同一份。 */
   runTask: RunTaskFn
+  /** 异步任务轮询入口（runtime.fetchTaskResult）。图/视频异步生成等终态用。 */
+  fetchTaskResult?: FetchTaskResultFn
   /** 该 projectId 是否正在某个 app 窗口里打开（命中则拒绝直写图变更）。headless: ()=>false。 */
   isProjectOpen?: (projectId: string) => boolean
 }
@@ -81,7 +83,7 @@ export function startRpcServer(options: RpcServerOptions): Promise<RpcServerHand
             throw new RpcError('该项目正在 Nomi 中打开；图变更请在 app 内操作，或关闭项目后再用外部调用（实时桥接为后续切片）。', 409)
           }
         }
-        const result = await dispatch(method, params, { runTask: options.runTask })
+        const result = await dispatch(method, params, { runTask: options.runTask, fetchTaskResult: options.fetchTaskResult })
         send(200, { ok: true, result })
       } catch (error) {
         const status = error instanceof RpcError ? error.httpStatus : 500

--- a/electron/capabilityCore/rpcServer.ts
+++ b/electron/capabilityCore/rpcServer.ts
@@ -1,0 +1,107 @@
+// 能力核 · 本地 RPC 传输（见 docs/plan/2026-06-20-capability-core-headless-exposure.md §S4）。
+//
+// 一个最小 JSON-over-HTTP server，只监听 127.0.0.1（绝不开公网，S6 安全门之一），token 鉴权
+// （Authorization: Bearer <token>，常数时间校验）。所有传输（CLI / MCP）都打它，路由到能力核。
+// 用 node:http，**不引新依赖**（P1 极简）。
+//
+// A/B 模式守卫（诚实、不静默损坏）：app 开着时，它内存 store 才是工程真相、会防抖回盘；此时对
+// **正在打开的项目**直写文件会被覆盖（数据丢失）。故注入 isProjectOpen()，命中即拒绝图变更并说人话
+// （A 模式实时桥接是后续切片）。headless host 里 isProjectOpen 恒 false → 全放行。
+import http from 'node:http'
+import type { AddressInfo } from 'node:net'
+
+import type { RunTaskFn } from './core'
+import { dispatch, MUTATION_METHODS, projectIdOf, RpcError } from './dispatcher'
+import { verifyToken } from './security'
+
+export type RpcServerOptions = {
+  /** 真实生成入口（runtime.runTask）。注入式：headless host 与 app 各自传同一份。 */
+  runTask: RunTaskFn
+  /** 该 projectId 是否正在某个 app 窗口里打开（命中则拒绝直写图变更）。headless: ()=>false。 */
+  isProjectOpen?: (projectId: string) => boolean
+}
+
+function readBody(req: http.IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let body = ''
+    let size = 0
+    const LIMIT = 8 * 1024 * 1024 // 8MB 上限，防内存炸
+    req.on('data', (chunk) => {
+      size += chunk.length
+      if (size > LIMIT) {
+        reject(new RpcError('请求体过大', 413))
+        req.destroy()
+        return
+      }
+      body += chunk
+    })
+    req.on('end', () => resolve(body))
+    req.on('error', reject)
+  })
+}
+
+function bearerToken(req: http.IncomingMessage): string {
+  const header = req.headers.authorization || ''
+  const match = /^Bearer\s+(.+)$/i.exec(Array.isArray(header) ? header[0] : header)
+  return match ? match[1].trim() : ''
+}
+
+export type RpcServerHandle = {
+  port: number
+  close: () => Promise<void>
+}
+
+/** 启动 RPC server，监听 127.0.0.1 随机端口。返回端口与关闭句柄。 */
+export function startRpcServer(options: RpcServerOptions): Promise<RpcServerHandle> {
+  const isProjectOpen = options.isProjectOpen || (() => false)
+
+  const server = http.createServer((req, res) => {
+    void (async () => {
+      const send = (status: number, payload: unknown) => {
+        const body = JSON.stringify(payload)
+        res.writeHead(status, { 'content-type': 'application/json', 'content-length': Buffer.byteLength(body) })
+        res.end(body)
+      }
+      try {
+        if (req.method !== 'POST' || req.url !== '/rpc') throw new RpcError('仅支持 POST /rpc', 404)
+        if (!verifyToken(bearerToken(req))) throw new RpcError('鉴权失败：token 无效', 401)
+        const raw = await readBody(req)
+        let parsed: { method?: unknown; params?: unknown }
+        try {
+          parsed = JSON.parse(raw || '{}')
+        } catch {
+          throw new RpcError('请求体非合法 JSON', 400)
+        }
+        const method = String(parsed.method || '')
+        const params = (parsed.params && typeof parsed.params === 'object' ? parsed.params : {}) as Record<string, unknown>
+        // A/B 守卫：app 开着且改的正是打开中的项目 → 拒绝，说人话。
+        if (MUTATION_METHODS.has(method)) {
+          const pid = projectIdOf(params)
+          if (pid && isProjectOpen(pid)) {
+            throw new RpcError('该项目正在 Nomi 中打开；图变更请在 app 内操作，或关闭项目后再用外部调用（实时桥接为后续切片）。', 409)
+          }
+        }
+        const result = await dispatch(method, params, { runTask: options.runTask })
+        send(200, { ok: true, result })
+      } catch (error) {
+        const status = error instanceof RpcError ? error.httpStatus : 500
+        send(status, { ok: false, error: error instanceof Error ? error.message : String(error) })
+      }
+    })()
+  })
+
+  return new Promise((resolve, reject) => {
+    server.on('error', reject)
+    // 0.0.0.0 绝不用——只 127.0.0.1，外网/局域网够不着。
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address() as AddressInfo
+      resolve({
+        port: address.port,
+        close: () =>
+          new Promise<void>((resolveClose) => {
+            server.close(() => resolveClose())
+          }),
+      })
+    })
+  })
+}

--- a/electron/capabilityCore/security.ts
+++ b/electron/capabilityCore/security.ts
@@ -1,0 +1,68 @@
+// 能力核 · 安全门（见 docs/plan/2026-06-20-capability-core-headless-exposure.md §S6）。
+//
+// 外部 agent（Claude Code / Codex）经 CLI / MCP 调能力核 = 能触发生成（花用户额度）+ 改工程文件。
+// 必须有门：① 本地 token 鉴权（任意进程想调先证明它拿到了用户机器上的 token 文件）；
+// ② RPC server 只监听 127.0.0.1（不开公网，见 rpcServer）。这是「别让任意 agent 静默烧钱」的地基。
+//
+// token / 实例广告落**确定路径** `~/.nomi/capability-core/`（可被 NOMI_CAPABILITY_DIR 覆盖）。
+// 为什么不用 electron userData：getName() 在 dev("nomi")/打包("Nomi") 不一致 → 纯 node 的 CLI 算不准；
+// 用 home 下固定路径，app 侧与 CLI 端算同一处，探测才可靠（隔离实例可设 NOMI_CAPABILITY_DIR 各自隔离）。
+// 首次需要时惰性生成 token；权限尽量收紧（0600）。
+import crypto from 'node:crypto'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+export const CAPABILITY_DIR_ENV = 'NOMI_CAPABILITY_DIR'
+const TOKEN_FILE = 'token'
+
+export function capabilityCoreDir(): string {
+  const configured = String(process.env[CAPABILITY_DIR_ENV] || '').trim()
+  return configured || path.join(os.homedir(), '.nomi', 'capability-core')
+}
+
+function ensureDir(dir: string): void {
+  fs.mkdirSync(dir, { recursive: true })
+}
+
+function tokenPath(): string {
+  return path.join(capabilityCoreDir(), TOKEN_FILE)
+}
+
+/** 读取已存在的 token（无则 null，不自动生成——读路径不该有副作用）。 */
+export function readToken(): string | null {
+  try {
+    const value = fs.readFileSync(tokenPath(), 'utf8').trim()
+    return value || null
+  } catch {
+    return null
+  }
+}
+
+/** 确保 token 存在并返回它（幂等：已存在直接返回，缺失才生成）。app 启动时调一次。 */
+export function ensureToken(): string {
+  const existing = readToken()
+  if (existing) return existing
+  const token = crypto.randomBytes(24).toString('hex')
+  const dir = capabilityCoreDir()
+  ensureDir(dir)
+  fs.writeFileSync(tokenPath(), token, { encoding: 'utf8', mode: 0o600 })
+  try {
+    fs.chmodSync(tokenPath(), 0o600)
+  } catch {
+    /* Windows 等无 POSIX 权限：忽略，token 仍只在 userData 内 */
+  }
+  return token
+}
+
+/**
+ * 恒定时间比较，防 token 鉴权被时序侧信道试探。长度不等直接 false（timingSafeEqual 要求等长）。
+ */
+export function verifyToken(provided: unknown): boolean {
+  const expected = readToken()
+  if (!expected || typeof provided !== 'string' || !provided) return false
+  const a = Buffer.from(provided)
+  const b = Buffer.from(expected)
+  if (a.length !== b.length) return false
+  return crypto.timingSafeEqual(a, b)
+}

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -52,9 +52,26 @@ import { VendorRequestError, encodeVendorErrorMessage } from "./vendor/vendorHtt
 import { traceVendorCompleted } from "./events/vendorCallTrace";
 import { registerOnboardingIpc } from "./ai/onboarding/onboardingIpc";
 import { registerUpdaterIpc } from "./update/autoUpdater";
+import { startCapabilityCore, stopCapabilityCore, setOpenProjectId } from "./capabilityCore/appIntegration";
 
 // 尽早安装：捕获引导阶段起的 uncaughtException / unhandledRejection，落盘到 app logs（P0-8）。
 installCrashHandlers();
+
+// 单实例锁（能力核前提，docs/plan/2026-06-20）：保证同一 user-data 只有一个 app 实例 = 工程文件的
+// 唯一写者，外部 CLI/MCP 才能安全地「app 开着走 RPC、关着走 headless」。隔离实例（eval/promo 用独立
+// --user-data-dir）拿到的是各自的锁，不受影响。拿不到锁 = 已有实例在跑 → 让出（聚焦老窗后退出）。
+const hasSingleInstanceLock = app.requestSingleInstanceLock();
+if (!hasSingleInstanceLock) {
+  app.quit();
+} else {
+  app.on("second-instance", () => {
+    const [existing] = BrowserWindow.getAllWindows();
+    if (existing) {
+      if (existing.isMinimized()) existing.restore();
+      existing.focus();
+    }
+  });
+}
 
 protocol.registerSchemesAsPrivileged([
   {
@@ -304,6 +321,9 @@ function registerIpc(): void {
   registerExportJobIpc();
   ipcMain.handle("nomi:tasks:run", (_event, payload) => runTaskIpcGuard(payload, () => runTask(payload)));
   ipcMain.handle("nomi:tasks:result", (_event, payload) => runTaskIpcGuard(payload, () => fetchTaskResult(payload)));
+  // 能力核 A/B 守卫：renderer 在打开/切换/关闭项目时上报当前打开的 projectId，
+  // 让外部调用拒绝直写「正在窗口里编辑」的工程（防内存 store 回盘覆盖，见 capabilityCore/rpcServer）。
+  ipcMain.on("nomi:capability:active-project", (_event, projectId: unknown) => setOpenProjectId(String(projectId || "")));
   registerAgentChatV2Ipc();
   registerTextStreamIpc();
   registerConversationsIpc();
@@ -338,7 +358,8 @@ function registerLocalProtocol(): void {
   });
 }
 
-app.whenReady().then(async () => {
+// 非主实例（没拿到单实例锁）不启动 UI / RPC——已让出给老实例（second-instance 已聚焦它）。
+if (hasSingleInstanceLock) app.whenReady().then(async () => {
   registerLocalProtocol();
   // 启动即探测系统/环境代理并应用到全局 fetch，让"测试连接/调 AI API/拉模型"能穿透代理。
   // 失败只记日志、不抛——绝不拖垮启动。须在任何出站请求前完成。
@@ -350,6 +371,9 @@ app.whenReady().then(async () => {
     console.error("[nomi:desktop] ensureBuiltinModelSeeds failed:", error);
   }
   registerIpc();
+  // 能力核对外口（RPC + 实例广告）：让外部 Claude Code/Codex 经 CLI/MCP 在本地驱动 Nomi。
+  // fail-open：内部不抛，绝不影响 app 启动。
+  await startCapabilityCore(runTask);
   await createWindow();
 
   app.on("activate", () => {
@@ -371,6 +395,8 @@ app.on("window-all-closed", () => {
 // 退出时中止所有在跑导出，否则 ffmpeg 子进程会变孤儿（继续占 CPU/写文件，直到自己跑完）。
 // abort → ffmpegRunner 监听 abort 后 kill 子进程。同步、不抛，绝不拖住退出。
 app.on("before-quit", () => {
+  // 能力核退出清理：清实例广告 + 关 RPC，让外部探测立刻知道「app 已关」。同步、不抛。
+  stopCapabilityCore();
   try {
     const aborted = abortAllActiveExports();
     if (aborted > 0) console.log(`[nomi:desktop] aborted ${aborted} in-flight export(s) on quit`);

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -373,7 +373,7 @@ if (hasSingleInstanceLock) app.whenReady().then(async () => {
   registerIpc();
   // 能力核对外口（RPC + 实例广告）：让外部 Claude Code/Codex 经 CLI/MCP 在本地驱动 Nomi。
   // fail-open：内部不抛，绝不影响 app 启动。
-  await startCapabilityCore(runTask);
+  await startCapabilityCore(runTask, fetchTaskResult);
   await createWindow();
 
   app.on("activate", () => {

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -188,4 +188,8 @@ contextBridge.exposeInMainWorld("nomiDesktop", {
     exportPackage: (dirName: string) => invokeSync("nomi:skill:export", dirName),
     importPackage: (payload: unknown) => invokeSync("nomi:skill:import", payload),
   },
+  // 能力核：上报当前窗口打开的项目，供外部调用的 A/B 守卫（防外部直写正在编辑的工程）。
+  capability: {
+    setActiveProject: (projectId: string) => ipcRenderer.send("nomi:capability:active-project", projectId),
+  },
 });

--- a/scripts/lib/nomiClient.mjs
+++ b/scripts/lib/nomiClient.mjs
@@ -71,9 +71,17 @@ function callViaHost(token, method, params) {
       reject(new Error(`headless host 未构建：${hostScript}（先 pnpm run build:electron）`))
       return
     }
+    // 把主 app 身份（package.json name）传给 host：dev spawn 的 electron 默认叫 "Electron"，safeStorage
+    // 解不开主 app 加密的 vendor key（身份不符）。host 收 NOMI_APP_NAME 后 setName 对齐 + 默认 userData 指向真数据。
+    let appName = ''
+    try {
+      appName = JSON.parse(fs.readFileSync(path.join(repoRoot, 'package.json'), 'utf8')).name || ''
+    } catch {
+      /* 读不到就不传，host 用继承身份 */
+    }
     const child = spawn(electronBinary, [hostScript, '--cmd', JSON.stringify({ token, method, params })], {
       stdio: ['ignore', 'pipe', 'pipe'],
-      env: { ...process.env },
+      env: { ...process.env, ...(process.env.NOMI_APP_NAME || appName ? { NOMI_APP_NAME: process.env.NOMI_APP_NAME || appName } : {}) },
     })
     let stdout = ''
     let stderr = ''

--- a/scripts/lib/nomiClient.mjs
+++ b/scripts/lib/nomiClient.mjs
@@ -1,0 +1,103 @@
+// 能力核 · 传输客户端（CLI 与 MCP server 共用，单一真相源 P1）。
+// 纯 node：探测运行中的 Nomi（~/.nomi/capability-core/instance.json，pid 存活）→ 走 RPC（A 模式）；
+// 没开 → spawn 无窗口 Electron host（B 模式）。鉴权：每次带 ~/.nomi/capability-core/token。
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { spawn } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+import { createRequire } from 'node:module'
+
+const require = createRequire(import.meta.url)
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..')
+
+export function capabilityCoreDir() {
+  const configured = String(process.env.NOMI_CAPABILITY_DIR || '').trim()
+  return configured || path.join(os.homedir(), '.nomi', 'capability-core')
+}
+
+export function readToken() {
+  try {
+    return fs.readFileSync(path.join(capabilityCoreDir(), 'token'), 'utf8').trim()
+  } catch {
+    return ''
+  }
+}
+
+function isAlive(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) return false
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch (error) {
+    return error.code === 'EPERM'
+  }
+}
+
+export function readLiveInstance() {
+  let parsed
+  try {
+    parsed = JSON.parse(fs.readFileSync(path.join(capabilityCoreDir(), 'instance.json'), 'utf8'))
+  } catch {
+    return null
+  }
+  if (!parsed || typeof parsed.pid !== 'number' || typeof parsed.port !== 'number') return null
+  if (!isAlive(parsed.pid)) return null
+  return parsed
+}
+
+async function callViaRpc(instance, token, method, params) {
+  const res = await fetch(`http://127.0.0.1:${instance.port}/rpc`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', authorization: `Bearer ${token}` },
+    body: JSON.stringify({ method, params }),
+  })
+  const body = await res.json()
+  if (!body.ok) throw new Error(body.error || `RPC ${res.status}`)
+  return body.result
+}
+
+function callViaHost(token, method, params) {
+  return new Promise((resolve, reject) => {
+    let electronBinary
+    try {
+      electronBinary = require('electron')
+    } catch {
+      reject(new Error('找不到 electron 可执行文件（dev 用；打包版 CLI 走应用内置 Electron，后续切片）'))
+      return
+    }
+    const hostScript = path.join(repoRoot, 'dist-electron', 'capabilityCore', 'host.js')
+    if (!fs.existsSync(hostScript)) {
+      reject(new Error(`headless host 未构建：${hostScript}（先 pnpm run build:electron）`))
+      return
+    }
+    const child = spawn(electronBinary, [hostScript, '--cmd', JSON.stringify({ token, method, params })], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: { ...process.env },
+    })
+    let stdout = ''
+    let stderr = ''
+    child.stdout.on('data', (chunk) => (stdout += chunk))
+    child.stderr.on('data', (chunk) => (stderr += chunk))
+    child.on('error', reject)
+    child.on('exit', () => {
+      try {
+        const match = stdout.trim().match(/\{[\s\S]*\}$/)
+        const body = JSON.parse(match ? match[0] : stdout)
+        if (!body.ok) reject(new Error(body.error || 'host 失败'))
+        else resolve(body.result)
+      } catch {
+        reject(new Error(`host 无有效响应。stdout=${stdout.slice(0, 400)} stderr=${stderr.slice(0, 400)}`))
+      }
+    })
+  })
+}
+
+/** 调一次能力核方法：app 开着→RPC，关着→headless host。无 token 抛清晰错误。 */
+export async function invoke(method, params) {
+  const token = readToken()
+  if (!token) throw new Error('未找到 token（先启动一次 Nomi 生成 token，路径 ~/.nomi/capability-core/token）')
+  const instance = readLiveInstance()
+  if (instance) return callViaRpc(instance, token, method, params)
+  return callViaHost(token, method, params)
+}

--- a/scripts/nomi-mcp.mjs
+++ b/scripts/nomi-mcp.mjs
@@ -1,0 +1,193 @@
+#!/usr/bin/env node
+// 能力核 · MCP server（见 docs/plan/2026-06-20-capability-core-headless-exposure.md §S7）。
+//
+// 手搓 stdio JSON-RPC 2.0（newline-delimited，MCP stdio transport 规范；协议形状经 Context7 核对 R5），
+// 不引 @modelcontextprotocol/sdk 依赖（P1 极简）。把能力核暴露成 MCP 工具，供 Claude Code / Codex / Cursor
+// 配置后实时驱动 Nomi。传输底座复用 scripts/lib/nomiClient.mjs（与 CLI 同一份 = P1）。
+//
+// 在 Claude Code 里配置（~/.claude.json 或项目 .mcp.json）：
+//   { "mcpServers": { "nomi": { "command": "node", "args": ["<repo>/scripts/nomi-mcp.mjs"] } } }
+import readline from 'node:readline'
+import { invoke } from './lib/nomiClient.mjs'
+
+const PROTOCOL_VERSION = '2025-11-25'
+
+// 工具定义：name → { description, inputSchema(JSON Schema), method(能力核方法), build(args→params) }。
+const TOOLS = [
+  {
+    name: 'nomi_list_projects',
+    description: '列出本机 Nomi 的所有项目（id / 名称 / 更新时间）。',
+    inputSchema: { type: 'object', properties: {} },
+    method: 'project.list',
+    build: () => ({}),
+  },
+  {
+    name: 'nomi_create_project',
+    description: '新建一个空白 Nomi 项目，返回项目 id。',
+    inputSchema: { type: 'object', properties: { name: { type: 'string', description: '项目名（可选）' } } },
+    method: 'project.create',
+    build: (a) => (a.name ? { name: a.name } : {}),
+  },
+  {
+    name: 'nomi_list_models',
+    description: '列出 Nomi 已接入且可用的生成模型（vendor / modelKey / 能力 kind / 名称），用于选型。',
+    inputSchema: { type: 'object', properties: {} },
+    method: 'models.list',
+    build: () => ({}),
+  },
+  {
+    name: 'nomi_read_canvas',
+    description: '读取某项目画布的节点与连线（精简视图，用于据此决策）。',
+    inputSchema: { type: 'object', properties: { projectId: { type: 'string' } }, required: ['projectId'] },
+    method: 'canvas.read',
+    build: (a) => ({ projectId: a.projectId }),
+  },
+  {
+    name: 'nomi_add_nodes',
+    description: '往项目画布批量加节点（镜头/文本/图片/视频等）。返回新建节点 id。',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        projectId: { type: 'string' },
+        nodes: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              kind: { type: 'string', description: 'text / image / video / shot / character / scene / audio 等' },
+              title: { type: 'string' },
+              prompt: { type: 'string' },
+            },
+          },
+        },
+      },
+      required: ['projectId', 'nodes'],
+    },
+    method: 'canvas.addNodes',
+    build: (a) => ({ projectId: a.projectId, nodes: a.nodes || [] }),
+  },
+  {
+    name: 'nomi_connect_nodes',
+    description: '连线（参考关系）。connections=[{source,target,mode?}]，mode 缺省 reference。',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        projectId: { type: 'string' },
+        connections: {
+          type: 'array',
+          items: { type: 'object', properties: { source: { type: 'string' }, target: { type: 'string' }, mode: { type: 'string' } }, required: ['source', 'target'] },
+        },
+      },
+      required: ['projectId', 'connections'],
+    },
+    method: 'canvas.connect',
+    build: (a) => ({ projectId: a.projectId, connections: a.connections || [] }),
+  },
+  {
+    name: 'nomi_set_node_prompt',
+    description: '改某节点的提示词（可选改标题）。',
+    inputSchema: {
+      type: 'object',
+      properties: { projectId: { type: 'string' }, nodeId: { type: 'string' }, prompt: { type: 'string' }, title: { type: 'string' } },
+      required: ['projectId', 'nodeId', 'prompt'],
+    },
+    method: 'canvas.setPrompt',
+    build: (a) => ({ projectId: a.projectId, nodeId: a.nodeId, prompt: a.prompt, title: a.title }),
+  },
+  {
+    name: 'nomi_delete_nodes',
+    description: '删除节点及其关联连线。',
+    inputSchema: { type: 'object', properties: { projectId: { type: 'string' }, nodeIds: { type: 'array', items: { type: 'string' } } }, required: ['projectId', 'nodeIds'] },
+    method: 'canvas.deleteNodes',
+    build: (a) => ({ projectId: a.projectId, nodeIds: a.nodeIds || [] }),
+  },
+  {
+    name: 'nomi_generate',
+    description: '触发一次生成（用 Nomi 的 archetype 正确组装参数 + 落资产回节点）。会花用户额度。intent=image/video/text/audio。',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        projectId: { type: 'string' },
+        vendor: { type: 'string' },
+        modelKey: { type: 'string' },
+        intent: { type: 'string', enum: ['image', 'video', 'text', 'audio'] },
+        prompt: { type: 'string' },
+        nodeId: { type: 'string', description: '在既有节点上生成（可选）' },
+        references: { type: 'array', items: { type: 'string' }, description: '参考图 URL（可选）' },
+      },
+      required: ['projectId', 'vendor', 'modelKey', 'intent', 'prompt'],
+    },
+    method: 'generate',
+    build: (a) => ({ projectId: a.projectId, vendor: a.vendor, modelKey: a.modelKey, intent: a.intent, prompt: a.prompt, nodeId: a.nodeId, references: a.references }),
+  },
+]
+
+const TOOL_BY_NAME = new Map(TOOLS.map((tool) => [tool.name, tool]))
+
+function send(message) {
+  process.stdout.write(JSON.stringify(message) + '\n')
+}
+
+function reply(id, result) {
+  send({ jsonrpc: '2.0', id, result })
+}
+
+function replyError(id, code, message) {
+  send({ jsonrpc: '2.0', id, error: { code, message } })
+}
+
+async function handle(message) {
+  const { id, method, params } = message
+  // 通知（无 id）不回响应。
+  if (id === undefined || id === null) return
+
+  if (method === 'initialize') {
+    reply(id, {
+      protocolVersion: PROTOCOL_VERSION,
+      capabilities: { tools: {} },
+      serverInfo: { name: 'nomi-capability-core', version: '0.1.0' },
+      instructions: '用 nomi_* 工具在本机驱动 Nomi：列项目/模型、建项目、读画布、加节点/连线/改提示词、触发生成。生成会花用户额度。',
+    })
+    return
+  }
+  if (method === 'tools/list') {
+    reply(id, { tools: TOOLS.map(({ name, description, inputSchema }) => ({ name, description, inputSchema })) })
+    return
+  }
+  if (method === 'tools/call') {
+    const name = params?.name
+    const tool = TOOL_BY_NAME.get(name)
+    if (!tool) {
+      replyError(id, -32602, `未知工具: ${name}`)
+      return
+    }
+    try {
+      const result = await invoke(tool.method, tool.build(params?.arguments || {}))
+      reply(id, { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] })
+    } catch (error) {
+      // 工具执行失败用 isError 返回（让模型看到错误而非协议级 error）。
+      reply(id, { content: [{ type: 'text', text: `错误：${error instanceof Error ? error.message : String(error)}` }], isError: true })
+    }
+    return
+  }
+  if (method === 'ping') {
+    reply(id, {})
+    return
+  }
+  replyError(id, -32601, `未实现的方法: ${method}`)
+}
+
+const rl = readline.createInterface({ input: process.stdin })
+rl.on('line', (line) => {
+  const trimmed = line.trim()
+  if (!trimmed) return
+  let message
+  try {
+    message = JSON.parse(trimmed)
+  } catch {
+    return // 非 JSON 行忽略（不崩）
+  }
+  void handle(message).catch((error) => {
+    if (message && message.id != null) replyError(message.id, -32603, error instanceof Error ? error.message : String(error))
+  })
+})

--- a/scripts/nomi.mjs
+++ b/scripts/nomi.mjs
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+// 能力核 · CLI 传输（见 docs/plan/2026-06-20-capability-core-headless-exposure.md §S5）。
+//
+// 纯 node 客户端。让外部 Claude Code / Codex 用 Bash 直接驱动 Nomi。传输逻辑在 scripts/lib/nomiClient.mjs
+// （与 MCP server 共用单一真相源）。
+//
+// 用法：
+//   node scripts/nomi.mjs status
+//   node scripts/nomi.mjs models
+//   node scripts/nomi.mjs projects
+//   node scripts/nomi.mjs project create "我的项目"
+//   node scripts/nomi.mjs canvas read <projectId>
+//   node scripts/nomi.mjs canvas add <projectId> <kind> [prompt]
+//   node scripts/nomi.mjs canvas connect <projectId> <sourceId> <targetId> [mode]
+//   node scripts/nomi.mjs canvas prompt <projectId> <nodeId> "<prompt>"
+//   node scripts/nomi.mjs canvas delete <projectId> <nodeId> [nodeId...]
+//   node scripts/nomi.mjs generate <projectId> <vendor> <modelKey> <intent> "<prompt>"
+import { invoke, readLiveInstance, readToken } from './lib/nomiClient.mjs'
+
+function parseArgs(argv) {
+  const [group, ...rest] = argv
+  switch (group) {
+    case 'status': {
+      const instance = readLiveInstance()
+      return {
+        local: true,
+        value: { appOpen: Boolean(instance), endpoint: instance ? `127.0.0.1:${instance.port}` : null, hasToken: Boolean(readToken()) },
+      }
+    }
+    case 'ping':
+      return { method: 'ping', params: {} }
+    case 'models':
+      return { method: 'models.list', params: {} }
+    case 'projects':
+      return { method: 'project.list', params: {} }
+    case 'project':
+      if (rest[0] === 'create') return { method: 'project.create', params: rest[1] ? { name: rest[1] } : {} }
+      break
+    case 'canvas': {
+      const [sub, projectId, ...args] = rest
+      if (sub === 'read') return { method: 'canvas.read', params: { projectId } }
+      if (sub === 'add') return { method: 'canvas.addNodes', params: { projectId, nodes: [{ kind: args[0] || 'text', prompt: args[1] }] } }
+      if (sub === 'connect') return { method: 'canvas.connect', params: { projectId, connections: [{ source: args[0], target: args[1], mode: args[2] }] } }
+      if (sub === 'prompt') return { method: 'canvas.setPrompt', params: { projectId, nodeId: args[0], prompt: args[1] } }
+      if (sub === 'delete') return { method: 'canvas.deleteNodes', params: { projectId, nodeIds: args } }
+      break
+    }
+    case 'generate': {
+      const [projectId, vendor, modelKey, intent, prompt] = rest
+      return { method: 'generate', params: { projectId, vendor, modelKey, intent: intent || 'image', prompt } }
+    }
+    default:
+      break
+  }
+  return null
+}
+
+async function main() {
+  const parsed = parseArgs(process.argv.slice(2))
+  if (!parsed) {
+    process.stderr.write('未知命令。见文件头用法。\n')
+    process.exit(2)
+  }
+  try {
+    const result = parsed.local ? parsed.value : await invoke(parsed.method, parsed.params)
+    process.stdout.write(JSON.stringify(result, null, 2) + '\n')
+  } catch (error) {
+    process.stderr.write(`错误：${error instanceof Error ? error.message : String(error)}\n`)
+    process.exit(1)
+  }
+}
+
+void main()

--- a/src/desktop/bridge.ts
+++ b/src/desktop/bridge.ts
@@ -260,6 +260,10 @@ export type DesktopBridge = {
     exportPackage: (dirName: string) => unknown
     importPackage: (payload: unknown) => unknown
   }
+  /** 能力核：上报当前打开项目，供外部调用的 A/B 守卫（可选——老 preload 无此口）。 */
+  capability?: {
+    setActiveProject: (projectId: string) => void
+  }
 }
 
 declare global {

--- a/src/workbench/project/workbenchProjectSession.ts
+++ b/src/workbench/project/workbenchProjectSession.ts
@@ -90,6 +90,9 @@ let activeWorkbenchProjectSaveTarget: ActiveWorkbenchProjectSaveTarget | null = 
 
 export function setActiveWorkbenchProjectSaveTarget(target: ActiveWorkbenchProjectSaveTarget | null): void {
   activeWorkbenchProjectSaveTarget = target
+  // 能力核 A/B 守卫：把「当前窗口打开的项目」上报主进程——外部 CLI/MCP 据此拒绝直写正在编辑的工程
+  // （防内存 store 防抖回盘覆盖外部改动）。可选口（老 preload 无 capability 即 no-op）。
+  getDesktopBridge()?.capability?.setActiveProject(target?.projectId ?? '')
 }
 
 export function clearActiveWorkbenchProjectSaveTarget(projectId?: string): void {


### PR DESCRIPTION
## 是什么
把 Nomi 的工程操作 + 生成能力抽成主进程**能力核**，供内部 agent 与外部 **Claude Code/Codex** 经 **CLI / MCP** 在本地驱动。开/不开 app 自动适配：开着走 RPC（A 模式），关着 spawn 无窗口 headless host（B 模式）。

对标 `basketikun/infinite-canvas` 的本地 Canvas Agent，但暴露的是 Nomi 的「正确性 + 一致性层」（archetype 参数 / 工程图 / 角色一致性）而非遥控 UI。方案见 `docs/plan/2026-06-20-capability-core-headless-exposure.md`。

## 切片（S1–S7，新子系统 `electron/capabilityCore/`）
- **canvasGraph** 纯图操作领域层 · **core** 编排（复用 `runtime.runTask`，不复制 archetype 投影=不违 P1）· **dispatcher** 路由单源
- **security** token（`~/.nomi/capability-core/`）· **lockfile** 实例探测 · **rpcServer** 127.0.0.1+token+A/B 守卫 · **appIntegration**+main.ts 单实例锁
- **host** 无窗口 Electron headless 宿主 · **scripts/nomi.mjs** CLI · **scripts/nomi-mcp.mjs** MCP（手搓 stdio JSON-RPC）+ 共用客户端

## 验证
单测 20/20（图操作9 + core5 + rpc6）+ MCP 握手/tools.list 9 工具 + CLI status + **五门全过**（独立干净工作树，与并行 spend-guard 改动隔离）。

## ⚠️ 未验证（需真机 + 额度）
真实生成 E2E / A 模式实时桥接（现 app 开着对打开中项目=409 拒绝，防覆盖）/ headless host spawn 往返 / MCP 在真 Claude Code 内 / 接 in-app 付费守卫 `grant-spend`。详见 plan 回填。

🤖 Generated with [Claude Code](https://claude.com/claude-code)