### PR TITLE
feat: 提示词库（借鉴 infinite-canvas）+ 节点 AI 优化下沉

### DIFF
--- a/docs/plan/2026-06-21-prompt-library.md
+++ b/docs/plan/2026-06-21-prompt-library.md
@@ -1,0 +1,96 @@
+# 提示词库 + 节点 AI 优化下沉
+
+日期：2026-06-21
+状态：已拍板，实现中
+触发：借鉴 basketikun/infinite-canvas 的提示词库；用户拍板「C 爬公开库打底 + AI 优化是招牌」「优化下沉成节点通用能力」「浮层从卡片放大浮到中央」「图+视频提示词都要、媒体也搬」「优化按钮用 Nomi 标记」。
+
+---
+
+## 1. 要解决的真实摩擦（为什么做）
+
+用户盯着空 prompt 框不知道写什么、也不知道怎么写才出好图/好视频。库解决前半句（靠封面图挑现成起点），节点上的 AI 优化解决后半句（顺手一句口语想法 → 把提示词改好）。两者解耦，无并行版。
+
+## 2. 范围
+
+**做：**
+- 主进程：从公开 GitHub 仓库拉取 + 解析 + 内存缓存（1h TTL，惰性刷新，失败回退旧缓存）提示词库，IPC 暴露给渲染层。图片 + 视频两类，封面媒体（图/视频 URL）一并带出。
+- 渲染层：提示词库面板（顶栏入口）= 画廊网格 + 搜索 + 分类/标签筛选 + 点卡片「从卡片放大浮到中央」的预览浮层 + 「送上画布」。
+- 节点 composer：新增「优化」按钮（Nomi 标记图标），调文本大脑流式改写当前 prompt，高亮回填。
+
+**不做（明确划界）：**
+- 不下载媒体到本地磁盘（v1 直接显示远端 URL；本地缓存首帧是后续切片）。
+- 不做「我的素材」收藏（参考项目有，本期砍，广度敌人）。
+- 不做服务端分页（数据在内存，渲染层虚拟化 + 过滤足够）。
+- 不碰对话流 agentChatV2（优化是 one-shot 文本任务，不拖记忆/tools/多步）。
+
+## 3. 数据源（实查锁定，2026-06-21）
+
+> 真相：图片侧有成熟结构化源；视频侧**没有**图片那样的理想富媒体仓库，最优是「结构干净的 + 媒体稳定的」双源拼。如实接，不硬凑。
+
+**图片（3 源）：**
+| 仓库 | 媒体宿主 | 解析锚点 |
+|---|---|---|
+| EvoLinkAI/awesome-gpt-image-2-API-and-Prompts | raw.githubusercontent（稳） | `### Case N: [title](url)` + `<img src=".../images/poster_caseN/output.jpg">` + `**Prompt:**` |
+| ImgEdify/Awesome-GPT4o-Image-Prompts（570★） | cdn.imgedify.com | `### title` + `**Prompt Text:** \`...\`` + `<img src="cdn.imgedify.com/...jpeg">` |
+| YouMind-OpenLab/awesome-nano-banana-pro-prompts（12.5k★） | cms-assets.youmind.com | `### No.N: title` + `<img src="cms-assets.youmind.com/...">` + `**Prompt:**` |
+
+**视频（2 源）：**
+| 仓库 | 媒体宿主 | 解析锚点 |
+|---|---|---|
+| zhangchenchen/awesome_sora2_prompt（223★，结构最干净） | video.twimg.com（token URL，可能失效→媒体降级处理） | `prompts/*.md`：`### title` + `**Prompt:**\n\`\`\`...\`\`\`` + `**Video Links:** [View](mp4)` |
+| hr98w/awesome-sora-prompts（OpenAI 官方 mp4，最稳） | cdn.openai.com/sora/videos/*.mp4（稳） | README/分文件，prompt + 官方 mp4 |
+
+媒体不可达兜底：视频封面 URL 失效时显示占位 + 仍可用 prompt（诚实标，不假装）。
+
+## 4. 架构与落点（file:line 来自勘查）
+
+### 4.1 主进程数据层（新建 `electron/promptLibrary/`）
+- `promptSources.ts` — 6 个源的配置（base URL、文件列表、parser 引用）。
+- `promptParsers.ts` — 每源一个纯函数 `(markdown) => LibraryPrompt[]`，正则解析（纯函数便于单测）。
+- `promptLibraryStore.ts` — 聚合所有源 + 模块级 TTL 缓存（仿 `electron/events/secretsProvider.ts:8-23`，失败回退旧缓存）。拉取用 `hardenedFetchText`（`electron/hardenedFetch.ts:214`，代理自动继承），仿 `electron/catalog/catalogCommit.ts:366`。
+- `promptLibraryIpc.ts` — `registerPromptLibraryIpc()`，`ipcMain.handle("nomi:prompt-library:list", ...)`（仿 `electron/memory/memoryIpc.ts`）。在 `electron/main.ts` 的 `registerIpc()`（:335 区）注册。
+- preload：`electron/preload.ts` 加 `promptLibrary: { list }`（仿 :86 memory 域）。
+- 类型：`src/desktop/bridge.ts` 的 `DesktopBridge` 加 `promptLibrary?`。
+- 渲染层 client：`src/workbench/api/promptLibraryApi.ts`（仿 `skillApi.ts:28` `requireDesktopRuntime`）。
+
+`LibraryPrompt` 类型：`{ id, title, prompt, mediaUrl, mediaType:'image'|'video', promptType:'image'|'video', tags[], source, sourceUrl }`。
+
+### 4.2 渲染层库面板（新建 `src/workbench/promptLibrary/`）
+仿 `AssetLibraryPanel`（事件驱动全局浮层），不污染三工作区模型：
+- `PromptLibraryPanel.tsx` — Portal/fixed 外壳 + ESC/点外关闭 + 头部 + 搜索 + 标签 chip（仿 `AssetLibraryPanel.tsx`）。
+- `PromptGrid.tsx` — 虚拟化网格（`@tanstack/react-virtual`，仿 `AssetLibraryPanel.tsx:106`）。
+- `PromptCard.tsx` — 单卡（封面 img/video + 标题 + 标签，视频带播放标，`React.memo`）。
+- `PromptPreviewOverlay.tsx` — 自研 FLIP 放大浮层：记录卡片 `getBoundingClientRect()`，`transform` 从卡片原位 `scale(.22)` 过渡到屏幕中央 + 遮罩（动画仿 `AssetLibraryPanel.tsx:313` keyframes，缓动用 Nomi `cubic-bezier(.2,.7,.3,1)`）。媒体 16:9，视频可播。底部「送上画布」+「复制」。
+- `usePromptLibrary.ts` — 数据 hook + 搜索/标签过滤纯函数。
+- `promptLibraryTypes.ts` — 渲染层类型。
+- 接线：① `NomiAppBar.tsx:9-13` 加 `openPromptLibrary()` 派 `nomi-open-prompt-library` + :181 旁加按钮（Nomi 标记/`IconBulb`）；② `NomiStudioApp.tsx:152` 仿写事件监听；③ :576 旁挂 `<PromptLibraryPanel>`。
+
+### 4.3 送上画布
+预览浮层「送上画布」→ `useGenerationCanvasStore.getState().addNode({ kind, prompt, select:true })`（`canvasNodeActions.ts:38`，自带碰撞避让）。kind 按 `promptType`：image→`'image'`、video→`'video'`（判别/映射 `generationNodeKinds.ts:94`，都默认落 `shots` 分镜）。需在 studio 上下文（面板本就在 studio 内）。
+
+### 4.4 节点 composer AI 优化（下沉成通用能力）
+- 按钮插入点：`NodeGenerationComposer.tsx` 底栏，参数 chip（:284）与生成钮（:285）之间。图标 = Nomi 标记（仿 `src/design/identity.tsx` `NomiLogoMark` SVG）。
+- 点开 → 小输入框「说一句你的想法」+ 优化钮。
+- 改写调用：复用现有文本任务流 `runWorkbenchTextTaskStream`（`taskApi.ts:123`）/ 'rewrite' 模式（`textActions.ts:15`，`buildTextPrompt:90`），把「原 prompt + 用户想法」拼成改写指令，流式 `onDelta` 回填。模型走 `chooseTextModel` 默认文本大脑（与创作助手同脑，P4 通用）。
+- 回填：`updateNode(node.id, { prompt })`（`canvasNodeActions.ts:88`，受控自动回灌 textarea）。高亮改动用临时态展示。
+- **不新建并行改写通道**：复用文本任务管线（P1）。
+
+## 5. 切片（每片五门绿 + commit）
+
+- **S0 数据层**：`electron/promptLibrary/*` + preload + bridge + api。单测覆盖每个 parser（喂样例 markdown 断言解析结果）。验收：单测绿 + 真机拉取打印条数。
+- **S1 库 UI**：面板 + 网格 + 卡片 + 预览浮层 + 入口接线。验收：与样张 `nomi_prompt_library_zoom_popover` 逐项对账 + 真机走查（搜索/筛选/浮层放大动画/视频封面播放）。
+- **S2 送上画布**：预览「送上画布」接 addNode。验收：真机点送 → 画布出对应 kind 节点 + prompt 已灌。
+- **S3 节点优化**：composer ✨ 按钮 + 流式改写 + 回填。验收：与样张 `nomi_node_composer_optimize_nomimark` 对账 + 真机优化一条出结果。
+
+## 6. 不动项
+- 不改三工作区模型（creation/generation/preview）。
+- 不改对话流 agentChatV2、文本任务底层 streamTextTask。
+- 不改现有 addNode/registry 语义，只调用。
+- 设计 token 全用现成 `nomi-*`，不新增 hex/任意尺寸。
+
+## 7. 回滚
+每切片独立 commit。库是纯增量（新目录 + 3 处接线 + composer 1 按钮），出问题 revert 对应 commit 即可，不影响现有功能。
+
+## 8. 验收门（push 前）
+五门：`check:filesize`（新文件均 ≤800）→ `check:tokens` → `lint:ci` → `typecheck` → `test`（parser 单测）→ `build`。
+体验：S1/S3 与获批样张逐项对账 + Playwright/真机截图人眼判断（P3/R13）。

--- a/electron/ai/agentChatV2.ts
+++ b/electron/ai/agentChatV2.ts
@@ -124,6 +124,19 @@ function chooseTextModel(prefModelKey?: string, preferImageInput = false): { ven
   throw new Error("No local text model is configured. Open model settings and add an API key.");
 }
 
+/**
+ * 解析默认文本大脑的 vendor/model 键（**不含 apiKey**,供渲染层经现成文本流式管线复用——
+ * 提示词优化与创作助手用同一个脑,P4 通用）。拿不到(没配文本模型)返回 null。
+ */
+export function resolveTextBrainKeys(): { vendor: string; modelKey: string } | null {
+  try {
+    const { vendor, model } = chooseTextModel();
+    return { vendor: vendor.key, modelKey: model.modelKey };
+  } catch {
+    return null;
+  }
+}
+
 // vendor→LanguageModel 构造已抽到 ./vendorLanguageModel（单一真相,与文本任务引擎共用）。
 
 // ---------------------------------------------------------------------------

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -47,6 +47,7 @@ import { registerConversationsIpc } from "./conversations/conversationsIpc";
 import { setEventLogSecretsProvider } from "./events/eventLogRepository";
 import { registerEventsIpc } from "./events/eventsIpc";
 import { registerMemoryIpc } from "./memory/memoryIpc";
+import { registerPromptLibraryIpc } from "./promptLibrary/promptLibraryIpc";
 import { catalogSecretsProvider } from "./events/secretsProvider";
 import { VendorRequestError, encodeVendorErrorMessage } from "./vendor/vendorHttp";
 import { traceVendorCompleted } from "./events/vendorCallTrace";
@@ -329,6 +330,7 @@ function registerIpc(): void {
   registerConversationsIpc();
   registerEventsIpc();
   registerMemoryIpc();
+  registerPromptLibraryIpc();
   registerOnboardingIpc();
   registerUpdaterIpc();
   // S4-1 评测安全铁律:事件落盘前,已配置的 vendor key 精确匹配脱敏(形态兜底之外的地基)。

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -89,6 +89,9 @@ contextBridge.exposeInMainWorld("nomiDesktop", {
     remove: (projectId: string, factId: string) =>
       ipcRenderer.invoke("nomi:memory:remove", { projectId, factId }) as Promise<{ ok: boolean; facts: unknown[] }>,
   },
+  promptLibrary: {
+    list: () => ipcRenderer.invoke("nomi:prompt-library:list") as Promise<{ ok: boolean; prompts: unknown[]; error?: string }>,
+  },
   review: {
     onEvent: (callback: (payload: unknown) => void) => {
       const listener = (_event: unknown, payload: unknown) => callback(payload);

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -91,6 +91,7 @@ contextBridge.exposeInMainWorld("nomiDesktop", {
   },
   promptLibrary: {
     list: () => ipcRenderer.invoke("nomi:prompt-library:list") as Promise<{ ok: boolean; prompts: unknown[]; error?: string }>,
+    textBrain: () => ipcRenderer.invoke("nomi:prompt-library:text-brain") as Promise<{ ok: boolean; brain: { vendor: string; modelKey: string } | null }>,
   },
   review: {
     onEvent: (callback: (payload: unknown) => void) => {

--- a/electron/promptLibrary/promptLibraryIpc.ts
+++ b/electron/promptLibrary/promptLibraryIpc.ts
@@ -1,0 +1,14 @@
+// 提示词库 IPC(仿 memory/memoryIpc.ts)。renderer 一次取全量(缓存),过滤/分页在渲染层做。
+import { ipcMain } from "electron";
+import { getPromptLibrary } from "./promptLibraryStore";
+
+export function registerPromptLibraryIpc(): void {
+  ipcMain.handle("nomi:prompt-library:list", async () => {
+    try {
+      const prompts = await getPromptLibrary();
+      return { ok: true, prompts };
+    } catch (error) {
+      return { ok: false, prompts: [], error: error instanceof Error ? error.message : String(error) };
+    }
+  });
+}

--- a/electron/promptLibrary/promptLibraryIpc.ts
+++ b/electron/promptLibrary/promptLibraryIpc.ts
@@ -1,6 +1,7 @@
 // 提示词库 IPC(仿 memory/memoryIpc.ts)。renderer 一次取全量(缓存),过滤/分页在渲染层做。
 import { ipcMain } from "electron";
 import { getPromptLibrary } from "./promptLibraryStore";
+import { resolveTextBrainKeys } from "../ai/agentChatV2";
 
 export function registerPromptLibraryIpc(): void {
   ipcMain.handle("nomi:prompt-library:list", async () => {
@@ -10,5 +11,11 @@ export function registerPromptLibraryIpc(): void {
     } catch (error) {
       return { ok: false, prompts: [], error: error instanceof Error ? error.message : String(error) };
     }
+  });
+
+  // 节点提示词优化用的文本大脑(vendor/modelKey,不含 apiKey)——渲染层据此走现成文本流式管线。
+  ipcMain.handle("nomi:prompt-library:text-brain", async () => {
+    const brain = resolveTextBrainKeys();
+    return { ok: Boolean(brain), brain };
   });
 }

--- a/electron/promptLibrary/promptLibraryStore.ts
+++ b/electron/promptLibrary/promptLibraryStore.ts
@@ -1,0 +1,70 @@
+// 提示词库聚合 + 1h TTL 内存缓存(仿 events/secretsProvider.ts:失败回退旧缓存)。
+// 拉取走 hardenedFetchText(代理自动继承,SSRF/超时加固);惰性刷新,无后台 timer(沿用代码库习惯)。
+import { hardenedFetchText } from "../hardenedFetch";
+import { PROMPT_SOURCES, type PromptSource } from "./promptSources";
+import type { LibraryPrompt } from "./promptLibraryTypes";
+
+const TTL_MS = 60 * 60 * 1000;
+const FETCH_MAX_BYTES = 12 * 1024 * 1024; // 大 README(900+ case)可达数 MB
+const FETCH_TIMEOUT_MS = 30_000;
+
+let cache: { at: number; prompts: LibraryPrompt[] } | null = null;
+let inflight: Promise<LibraryPrompt[]> | null = null;
+
+async function loadSource(source: PromptSource): Promise<LibraryPrompt[]> {
+  const parsed: LibraryPrompt[] = [];
+  const seen = new Set<string>();
+  for (const file of source.files) {
+    let markdown = "";
+    try {
+      const res = await hardenedFetchText(`${source.rawBase}/${file}`, { maxBytes: FETCH_MAX_BYTES, timeoutMs: FETCH_TIMEOUT_MS });
+      markdown = res.text;
+    } catch {
+      continue; // 单文件 404/超时不拖垮整源
+    }
+    for (const item of source.parse(markdown, source.rawBase)) {
+      const key = item.prompt.slice(0, 120);
+      if (!item.prompt || seen.has(key)) continue;
+      seen.add(key);
+      parsed.push({
+        ...item,
+        id: `${source.id}-${parsed.length + 1}`,
+        promptType: source.promptType,
+        source: source.label,
+        sourceId: source.id,
+        sourceUrl: source.sourceUrl,
+      });
+      if (parsed.length >= source.cap) return parsed;
+    }
+  }
+  return parsed;
+}
+
+async function loadAll(): Promise<LibraryPrompt[]> {
+  const settled = await Promise.all(
+    PROMPT_SOURCES.map((source) => loadSource(source).catch(() => [] as LibraryPrompt[])),
+  );
+  return settled.flat();
+}
+
+/** 取全部提示词;命中缓存即返,否则拉取;全失败回退旧缓存(可能空)。 */
+export async function getPromptLibrary(): Promise<LibraryPrompt[]> {
+  if (cache && Date.now() - cache.at < TTL_MS) return cache.prompts;
+  if (inflight) return inflight;
+  inflight = loadAll()
+    .then((prompts) => {
+      if (prompts.length > 0) cache = { at: Date.now(), prompts };
+      return cache?.prompts ?? prompts;
+    })
+    .catch(() => cache?.prompts ?? [])
+    .finally(() => {
+      inflight = null;
+    });
+  return inflight;
+}
+
+/** 测试/手动失效。 */
+export function resetPromptLibraryCache(): void {
+  cache = null;
+  inflight = null;
+}

--- a/electron/promptLibrary/promptLibraryTypes.ts
+++ b/electron/promptLibrary/promptLibraryTypes.ts
@@ -1,0 +1,23 @@
+// 提示词库数据形态(单一真相源)。主进程解析公开仓库 → 这个形状 → IPC 给渲染层。
+export type PromptMediaType = "image" | "video";
+
+/** parser 产出的原子(还没补 id/source 元信息)。 */
+export type ParsedPrompt = {
+  title: string;
+  prompt: string;
+  /** 封面媒体 URL;视频源可能缺(token 失效)→ 空串,UI 显占位。 */
+  mediaUrl: string;
+  mediaType: PromptMediaType;
+};
+
+/** 对外的完整提示词条目。 */
+export type LibraryPrompt = ParsedPrompt & {
+  id: string;
+  /** 这条提示词产出的是图还是视频(决定送上画布建哪种节点)。 */
+  promptType: PromptMediaType;
+  /** 人话来源标签(显示在卡片上)。 */
+  source: string;
+  sourceId: string;
+  /** 仓库地址(详情可跳转)。 */
+  sourceUrl: string;
+};

--- a/electron/promptLibrary/promptParsers.test.ts
+++ b/electron/promptLibrary/promptParsers.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import { parseEvoLinkAI, parseImgEdify, parseYouMind, parseSora2, parseSoraOfficial, splitBlocks } from "./promptParsers";
+
+describe("splitBlocks", () => {
+  it("按行首标题切块,每块含到下一标题前", () => {
+    const md = "intro\n### A\nbody a\n### B\nbody b\n";
+    const blocks = splitBlocks(md, "^### .+");
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0]).toContain("body a");
+    expect(blocks[0]).not.toContain("body b");
+  });
+});
+
+describe("parseEvoLinkAI", () => {
+  const base = "https://raw.githubusercontent.com/EvoLinkAI/awesome-gpt-image-2-API-and-Prompts/main";
+  it("抓标题+代码块 prompt,封面从 case 号派生", () => {
+    const md = `### Case 12: [赛博城市](https://x.com/a) (by [@u](https://x.com/u))\n\n**Prompt:**\n\`\`\`\na neon cyberpunk city at night\n\`\`\`\n`;
+    const r = parseEvoLinkAI(md, base);
+    expect(r).toHaveLength(1);
+    expect(r[0].title).toBe("赛博城市");
+    expect(r[0].prompt).toBe("a neon cyberpunk city at night");
+    expect(r[0].mediaUrl).toBe(`${base}/images/poster_case12/output.jpg`);
+    expect(r[0].mediaType).toBe("image");
+  });
+  it("优先用 block 内的 img src", () => {
+    const md = `### Case 3: [T](https://x.com/a)\n<img src="${base}/images/poster_case3/output.jpg" width="400">\n**Prompt:**\n\`\`\`\nhello\n\`\`\`\n`;
+    expect(parseEvoLinkAI(md, base)[0].mediaUrl).toContain("poster_case3");
+  });
+  it("缺 prompt 的 block 跳过", () => {
+    expect(parseEvoLinkAI("### Case 9: [无提示](https://x.com/a)\n只有标题\n", base)).toHaveLength(0);
+  });
+});
+
+describe("parseImgEdify", () => {
+  it("抓 **Prompt Text:** 行内码 + cdn 封面", () => {
+    const md = `### 人物肖像\n- **Prompt Text:** \`a portrait of a woman\`\n<img src="https://cdn.imgedify.com/imgedify/images/x.jpeg" height="400">\n`;
+    const r = parseImgEdify(md);
+    expect(r).toHaveLength(1);
+    expect(r[0].prompt).toBe("a portrait of a woman");
+    expect(r[0].mediaUrl).toContain("cdn.imgedify.com");
+  });
+  it("缺封面跳过", () => {
+    expect(parseImgEdify("### T\n- **Prompt Text:** `x`\n")).toHaveLength(0);
+  });
+});
+
+describe("parseYouMind", () => {
+  it("抓 No.N 标题 + #### Prompt 代码块 + cms 封面", () => {
+    const md = `### No. 5: 水彩风\n\n#### 📖 Description\n\nsome desc\n\n#### 📝 Prompt\n\n\`\`\`\nwatercolor village morning\n\`\`\`\n\n#### 🖼️ Generated Images\n\n<img src="https://cms-assets.youmind.com/media/abc.jpg" width="700">\n`;
+    const r = parseYouMind(md);
+    expect(r).toHaveLength(1);
+    expect(r[0].title).toBe("水彩风");
+    expect(r[0].prompt).toBe("watercolor village morning");
+    expect(r[0].mediaUrl).toContain("cms-assets.youmind.com");
+  });
+});
+
+describe("parseSora2", () => {
+  it("抓代码块 prompt + twitter mp4", () => {
+    const md = `### 东京漫步\n\n**Prompt:**\n\`\`\`\na walk through tokyo at dusk\n\`\`\`\n\n**Video Links:**\n- Sora 2: [View](https://video.twimg.com/amplify_video/1/x.mp4)\n`;
+    const r = parseSora2(md);
+    expect(r).toHaveLength(1);
+    expect(r[0].title).toBe("东京漫步");
+    expect(r[0].prompt).toBe("a walk through tokyo at dusk");
+    expect(r[0].mediaUrl).toContain("video.twimg.com");
+    expect(r[0].mediaType).toBe("video");
+  });
+  it("缺 mp4 仍保留(mediaUrl 空,UI 占位)", () => {
+    const md = `### 无媒体\n**Prompt:**\n\`\`\`\nsomething\n\`\`\`\n`;
+    const r = parseSora2(md);
+    expect(r).toHaveLength(1);
+    expect(r[0].mediaUrl).toBe("");
+  });
+});
+
+describe("parseSoraOfficial", () => {
+  it("媒体锚定:> 引用 prompt + Generated Videos 链接,标题取 mp4 文件名", () => {
+    const md = `> A stylish woman walks down a Tokyo street filled with neon.\n\nGenerated Videos: [link](https://cdn.openai.com/sora/videos/tokyo-walk.mp4)\n\n> Several giant wooly mammoths approach treading through a snowy meadow.\n\nGenerated Videos: [link](https://cdn.openai.com/sora/videos/wooly-mammoth.mp4)\n`;
+    const r = parseSoraOfficial(md);
+    expect(r).toHaveLength(2);
+    expect(r[0].title).toBe("Tokyo Walk");
+    expect(r[0].prompt).toContain("Tokyo street");
+    expect(r[0].mediaUrl).toBe("https://cdn.openai.com/sora/videos/tokyo-walk.mp4");
+    expect(r[1].title).toBe("Wooly Mammoth");
+  });
+  it("无 Generated Videos 链接的文本跳过", () => {
+    expect(parseSoraOfficial("> just a quote\n\nsome text\n")).toHaveLength(0);
+  });
+});

--- a/electron/promptLibrary/promptParsers.ts
+++ b/electron/promptLibrary/promptParsers.ts
@@ -1,0 +1,116 @@
+// 公开提示词仓库的 markdown 解析器(纯函数,无 electron 依赖 → 可独立单测)。
+// 解析锚点来自 2026-06-21 实查(docs/plan/2026-06-21-prompt-library.md §3)。
+// 容错铁律:任一 block 缺 prompt/媒体就跳过这条,不让坏数据污染;一个源解析失败上层兜回旧缓存。
+import type { ParsedPrompt } from "./promptLibraryTypes";
+
+/** 按「行首标题」把文档切成块,每块从一个标题到下一个标题之前。 */
+export function splitBlocks(markdown: string, headingSource: string): string[] {
+  const re = new RegExp(headingSource, "gm");
+  const starts: number[] = [];
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(markdown))) starts.push(match.index);
+  return starts.map((start, i) => markdown.slice(start, i + 1 < starts.length ? starts[i + 1] : undefined));
+}
+
+function first(text: string, re: RegExp): string | null {
+  const m = text.match(re);
+  return m && m[1] != null ? m[1] : null;
+}
+
+function clean(text: string): string {
+  return text.replace(/\r/g, "").replace(/^\s+|\s+$/g, "");
+}
+
+function stripInline(text: string): string {
+  return text.replace(/[#*`>]/g, "").trim();
+}
+
+/** **Prompt:** 后的代码块或紧随段落(到下一个标题/分隔/img 为止)。 */
+function extractPrompt(block: string): string | null {
+  const fenced = first(block, /\*\*Prompt[^*]*:?\*\*\s*\n+```[a-zA-Z]*\n([\s\S]*?)\n```/);
+  if (fenced) return clean(fenced);
+  const inline = first(block, /\*\*Prompt[^*]*:?\*\*\s*`([^`]+)`/);
+  if (inline) return clean(inline);
+  const para = first(block, /\*\*Prompt[^*]*:?\*\*\s*\n+([\s\S]*?)(?:\n###|\n---|\n<img|\n!\[|\n\*\*|$)/);
+  return para ? clean(para) : null;
+}
+
+/** EvoLinkAI/awesome-gpt-image-2-API-and-Prompts —— `### Case N` + raw github 封面图。 */
+export function parseEvoLinkAI(markdown: string, rawBase: string): ParsedPrompt[] {
+  const out: ParsedPrompt[] = [];
+  for (const block of splitBlocks(markdown, "^### Case \\d+:")) {
+    const head = block.match(/^### Case (\d+):\s*\[([^\]]+)\]/);
+    if (!head) continue;
+    const prompt = extractPrompt(block);
+    if (!prompt) continue;
+    const found = first(block, /<img[^>]+src="(https:\/\/raw\.githubusercontent\.com\/[^"]+?)"/);
+    const mediaUrl = found || `${rawBase}/images/poster_case${head[1]}/output.jpg`;
+    out.push({ title: stripInline(head[2]), prompt, mediaUrl, mediaType: "image" });
+  }
+  return out;
+}
+
+/** ImgEdify/Awesome-GPT4o-Image-Prompts —— `### 标题` + `**Prompt Text:** \`...\`` + cdn 封面。 */
+export function parseImgEdify(markdown: string): ParsedPrompt[] {
+  const out: ParsedPrompt[] = [];
+  for (const block of splitBlocks(markdown, "^### .+")) {
+    const head = block.match(/^### (.+)/);
+    if (!head) continue;
+    const prompt = extractPrompt(block);
+    const mediaUrl = first(block, /<img[^>]+src="(https:\/\/cdn\.imgedify\.com\/[^"]+)"/);
+    if (!prompt || !mediaUrl) continue;
+    out.push({ title: stripInline(head[1]), prompt, mediaUrl, mediaType: "image" });
+  }
+  return out;
+}
+
+/** YouMind nano-banana-pro / gpt-image-2 —— `### No.N: 标题` + `#### 📝 Prompt` 代码块 + cms 封面。 */
+export function parseYouMind(markdown: string): ParsedPrompt[] {
+  const out: ParsedPrompt[] = [];
+  for (const block of splitBlocks(markdown, "^### No\\.?\\s*\\d+")) {
+    const head = block.match(/^### No\.?\s*(\d+):?\s*(.*)/);
+    if (!head) continue;
+    const prompt =
+      first(block, /####[^\n]*Prompt[^\n]*\n+```[a-zA-Z]*\n([\s\S]*?)\n```/) ||
+      first(block, /####[^\n]*Prompt[^\n]*\n+([\s\S]*?)(?:\n####|\n###|$)/);
+    const mediaUrl = first(block, /<img[^>]+src="(https:\/\/cms-assets\.youmind\.com\/[^"]+)"/);
+    if (!prompt || !mediaUrl) continue;
+    const title = stripInline(head[2]) || `提示词 ${head[1]}`;
+    out.push({ title, prompt: clean(prompt), mediaUrl, mediaType: "image" });
+  }
+  return out;
+}
+
+/** zhangchenchen/awesome_sora2_prompt —— `### 标题` + `**Prompt:**` 代码块 + twitter mp4(可能缺)。 */
+export function parseSora2(markdown: string): ParsedPrompt[] {
+  const out: ParsedPrompt[] = [];
+  for (const block of splitBlocks(markdown, "^### .+")) {
+    const head = block.match(/^### (.+)/);
+    if (!head) continue;
+    const prompt = extractPrompt(block);
+    if (!prompt) continue;
+    const mediaUrl = first(block, /\((https:\/\/[^)\s]+\.mp4[^)\s]*)\)/) || "";
+    out.push({ title: stripInline(head[1]), prompt, mediaUrl: mediaUrl || "", mediaType: "video" });
+  }
+  return out;
+}
+
+/** mp4 文件名 → 人话标题:`tokyo-walk.mp4` → `Tokyo Walk`。 */
+function titleFromMediaUrl(url: string): string {
+  const file = url.split("/").pop() || "";
+  const stem = file.replace(/\.[a-z0-9]+$/i, "").replace(/[-_]+/g, " ").trim();
+  return stem ? stem.replace(/\b\w/g, (c) => c.toUpperCase()) : "Sora";
+}
+
+/** hr98w/awesome-sora-prompts —— 媒体锚定:`> prompt` 紧跟 `Generated Videos: [link](mp4)`,标题取 mp4 文件名。 */
+export function parseSoraOfficial(markdown: string): ParsedPrompt[] {
+  const out: ParsedPrompt[] = [];
+  const re = />\s*([^\n]+)\n+(?:Generated\s+Videos?|Video|视频)[^\n]*\[[^\]]*\]\((https:\/\/cdn\.openai\.com\/sora\/videos\/[^)\s]+\.mp4)\)/gi;
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(markdown))) {
+    const prompt = clean(match[1]);
+    if (prompt.length < 8) continue;
+    out.push({ title: titleFromMediaUrl(match[2]), prompt, mediaUrl: match[2], mediaType: "video" });
+  }
+  return out;
+}

--- a/electron/promptLibrary/promptSources.ts
+++ b/electron/promptLibrary/promptSources.ts
@@ -1,0 +1,80 @@
+// 已接入的公开提示词仓库清单(实查锁定 2026-06-21)。
+// 每源:从 rawBase 拉 files,逐文件喂 parse,聚合。图片源媒体稳;视频源结构干净但媒体可能降级。
+import type { ParsedPrompt } from "./promptLibraryTypes";
+import { parseEvoLinkAI, parseImgEdify, parseSora2, parseSoraOfficial, parseYouMind } from "./promptParsers";
+
+export type PromptSource = {
+  id: string;
+  label: string;
+  sourceUrl: string;
+  promptType: "image" | "video";
+  rawBase: string;
+  files: string[];
+  /** 每源最多保留多少条(防单源 900+ 撑爆 payload)。 */
+  cap: number;
+  parse: (markdown: string, rawBase: string) => ParsedPrompt[];
+};
+
+const gh = (owner: string, repo: string) => ({
+  url: `https://github.com/${owner}/${repo}`,
+  raw: `https://raw.githubusercontent.com/${owner}/${repo}/main`,
+});
+
+const evo = gh("EvoLinkAI", "awesome-gpt-image-2-API-and-Prompts");
+const imgEdify = gh("ImgEdify", "Awesome-GPT4o-Image-Prompts");
+const youMind = gh("YouMind-OpenLab", "awesome-nano-banana-pro-prompts");
+const sora2 = gh("zhangchenchen", "awesome_sora2_prompt");
+const soraOfficial = gh("hr98w", "awesome-sora-prompts");
+
+export const PROMPT_SOURCES: PromptSource[] = [
+  {
+    id: "evolink-gpt-image-2",
+    label: "GPT Image 2",
+    sourceUrl: evo.url,
+    promptType: "image",
+    rawBase: evo.raw,
+    files: ["README.md"],
+    cap: 280,
+    parse: parseEvoLinkAI,
+  },
+  {
+    id: "youmind-nano-banana-pro",
+    label: "Nano Banana Pro",
+    sourceUrl: youMind.url,
+    promptType: "image",
+    rawBase: youMind.raw,
+    files: ["README.md"],
+    cap: 280,
+    parse: parseYouMind,
+  },
+  {
+    id: "imgedify-gpt4o",
+    label: "GPT-4o 图像",
+    sourceUrl: imgEdify.url,
+    promptType: "image",
+    rawBase: imgEdify.raw,
+    files: ["README.md"],
+    cap: 200,
+    parse: parseImgEdify,
+  },
+  {
+    id: "sora2-viral",
+    label: "Sora 2",
+    sourceUrl: sora2.url,
+    promptType: "video",
+    rawBase: sora2.raw,
+    files: ["prompts/official-prompts.md", "prompts/sora2-viral-prompts.md", "prompts/hyperrealism-landscapes.md"],
+    cap: 200,
+    parse: parseSora2,
+  },
+  {
+    id: "sora-official",
+    label: "Sora 官方",
+    sourceUrl: soraOfficial.url,
+    promptType: "video",
+    rawBase: soraOfficial.raw,
+    files: ["README.md", "animating-prompts.md", "image-generation-prompts.md", "video-editing-prompts.md"],
+    cap: 120,
+    parse: parseSoraOfficial,
+  },
+];

--- a/src/desktop/bridge.ts
+++ b/src/desktop/bridge.ts
@@ -174,6 +174,10 @@ export type DesktopBridge = {
     update: (projectId: string, factId: string, patch: { text?: string; pinned?: boolean }) => Promise<{ ok: boolean; facts: unknown[] }>
     remove: (projectId: string, factId: string) => Promise<{ ok: boolean; facts: unknown[] }>
   }
+  /** 提示词库:主进程聚合公开仓库提示词(图/视频)+1h 缓存,renderer 取全量后本地过滤。 */
+  promptLibrary?: {
+    list: () => Promise<{ ok: boolean; prompts: unknown[]; error?: string }>
+  }
   /** S4-2b 技术自检结果广播(主进程异步旁路 → 节点 ⚠ 投影)。 */
   review?: {
     onEvent: (callback: (payload: unknown) => void) => () => void

--- a/src/desktop/bridge.ts
+++ b/src/desktop/bridge.ts
@@ -174,9 +174,11 @@ export type DesktopBridge = {
     update: (projectId: string, factId: string, patch: { text?: string; pinned?: boolean }) => Promise<{ ok: boolean; facts: unknown[] }>
     remove: (projectId: string, factId: string) => Promise<{ ok: boolean; facts: unknown[] }>
   }
-  /** 提示词库:主进程聚合公开仓库提示词(图/视频)+1h 缓存,renderer 取全量后本地过滤。 */
+  /** 提示词库:主进程聚合公开仓库提示词(图/视频)+1h 缓存,renderer 取全量后本地过滤。
+   *  textBrain=节点提示词优化用的文本大脑键(不含 apiKey,渲染层据此走现成文本流式)。 */
   promptLibrary?: {
     list: () => Promise<{ ok: boolean; prompts: unknown[]; error?: string }>
+    textBrain: () => Promise<{ ok: boolean; brain: { vendor: string; modelKey: string } | null }>
   }
   /** S4-2b 技术自检结果广播(主进程异步旁路 → 节点 ⚠ 投影)。 */
   review?: {

--- a/src/ui/app-shell/NomiAppBar.tsx
+++ b/src/ui/app-shell/NomiAppBar.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { IconDownload, IconPhoto, IconPlugConnected } from '@tabler/icons-react'
+import { IconDownload, IconPhoto, IconPlugConnected, IconBulb } from '@tabler/icons-react'
 import type { WorkspaceMode } from '../../workbench/workbenchStore'
 import { NomiBrand, NomiStepper, WorkbenchButton } from '../../design'
 import { OnboardingChecklist } from '../../workbench/onboarding/OnboardingChecklist'
@@ -10,6 +10,11 @@ import { cn } from '../../utils/cn'
 // 上传已移进面板内部，AppBar 只负责发开面板事件（仿 nomi-open-model-catalog）。
 function openAssetLibrary(): void {
   window.dispatchEvent(new CustomEvent('nomi-open-asset-library'))
+}
+
+// 「提示词库」点击 → 打开提示词库面板（仿素材库的事件驱动开法）。
+function openPromptLibrary(): void {
+  window.dispatchEvent(new CustomEvent('nomi-open-prompt-library'))
 }
 
 type NomiAppBarProps = {
@@ -178,6 +183,23 @@ export default function NomiAppBar({ workspaceMode, onWorkspaceModeChange, proje
       >
         {/* 上手 4 步引导入口：停靠顶栏(始终高/不遮画布)，4/4 自动消失。 */}
         <OnboardingChecklist />
+        <WorkbenchButton
+          className={cn(
+            'nomi-appbar__ghost',
+            'inline-flex items-center gap-1.5 h-[30px] px-2.5',
+            'border border-transparent rounded-[var(--nomi-radius-sm)]',
+            'bg-transparent text-[var(--nomi-ink-80)] font-inherit text-body-sm',
+            'transition-[background,color] duration-[var(--nomi-transition-fast)]',
+            'hover:bg-[var(--nomi-ink-05)] hover:text-[var(--nomi-ink)]',
+            'max-[700px]:w-[30px] max-[700px]:h-[30px] max-[700px]:justify-center max-[700px]:p-0',
+          )}
+          aria-label="打开提示词库"
+          title="提示词库"
+          onClick={openPromptLibrary}
+        >
+          <IconBulb size={15} stroke={1.7} />
+          <span className={cn('nomi-appbar__action-text', 'max-[700px]:hidden')}>提示词库</span>
+        </WorkbenchButton>
         <WorkbenchButton
           className={cn(
             'nomi-appbar__ghost',

--- a/src/workbench/NomiStudioApp.tsx
+++ b/src/workbench/NomiStudioApp.tsx
@@ -55,6 +55,11 @@ const AssetLibraryPanel = lazyWithChunkBoundary("素材库", () =>
         default: module.AssetLibraryPanel,
     })),
 );
+const PromptLibraryPanel = lazyWithChunkBoundary("提示词库", () =>
+    import("./promptLibrary/PromptLibraryPanel").then((module) => ({
+        default: module.PromptLibraryPanel,
+    })),
+);
 const GenerationCanvas = lazyWithChunkBoundary(
     "生成画布",
     () => import("./generationCanvas/components/GenerationCanvas"),
@@ -101,6 +106,7 @@ export default function NomiStudioApp(): JSX.Element {
         React.useState(true);
     const [modelCatalogOpened, setModelCatalogOpened] = React.useState(false);
     const [assetLibraryOpened, setAssetLibraryOpened] = React.useState(false);
+    const [promptLibraryOpened, setPromptLibraryOpened] = React.useState(false);
     // 首启开屏：仅首次未看过时自动放；看过后可经项目库「看看 Nomi」重看。
     const [splashDone, setSplashDone] = React.useState(() => hasSeenSplash());
     const { hasTextModel, refresh: refreshModelStatus } = useHasTextModel();
@@ -154,6 +160,19 @@ export default function NomiStudioApp(): JSX.Element {
             window.removeEventListener(
                 "nomi-open-asset-library",
                 handleOpenAssetLibrary,
+            );
+    }, []);
+
+    React.useEffect(() => {
+        const handleOpenPromptLibrary = () => setPromptLibraryOpened(true);
+        window.addEventListener(
+            "nomi-open-prompt-library",
+            handleOpenPromptLibrary,
+        );
+        return () =>
+            window.removeEventListener(
+                "nomi-open-prompt-library",
+                handleOpenPromptLibrary,
             );
     }, []);
 
@@ -572,6 +591,13 @@ export default function NomiStudioApp(): JSX.Element {
                     opened={assetLibraryOpened}
                     onClose={() => setAssetLibraryOpened(false)}
                     projectId={activeProject?.id ?? null}
+                />
+            </React.Suspense>
+
+            <React.Suspense fallback={null}>
+                <PromptLibraryPanel
+                    opened={promptLibraryOpened}
+                    onClose={() => setPromptLibraryOpened(false)}
                 />
             </React.Suspense>
 

--- a/src/workbench/api/promptLibraryApi.ts
+++ b/src/workbench/api/promptLibraryApi.ts
@@ -1,0 +1,65 @@
+// 渲染层取提示词库的唯一入口(镜像 skillApi 的 requireDesktopRuntime 范式)。
+// 主进程已聚合+缓存;这里取全量,搜索/分类过滤是平凡纯函数,放渲染层(不重复后端逻辑)。
+import { getDesktopBridge, type DesktopBridge } from '../../desktop/bridge'
+
+export type PromptMediaType = 'image' | 'video'
+
+export type LibraryPrompt = {
+  id: string
+  title: string
+  prompt: string
+  mediaUrl: string
+  mediaType: PromptMediaType
+  promptType: PromptMediaType
+  tags: string[]
+  source: string
+  sourceId: string
+  sourceUrl: string
+}
+
+function requireDesktopRuntime(feature: string): DesktopBridge {
+  const desktop = getDesktopBridge()
+  if (!desktop?.promptLibrary) throw new Error(`${feature} requires the Electron desktop runtime`)
+  return desktop
+}
+
+function toPrompt(raw: unknown): LibraryPrompt | null {
+  if (!raw || typeof raw !== 'object') return null
+  const r = raw as Record<string, unknown>
+  const id = String(r.id ?? '')
+  const prompt = String(r.prompt ?? '')
+  if (!id || !prompt) return null
+  const mediaType: PromptMediaType = r.mediaType === 'video' ? 'video' : 'image'
+  const promptType: PromptMediaType = r.promptType === 'video' ? 'video' : 'image'
+  return {
+    id,
+    title: String(r.title ?? '未命名'),
+    prompt,
+    mediaUrl: String(r.mediaUrl ?? ''),
+    mediaType,
+    promptType,
+    tags: Array.isArray(r.tags) ? r.tags.map((t) => String(t)) : [],
+    source: String(r.source ?? ''),
+    sourceId: String(r.sourceId ?? ''),
+    sourceUrl: String(r.sourceUrl ?? ''),
+  }
+}
+
+export async function fetchPromptLibrary(): Promise<LibraryPrompt[]> {
+  const desktop = requireDesktopRuntime('prompt library')
+  const res = await desktop.promptLibrary!.list()
+  if (!res?.ok || !Array.isArray(res.prompts)) return []
+  return res.prompts.map(toPrompt).filter((p): p is LibraryPrompt => p !== null)
+}
+
+export type PromptCategory = 'all' | 'image' | 'video'
+
+/** 平凡过滤:分类(全部/图片/视频)+ 关键词(标题/正文/来源)。 */
+export function filterPrompts(items: LibraryPrompt[], category: PromptCategory, keyword: string): LibraryPrompt[] {
+  const kw = keyword.trim().toLowerCase()
+  return items.filter((item) => {
+    if (category !== 'all' && item.promptType !== category) return false
+    if (!kw) return true
+    return `${item.title} ${item.prompt} ${item.source}`.toLowerCase().includes(kw)
+  })
+}

--- a/src/workbench/api/promptLibraryApi.ts
+++ b/src/workbench/api/promptLibraryApi.ts
@@ -52,6 +52,13 @@ export async function fetchPromptLibrary(): Promise<LibraryPrompt[]> {
   return res.prompts.map(toPrompt).filter((p): p is LibraryPrompt => p !== null)
 }
 
+/** 节点提示词优化用的文本大脑键(与创作助手同脑);未配文本模型返回 null。 */
+export async function getTextBrain(): Promise<{ vendor: string; modelKey: string } | null> {
+  const desktop = requireDesktopRuntime('prompt optimize')
+  const res = await desktop.promptLibrary!.textBrain()
+  return res?.ok && res.brain ? res.brain : null
+}
+
 export type PromptCategory = 'all' | 'image' | 'video'
 
 /** 平凡过滤:分类(全部/图片/视频)+ 关键词(标题/正文/来源)。 */

--- a/src/workbench/generationCanvas/nodes/NodeGenerationComposer.tsx
+++ b/src/workbench/generationCanvas/nodes/NodeGenerationComposer.tsx
@@ -13,6 +13,7 @@ import { useBatchPlanPreviewStore } from '../components/batchPlanPreview'
 import NodeParameterControls from './NodeParameterControls'
 import { GENERATE_BUTTON_CLASS } from './nodeComposerStyles'
 import { NodeLockBadge } from './NodeLockBadge'
+import { NodePromptOptimizer } from './NodePromptOptimizer'
 import { useNodeAssetDrop } from './useNodeAssetDrop'
 import { persistActiveWorkbenchProjectNow } from '../../project/workbenchProjectSession'
 import {
@@ -289,6 +290,9 @@ export default function NodeGenerationComposer({ node, visualSize }: Props): JSX
             selected 恒为真（composer 只在选中时挂载）→ 始终可见：未锁=描边开锁、已锁=实心锁。 */}
         <NodeLockBadge nodeId={node.id} locked={node.locked} selected />
         <NodeParameterControls node={node} section="parameters" />
+        {(nodeExecutionKind === 'image' || nodeExecutionKind === 'video') && !node.locked ? (
+          <NodePromptOptimizer node={node} isVideo={nodeExecutionKind === 'video'} />
+        ) : null}
         {(() => {
           const disabledReason = !canGenerateNow && !isGenerating
             ? nodeExecutionKind === 'video'

--- a/src/workbench/generationCanvas/nodes/NodePromptOptimizer.tsx
+++ b/src/workbench/generationCanvas/nodes/NodePromptOptimizer.tsx
@@ -1,0 +1,117 @@
+/**
+ * 节点 prompt 的「AI 优化」按钮(下沉成节点通用能力,不在提示词库内重复 —— P1)。
+ * 用 Nomi 标记图标,点开说一句想法 → 用文本大脑(与创作助手同脑)流式改写当前 prompt 并逐字回填。
+ * 复用现成文本流式管线(runWorkbenchTextTaskStream + prompt_refine),不新建改写通道。
+ */
+import React from 'react'
+import { IconX } from '@tabler/icons-react'
+import { cn } from '../../../utils/cn'
+import { NomiLogoMark } from '../../../design'
+import { getTextBrain } from '../../api/promptLibraryApi'
+import { runWorkbenchTextTaskStream } from '../../api/taskApi'
+import { useGenerationCanvasStore } from '../store/generationCanvasStore'
+import type { GenerationCanvasNode } from '../model/generationCanvasTypes'
+
+function buildOptimizePrompt(original: string, idea: string, isVideo: boolean): string {
+  const kind = isVideo ? '视频生成' : '图像生成'
+  return [
+    `你是${kind}提示词专家。请优化下面这条${kind}提示词，让它更具体、更易出好${isVideo ? '片' : '图'}：`,
+    `"""\n${original || '(空白，请根据想法补全)'}\n"""`,
+    idea ? `结合用户的想法：${idea}` : '',
+    isVideo ? '补充镜头运动、节奏、光影、画质等要点；' : '补充光线、构图、风格、画质等要点；',
+    '保持原意，只输出优化后的提示词本身，不要解释、不要加引号、不要分点。',
+  ].filter(Boolean).join('\n')
+}
+
+export function NodePromptOptimizer({ node, isVideo }: { node: GenerationCanvasNode; isVideo: boolean }): JSX.Element {
+  const [open, setOpen] = React.useState(false)
+  const [idea, setIdea] = React.useState('')
+  const [running, setRunning] = React.useState(false)
+  const [error, setError] = React.useState<string | null>(null)
+  const abortRef = React.useRef<AbortController | null>(null)
+
+  const run = React.useCallback(async () => {
+    setRunning(true)
+    setError(null)
+    const ctrl = new AbortController()
+    abortRef.current = ctrl
+    try {
+      const brain = await getTextBrain()
+      if (!brain) {
+        setError('请先在「模型接入」里启用一个文本模型')
+        return
+      }
+      const prompt = buildOptimizePrompt(node.prompt || '', idea.trim(), isVideo)
+      let acc = ''
+      await runWorkbenchTextTaskStream(
+        brain.vendor,
+        { kind: 'prompt_refine', prompt, extras: { modelKey: brain.modelKey } },
+        {
+          signal: ctrl.signal,
+          onDelta: (delta) => {
+            acc += delta
+            // 逐字回填:流式期 persist:false(不进撤销/不落盘),受控编辑器即时重渲。
+            useGenerationCanvasStore.getState().updateNode(node.id, { prompt: acc }, { persist: false })
+          },
+        },
+      )
+      const final = acc.trim()
+      if (final) useGenerationCanvasStore.getState().updateNode(node.id, { prompt: final })
+      setOpen(false)
+      setIdea('')
+    } catch (e) {
+      if (e instanceof DOMException && e.name === 'AbortError') return
+      setError(e instanceof Error ? e.message : '优化失败')
+    } finally {
+      setRunning(false)
+      abortRef.current = null
+    }
+  }, [node.id, node.prompt, idea, isVideo])
+
+  const toggle = React.useCallback(() => {
+    if (running) return
+    setOpen((prev) => !prev)
+    setError(null)
+  }, [running])
+
+  return (
+    <div className={cn('relative ml-auto')}>
+      {open ? (
+        <div className={cn('absolute bottom-full right-0 mb-2 w-[260px] z-10', 'bg-nomi-paper border border-nomi-line rounded-nomi shadow-nomi-md p-2.5')}>
+          <div className={cn('flex items-center gap-1.5 mb-2 text-caption text-nomi-ink-60')}>
+            <NomiLogoMark size={14} />
+            说一句想法，Nomi 帮你改这条
+          </div>
+          <textarea
+            className={cn('w-full h-[52px] resize-none rounded-nomi-sm border border-nomi-line bg-nomi-paper px-2 py-1.5', 'text-body-sm text-nomi-ink placeholder:text-nomi-ink-40 outline-none focus:border-nomi-accent')}
+            value={idea}
+            placeholder="如：换成黄昏、情绪更紧张、加点雾气…（留空也能优化）"
+            disabled={running}
+            aria-label="优化想法"
+            onChange={(e) => setIdea(e.currentTarget.value)}
+            onKeyDown={(e) => { if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) void run() }}
+          />
+          {error ? <div className={cn('mt-1.5 text-micro text-workbench-danger')}>{error}</div> : null}
+          <button
+            type="button"
+            className={cn('mt-2 w-full h-8 rounded-full cursor-pointer border-0 text-caption font-semibold', 'bg-nomi-ink text-nomi-paper hover:bg-nomi-accent disabled:opacity-60', 'transition-[background] duration-[var(--nomi-transition-fast)]')}
+            disabled={running}
+            onClick={() => void run()}
+          >
+            {running ? '优化中…' : '优化这条提示词'}
+          </button>
+        </div>
+      ) : null}
+      <button
+        type="button"
+        className={cn('inline-flex items-center gap-1.5 h-[30px] px-2.5 rounded-full cursor-pointer', 'border border-nomi-line bg-nomi-paper text-nomi-ink-80 text-caption', 'hover:border-nomi-accent hover:text-nomi-ink transition-[border-color,color] duration-[var(--nomi-transition-fast)]')}
+        aria-label="用 Nomi 优化提示词"
+        title="用 Nomi 优化提示词"
+        onClick={toggle}
+      >
+        {open ? <IconX size={14} stroke={1.8} /> : <NomiLogoMark size={14} />}
+        优化
+      </button>
+    </div>
+  )
+}

--- a/src/workbench/generationCanvas/nodes/NodePromptOptimizer.tsx
+++ b/src/workbench/generationCanvas/nodes/NodePromptOptimizer.tsx
@@ -1,6 +1,7 @@
 /**
  * 节点 prompt 的「AI 优化」按钮(下沉成节点通用能力,不在提示词库内重复 —— P1)。
- * 用 Nomi 标记图标,点开说一句想法 → 用文本大脑(与创作助手同脑)流式改写当前 prompt 并逐字回填。
+ * 用 Nomi 标记图标,点开说一句想法 → 文本大脑(与创作助手同脑)流式改写 →
+ * 完成后高亮展示「改了哪些」(diff),用户确认再应用到提示词(creator control:不擅自覆盖)。
  * 复用现成文本流式管线(runWorkbenchTextTaskStream + prompt_refine),不新建改写通道。
  */
 import React from 'react'
@@ -11,6 +12,7 @@ import { getTextBrain } from '../../api/promptLibraryApi'
 import { runWorkbenchTextTaskStream } from '../../api/taskApi'
 import { useGenerationCanvasStore } from '../store/generationCanvasStore'
 import type { GenerationCanvasNode } from '../model/generationCanvasTypes'
+import { diffPromptWords } from './promptDiff'
 
 function buildOptimizePrompt(original: string, idea: string, isVideo: boolean): string {
   const kind = isVideo ? '视频生成' : '图像生成'
@@ -28,11 +30,23 @@ export function NodePromptOptimizer({ node, isVideo }: { node: GenerationCanvasN
   const [idea, setIdea] = React.useState('')
   const [running, setRunning] = React.useState(false)
   const [error, setError] = React.useState<string | null>(null)
+  const [streamed, setStreamed] = React.useState('') // 流式累积(进行中)
+  const [result, setResult] = React.useState<string | null>(null) // 完成的优化文本(待确认)
+  const originalRef = React.useRef('')
   const abortRef = React.useRef<AbortController | null>(null)
+
+  const reset = React.useCallback(() => {
+    setStreamed('')
+    setResult(null)
+    setError(null)
+  }, [])
 
   const run = React.useCallback(async () => {
     setRunning(true)
     setError(null)
+    setResult(null)
+    setStreamed('')
+    originalRef.current = node.prompt || ''
     const ctrl = new AbortController()
     abortRef.current = ctrl
     try {
@@ -41,7 +55,7 @@ export function NodePromptOptimizer({ node, isVideo }: { node: GenerationCanvasN
         setError('请先在「模型接入」里启用一个文本模型')
         return
       }
-      const prompt = buildOptimizePrompt(node.prompt || '', idea.trim(), isVideo)
+      const prompt = buildOptimizePrompt(originalRef.current, idea.trim(), isVideo)
       let acc = ''
       await runWorkbenchTextTaskStream(
         brain.vendor,
@@ -50,15 +64,13 @@ export function NodePromptOptimizer({ node, isVideo }: { node: GenerationCanvasN
           signal: ctrl.signal,
           onDelta: (delta) => {
             acc += delta
-            // 逐字回填:流式期 persist:false(不进撤销/不落盘),受控编辑器即时重渲。
-            useGenerationCanvasStore.getState().updateNode(node.id, { prompt: acc }, { persist: false })
+            setStreamed(acc)
           },
         },
       )
       const final = acc.trim()
-      if (final) useGenerationCanvasStore.getState().updateNode(node.id, { prompt: final })
-      setOpen(false)
-      setIdea('')
+      if (final) setResult(final)
+      else setError('没拿到优化结果，请重试')
     } catch (e) {
       if (e instanceof DOMException && e.name === 'AbortError') return
       setError(e instanceof Error ? e.message : '优化失败')
@@ -66,42 +78,91 @@ export function NodePromptOptimizer({ node, isVideo }: { node: GenerationCanvasN
       setRunning(false)
       abortRef.current = null
     }
-  }, [node.id, node.prompt, idea, isVideo])
+  }, [node.prompt, idea, isVideo])
+
+  const apply = React.useCallback(() => {
+    if (!result) return
+    useGenerationCanvasStore.getState().updateNode(node.id, { prompt: result })
+    setOpen(false)
+    setIdea('')
+    reset()
+  }, [result, node.id, reset])
 
   const toggle = React.useCallback(() => {
-    if (running) return
-    setOpen((prev) => !prev)
-    setError(null)
-  }, [running])
+    if (running) {
+      abortRef.current?.abort()
+      return
+    }
+    setOpen((prev) => {
+      if (prev) reset()
+      return !prev
+    })
+  }, [running, reset])
+
+  const diff = result != null ? diffPromptWords(originalRef.current, result) : null
 
   return (
     <div className={cn('relative ml-auto')}>
       {open ? (
-        <div className={cn('absolute bottom-full right-0 mb-2 w-[260px] z-10', 'bg-nomi-paper border border-nomi-line rounded-nomi shadow-nomi-md p-2.5')}>
+        <div className={cn('absolute bottom-full right-0 mb-2 w-[280px] z-10', 'bg-nomi-paper border border-nomi-line rounded-nomi shadow-nomi-md p-2.5')}>
           <div className={cn('flex items-center gap-1.5 mb-2 text-caption text-nomi-ink-60')}>
             <NomiLogoMark size={14} />
-            说一句想法，Nomi 帮你改这条
+            {result != null ? 'Nomi 优化版（高亮=改动）' : '说一句想法，Nomi 帮你改这条'}
           </div>
-          <textarea
-            className={cn('w-full h-[52px] resize-none rounded-nomi-sm border border-nomi-line bg-nomi-paper px-2 py-1.5', 'text-body-sm text-nomi-ink placeholder:text-nomi-ink-40 outline-none focus:border-nomi-accent')}
-            value={idea}
-            placeholder="如：换成黄昏、情绪更紧张、加点雾气…（留空也能优化）"
-            disabled={running}
-            aria-label="优化想法"
-            onChange={(e) => setIdea(e.currentTarget.value)}
-            onKeyDown={(e) => { if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) void run() }}
-          />
-          {error ? <div className={cn('mt-1.5 text-micro text-workbench-danger')}>{error}</div> : null}
-          <button
-            type="button"
-            className={cn('mt-2 w-full h-8 rounded-full cursor-pointer border-0 text-caption font-semibold', 'bg-nomi-ink text-nomi-paper hover:bg-nomi-accent disabled:opacity-60', 'transition-[background] duration-[var(--nomi-transition-fast)]')}
-            disabled={running}
-            onClick={() => void run()}
-          >
-            {running ? '优化中…' : '优化这条提示词'}
-          </button>
+
+          {result != null ? (
+            <>
+              <div className={cn('max-h-[160px] overflow-y-auto rounded-nomi-sm border border-nomi-line bg-nomi-paper px-2 py-1.5 text-body-sm leading-relaxed text-nomi-ink')}>
+                {diff!.map((seg, i) => (
+                  <span key={i} className={seg.added ? cn('bg-nomi-accent-soft text-nomi-accent rounded-nomi-sm px-px') : undefined}>
+                    {seg.text}
+                  </span>
+                ))}
+              </div>
+              <div className={cn('mt-2 flex gap-2')}>
+                <button
+                  type="button"
+                  className={cn('flex-1 h-8 rounded-full cursor-pointer border-0 text-caption font-semibold', 'bg-nomi-ink text-nomi-paper hover:bg-nomi-accent transition-[background] duration-[var(--nomi-transition-fast)]')}
+                  onClick={apply}
+                >
+                  应用到提示词
+                </button>
+                <button
+                  type="button"
+                  className={cn('h-8 px-3 rounded-full cursor-pointer border border-nomi-line bg-transparent text-caption text-nomi-ink-80 hover:bg-nomi-ink-05')}
+                  onClick={() => void run()}
+                >
+                  重新优化
+                </button>
+              </div>
+            </>
+          ) : running ? (
+            <div className={cn('rounded-nomi-sm border border-nomi-line bg-nomi-paper px-2 py-1.5 min-h-[52px] text-body-sm leading-relaxed text-nomi-ink-80 whitespace-pre-wrap')}>
+              {streamed || '正在优化…'}
+            </div>
+          ) : (
+            <>
+              <textarea
+                className={cn('w-full h-[52px] resize-none rounded-nomi-sm border border-nomi-line bg-nomi-paper px-2 py-1.5', 'text-body-sm text-nomi-ink placeholder:text-nomi-ink-40 outline-none focus:border-nomi-accent')}
+                value={idea}
+                placeholder="如：换成黄昏、情绪更紧张、加点雾气…（留空也能优化）"
+                aria-label="优化想法"
+                onChange={(e) => setIdea(e.currentTarget.value)}
+                onKeyDown={(e) => { if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) void run() }}
+              />
+              {error ? <div className={cn('mt-1.5 text-micro text-workbench-danger')}>{error}</div> : null}
+              <button
+                type="button"
+                className={cn('mt-2 w-full h-8 rounded-full cursor-pointer border-0 text-caption font-semibold', 'bg-nomi-ink text-nomi-paper hover:bg-nomi-accent transition-[background] duration-[var(--nomi-transition-fast)]')}
+                onClick={() => void run()}
+              >
+                优化这条提示词
+              </button>
+            </>
+          )}
         </div>
       ) : null}
+
       <button
         type="button"
         className={cn('inline-flex items-center gap-1.5 h-[30px] px-2.5 rounded-full cursor-pointer', 'border border-nomi-line bg-nomi-paper text-nomi-ink-80 text-caption', 'hover:border-nomi-accent hover:text-nomi-ink transition-[border-color,color] duration-[var(--nomi-transition-fast)]')}
@@ -110,7 +171,7 @@ export function NodePromptOptimizer({ node, isVideo }: { node: GenerationCanvasN
         onClick={toggle}
       >
         {open ? <IconX size={14} stroke={1.8} /> : <NomiLogoMark size={14} />}
-        优化
+        {running ? '优化中…' : '优化'}
       </button>
     </div>
   )

--- a/src/workbench/generationCanvas/nodes/promptDiff.test.ts
+++ b/src/workbench/generationCanvas/nodes/promptDiff.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { diffPromptWords } from './promptDiff'
+
+describe('diffPromptWords', () => {
+  it('纯新增:原文整段保留,尾部追加标 added', () => {
+    const segs = diffPromptWords('一只猫', '一只猫，电影感布光')
+    expect(segs.filter((s) => !s.added).map((s) => s.text).join('')).toContain('一只猫')
+    expect(segs.some((s) => s.added && s.text.includes('电影感布光'))).toBe(true)
+  })
+
+  it('完全相同:无 added 段', () => {
+    const segs = diffPromptWords('a cat on a mat', 'a cat on a mat')
+    expect(segs.every((s) => !s.added)).toBe(true)
+  })
+
+  it('中间插入:只标新增的中段', () => {
+    const segs = diffPromptWords('猫坐在垫子上', '猫安静地坐在柔软的垫子上')
+    const added = segs.filter((s) => s.added).map((s) => s.text).join('')
+    expect(added).toContain('安静')
+    expect(segs.filter((s) => !s.added).map((s) => s.text).join('')).toContain('坐在')
+  })
+
+  it('拼回优化后文本无损(added+keep 顺序拼接=optimized)', () => {
+    const optimized = 'a fluffy cat on a warm mat'
+    const segs = diffPromptWords('a cat on a mat', optimized)
+    expect(segs.map((s) => s.text).join('')).toBe(optimized)
+  })
+
+  it('空原文:全部标 added', () => {
+    const segs = diffPromptWords('', 'brand new prompt')
+    expect(segs.length).toBeGreaterThan(0)
+    expect(segs.every((s) => s.added)).toBe(true)
+  })
+})

--- a/src/workbench/generationCanvas/nodes/promptDiff.ts
+++ b/src/workbench/generationCanvas/nodes/promptDiff.ts
@@ -1,0 +1,43 @@
+// 词级 LCS diff:把优化后文本拆成段,标出相对原文「新增/改动」的部分,供「高亮=改动」展示。
+// 纯函数(可单测)。中英混排:CJK 按单字、Latin/数字按词、其它按单字符切,空白单独成 token。
+export type DiffSegment = { text: string; added: boolean }
+
+function tokenize(text: string): string[] {
+  return text.match(/[A-Za-z0-9]+|[一-鿿]|\s+|[^\sA-Za-z0-9]/g) || []
+}
+
+/** 返回「优化后文本」的分段:added=true 的段是相对原文新增/改动的部分。 */
+export function diffPromptWords(original: string, optimized: string): DiffSegment[] {
+  const a = tokenize(original)
+  const b = tokenize(optimized)
+  const m = a.length
+  const n = b.length
+  // dp[i][j] = a[i:] 与 b[j:] 的最长公共子序列长度。
+  const dp: number[][] = Array.from({ length: m + 1 }, () => new Array<number>(n + 1).fill(0))
+  for (let i = m - 1; i >= 0; i--) {
+    for (let j = n - 1; j >= 0; j--) {
+      dp[i][j] = a[i] === b[j] ? dp[i + 1][j + 1] + 1 : Math.max(dp[i + 1][j], dp[i][j + 1])
+    }
+  }
+  const segments: DiffSegment[] = []
+  const push = (text: string, added: boolean) => {
+    const last = segments[segments.length - 1]
+    if (last && last.added === added) last.text += text
+    else segments.push({ text, added })
+  }
+  let i = 0
+  let j = 0
+  while (j < n) {
+    if (i < m && a[i] === b[j]) {
+      push(b[j], false)
+      i++
+      j++
+    } else if (i < m && dp[i + 1][j] >= dp[i][j + 1]) {
+      i++ // 原文删除的 token,不体现在优化后文本里
+    } else {
+      push(b[j], true) // 优化后新增/改动的 token
+      j++
+    }
+  }
+  return segments
+}

--- a/src/workbench/promptLibrary/PromptCard.tsx
+++ b/src/workbench/promptLibrary/PromptCard.tsx
@@ -1,0 +1,71 @@
+import React from 'react'
+import { IconPlayerPlayFilled, IconPhoto, IconVideo } from '@tabler/icons-react'
+import { cn } from '../../utils/cn'
+import type { LibraryPrompt } from '../api/promptLibraryApi'
+
+type Props = {
+  prompt: LibraryPrompt
+  onSelect: (prompt: LibraryPrompt, rect: DOMRect) => void
+}
+
+// 单张提示词卡:封面(图<img>/视频<video 首帧>)+标题渐变压字+类型角标。memo 化(搜索/滚动重渲不重建)。
+export const PromptCard = React.memo(function PromptCard({ prompt, onSelect }: Props): JSX.Element {
+  const [broken, setBroken] = React.useState(false)
+  const isVideo = prompt.mediaType === 'video'
+  const hasMedia = Boolean(prompt.mediaUrl) && !broken
+
+  return (
+    <button
+      type="button"
+      onClick={(event) => onSelect(prompt, event.currentTarget.getBoundingClientRect())}
+      className={cn(
+        'group relative block w-full aspect-[4/3] overflow-hidden text-left cursor-pointer',
+        'rounded-nomi border border-nomi-line bg-nomi-ink-05',
+        'transition-[transform,box-shadow] duration-[var(--nomi-transition-fast)]',
+        'hover:-translate-y-0.5 hover:shadow-nomi-md',
+      )}
+      title={prompt.title}
+    >
+      {hasMedia ? (
+        isVideo ? (
+          <video
+            src={prompt.mediaUrl}
+            muted
+            playsInline
+            preload="metadata"
+            className={cn('absolute inset-0 w-full h-full object-cover')}
+            onError={() => setBroken(true)}
+          />
+        ) : (
+          <img
+            src={prompt.mediaUrl}
+            alt={prompt.title}
+            loading="lazy"
+            className={cn('absolute inset-0 w-full h-full object-cover')}
+            onError={() => setBroken(true)}
+          />
+        )
+      ) : (
+        <div className={cn('absolute inset-0 grid place-items-center text-nomi-ink-30')}>
+          {isVideo ? <IconVideo size={30} stroke={1.4} /> : <IconPhoto size={30} stroke={1.4} />}
+        </div>
+      )}
+
+      <span className={cn(
+        'absolute top-1.5 left-1.5 inline-flex items-center gap-1 px-1.5 py-px rounded-full text-micro leading-none',
+        'bg-[oklch(0.2_0.01_80/0.55)] text-nomi-paper backdrop-blur-sm',
+      )}>
+        {isVideo ? <IconPlayerPlayFilled size={9} /> : null}
+        {isVideo ? '视频' : '图片'}
+      </span>
+
+      <span className={cn(
+        'absolute left-0 right-0 bottom-0 px-2 pt-3 pb-1.5',
+        'bg-gradient-to-t from-[oklch(0_0_0/0.62)] to-transparent',
+      )}>
+        <span className={cn('block text-caption text-nomi-paper font-medium truncate')}>{prompt.title}</span>
+        <span className={cn('block text-micro text-nomi-paper/70 truncate')}>{prompt.source}</span>
+      </span>
+    </button>
+  )
+})

--- a/src/workbench/promptLibrary/PromptLibraryPanel.tsx
+++ b/src/workbench/promptLibrary/PromptLibraryPanel.tsx
@@ -1,0 +1,204 @@
+/**
+ * 提示词库面板。借鉴 infinite-canvas 的提示词库,但瘦身:库只管「靠封面挑起点 → 送上画布」,
+ * AI 优化下沉到节点 composer(不在库内重复)。居中大画廊 + 遮罩;点卡片 FLIP 放大浮到中央预览。
+ * 数据由主进程聚合公开仓库(图/视频)+1h 缓存,渲染层取全量后本地过滤(usePromptLibrary)。
+ */
+import React from 'react'
+import { Portal } from '@mantine/core'
+import { useVirtualizer } from '@tanstack/react-virtual'
+import { IconSearch, IconX, IconBulb, IconRefresh } from '@tabler/icons-react'
+import { cn } from '../../utils/cn'
+import { NomiLoadingMark, NomiWordmark } from '../../design'
+import { showUndoToast } from '../../utils/showUndoToast'
+import { useGenerationCanvasStore } from '../generationCanvas/store/generationCanvasStore'
+import { filterPrompts, type LibraryPrompt, type PromptCategory } from '../api/promptLibraryApi'
+import { usePromptLibrary } from './usePromptLibrary'
+import { PromptCard } from './PromptCard'
+import { PromptPreviewOverlay } from './PromptPreviewOverlay'
+
+const GRID_COLS = 4
+const ESTIMATED_ROW_HEIGHT = 188
+
+const CATEGORY_OPTIONS: { value: PromptCategory; label: string }[] = [
+  { value: 'all', label: '全部' },
+  { value: 'image', label: '图片' },
+  { value: 'video', label: '视频' },
+]
+
+type Props = {
+  opened: boolean
+  onClose: () => void
+}
+
+type Selected = { prompt: LibraryPrompt; rect: DOMRect }
+
+export function PromptLibraryPanel({ opened, onClose }: Props): JSX.Element | null {
+  const panelRef = React.useRef<HTMLDivElement>(null)
+  const [category, setCategory] = React.useState<PromptCategory>('all')
+  const [query, setQuery] = React.useState('')
+  const [selected, setSelected] = React.useState<Selected | null>(null)
+  const [scrollEl, setScrollEl] = React.useState<HTMLDivElement | null>(null)
+
+  const { items, loading, error, reload } = usePromptLibrary(opened)
+  const visible = React.useMemo(() => filterPrompts(items, category, query), [items, category, query])
+
+  const rowCount = Math.ceil(visible.length / GRID_COLS)
+  const rowVirtualizer = useVirtualizer({
+    count: rowCount,
+    getScrollElement: () => scrollEl,
+    estimateSize: () => ESTIMATED_ROW_HEIGHT,
+    overscan: 3,
+  })
+
+  React.useEffect(() => {
+    if (!opened) return
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && !selected) onClose()
+    }
+    window.addEventListener('keydown', handler)
+    return () => window.removeEventListener('keydown', handler)
+  }, [opened, onClose, selected])
+
+  const handleSelect = React.useCallback((prompt: LibraryPrompt, rect: DOMRect) => {
+    setSelected({ prompt, rect })
+  }, [])
+
+  // 送上画布:按提示词类型建图/视频节点(都落分镜),prompt 直接灌入;撤销 toast 可删。
+  const handleSendToCanvas = React.useCallback((prompt: LibraryPrompt) => {
+    const store = useGenerationCanvasStore.getState()
+    const node = store.addNode({
+      kind: prompt.promptType === 'video' ? 'video' : 'image',
+      prompt: prompt.prompt,
+      select: true,
+    })
+    showUndoToast({
+      message: `已送上画布 · ${prompt.promptType === 'video' ? '视频' : '分镜'}节点`,
+      onUndo: () => useGenerationCanvasStore.getState().deleteNode(node.id),
+    })
+  }, [])
+
+  if (!opened) return null
+
+  return (
+    <Portal>
+      <div
+        className={cn('fixed inset-0 grid place-items-center p-6')}
+        style={{ zIndex: 4000, background: 'oklch(0.2 0.01 80 / 0.34)', animation: 'nomi-fade 140ms cubic-bezier(.2,.7,.3,1)' }}
+        onMouseDown={(e) => { if (e.target === e.currentTarget) onClose() }}
+      >
+        <div
+          ref={panelRef}
+          role="dialog"
+          aria-label="提示词库"
+          className={cn('w-[960px] max-w-full h-[86vh] flex flex-col overflow-hidden', 'bg-nomi-paper border border-nomi-line rounded-nomi-lg shadow-nomi-lg')}
+          style={{ animation: 'nomi-panel-pop 160ms cubic-bezier(.2,.7,.3,1)' }}
+        >
+          {/* 头部 */}
+          <div className={cn('flex items-center gap-2 px-5 pt-4 pb-3 border-b border-nomi-line')}>
+            <IconBulb size={18} stroke={1.6} className={cn('text-nomi-accent')} />
+            <b className={cn('text-title font-bold text-nomi-ink')}>提示词库</b>
+            <NomiWordmark fontSize={13} className={cn('text-nomi-ink-40')} />
+            <span className={cn('text-caption text-nomi-ink-40')}>· {items.length}</span>
+            <span className={cn('flex-1')} />
+            <button
+              type="button"
+              className={cn('w-7 h-7 grid place-items-center rounded-nomi-sm cursor-pointer border-0 bg-transparent', 'text-nomi-ink-40 hover:text-nomi-ink hover:bg-nomi-ink-05')}
+              aria-label="关闭提示词库"
+              onClick={onClose}
+            >
+              <IconX size={16} stroke={2} />
+            </button>
+          </div>
+
+          {/* 工具行 */}
+          <div className={cn('flex items-center gap-2 px-5 py-2.5')}>
+            <div className={cn('shrink-0 inline-flex bg-nomi-ink-05 rounded-full p-0.5')} role="tablist" aria-label="提示词类型筛选">
+              {CATEGORY_OPTIONS.map((option) => {
+                const active = category === option.value
+                return (
+                  <button
+                    key={option.value}
+                    type="button"
+                    role="tab"
+                    aria-selected={active}
+                    className={cn('px-3 py-1 rounded-full text-caption cursor-pointer border-0 bg-transparent whitespace-nowrap', 'transition-[background,color] duration-[var(--nomi-transition-fast)]', active ? 'bg-nomi-paper text-nomi-ink font-semibold shadow-nomi-sm' : 'text-nomi-ink-60 hover:text-nomi-ink')}
+                    onClick={() => setCategory(option.value)}
+                  >
+                    {option.label}
+                  </button>
+                )
+              })}
+            </div>
+            <div className={cn('flex-1 inline-flex items-center gap-1.5 h-[30px] px-2.5', 'border border-nomi-line rounded-full text-nomi-ink-40 focus-within:border-nomi-accent')}>
+              <IconSearch size={13} stroke={1.8} />
+              <input
+                className={cn('flex-1 min-w-0 bg-transparent border-0 outline-none text-caption text-nomi-ink placeholder:text-nomi-ink-40')}
+                type="text"
+                value={query}
+                placeholder="搜提示词…"
+                aria-label="搜索提示词"
+                onChange={(event) => setQuery(event.currentTarget.value)}
+              />
+            </div>
+          </div>
+
+          {/* 网格 / 状态 */}
+          <div ref={setScrollEl} className={cn('flex-1 overflow-y-auto px-5 pb-5')}>
+            {loading && !items.length ? (
+              <div className={cn('flex flex-col items-center justify-center gap-3 py-20 text-nomi-ink-40')}>
+                <NomiLoadingMark size={28} />
+                <span className={cn('text-caption')}>正在从公开库拉取提示词…</span>
+              </div>
+            ) : error && !items.length ? (
+              <div className={cn('flex flex-col items-center justify-center gap-3 py-20 text-center')}>
+                <div className={cn('text-body font-semibold text-nomi-ink')}>没拉到提示词</div>
+                <div className={cn('text-caption text-nomi-ink-40 max-w-[320px]')}>{error}</div>
+                <button type="button" onClick={reload} className={cn('inline-flex items-center gap-1.5 h-8 px-3.5 rounded-full cursor-pointer', 'border border-nomi-line bg-transparent text-nomi-ink-80 text-caption hover:bg-nomi-ink-05')}>
+                  <IconRefresh size={14} stroke={1.8} />重试
+                </button>
+              </div>
+            ) : !visible.length ? (
+              <div className={cn('flex flex-col items-center justify-center gap-2 py-20 text-center')}>
+                <div className={cn('text-body font-semibold text-nomi-ink')}>没有匹配的提示词</div>
+                <div className={cn('text-caption text-nomi-ink-40')}>换个筛选或搜索词试试。</div>
+              </div>
+            ) : (
+              <div style={{ height: rowVirtualizer.getTotalSize(), width: '100%', position: 'relative' }}>
+                {rowVirtualizer.getVirtualItems().map((virtualRow) => {
+                  const start = virtualRow.index * GRID_COLS
+                  const rowItems = visible.slice(start, start + GRID_COLS)
+                  return (
+                    <div
+                      key={virtualRow.key}
+                      data-index={virtualRow.index}
+                      className={cn('grid grid-cols-4 gap-3 pb-3')}
+                      style={{ position: 'absolute', top: 0, left: 0, width: '100%', transform: `translateY(${virtualRow.start}px)` }}
+                    >
+                      {rowItems.map((prompt) => (
+                        <PromptCard key={prompt.id} prompt={prompt} onSelect={handleSelect} />
+                      ))}
+                    </div>
+                  )
+                })}
+              </div>
+            )}
+          </div>
+        </div>
+
+        <style>{`
+          @keyframes nomi-fade { from { opacity: 0 } to { opacity: 1 } }
+          @keyframes nomi-panel-pop { from { opacity: 0; transform: translateY(-6px) scale(0.99) } to { opacity: 1; transform: translateY(0) scale(1) } }
+        `}</style>
+      </div>
+
+      {selected ? (
+        <PromptPreviewOverlay
+          prompt={selected.prompt}
+          originRect={selected.rect}
+          onClose={() => setSelected(null)}
+          onSendToCanvas={handleSendToCanvas}
+        />
+      ) : null}
+    </Portal>
+  )
+}

--- a/src/workbench/promptLibrary/PromptPreviewOverlay.tsx
+++ b/src/workbench/promptLibrary/PromptPreviewOverlay.tsx
@@ -1,0 +1,161 @@
+import React from 'react'
+import { Portal } from '@mantine/core'
+import { IconCopy, IconExternalLink, IconLayoutBoard, IconCheck, IconX, IconVideo, IconPhoto } from '@tabler/icons-react'
+import { cn } from '../../utils/cn'
+import type { LibraryPrompt } from '../api/promptLibraryApi'
+
+type Props = {
+  prompt: LibraryPrompt
+  originRect: DOMRect
+  onClose: () => void
+  onSendToCanvas: (prompt: LibraryPrompt) => void
+}
+
+const EASE = 'cubic-bezier(.2, .7, .3, 1)'
+const ANIM_MS = 260
+
+// 预览浮层:从被点卡片的位置 FLIP 放大浮到屏幕中央(transform-origin 0 0,先映射回原位再过渡到正位)。
+export function PromptPreviewOverlay({ prompt, originRect, onClose, onSendToCanvas }: Props): JSX.Element {
+  const boxRef = React.useRef<HTMLDivElement>(null)
+  const [closing, setClosing] = React.useState(false)
+  const [sent, setSent] = React.useState(false)
+  const [copied, setCopied] = React.useState(false)
+  const isVideo = prompt.mediaType === 'video'
+  const hasMedia = Boolean(prompt.mediaUrl)
+
+  const mapToOrigin = React.useCallback((box: HTMLDivElement) => {
+    const rect = box.getBoundingClientRect()
+    const scale = originRect.width / rect.width
+    const dx = originRect.left - rect.left
+    const dy = originRect.top - rect.top
+    return `translate(${dx}px, ${dy}px) scale(${scale})`
+  }, [originRect])
+
+  // 进场:挂载即贴回原卡位置 → 下一帧过渡到正位。
+  React.useLayoutEffect(() => {
+    const box = boxRef.current
+    if (!box) return
+    box.style.transformOrigin = '0 0'
+    box.style.transform = mapToOrigin(box)
+    box.style.opacity = '0.4'
+    const id = requestAnimationFrame(() => {
+      box.style.transition = `transform ${ANIM_MS}ms ${EASE}, opacity ${ANIM_MS}ms ${EASE}`
+      box.style.transform = 'translate(0, 0) scale(1)'
+      box.style.opacity = '1'
+    })
+    return () => cancelAnimationFrame(id)
+  }, [mapToOrigin])
+
+  const close = React.useCallback(() => {
+    const box = boxRef.current
+    if (!box || closing) {
+      onClose()
+      return
+    }
+    setClosing(true)
+    box.style.transition = `transform ${ANIM_MS}ms ${EASE}, opacity ${ANIM_MS}ms ${EASE}`
+    box.style.transform = mapToOrigin(box)
+    box.style.opacity = '0'
+    window.setTimeout(onClose, ANIM_MS)
+  }, [closing, mapToOrigin, onClose])
+
+  React.useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') close()
+    }
+    window.addEventListener('keydown', handler)
+    return () => window.removeEventListener('keydown', handler)
+  }, [close])
+
+  const handleSend = () => {
+    onSendToCanvas(prompt)
+    setSent(true)
+    window.setTimeout(close, 950)
+  }
+  const handleCopy = () => {
+    void navigator.clipboard?.writeText(prompt.prompt).catch(() => undefined)
+    setCopied(true)
+  }
+
+  return (
+    <Portal>
+      <div
+        role="dialog"
+        aria-label={prompt.title}
+        className={cn('fixed inset-0 grid place-items-center p-6')}
+        style={{ zIndex: 4200, background: 'oklch(0.2 0.01 80 / 0.42)', animation: `nomi-fade ${ANIM_MS}ms ${EASE}` }}
+        onMouseDown={(e) => { if (e.target === e.currentTarget) close() }}
+      >
+        <div
+          ref={boxRef}
+          className={cn('w-[560px] max-w-full max-h-[88vh] flex flex-col overflow-hidden', 'bg-nomi-paper border border-nomi-line rounded-nomi-lg shadow-nomi-lg')}
+        >
+          {/* 媒体 16:9 */}
+          <div className={cn('relative w-full bg-nomi-ink-05')} style={{ aspectRatio: '16 / 9' }}>
+            {hasMedia ? (
+              isVideo ? (
+                <video src={prompt.mediaUrl} controls autoPlay muted loop playsInline className={cn('absolute inset-0 w-full h-full object-cover')} />
+              ) : (
+                <img src={prompt.mediaUrl} alt={prompt.title} className={cn('absolute inset-0 w-full h-full object-cover')} />
+              )
+            ) : (
+              <div className={cn('absolute inset-0 grid place-items-center gap-1 text-nomi-ink-30')}>
+                {isVideo ? <IconVideo size={40} stroke={1.3} /> : <IconPhoto size={40} stroke={1.3} />}
+                <span className={cn('text-caption text-nomi-ink-40')}>此条暂无封面媒体</span>
+              </div>
+            )}
+            <span className={cn('absolute top-2.5 left-2.5 px-2 py-0.5 rounded-full text-micro', 'bg-[oklch(0.2_0.01_80/0.55)] text-nomi-paper backdrop-blur-sm')}>
+              {isVideo ? '视频' : '图片'} · {prompt.source}
+            </span>
+            <button
+              type="button"
+              aria-label="关闭"
+              onClick={close}
+              className={cn('absolute top-2 right-2 w-7 h-7 grid place-items-center rounded-full cursor-pointer border-0', 'bg-[oklch(0.2_0.01_80/0.5)] text-nomi-paper hover:bg-[oklch(0.2_0.01_80/0.7)]')}
+            >
+              <IconX size={16} stroke={2} />
+            </button>
+          </div>
+
+          {/* 内容 */}
+          <div className={cn('flex-1 min-h-0 overflow-y-auto px-4 pt-3.5 pb-4')}>
+            <div className={cn('text-title font-semibold text-nomi-ink mb-2')}>{prompt.title}</div>
+            <p className={cn('text-body-sm leading-relaxed text-nomi-ink-80 whitespace-pre-wrap')}>{prompt.prompt}</p>
+          </div>
+
+          {/* 操作 */}
+          <div className={cn('flex items-center gap-2 px-4 py-3 border-t border-nomi-line')}>
+            <button
+              type="button"
+              onClick={handleSend}
+              className={cn('inline-flex items-center gap-1.5 h-9 px-4 rounded-full cursor-pointer border-0', 'bg-nomi-ink text-nomi-paper text-body-sm font-semibold hover:bg-nomi-accent', 'transition-[background] duration-[var(--nomi-transition-fast)]')}
+            >
+              {sent ? <IconCheck size={16} stroke={2} /> : <IconLayoutBoard size={16} stroke={1.8} />}
+              {sent ? '已送上画布' : '送上画布'}
+            </button>
+            <button
+              type="button"
+              onClick={handleCopy}
+              aria-label="复制提示词"
+              className={cn('inline-flex items-center gap-1.5 h-9 px-3 rounded-full cursor-pointer', 'border border-nomi-line bg-transparent text-nomi-ink-80 text-body-sm hover:bg-nomi-ink-05')}
+            >
+              {copied ? <IconCheck size={15} stroke={2} /> : <IconCopy size={15} stroke={1.8} />}
+              {copied ? '已复制' : '复制'}
+            </button>
+            <span className={cn('flex-1')} />
+            <a
+              href={prompt.sourceUrl}
+              target="_blank"
+              rel="noreferrer"
+              className={cn('inline-flex items-center gap-1 text-caption text-nomi-ink-40 hover:text-nomi-ink')}
+            >
+              <IconExternalLink size={13} stroke={1.7} />
+              来源
+            </a>
+          </div>
+        </div>
+        <style>{`@keyframes nomi-fade { from { opacity: 0 } to { opacity: 1 } }`}</style>
+      </div>
+    </Portal>
+  )
+}

--- a/src/workbench/promptLibrary/usePromptLibrary.ts
+++ b/src/workbench/promptLibrary/usePromptLibrary.ts
@@ -1,0 +1,34 @@
+import React from 'react'
+import { fetchPromptLibrary, type LibraryPrompt } from '../api/promptLibraryApi'
+
+type State = { items: LibraryPrompt[]; loading: boolean; error: string | null }
+
+// 模块级缓存:面板反复开关不重拉(主进程也有 1h 缓存,这层省 IPC 往返+解析)。
+let cached: LibraryPrompt[] | null = null
+
+/** 提示词库数据:首次打开拉取,之后命中模块缓存;失败给可重试态。 */
+export function usePromptLibrary(opened: boolean): State & { reload: () => void } {
+  const [state, setState] = React.useState<State>({ items: cached ?? [], loading: false, error: null })
+
+  const load = React.useCallback((force: boolean) => {
+    if (!force && cached) {
+      setState({ items: cached, loading: false, error: null })
+      return
+    }
+    setState((prev) => ({ ...prev, loading: true, error: null }))
+    fetchPromptLibrary()
+      .then((items) => {
+        cached = items
+        setState({ items, loading: false, error: items.length ? null : '暂时没拉到提示词，稍后重试' })
+      })
+      .catch((error: unknown) => {
+        setState({ items: cached ?? [], loading: false, error: error instanceof Error ? error.message : '加载失败' })
+      })
+  }, [])
+
+  React.useEffect(() => {
+    if (opened) load(false)
+  }, [opened, load])
+
+  return { ...state, reload: () => load(true) }
+}


### PR DESCRIPTION
借鉴 basketikun/infinite-canvas 的提示词库。用户拍板：C 爬公开库打底 + AI 优化是招牌、优化下沉成节点通用能力、浮层从卡片放大浮到中央、图+视频都要、优化按钮用 Nomi 标记。

## 做了什么
- **数据层** `electron/promptLibrary/`：聚合 5 个公开仓库（图：EvoLink/YouMind/ImgEdify｜视频：Sora2/Sora官方），解析器纯函数+单测，hardenedFetch 拉取（代理继承）+1h TTL 缓存（失败回退旧）。真实 markdown 离线验证 571 条全带媒体。
- **库 UI** `src/workbench/promptLibrary/`：顶栏 💡 入口 → 居中大画廊+搜索+图/视频筛选 → 点卡 FLIP 放大浮到中央预览 → 送上画布（按 promptType 建 image/video 节点+灌 prompt+撤销 toast）。
- **节点优化** `NodePromptOptimizer`：composer 上 Nomi 标记按钮，说一句想法 → 文本大脑（与创作助手同脑，复用 runWorkbenchTextTaskStream+prompt_refine）流式改写 → 词级 diff 高亮「改了哪些」→ 确认应用（creator control）。

## 验证
- 五门：filesize/tokens/lint/typecheck/build 全过；parser+diff 单测绿。
- 真机走查（Playwright _electron，截图人眼判断）：库开/571提示词/封面/搜索筛选/FLIP浮层/送画布建节点灌prompt+撤销toast/视频占位/优化按钮+面板+缺模型优雅态。

## 诚实说明
- 视频提示词无图片那样的结构化富媒体源；twitter 媒体会失效→显占位（prompt 仍可用）。
- 优化 live 质量未驱动（免花额度）；diff 逻辑单测覆盖，真实实例配文本模型即出高亮。

方案：docs/plan/2026-06-21-prompt-library.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)