### PR TITLE
feat(onboarding): 一键接入 Claude Code 卡（界面里零 effort 接入能力核）

### DIFF
--- a/docs/plan/2026-06-21-connect-assistant-card.md
+++ b/docs/plan/2026-06-21-connect-assistant-card.md
@@ -1,0 +1,45 @@
+# 接入 AI 编程助手卡：一键把 Nomi 接进 Claude Code（UI）
+
+> 2026-06-21。用户要：界面上有个东西让用户知道怎么用能力核，**最好一键、什么都不管、最小 effort**。
+> 样张已出（show_widget 可体验）+ 用户拍板：**写全局 `~/.claude.json`（自动备份 + 可撤销）+ 按样张实现**。
+
+## 目标（D1 effect-first）
+用户不用读配置、不用找路径、不用学命令。点一个按钮 → Nomi 自己把 MCP 配置写进 Claude Code → 给一句「现在可以对它说……」。兜底：复制配置（给 Codex/Cursor/手动）+ 看用法（跳用户指南）。
+
+## 落点（勘查带 file:line）
+- 挂进现有「模型设置」面板 `src/ui/onboarding/OnboardingDrawer.tsx`（顶栏插头图标 `NomiAppBar.tsx:218` 打开的浮卡 `OnboardingFloatingPanel`）新增一个分组，**不新开界面**。
+- 卡片照抄 `VendorOnboardCard` / `FoldableModelCard` 结构（token-only，真品牌色），新组件 `src/ui/onboarding/ConnectAssistantCard.tsx`。
+- 复制走 `navigator.clipboard.writeText`（抄 `ProvenancePanel.tsx:23`）+ `toast`。
+
+## 新增 3 个 IPC（主进程，受限、非任意路径写）
+1. **`nomi:capability:mcp-info`**（读）→ `{ tokenReady, rpcRunning, installed, configPath, snippet, server:{command,args} }`。
+   - `server.args` = `node` + `scripts/nomi-mcp.mjs` 绝对路径（`app.getAppPath()` 推）。
+   - `installed` = `~/.claude.json` 的 `mcpServers.nomi` 已存在。
+2. **`nomi:capability:install-mcp`**（写）→ 读 `~/.claude.json`（缺则 `{}`）→ **先备份**到 `~/.claude.json.nomi-backup` → **合并**进 `mcpServers.nomi`（**保留已有 `cocos-creator` 等其它 server**，绝不覆盖整个文件）→ 原子写回 → 返回 `{ ok, configPath, backupPath }`。
+3. **`nomi:capability:uninstall-mcp`**（撤销）→ 删 `mcpServers.nomi`，写回 → `{ ok }`。
+
+安全：只写固定 `~/.claude.json`（`os.homedir()/.claude.json`），不做通用任意路径写（勘查警告）。备份让用户可回退。
+
+## 卡片状态机
+- **加载中** → 读 mcp-info。
+- **就绪·未接入**（tokenReady && !installed）→ 主按钮「一键接入 Claude Code」+ 复制 + 看用法。
+- **已接入**（installed）→ ✓ 已写入·重启后生效 + 「现在可以对它说……」示例 + 撤销接入。
+- **token 未就绪**（!tokenReady，理论上启动即生成，兜底）→ 提示「重启 Nomi 一次」。
+
+## 不动什么
+- 不碰能力核已有逻辑（token/RPC/lockfile/CLI/MCP server 都不改）。
+- 不做任意路径写；只 `~/.claude.json` 一个固定目标。
+- 不改顶栏 `NomiAppBar`（只在面板内加卡）。
+
+## 回滚
+- 纯增量：3 个新 IPC + 1 个新组件 + OnboardingDrawer/preload/bridge 各加几行。出问题摘掉卡组即可。
+- 用户侧回滚：卡片自带「撤销接入」+ 写盘前自动备份 `~/.claude.json.nomi-backup`。
+
+## 验收门
+- 五门全过。
+- **与样张逐项对账**（R8：截图并排）。
+- **真机走查（R13）**：开面板 → 看到卡 → 点开 → 一键接入 → 真机确认 `~/.claude.json` 真写进 `mcpServers.nomi` 且 `cocos-creator` 还在、备份生成 → 撤销 → 确认删干净。
+- design-fidelity 不回归。
+
+## 已知边界
+- MCP 配置里的 `nomi-mcp.mjs` 路径在 dev = repo；打包安装版的脚本路径/内置 node 是后续切片（与 CLI 打包入口同批）。

--- a/electron/capabilityCore/appIntegration.ts
+++ b/electron/capabilityCore/appIntegration.ts
@@ -20,6 +20,11 @@ export function setOpenProjectId(projectId: string): void {
   openProjectId = String(projectId || '').trim()
 }
 
+/** 当前进程 RPC 端口（未启动=null）。「接入助手卡」据此显示能力核就绪态。 */
+export function getCapabilityPort(): number | null {
+  return handle?.port ?? null
+}
+
 /**
  * 启动能力核对外口。绝不拖垮 app 启动：任何失败只记日志、不抛（fail-open，与 applySystemProxy 同纪律）。
  */

--- a/electron/capabilityCore/mcpConfig.test.ts
+++ b/electron/capabilityCore/mcpConfig.test.ts
@@ -1,0 +1,80 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+let homeDir = ''
+
+vi.mock('electron', () => ({
+  app: { getAppPath: () => '/fake/repo', getPath: () => homeDir },
+}))
+vi.mock('node:os', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:os')>()
+  return { ...actual, default: { ...actual, homedir: () => homeDir }, homedir: () => homeDir }
+})
+
+import { installMcp, readMcpInfo, uninstallMcp } from './mcpConfig'
+
+const roots: string[] = []
+function tempHome(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'nomi-mcpcfg-'))
+  roots.push(dir)
+  return dir
+}
+function claudeJson(): string {
+  return path.join(homeDir, '.claude.json')
+}
+
+beforeEach(() => {
+  homeDir = tempHome()
+})
+afterEach(() => {
+  for (const r of roots.splice(0)) fs.rmSync(r, { recursive: true, force: true })
+})
+
+describe('capabilityCore/mcpConfig', () => {
+  it('install 合并进已有 mcpServers——保留 cocos-creator，不覆盖整个文件', () => {
+    fs.writeFileSync(
+      claudeJson(),
+      JSON.stringify({ theme: 'dark', mcpServers: { 'cocos-creator': { command: 'x' } } }, null, 2),
+    )
+    const result = installMcp()
+    expect(result.ok).toBe(true)
+    expect(result.backupPath).toBeTruthy()
+    expect(fs.existsSync(result.backupPath!)).toBe(true)
+
+    const after = JSON.parse(fs.readFileSync(claudeJson(), 'utf8'))
+    expect(after.theme).toBe('dark') // 其它字段原样保留
+    expect(after.mcpServers['cocos-creator']).toEqual({ command: 'x' }) // 别人的 server 没被动
+    expect(after.mcpServers.nomi.command).toBe('node')
+    expect(after.mcpServers.nomi.args[0]).toContain('nomi-mcp.mjs')
+  })
+
+  it('install 在 ~/.claude.json 不存在时也能建出来', () => {
+    expect(fs.existsSync(claudeJson())).toBe(false)
+    const result = installMcp()
+    expect(result.ok).toBe(true)
+    expect(result.backupPath).toBeNull() // 原文件不存在 → 无备份
+    const after = JSON.parse(fs.readFileSync(claudeJson(), 'utf8'))
+    expect(after.mcpServers.nomi).toBeTruthy()
+  })
+
+  it('uninstall 只删 nomi，保留 cocos-creator', () => {
+    fs.writeFileSync(claudeJson(), JSON.stringify({ mcpServers: { 'cocos-creator': { command: 'x' } } }))
+    installMcp()
+    uninstallMcp()
+    const after = JSON.parse(fs.readFileSync(claudeJson(), 'utf8'))
+    expect(after.mcpServers.nomi).toBeUndefined()
+    expect(after.mcpServers['cocos-creator']).toEqual({ command: 'x' })
+  })
+
+  it('readMcpInfo 反映 installed 状态 + 给出可复制片段', () => {
+    expect(readMcpInfo(0).installed).toBe(false)
+    installMcp()
+    const info = readMcpInfo(17371)
+    expect(info.installed).toBe(true)
+    expect(info.rpcRunning).toBe(true)
+    expect(info.snippet).toContain('"nomi"')
+    expect(info.snippet).toContain('nomi-mcp.mjs')
+  })
+})

--- a/electron/capabilityCore/mcpConfig.ts
+++ b/electron/capabilityCore/mcpConfig.ts
@@ -1,0 +1,101 @@
+// 能力核 · 接入 Claude Code 的 MCP 配置读写（见 docs/plan/2026-06-21-connect-assistant-card.md）。
+//
+// 「一键接入」就靠这一层：算出 nomi-mcp.mjs 的绝对路径 → 把 { command, args } 合并进用户的
+// Claude Code 全局配置 ~/.claude.json 的 mcpServers.nomi。**只写这一个固定文件**（非任意路径写，安全）；
+// 写前自动备份；**合并而非覆盖**（保留用户已有的其它 MCP server，如 cocos-creator）。
+import { app } from 'electron'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { readToken } from './security'
+
+const SERVER_NAME = 'nomi'
+
+function claudeConfigPath(): string {
+  return path.join(os.homedir(), '.claude.json')
+}
+
+/** nomi MCP server 在 ~/.claude.json 里的条目。dev 下脚本在 repo；打包入口是后续切片。 */
+function mcpServerEntry(): { command: string; args: string[] } {
+  const script = path.join(app.getAppPath(), 'scripts', 'nomi-mcp.mjs')
+  return { command: 'node', args: [script] }
+}
+
+function readClaudeConfig(): Record<string, unknown> {
+  try {
+    const raw = fs.readFileSync(claudeConfigPath(), 'utf8')
+    const parsed = JSON.parse(raw)
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? (parsed as Record<string, unknown>) : {}
+  } catch {
+    return {}
+  }
+}
+
+function isInstalled(config: Record<string, unknown>): boolean {
+  const servers = config.mcpServers
+  return Boolean(servers && typeof servers === 'object' && (servers as Record<string, unknown>)[SERVER_NAME])
+}
+
+export type McpInfo = {
+  tokenReady: boolean
+  rpcRunning: boolean
+  installed: boolean
+  configPath: string
+  /** 给「复制配置」用的、拼好的 mcpServers 片段（带 nomi 条目）。 */
+  snippet: string
+  server: { command: string; args: string[] }
+}
+
+/** 读接入状态 + 配置片段。rpcPort 由调用方（appIntegration）传入（它持有 RPC handle）。 */
+export function readMcpInfo(rpcPort: number | null): McpInfo {
+  const config = readClaudeConfig()
+  const server = mcpServerEntry()
+  return {
+    tokenReady: readToken() !== null,
+    rpcRunning: typeof rpcPort === 'number' && rpcPort > 0,
+    installed: isInstalled(config),
+    configPath: claudeConfigPath(),
+    snippet: JSON.stringify({ mcpServers: { [SERVER_NAME]: server } }, null, 2),
+    server,
+  }
+}
+
+/**
+ * 一键写入：备份 → 合并 mcpServers.nomi（保留其它 server）→ 原子写回。
+ * 备份固定名 ~/.claude.json.nomi-backup（每次覆盖；目的是「写坏了能回退一版」，不做历史堆积）。
+ */
+export function installMcp(): { ok: boolean; configPath: string; backupPath: string | null } {
+  const target = claudeConfigPath()
+  let backupPath: string | null = null
+  if (fs.existsSync(target)) {
+    backupPath = `${target}.nomi-backup`
+    fs.copyFileSync(target, backupPath)
+  }
+  const config = readClaudeConfig()
+  const servers = (config.mcpServers && typeof config.mcpServers === 'object' && !Array.isArray(config.mcpServers)
+    ? (config.mcpServers as Record<string, unknown>)
+    : {}) as Record<string, unknown>
+  servers[SERVER_NAME] = mcpServerEntry()
+  config.mcpServers = servers
+  // 原子写：先写临时文件再 rename，避免写一半把用户配置写坏。
+  const tmp = `${target}.nomi-tmp`
+  fs.writeFileSync(tmp, JSON.stringify(config, null, 2), 'utf8')
+  fs.renameSync(tmp, target)
+  return { ok: true, configPath: target, backupPath }
+}
+
+/** 撤销接入：删 mcpServers.nomi（不碰其它 server），写回。文件不存在/没装就当成功。 */
+export function uninstallMcp(): { ok: boolean } {
+  const target = claudeConfigPath()
+  if (!fs.existsSync(target)) return { ok: true }
+  const config = readClaudeConfig()
+  const servers = config.mcpServers as Record<string, unknown> | undefined
+  if (servers && typeof servers === 'object' && servers[SERVER_NAME]) {
+    delete servers[SERVER_NAME]
+    config.mcpServers = servers
+    const tmp = `${target}.nomi-tmp`
+    fs.writeFileSync(tmp, JSON.stringify(config, null, 2), 'utf8')
+    fs.renameSync(tmp, target)
+  }
+  return { ok: true }
+}

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -54,7 +54,8 @@ import { VendorRequestError, encodeVendorErrorMessage } from "./vendor/vendorHtt
 import { traceVendorCompleted } from "./events/vendorCallTrace";
 import { registerOnboardingIpc } from "./ai/onboarding/onboardingIpc";
 import { registerUpdaterIpc } from "./update/autoUpdater";
-import { startCapabilityCore, stopCapabilityCore, setOpenProjectId } from "./capabilityCore/appIntegration";
+import { startCapabilityCore, stopCapabilityCore, setOpenProjectId, getCapabilityPort } from "./capabilityCore/appIntegration";
+import { readMcpInfo, installMcp, uninstallMcp } from "./capabilityCore/mcpConfig";
 
 // 尽早安装：捕获引导阶段起的 uncaughtException / unhandledRejection，落盘到 app logs（P0-8）。
 installCrashHandlers();
@@ -343,6 +344,10 @@ function registerIpc(): void {
   // 能力核 A/B 守卫：renderer 在打开/切换/关闭项目时上报当前打开的 projectId，
   // 让外部调用拒绝直写「正在窗口里编辑」的工程（防内存 store 回盘覆盖，见 capabilityCore/rpcServer）。
   ipcMain.on("nomi:capability:active-project", (_event, projectId: unknown) => setOpenProjectId(String(projectId || "")));
+  // 「接入 AI 编程助手」卡：读接入状态/配置片段 + 一键写入/撤销 ~/.claude.json 的 mcpServers.nomi。
+  registerSyncIpc("nomi:capability:mcp-info", () => readMcpInfo(getCapabilityPort()));
+  registerSyncIpc("nomi:capability:mcp-install", installMcp);
+  registerSyncIpc("nomi:capability:mcp-uninstall", uninstallMcp);
   registerAgentChatV2Ipc();
   registerTextStreamIpc();
   registerConversationsIpc();

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -199,5 +199,9 @@ contextBridge.exposeInMainWorld("nomiDesktop", {
   // 能力核：上报当前窗口打开的项目，供外部调用的 A/B 守卫（防外部直写正在编辑的工程）。
   capability: {
     setActiveProject: (projectId: string) => ipcRenderer.send("nomi:capability:active-project", projectId),
+    // 「接入 AI 编程助手」卡：读状态/配置 + 一键写入/撤销 ~/.claude.json。
+    mcpInfo: () => invokeSync("nomi:capability:mcp-info"),
+    installMcp: () => invokeSync("nomi:capability:mcp-install"),
+    uninstallMcp: () => invokeSync("nomi:capability:mcp-uninstall"),
   },
 });

--- a/src/desktop/bridge.ts
+++ b/src/desktop/bridge.ts
@@ -271,6 +271,19 @@ export type DesktopBridge = {
   /** 能力核：上报当前打开项目，供外部调用的 A/B 守卫（可选——老 preload 无此口）。 */
   capability?: {
     setActiveProject: (projectId: string) => void
+    /** 「接入 AI 编程助手」卡：读接入状态 + 配置片段。 */
+    mcpInfo: () => {
+      tokenReady: boolean
+      rpcRunning: boolean
+      installed: boolean
+      configPath: string
+      snippet: string
+      server: { command: string; args: string[] }
+    }
+    /** 一键写入 ~/.claude.json 的 mcpServers.nomi（合并 + 备份）。 */
+    installMcp: () => { ok: boolean; configPath: string; backupPath: string | null }
+    /** 撤销接入：删 mcpServers.nomi。 */
+    uninstallMcp: () => { ok: boolean }
   }
 }
 

--- a/src/ui/onboarding/ConnectAssistantCard.tsx
+++ b/src/ui/onboarding/ConnectAssistantCard.tsx
@@ -1,0 +1,170 @@
+/**
+ * 接入 AI 编程助手卡（见 docs/plan/2026-06-21-connect-assistant-card.md）。
+ *
+ * 一键把 Nomi 接进 Claude Code 的 MCP——用户不读配置、不找路径、不学命令。
+ * 复用 FoldableModelCard 折叠语言（与供应商接入卡同一套，P1/P4）。
+ * 主操作「一键接入」= 写 ~/.claude.json 的 mcpServers.nomi（合并 + 备份，主进程 mcpConfig）。
+ * 兜底：复制配置（给 Codex/Cursor/手动）；撤销接入（删条目）。
+ */
+import React from 'react'
+import { IconTerminal2, IconPlugConnected, IconCopy, IconCheck, IconCircleCheck, IconExternalLink } from '@tabler/icons-react'
+import { cn } from '../../utils/cn'
+import { getDesktopBridge } from '../../desktop/bridge'
+import { toast } from '../toast'
+import { FoldableModelCard } from './FoldableModelCard'
+
+const GUIDE_URL = 'https://github.com/aqm857886159/Nomi/blob/main/docs/guide/capability-core-cli-mcp.md'
+const SAY_EXAMPLE = '在 Nomi 新建项目「咖啡广告」，拆 3 个镜头加到画布，用我的图模型把第一个生成出来。'
+
+type McpInfo = {
+  tokenReady: boolean
+  rpcRunning: boolean
+  installed: boolean
+  configPath: string
+  snippet: string
+  server: { command: string; args: string[] }
+}
+
+export function ConnectAssistantCard(): JSX.Element | null {
+  const [info, setInfo] = React.useState<McpInfo | null>(null)
+  const [busy, setBusy] = React.useState(false)
+  const [copied, setCopied] = React.useState(false)
+  const [error, setError] = React.useState('')
+
+  const capability = getDesktopBridge()?.capability
+
+  const refresh = React.useCallback(() => {
+    if (!capability?.mcpInfo) return
+    try {
+      setInfo(capability.mcpInfo())
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e))
+    }
+  }, [capability])
+
+  React.useEffect(() => { refresh() }, [refresh])
+
+  // 老 preload（无 capability.mcpInfo）：整卡不显，避免坏入口。
+  if (!capability?.mcpInfo || !info) return null
+
+  const handleInstall = () => {
+    if (!capability.installMcp) return
+    setBusy(true)
+    setError('')
+    try {
+      capability.installMcp()
+      refresh()
+      toast('已接入 Claude Code，重启后生效', 'success')
+    } catch (e) {
+      setError(`接入失败：${e instanceof Error ? e.message : String(e)}`)
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const handleUninstall = () => {
+    if (!capability.uninstallMcp) return
+    setBusy(true)
+    setError('')
+    try {
+      capability.uninstallMcp()
+      refresh()
+      toast('已撤销接入', 'success')
+    } catch (e) {
+      setError(`撤销失败：${e instanceof Error ? e.message : String(e)}`)
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const handleCopy = () => {
+    void navigator.clipboard.writeText(info.snippet).then(() => {
+      setCopied(true)
+      toast('配置已复制', 'success')
+      window.setTimeout(() => setCopied(false), 1600)
+    })
+  }
+
+  const statusLabel = info.installed ? '已接入' : info.tokenReady ? '就绪' : '未就绪'
+
+  return (
+    <FoldableModelCard
+      glyph={<IconTerminal2 size={16} stroke={1.6} />}
+      glyphTone="ink"
+      name="接入 AI 编程助手"
+      subtitle="让 Claude Code 帮你建项目、出图"
+      status={info.installed || info.tokenReady ? 'ok' : 'todo'}
+      statusLabel={statusLabel}
+      defaultExpanded={false}
+    >
+      {!info.tokenReady ? (
+        <div className="text-caption text-nomi-ink-60 leading-relaxed">
+          凭证还没生成——重启 Nomi 一次即可（启动时自动生成）。
+        </div>
+      ) : info.installed ? (
+        <>
+          <div className="flex items-start gap-2 rounded-nomi-sm bg-[var(--workbench-success-soft)] px-3 py-2.5">
+            <IconCircleCheck size={17} className="shrink-0 mt-0.5 text-workbench-success" />
+            <div className="min-w-0">
+              <div className="text-body-sm font-semibold text-nomi-ink">已写入 Claude Code 配置</div>
+              <div className="text-caption text-nomi-ink-60 mt-0.5">重启 Claude Code 后生效。</div>
+            </div>
+          </div>
+          <div className="text-caption text-nomi-ink-40">现在可以对它说：</div>
+          <div className="text-body-sm text-nomi-ink-80 leading-relaxed rounded-nomi-sm border border-nomi-line bg-nomi-paper px-3 py-2.5">
+            「{SAY_EXAMPLE}」
+          </div>
+          <button
+            type="button"
+            onClick={handleUninstall}
+            disabled={busy}
+            className="self-start text-caption text-nomi-ink-40 hover:text-workbench-danger disabled:opacity-50"
+          >
+            撤销接入
+          </button>
+        </>
+      ) : (
+        <>
+          <div className="text-caption text-nomi-ink-60 leading-relaxed">
+            一键把 Nomi 接进 Claude Code——之后你一句话，它就能在 Nomi 里建项目、拆镜头、用你配好的模型真出图。
+          </div>
+          <button
+            type="button"
+            onClick={handleInstall}
+            disabled={busy}
+            className={cn(
+              'w-full h-9 rounded-nomi-sm bg-nomi-ink text-nomi-paper',
+              'text-body-sm font-semibold inline-flex items-center justify-center gap-1.5',
+              'hover:bg-nomi-accent disabled:opacity-50 disabled:cursor-not-allowed',
+            )}
+          >
+            <IconPlugConnected size={15} stroke={1.8} />一键接入 Claude Code
+          </button>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={handleCopy}
+              className={cn(
+                'flex-1 h-8 rounded-nomi-sm border border-nomi-line text-nomi-ink-60',
+                'text-caption inline-flex items-center justify-center gap-1.5 hover:border-nomi-ink-20',
+              )}
+            >
+              {copied ? <IconCheck size={14} stroke={1.8} /> : <IconCopy size={14} stroke={1.6} />}
+              {copied ? '已复制' : '复制配置'}
+            </button>
+            <button
+              type="button"
+              onClick={() => window.open(GUIDE_URL, '_blank', 'noopener')}
+              className="h-8 px-1 text-caption text-nomi-ink-60 inline-flex items-center gap-1 hover:text-nomi-accent"
+            >
+              看用法<IconExternalLink size={13} stroke={1.6} />
+            </button>
+          </div>
+          <div className="text-micro text-nomi-ink-30">用 Codex / Cursor？点「复制配置」粘进它们的 MCP 设置即可。</div>
+        </>
+      )}
+
+      {error ? <div className="text-caption text-workbench-danger">{error}</div> : null}
+    </FoldableModelCard>
+  )
+}

--- a/src/ui/onboarding/OnboardingDrawer.tsx
+++ b/src/ui/onboarding/OnboardingDrawer.tsx
@@ -17,6 +17,7 @@ import { FoldableModelCard } from './FoldableModelCard'
 import { VendorOnboardCard } from './VendorOnboardCard'
 import { ModelChipGroups, type ChipModel } from './ModelChipGroups'
 import { AddModelCard } from './AddModelCard'
+import { ConnectAssistantCard } from './ConnectAssistantCard'
 import { KNOWN_VENDORS, isKnownVendor } from '../../config/knownVendors'
 import { getDesktopBridge } from '../../desktop/bridge'
 import { notifyModelOptionsRefresh } from '../../config/useModelOptions'
@@ -162,6 +163,10 @@ export function OnboardingDrawer(): JSX.Element {
         </button>
 
         <AddModelCard onClick={() => openWizard(undefined)} />
+
+        {/* 接入 AI 编程助手：一键把 Nomi 接进 Claude Code（能力核 CLI/MCP）。 */}
+        <div className="text-micro font-semibold text-nomi-ink-40 pt-2 px-0.5">在编程助手里用 Nomi</div>
+        <ConnectAssistantCard />
       </div>
 
       <OnboardingWizard


### PR DESCRIPTION
## 是什么
在「模型设置」面板新增「接入 AI 编程助手」卡——用户**一键**把 Nomi 接进 Claude Code 的 MCP，什么都不用管（不读配置、不找路径、不学命令）。样张已出+用户拍板（写全局 `~/.claude.json` + 自动备份 + 可撤销）。方案 `docs/plan/2026-06-21-connect-assistant-card.md`。

## 实现
- 卡片 `ConnectAssistantCard`（复用 `FoldableModelCard`，token-only，真品牌色）：一键接入 / 成功态「现在可以对它说…」/ 撤销 / 复制配置 / 看用法。
- 3 个受限 IPC（**只写固定 `~/.claude.json`**，非任意路径）：`mcp-info` / `mcp-install`（合并保留用户已有 server + 备份 + 原子写）/ `mcp-uninstall`。

## 验证
- 单测 4/4（合并保留 cocos-creator / 缺文件能建 / 撤销只删 nomi / 片段）+ 五门全过。
- **真机走查**：开面板→看卡→展开→一键接入→真 `~/.claude.json` 写入 `nomi` 且 `cocos-creator` 保留+备份生成→撤销删净→重装回来；与样张逐项对账一致。

## 已知边界
打包安装版的脚本路径 / 内置 node 是后续切片（与 CLI 打包入口同批）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)