### PR TITLE
feat(scene3d): route director reference packs to video

### DIFF
--- a/docs/design/mockups/scene3d-reference-pack.html
+++ b/docs/design/mockups/scene3d-reference-pack.html
@@ -1,0 +1,364 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Scene3D Reference Pack Mockup</title>
+  <style>
+    :root {
+      --nomi-font-sans: "Inter Variable", Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      --nomi-font-mono: "SF Mono", "Cascadia Code", "Roboto Mono", monospace;
+      --nomi-bg: oklch(0.985 0.003 90);
+      --nomi-paper: oklch(1 0 0);
+      --nomi-ink: oklch(0.22 0.01 80);
+      --nomi-ink-80: oklch(0.32 0.01 80);
+      --nomi-ink-60: oklch(0.50 0.01 80);
+      --nomi-ink-40: oklch(0.68 0.01 80);
+      --nomi-ink-30: oklch(0.78 0.008 80);
+      --nomi-ink-20: oklch(0.88 0.005 80);
+      --nomi-ink-10: oklch(0.94 0.003 80);
+      --nomi-ink-05: oklch(0.97 0.003 80);
+      --nomi-line: oklch(0.91 0.004 80);
+      --nomi-line-soft: oklch(0.95 0.003 80);
+      --nomi-accent: oklch(0.55 0.13 250);
+      --nomi-accent-soft: color-mix(in oklch, var(--nomi-accent) 12%, var(--nomi-paper));
+      --nomi-radius-sm: 6px;
+      --nomi-radius: 10px;
+      --nomi-radius-pill: 999px;
+      --nomi-shadow-md: 0 14px 32px color-mix(in oklch, var(--nomi-ink) 16%, transparent);
+      --nomi-space-1: 4px;
+      --nomi-space-1-5: 6px;
+      --nomi-space-2: 8px;
+      --nomi-space-2-5: 10px;
+      --nomi-space-3: 12px;
+      --nomi-space-4: 16px;
+      --nomi-space-5: 20px;
+      --nomi-space-6: 24px;
+      --nomi-text-micro: 11px;
+      --nomi-text-caption: 12px;
+      --nomi-text-body-sm: 13px;
+      --nomi-text-body: 14px;
+      --nomi-text-title: 16px;
+      --nomi-weight-title: 650;
+    }
+    :root[data-mantine-color-scheme="dark"] {
+      --nomi-bg: oklch(0.18 0.01 80);
+      --nomi-paper: oklch(0.22 0.012 80);
+      --nomi-ink: oklch(0.96 0.003 90);
+      --nomi-ink-80: oklch(0.88 0.005 90);
+      --nomi-ink-60: oklch(0.72 0.006 90);
+      --nomi-ink-40: oklch(0.58 0.006 90);
+      --nomi-ink-30: oklch(0.46 0.007 85);
+      --nomi-ink-20: oklch(0.38 0.008 80);
+      --nomi-ink-10: oklch(0.30 0.008 80);
+      --nomi-ink-05: oklch(0.26 0.008 80);
+      --nomi-line: oklch(0.34 0.008 80);
+      --nomi-line-soft: oklch(0.30 0.008 80);
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      min-height: 100vh;
+      background: var(--nomi-bg);
+      color: var(--nomi-ink);
+      font-family: var(--nomi-font-sans);
+      font-size: var(--nomi-text-body-sm);
+    }
+    .shell {
+      display: grid;
+      grid-template-rows: 52px minmax(0, 1fr);
+      min-height: 100vh;
+    }
+    .topbar {
+      display: flex;
+      align-items: center;
+      gap: var(--nomi-space-3);
+      border-bottom: 1px solid var(--nomi-line);
+      background: var(--nomi-paper);
+      padding: 0 var(--nomi-space-4);
+    }
+    .title { font-weight: var(--nomi-weight-title); }
+    .spacer { flex: 1; }
+    .toolset {
+      display: flex;
+      gap: var(--nomi-space-1);
+      border: 1px solid var(--nomi-line-soft);
+      background: var(--nomi-paper);
+      border-radius: var(--nomi-radius);
+      padding: 2px;
+    }
+    .icon-btn {
+      height: 28px;
+      min-width: 28px;
+      border: 0;
+      border-radius: var(--nomi-radius-sm);
+      background: transparent;
+      color: var(--nomi-ink-60);
+      font: inherit;
+    }
+    .icon-btn.active {
+      background: var(--nomi-ink);
+      color: var(--nomi-paper);
+    }
+    .main {
+      display: grid;
+      grid-template-columns: 260px minmax(360px, 1fr) 300px;
+      min-height: 0;
+    }
+    .side {
+      min-height: 0;
+      overflow: auto;
+      border-right: 1px solid var(--nomi-line);
+      background: var(--nomi-paper);
+      padding: var(--nomi-space-3);
+    }
+    .right {
+      border-left: 1px solid var(--nomi-line);
+      border-right: 0;
+    }
+    .side h2 {
+      margin: 0 0 var(--nomi-space-2-5);
+      font-size: var(--nomi-text-caption);
+      font-weight: var(--nomi-weight-title);
+    }
+    .row {
+      display: grid;
+      grid-template-columns: 24px minmax(0, 1fr) 26px;
+      align-items: center;
+      gap: var(--nomi-space-1-5);
+      min-height: 32px;
+      border-radius: var(--nomi-radius-sm);
+      padding: var(--nomi-space-1);
+      color: var(--nomi-ink-60);
+    }
+    .row.active { background: var(--nomi-ink-05); color: var(--nomi-ink); }
+    .viewport {
+      position: relative;
+      overflow: hidden;
+      background:
+        linear-gradient(transparent 23px, var(--nomi-line-soft) 24px),
+        linear-gradient(90deg, transparent 23px, var(--nomi-line-soft) 24px),
+        var(--nomi-ink-05);
+      background-size: 24px 24px;
+    }
+    .stage {
+      position: absolute;
+      inset: 44px 48px 96px;
+      border-radius: var(--nomi-radius);
+      border: 1px solid var(--nomi-line);
+      background: color-mix(in oklch, var(--nomi-paper) 82%, transparent);
+      box-shadow: var(--nomi-shadow-md);
+    }
+    .camera-card {
+      position: absolute;
+      right: var(--nomi-space-6);
+      top: var(--nomi-space-5);
+      width: 260px;
+      border: 1px solid var(--nomi-line);
+      border-radius: var(--nomi-radius);
+      background: var(--nomi-paper);
+      padding: 10px;
+      box-shadow: var(--nomi-shadow-md);
+    }
+    .preview {
+      aspect-ratio: 2.39 / 1;
+      border-radius: var(--nomi-radius-sm);
+      background:
+        linear-gradient(90deg, var(--nomi-ink-20), transparent 42%),
+        linear-gradient(var(--nomi-ink-10), var(--nomi-ink-05));
+      border: 1px solid var(--nomi-line-soft);
+      margin-bottom: var(--nomi-space-2);
+    }
+    .bottom {
+      position: absolute;
+      left: 24px;
+      right: 24px;
+      bottom: 18px;
+      display: flex;
+      align-items: center;
+      gap: var(--nomi-space-2);
+      border: 1px solid var(--nomi-line);
+      border-radius: var(--nomi-radius);
+      background: var(--nomi-paper);
+      padding: var(--nomi-space-2);
+      box-shadow: var(--nomi-shadow-md);
+    }
+    .pill {
+      display: inline-flex;
+      align-items: center;
+      gap: var(--nomi-space-1-5);
+      height: 26px;
+      border-radius: var(--nomi-radius-pill);
+      background: var(--nomi-ink-05);
+      color: var(--nomi-ink-60);
+      padding: 0 var(--nomi-space-2-5);
+      font-size: var(--nomi-text-micro);
+      white-space: nowrap;
+    }
+    .section {
+      display: grid;
+      gap: var(--nomi-space-2);
+      border: 1px solid var(--nomi-line-soft);
+      border-radius: var(--nomi-radius);
+      background: var(--nomi-paper);
+      padding: var(--nomi-space-2);
+      margin-bottom: var(--nomi-space-2-5);
+    }
+    .section.soft { background: var(--nomi-ink-05); }
+    .section-title {
+      display: flex;
+      align-items: center;
+      gap: var(--nomi-space-1-5);
+      font-size: var(--nomi-text-caption);
+      font-weight: var(--nomi-weight-title);
+    }
+    .muted { color: var(--nomi-ink-60); font-size: var(--nomi-text-micro); }
+    .grid2 { display: grid; grid-template-columns: 1fr 1fr; gap: var(--nomi-space-2); }
+    .grid3 { display: grid; grid-template-columns: repeat(3, 1fr); gap: var(--nomi-space-1-5); }
+    .field {
+      display: grid;
+      gap: var(--nomi-space-1);
+      font-size: var(--nomi-text-micro);
+      color: var(--nomi-ink-60);
+    }
+    .input {
+      height: 32px;
+      border: 1px solid var(--nomi-line);
+      border-radius: var(--nomi-radius-sm);
+      background: var(--nomi-paper);
+      color: var(--nomi-ink);
+      padding: 0 var(--nomi-space-2);
+    }
+    .move {
+      height: 32px;
+      border: 1px solid var(--nomi-line-soft);
+      border-radius: var(--nomi-radius-sm);
+      background: var(--nomi-ink-05);
+      color: var(--nomi-ink-60);
+      font: inherit;
+      font-size: var(--nomi-text-caption);
+    }
+    .move.zoom {
+      border-style: dashed;
+      border-color: var(--nomi-ink-30, var(--nomi-ink-40));
+      color: var(--nomi-ink-80);
+      background: color-mix(in oklch, var(--nomi-accent) 7%, var(--nomi-paper));
+    }
+    .primary {
+      border: 1px solid var(--nomi-ink);
+      background: var(--nomi-ink);
+      color: var(--nomi-paper);
+    }
+    .reference {
+      border-color: color-mix(in oklch, var(--nomi-accent) 38%, var(--nomi-line));
+      background: var(--nomi-accent-soft);
+    }
+    .reference .chipline {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 6px;
+    }
+    .refchip {
+      display: flex;
+      align-items: center;
+      gap: var(--nomi-space-1-5);
+      min-width: 0;
+      border-radius: var(--nomi-radius-sm);
+      background: var(--nomi-paper);
+      color: var(--nomi-ink-60);
+      padding: var(--nomi-space-1-5);
+      font-size: var(--nomi-text-micro);
+    }
+    .refchip strong {
+      color: var(--nomi-ink);
+      font-weight: var(--nomi-weight-title);
+    }
+    @media (max-width: 900px) {
+      .main { grid-template-columns: 1fr; }
+      .side { display: none; }
+      .right { display: block; border-left: 0; border-top: 1px solid var(--nomi-line); }
+    }
+  </style>
+</head>
+<body>
+  <div class="shell">
+    <header class="topbar">
+      <span class="title">3D 场景 · 广告镜头 01</span>
+      <span class="spacer"></span>
+      <div class="toolset">
+        <button class="icon-btn active" aria-label="平移视图">↕</button>
+        <button class="icon-btn" aria-label="旋转视图">↻</button>
+      </div>
+      <div class="toolset">
+        <button class="icon-btn" aria-label="适配视图">□</button>
+        <button class="icon-btn" aria-label="播放预览">▶</button>
+      </div>
+      <button class="icon-btn" aria-label="关闭">×</button>
+    </header>
+    <main class="main">
+      <aside class="side">
+        <h2>场景节点</h2>
+        <div class="row active"><span>◉</span><span>主相机</span><span>⌖</span></div>
+        <div class="row"><span>▧</span><span>城市街道模板</span><span>⌖</span></div>
+        <div class="row"><span>◆</span><span>道具 · 路灯</span><span>⌖</span></div>
+        <div class="row"><span>●</span><span>角色 A</span><span>⌖</span></div>
+        <div class="row"><span>●</span><span>角色 B</span><span>⌖</span></div>
+      </aside>
+      <section class="viewport">
+        <div class="stage"></div>
+        <div class="camera-card">
+          <div class="preview"></div>
+          <div class="grid2">
+            <span class="pill">2.39:1</span>
+            <span class="pill">50mm</span>
+          </div>
+        </div>
+        <div class="bottom">
+          <span class="pill">添加 ▾</span>
+          <span class="pill">操控角色</span>
+          <span class="pill primary">录 take</span>
+          <span class="spacer"></span>
+          <span class="pill">时间轴 5s</span>
+        </div>
+      </section>
+      <aside class="side right">
+        <h2>属性</h2>
+        <div class="section">
+          <div class="field"><span>名称</span><div class="input">主相机</div></div>
+          <div class="grid2">
+            <div class="field"><span>画幅</span><div class="input">2.39:1</div></div>
+            <div class="field"><span>焦段</span><div class="input">50mm</div></div>
+          </div>
+        </div>
+        <div class="section reference">
+          <div class="section-title">⌁ 参考输出</div>
+          <div class="muted">video_ref · 镜头 01 / Seedance 全能参考</div>
+          <div class="chipline">
+            <div class="refchip"><span>▸</span><strong>录 take</strong><span>video_ref</span></div>
+            <div class="refchip"><span>□</span><strong>首/尾帧</strong><span>first/last</span></div>
+          </div>
+        </div>
+        <div class="section">
+          <div class="section-title">运镜预设</div>
+          <div class="grid2">
+            <label class="field"><span>时长</span><input class="input" value="5s"></label>
+            <label class="field"><span>幅度</span><input class="input" value="60%"></label>
+          </div>
+          <div class="grid3">
+            <button class="move">推近</button>
+            <button class="move">拉远</button>
+            <button class="move">环绕</button>
+            <button class="move">摇左</button>
+            <button class="move">横移</button>
+            <button class="move">升降</button>
+            <button class="move zoom">变焦推</button>
+            <button class="move zoom">变焦拉</button>
+            <button class="move zoom">希区柯克</button>
+          </div>
+          <button class="move">导出运镜首尾帧</button>
+        </div>
+      </aside>
+    </main>
+  </div>
+</body>
+</html>

--- a/docs/plan/2026-07-04-scene3d-reference-pack.md
+++ b/docs/plan/2026-07-04-scene3d-reference-pack.md
@@ -1,0 +1,98 @@
+# Scene3D 导演参考包（基于最新版导演台）
+
+日期：2026-07-04
+基线：`origin/main@0f132880`，承接 `2026-07-03-scene3d-director-upgrade.md`、`2026-06-21-staging-reference-tool.md`、`2026-06-30-game-style-3d-character-control.md`、`2026-06-06-reference-v4-implementation-spec.md`。
+
+## 0. 结论
+
+最新版已经不是“没有导演台”，而是已有四条强地基：
+
+- 白膜置景：场景模板、语义道具、假人/群众、姿势库、相机/焦段/画幅。
+- 人当导演：选相机、点运镜预设、调焦段、手持抖动、录 take。
+- 参考视频：`CameraMoveCaptureHost` 能把 3D take 采帧成 mp4，并把它写进目标视频节点的 `video_ref`。
+- 参考图：站位工具已能离屏出 composition_ref，运镜首尾帧也已能导出为图片节点。
+
+缺口不是再做一个独立“参考出口”，而是把“用户调用路径 + 目标路由 + 参考包状态”显性化：用户像导演一样置景/摆人/放道具/设相机/录镜头后，系统明确告诉他这次会产出什么参考、喂给哪个视频节点、走 `video_ref` 还是降级。
+
+## 1. 外部调研对齐
+
+- Higgsfield Cinema Studio 的强点是摄影师心智：镜头、焦段、灯光、风格、AI co-director、可复用 Elements；Higgsfield WAN Camera Control 公开强调相机运动预设、主体稳定、最高 10s 和 20+ 动态镜头。
+- Seedance 2.0 官方强调图/音/视频多模态参考，以及对 performance、lighting、shadow、camera movement 的 director-level control。
+- Kling Motion Control 更偏“角色动作/表情从参考视频提取”，适合人物运动迁移，不等同于全场 3D 置景。
+- Runway Gen-4 References 的核心是角色/物体/地点的一致性，多参考图维持世界，而不是 3D 白膜导演台。
+- PrevizWhiz 研究给出同方向验证：粗 3D 场景 + 生成式图/视频模型，可以降低 previz 门槛，补手绘 storyboard 缺空间精度、传统 3D previz 过重的问题。
+- Uni3C / ReCamMaster 类研究说明 3D 几何先验和相机轨迹对视频可控性是硬价值；但 Nomi 当前产品路线应先用 training-free 灰模参考包，不做模型训练。
+
+判断：Nomi 的差异化不是“也有 camera preset”，而是 **本地 3D 导演台 → 可复用参考包 → 画布节点路由 → 模型槽位投递** 的闭环。
+
+## 2. 用户怎么调用
+
+主流程：
+
+1. 画布上新建/打开 `scene3d` 节点。
+2. 在底部“添加”里套场景模板，放道具、人物、相机。
+3. 选中相机，在右侧“运镜预设”里点推/拉/环绕/变焦等，必要时调焦段、画幅、手持抖动。
+4. 把 `scene3d` 节点连到目标视频镜头节点。
+5. 需要参考图：点“导出运镜首尾帧”，系统创建两张图片节点，并自动连到目标视频节点的 `first_frame` / `last_frame`（目标模型支持时）。
+6. 需要参考视频：底部进入角色/相机操控并“录 take”，系统创建“录制走位参考”节点，离屏采帧成 mp4，并自动写入目标视频节点的 `video_ref`（目标模型支持时）。
+
+降级：
+
+- 目标模型支持 `video_ref`：录 take 自动走参考视频主路。
+- 目标模型没有 `video_ref`：写结构化运镜 prompt，作为弱降级。
+- 目标模型有首尾帧槽：首尾帧参考图自动接边。
+- 没连接目标视频节点：仍会产出图片/mp4 留在画布，但不会喂入目标。
+
+## 3. 本轮已改代码方案
+
+### S1 参考目标摘要纯函数
+
+新增 `scene3dReferenceDirector.ts`：
+
+- `summarizeScene3DReferenceTarget(sourceNodeId, nodes, edges)`：从 Scene3D 出边找下游视频目标，读取模型 archetype，判断 `video_ref`、当前模式帧槽、任意模式帧槽。
+- `referenceSlotForScene3DCaptureTitle(title)`：把“运镜首帧/尾帧”截图标题映射到 `first_frame` / `last_frame`。
+- `shouldAttachScene3DFrameReference(target, slot)`：只有目标视频模型确实声明可吃该帧参考时才自动接边。
+
+### S2 Scene3D 编辑器接线
+
+`Scene3DEditor.tsx`：
+
+- 从 canvas store 读取 nodes/edges，生成 `referenceTarget`。
+- 把 `referenceTarget` 传入全屏导演台。
+- `handleScreenshot` 在创建首/尾帧图片后，如果存在可消费的下游视频目标，自动 `connectNodes(imageNode.id, targetNodeId, first_frame/last_frame)`。
+
+### S3 右侧面板 UX
+
+`scene3dCameraMovePanel.tsx`：
+
+- 在“运镜预设”里新增小型“参考输出”状态块。
+- 显示目标状态：`未连接视频镜头` / `video_ref · 目标镜头` / `prompt · 目标镜头`。
+- 显示视频路线：`录 take → video_ref` / `录 take → 运镜文字`。
+- 显示帧图路线：`首帧 / 尾帧` / `首帧` / `不可接帧槽`。
+
+## 4. 设计原则
+
+- 不新开第二套参考系统，继续服从 V4 参考区的 typed slot/edge 设计。
+- UI 只做状态显性化，不把导演台变成说明书。
+- `video_ref` 是主路；首尾帧是模型不吃视频参考、或用户需要关键构图锚点时的补充。
+- 灰模只负责空间、镜头、动作大势；身份一致性仍靠角色参考图/模型原生 identity/后续 Wan Animate 类驱动。
+
+## 5. 测试系统
+
+已新增/需执行：
+
+- 单测：`scene3dReferenceDirector.test.ts`
+  - 检测下游 video target。
+  - 检测 Seedance apimart omni 的 `video_ref` 路由。
+  - 检测首尾帧标题到槽位映射。
+  - 检测非视频下游不会误判为目标。
+- UX：`tests/ux/scene3d-reference-pack.walk.mjs`
+  - Electron + Playwright 真机点击，覆盖打开 3D、选相机、查看参考输出状态、点击“推近”、导出首尾帧、验证画布边。
+  - 继续点击“操控”→“录 take”→停止，等待本地 mp4 写入目标视频节点 `referenceVideoUrls`，验证 `video_ref` 闭环。
+- 单测：`cameraMoveTargetAttach.test.ts`
+  - 检测录 take mp4 注入 Seedance apimart `video_ref`、保留 variant 轴、幂等去重、无 `video_ref` 模型的 prompt 降级。
+
+## 6. 下一步切片
+
+- T1：把目标视频节点标题/模式变化做更细的 toast：接帧成功、目标无帧槽、目标无 video_ref。
+- T2：生成质量评测：同一镜头对比无参考 / 首尾帧 / video_ref 三组输出，看运镜一致性、主体漂移、构图承接。

--- a/docs/plan/INDEX.md
+++ b/docs/plan/INDEX.md
@@ -41,6 +41,7 @@
 | [2026-06-06-P0-P1-execution-log.md](2026-06-06-P0-P1-execution-log.md) | 通用素材系统 P0+P1 执行日志 | 📎 |
 | [2026-06-06-reference-at-and-sources.md](2026-06-06-reference-at-and-sources.md) | 通用「素材引用」系统（非 Seedance 专用） | 🚧 |
 | [2026-06-06-drop-and-wire-execution.md](2026-06-06-drop-and-wire-execution.md) | 拖入/连线→参考（drop-and-wire） | 🚧 |
+| [2026-07-04-scene3d-reference-pack.md](2026-07-04-scene3d-reference-pack.md) | Scene3D 导演参考包：白膜置景/运镜首尾帧/录 take → 目标视频参考槽 | 🚧 |
 | [2026-05-31-asset-node-and-canvas-perf.md](2026-05-31-asset-node-and-canvas-perf.md) | 素材节点(≠生成节点) + A1.5 组件抽取 | ✅ |
 | [2026-05-31-canvas-image-resize-crop.md](2026-05-31-canvas-image-resize-crop.md) | 画布图片等比缩放+裁剪（Figma 式） | 📋 |
 | [2026-05-31-three-canvas-bugs.md](2026-05-31-three-canvas-bugs.md) | 修三个生成画布 bug | 🚧 |

--- a/electron/workspace/workspaceManifest.ts
+++ b/electron/workspace/workspaceManifest.ts
@@ -162,7 +162,8 @@ export function readWorkspaceManifest(rootPath: string): WorkspaceProjectRecordV
       readProjectJsonFileWithEmbeddedMediaSlimming(rootPath, filePath),
     );
   } catch (error) {
-    console.warn(`[workspace] failed to read workspace manifest: ${rootPath}`, error);
+    const message = error instanceof Error ? error.message : String(error);
+    console.warn(`[workspace] failed to read workspace manifest: ${rootPath} (${message})`);
     return null;
   }
 }

--- a/electron/workspace/workspaceManifest.ts
+++ b/electron/workspace/workspaceManifest.ts
@@ -152,13 +152,19 @@ export function readProjectJsonTopLevelFields(
 }
 
 export function readWorkspaceManifest(rootPath: string): WorkspaceProjectRecordV2 | null {
-  const filePath = workspaceProjectFile(rootPath);
-  if (!fs.existsSync(filePath)) {
+  let filePath: string;
+  try {
+    filePath = workspaceProjectFile(rootPath);
+    if (!fs.existsSync(filePath)) {
+      return null;
+    }
+    return normalizeWorkspaceProjectRecord(
+      readProjectJsonFileWithEmbeddedMediaSlimming(rootPath, filePath),
+    );
+  } catch (error) {
+    console.warn(`[workspace] failed to read workspace manifest: ${rootPath}`, error);
     return null;
   }
-  return normalizeWorkspaceProjectRecord(
-    readProjectJsonFileWithEmbeddedMediaSlimming(rootPath, filePath),
-  );
 }
 
 export function readWorkspaceManifestSummary(

--- a/electron/workspace/workspaceManifest.ts
+++ b/electron/workspace/workspaceManifest.ts
@@ -32,6 +32,10 @@ function toProjectRecordObject(value: unknown): Record<string, unknown> | null {
     : null;
 }
 
+function isWorkspaceBoundaryError(error: unknown): boolean {
+  return error instanceof Error && /inside the selected workspace/i.test(error.message);
+}
+
 function uniqueEmbeddedAssetPath(rootPath: string, fileName: string): { absolutePath: string; relativePath: string } {
   const assetDir = workspaceAssetsGeneratedDir(rootPath);
   fs.mkdirSync(assetDir, { recursive: true });
@@ -162,6 +166,9 @@ export function readWorkspaceManifest(rootPath: string): WorkspaceProjectRecordV
       readProjectJsonFileWithEmbeddedMediaSlimming(rootPath, filePath),
     );
   } catch (error) {
+    if (isWorkspaceBoundaryError(error)) {
+      throw error;
+    }
     const message = error instanceof Error ? error.message : String(error);
     console.warn(`[workspace] failed to read workspace manifest: ${rootPath} (${message})`);
     return null;

--- a/electron/workspace/workspaceRepository.test.ts
+++ b/electron/workspace/workspaceRepository.test.ts
@@ -135,6 +135,36 @@ describe("workspace repository", () => {
     expect(resolveWorkspaceProjectDir(created.id, repoDeps)).toBeNull();
   });
 
+  it("keeps readable projects available when one workspace manifest is broken", () => {
+    const brokenRoot = makeTempDir();
+    const healthyRoot = makeTempDir();
+    const repoDeps = deps();
+    const broken = createWorkspaceProject(
+      { rootPath: brokenRoot, record: { name: "Broken Manifest", payload: {} } },
+      repoDeps,
+    );
+    const healthy = createWorkspaceProject(
+      { rootPath: healthyRoot, record: { name: "Healthy", payload: { script: "ok" } } },
+      repoDeps,
+    );
+    fs.writeFileSync(workspaceProjectFile(brokenRoot), "{bad json");
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    const projects = listWorkspaceProjects(repoDeps);
+
+    expect(projects.find((project) => project.id === healthy.id)).toMatchObject({
+      id: healthy.id,
+      missing: false,
+    });
+    expect(projects.find((project) => project.id === broken.id)).toMatchObject({
+      id: broken.id,
+      missing: true,
+    });
+    expect(readWorkspaceProject(healthy.id, repoDeps)).toMatchObject({ id: healthy.id });
+    expect(readWorkspaceProject(broken.id, repoDeps)).toBeNull();
+    warnSpy.mockRestore();
+  });
+
   it("returns null for stale registry entries whose manifest id does not match", () => {
     const staleRoot = makeTempDir();
     const actualRoot = makeTempDir();

--- a/src/workbench/generationCanvas/nodes/Scene3DEditor.tsx
+++ b/src/workbench/generationCanvas/nodes/Scene3DEditor.tsx
@@ -13,6 +13,11 @@ import { cloneScene3DState, normalizeScene3DState } from './scene3d/scene3dSeria
 import { persistScene3DScreenshot } from './scene3d/scene3dScreenshot'
 import { frameCountForDuration } from './scene3d/takeRecording'
 import { isVideoLikeGenerationNodeKind } from '../model/generationNodeKinds'
+import {
+  referenceSlotForScene3DCaptureTitle,
+  shouldAttachScene3DFrameReference,
+  summarizeScene3DReferenceTarget,
+} from './scene3d/scene3dReferenceDirector'
 import type { Scene3DCaptureResult, Scene3DState } from './scene3d/scene3dTypes'
 
 const loadScene3DFullscreen = () => import('./scene3d/Scene3DFullscreen')
@@ -125,9 +130,15 @@ function Scene3DEditor({ node, width, height, readOnly = false }: Scene3DEditorP
   const updateNode = useGenerationCanvasStore((state) => state.updateNode)
   const addNode = useGenerationCanvasStore((state) => state.addNode)
   const connectNodes = useGenerationCanvasStore((state) => state.connectNodes)
+  const canvasNodes = useGenerationCanvasStore((state) => state.nodes)
+  const canvasEdges = useGenerationCanvasStore((state) => state.edges)
   const requestCanvasFit = useWorkbenchStore((state) => state.requestCanvasFit)
   const sceneState = React.useMemo(() => readScene3DState(node), [node.id, node.meta?.scene3dState])
   const sceneStateKey = React.useMemo(() => scene3DStateKey(sceneState), [sceneState])
+  const referenceTarget = React.useMemo(
+    () => summarizeScene3DReferenceTarget(node.id, canvasNodes, canvasEdges),
+    [canvasEdges, canvasNodes, node.id],
+  )
   const persistedSceneStateKeyRef = React.useRef(sceneStateKey)
   const lastThumbnailRef = React.useRef(sceneState.lastThumbnail)
   const thumbnailUrl = sceneState.lastThumbnail
@@ -267,6 +278,14 @@ function Scene3DEditor({ node, width, height, readOnly = false }: Scene3DEditorP
         },
       })
       connectNodes(node.id, screenshotNode.id, 'reference')
+      const targetSlot = referenceSlotForScene3DCaptureTitle(capture.title)
+      if (
+        targetSlot &&
+        referenceTarget.state !== 'not-connected' &&
+        shouldAttachScene3DFrameReference(referenceTarget, targetSlot)
+      ) {
+        connectNodes(screenshotNode.id, referenceTarget.targetNodeId, targetSlot)
+      }
 
       const current = useGenerationCanvasStore.getState().nodes.find((candidate) => candidate.id === node.id)
       const nextSceneState = persistableScene3DState({
@@ -285,7 +304,7 @@ function Scene3DEditor({ node, width, height, readOnly = false }: Scene3DEditorP
     } catch (error) {
       toast(error instanceof Error ? error.message : '截图失败，请重试', 'error')
     }
-  }, [addNode, connectNodes, node.id, node.meta, node.position.x, node.position.y, updateNode, width])
+  }, [addNode, connectNodes, node.id, node.meta, node.position.x, node.position.y, referenceTarget, updateNode, width])
 
   const takeCaptureStatus = readTakeCaptureStatus(node)
 
@@ -375,6 +394,7 @@ function Scene3DEditor({ node, width, height, readOnly = false }: Scene3DEditorP
             onScreenshot={(capture) => { void handleScreenshot(capture) }}
             onStateChange={handleStateChange}
             onRecordTake={readOnly ? undefined : handleRecordTake}
+            referenceTarget={referenceTarget}
           />
         </React.Suspense>
       ) : null}

--- a/src/workbench/generationCanvas/nodes/scene3d/CameraMoveCaptureHost.tsx
+++ b/src/workbench/generationCanvas/nodes/scene3d/CameraMoveCaptureHost.tsx
@@ -16,11 +16,8 @@ import {
   type CameraMoveCaptureOutcome,
 } from './cameraMoveCaptureRetry'
 import type { GenerationCanvasNode } from '../../model/generationCanvasTypes'
-import { archetypeForNode, findVideoRefMode } from '../../agent/referenceEdgeCapability'
-import { applyArchetypeModeSwitch, readArchetypeArray } from '../controls/archetypeMeta'
-import { CAMERA_MOVE_LABEL, CAMERA_MOVE_DESC, type CameraMove } from './cameraMoveVocab'
-import { isVideoLikeGenerationNodeKind } from '../../model/generationNodeKinds'
-import { toast } from '../../../../ui/toast'
+import type { CameraMove } from './cameraMoveVocab'
+import { attachCameraMoveToTarget } from './cameraMoveTargetAttach'
 
 type CameraMoveAutoCapture = {
   targetNodeId?: string
@@ -93,64 +90,6 @@ function clampFps(value: number | undefined): number {
   const n = value ?? DEFAULT_FPS
   if (!Number.isFinite(n) || n <= 0) return DEFAULT_FPS
   return Math.min(60, Math.max(24, n)) // 下限 24：Seedance 参考视频帧率必须 ≥23.8 FPS
-}
-
-/** 运镜 prompt 地板（通用，全供应商可用）：人话点出该镜的运镜，作为不吃视频参考时的降级。 */
-function cameraMoveDirective(move: CameraMove | undefined): string {
-  if (!move) return ''
-  return `\n镜头运动：${CAMERA_MOVE_LABEL[move]}（${CAMERA_MOVE_DESC[move]}）`
-}
-
-/**
- * S3 喂入：把运镜小片 mp4 喂给目标镜头视频节点。
- * - 目标模型有 video_ref 槽（如 Seedance 2.0 全能参考）→ 切到该模式 + meta.referenceVideoUrls 追加 mp4 +
- *   prompt 追加「参考视频运镜」指令（模型无关，引用视频，只迁运镜不迁内容）。
- * - 无 video_ref 槽 → 降级：只追加结构化运镜 prompt 地板（CAMERA_MOVE_LABEL/DESC），并标注跳过视频参考。
- *   （吃首尾帧的供应商的完整首尾帧降级是后续切片，这里先做 prompt 地板。）
- */
-function attachCameraMoveToTarget(targetNodeId: string, mp4Url: string, move: CameraMove | undefined): void {
-  const store = useGenerationCanvasStore.getState()
-  const target = store.nodes.find((node) => node.id === targetNodeId)
-  if (!target) return
-  // P2-A 校验目标节点种类:运镜参考只能喂视频生成节点。指到图片节点 → 没有 video_ref 槽,
-  // 旧逻辑会静默把无用的运镜 prompt 追加到图片上(图片模型不懂"镜头运动")。诚实跳过并提示。
-  if (!isVideoLikeGenerationNodeKind(target.kind)) {
-    toast('运镜参考只能喂给视频镜头节点，已跳过（目标不是视频节点）', 'warning')
-    return
-  }
-  const meta = { ...(target.meta || {}) } as Record<string, unknown>
-  // P3-A 用 meta 标志判重附（不再靠 prompt 子串嗅探,基础 prompt 含 @Video1/「镜头运动：」会误判）。
-  if (meta.cameraMoveAttached === true) return
-  const archetype = archetypeForNode(target)
-  const videoRef = findVideoRefMode(archetype)
-  if (archetype && videoRef) {
-    // P2-B 切模式前先看旧模式是否设了首/尾帧、而目标(video_ref)模式没有该槽 → 会在投影时被静默丢弃。
-    // 留痕告诉用户「模式变了，首帧不再注入」，不静默改。
-    const hadFirstOrLast =
-      (typeof meta.firstFrameUrl === 'string' && meta.firstFrameUrl.trim().length > 0) ||
-      (typeof meta.lastFrameUrl === 'string' && meta.lastFrameUrl.trim().length > 0)
-    // 切到含 video_ref 的模式（已在该模式则 applyArchetypeModeSwitch 幂等）。
-    let nextMeta = applyArchetypeModeSwitch(meta, archetype, videoRef.modeId)
-    const existing = readArchetypeArray(nextMeta, videoRef.metaKey)
-    const referenceVideoUrls = existing.includes(mp4Url) ? existing : [...existing, mp4Url]
-    nextMeta = { ...nextMeta, [videoRef.metaKey]: referenceVideoUrls, cameraMoveAttached: true }
-    const targetMode = archetype.modes.find((m) => m.id === videoRef.modeId)
-    const targetHasFrameSlot = targetMode?.slots.some((s) => s.kind === 'first_frame' || s.kind === 'last_frame') ?? false
-    if (hadFirstOrLast && !targetHasFrameSlot) {
-      toast('已切换到全能参考模式以注入运镜参考视频（该模式无首/尾帧，原首帧不再生效）', 'warning')
-    }
-    const directive = `\n@Video1 跟随这段参考视频的运镜（只参考镜头运动，画面内容由角色参考与文字决定）。`
-    const basePrompt = typeof target.prompt === 'string' ? target.prompt : ''
-    const prompt = basePrompt.includes('@Video1') ? basePrompt : `${basePrompt}${directive}`
-    store.updateNode(targetNodeId, { meta: nextMeta, prompt })
-    return
-  }
-  // 降级：视频节点但模型无视频参考槽 → 只补结构化运镜 prompt 地板（保留模型不变）。
-  const directive = cameraMoveDirective(move)
-  if (!directive) return
-  const basePrompt = typeof target.prompt === 'string' ? target.prompt : ''
-  const prompt = basePrompt.includes('镜头运动：') ? basePrompt : `${basePrompt}${directive}`
-  store.updateNode(targetNodeId, { meta: { ...meta, cameraMoveAttached: true }, prompt })
 }
 
 /** 把成功产物写回 scene3d 节点 meta + 喂入目标镜头。清标志留给调用方（重试期间不清）。 */

--- a/src/workbench/generationCanvas/nodes/scene3d/Scene3DFullscreen.tsx
+++ b/src/workbench/generationCanvas/nodes/scene3d/Scene3DFullscreen.tsx
@@ -27,9 +27,7 @@ import {
   type Scene3DState,
   type Scene3DTransformMode,
 } from './scene3dTypes'
-import {
-  FULLSCREEN_Z_INDEX,
-} from './scene3dConstants'
+import { FULLSCREEN_Z_INDEX } from './scene3dConstants'
 import { PanelButton, CanvasPanelRestoreButton } from './scene3dToolbar'
 import {
   levelEditorCameraRotation,
@@ -57,6 +55,7 @@ import {
 } from './scene3dTrajectorySurfaces'
 import { removeTrajectoryBindingsForNode } from './scene3dTrajectoryState'
 import { cameraWithPlaybackPosition } from './scene3dPlayback'
+import type { Scene3DReferenceTargetSummary } from './scene3dReferenceDirector'
 import {
   useScene3DClipboardActions,
   useScene3DTrajectoryModeActions,
@@ -77,6 +76,7 @@ type Scene3DFullscreenProps = {
   // 录 take（S2）：把录制好的（含角色/机位轨迹的）场景交回宿主建 scene3d 节点 + 打捕获标志。
   // 可选——未传则不出现「录 take」按钮（如样张/只读环境）。
   onRecordTake?: (recordedState: Scene3DState) => void
+  referenceTarget?: Scene3DReferenceTargetSummary
 }
 
 export default function Scene3DFullscreen({
@@ -87,6 +87,7 @@ export default function Scene3DFullscreen({
   onStateChange,
   onScreenshot,
   onRecordTake,
+  referenceTarget,
 }: Scene3DFullscreenProps): JSX.Element {
   const [state, setState] = React.useState(() => cloneScene3DState(initialState))
   const [selection, setSelection] = React.useState<Scene3DSelection>(null)
@@ -785,6 +786,7 @@ export default function Scene3DFullscreen({
                 }))}
                 onApplyCameraMove={applyCameraMove}
                 onExportCameraMoveFrames={(cameraId) => { void exportCameraMoveFrames(cameraId) }}
+                referenceTarget={referenceTarget}
               />
             </motion.aside>
           ) : null}

--- a/src/workbench/generationCanvas/nodes/scene3d/cameraMoveTargetAttach.test.ts
+++ b/src/workbench/generationCanvas/nodes/scene3d/cameraMoveTargetAttach.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { useGenerationCanvasStore } from '../../store/generationCanvasStore'
+import type { GenerationCanvasNode } from '../../model/generationCanvasTypes'
+import { attachCameraMoveToTarget } from './cameraMoveTargetAttach'
+
+function node(id: string, kind: GenerationCanvasNode['kind'], patch: Partial<GenerationCanvasNode> = {}): GenerationCanvasNode {
+  return {
+    id,
+    kind,
+    title: id,
+    position: { x: 0, y: 0 },
+    prompt: '',
+    references: [],
+    history: [],
+    status: 'idle',
+    meta: {},
+    ...patch,
+  }
+}
+
+function restore(nodes: GenerationCanvasNode[]): void {
+  useGenerationCanvasStore.getState().restoreSnapshot({
+    nodes,
+    edges: [],
+    selectedNodeIds: [],
+    groups: [],
+  })
+}
+
+function current(id: string): GenerationCanvasNode {
+  const found = useGenerationCanvasStore.getState().nodes.find((candidate) => candidate.id === id)
+  if (!found) throw new Error(`Missing node ${id}`)
+  return found
+}
+
+describe('attachCameraMoveToTarget', () => {
+  beforeEach(() => {
+    restore([])
+  })
+
+  it('routes a recorded take into Seedance omni video_ref and preserves the variant axis', () => {
+    restore([
+      node('shot', 'video', {
+        prompt: '城市街道里的主角回头',
+        meta: {
+          archetype: { id: 'seedance-2-apimart', modeId: 't2v', variantId: 'fast' },
+          modelKey: 'doubao-seedance-2.0-fast',
+          referenceVideoUrls: ['nomi-local://asset/old.mp4'],
+        },
+      }),
+    ])
+
+    attachCameraMoveToTarget('shot', 'nomi-local://asset/camera-move.mp4', 'push_in')
+
+    const shot = current('shot')
+    expect(shot.meta?.archetype).toEqual({ id: 'seedance-2-apimart', modeId: 'omni', variantId: 'fast' })
+    expect(shot.meta?.referenceVideoUrls).toEqual([
+      'nomi-local://asset/old.mp4',
+      'nomi-local://asset/camera-move.mp4',
+    ])
+    expect(shot.meta?.cameraMoveAttached).toBe(true)
+    expect(shot.prompt).toContain('@Video1 跟随这段参考视频的运镜')
+  })
+
+  it('is idempotent once a camera move has been attached', () => {
+    restore([
+      node('shot', 'video', {
+        prompt: '已有 @Video1 指令',
+        meta: {
+          archetype: { id: 'seedance-2-apimart', modeId: 'omni', variantId: 'standard' },
+          referenceVideoUrls: ['nomi-local://asset/camera-move.mp4'],
+          cameraMoveAttached: true,
+        },
+      }),
+    ])
+
+    attachCameraMoveToTarget('shot', 'nomi-local://asset/another.mp4', 'pull_out')
+
+    const shot = current('shot')
+    expect(shot.meta?.referenceVideoUrls).toEqual(['nomi-local://asset/camera-move.mp4'])
+    expect(shot.prompt).toBe('已有 @Video1 指令')
+  })
+
+  it('falls back to a structured camera move prompt when the video model has no video_ref slot', () => {
+    restore([
+      node('shot', 'video', {
+        prompt: '纯文本视频镜头',
+        meta: { archetype: { id: 'runninghub-seedance', modeId: 'text' } },
+      }),
+    ])
+
+    attachCameraMoveToTarget('shot', 'nomi-local://asset/camera-move.mp4', 'push_in')
+
+    const shot = current('shot')
+    expect(shot.meta?.archetype).toEqual({ id: 'runninghub-seedance', modeId: 'text' })
+    expect(shot.meta?.referenceVideoUrls).toBeUndefined()
+    expect(shot.meta?.cameraMoveAttached).toBe(true)
+    expect(shot.prompt).toContain('镜头运动：推近')
+  })
+})

--- a/src/workbench/generationCanvas/nodes/scene3d/cameraMoveTargetAttach.ts
+++ b/src/workbench/generationCanvas/nodes/scene3d/cameraMoveTargetAttach.ts
@@ -1,0 +1,64 @@
+import { useGenerationCanvasStore } from '../../store/generationCanvasStore'
+import { archetypeForNode, findVideoRefMode } from '../../agent/referenceEdgeCapability'
+import { applyArchetypeModeSwitch, readArchetypeArray } from '../controls/archetypeMeta'
+import { isVideoLikeGenerationNodeKind } from '../../model/generationNodeKinds'
+import { toast } from '../../../../ui/toast'
+import { CAMERA_MOVE_LABEL, CAMERA_MOVE_DESC, type CameraMove } from './cameraMoveVocab'
+
+/** 运镜 prompt 地板（通用，全供应商可用）：人话点出该镜的运镜，作为不吃视频参考时的降级。 */
+function cameraMoveDirective(move: CameraMove | undefined): string {
+  if (!move) return ''
+  return `\n镜头运动：${CAMERA_MOVE_LABEL[move]}（${CAMERA_MOVE_DESC[move]}）`
+}
+
+/**
+ * S3 喂入：把运镜小片 mp4 喂给目标镜头视频节点。
+ * - 目标模型有 video_ref 槽（如 Seedance 2.0 全能参考）→ 切到该模式 + meta.referenceVideoUrls 追加 mp4 +
+ *   prompt 追加「参考视频运镜」指令（模型无关，引用视频，只迁运镜不迁内容）。
+ * - 无 video_ref 槽 → 降级：只追加结构化运镜 prompt 地板（CAMERA_MOVE_LABEL/DESC），并标注跳过视频参考。
+ *   （吃首尾帧的供应商的完整首尾帧降级是后续切片，这里先做 prompt 地板。）
+ */
+export function attachCameraMoveToTarget(targetNodeId: string, mp4Url: string, move: CameraMove | undefined): void {
+  const store = useGenerationCanvasStore.getState()
+  const target = store.nodes.find((node) => node.id === targetNodeId)
+  if (!target) return
+  // P2-A 校验目标节点种类:运镜参考只能喂视频生成节点。指到图片节点 → 没有 video_ref 槽,
+  // 旧逻辑会静默把无用的运镜 prompt 追加到图片上(图片模型不懂"镜头运动")。诚实跳过并提示。
+  if (!isVideoLikeGenerationNodeKind(target.kind)) {
+    toast('运镜参考只能喂给视频镜头节点，已跳过（目标不是视频节点）', 'warning')
+    return
+  }
+  const meta = { ...(target.meta || {}) } as Record<string, unknown>
+  // P3-A 用 meta 标志判重附（不再靠 prompt 子串嗅探,基础 prompt 含 @Video1/「镜头运动：」会误判）。
+  if (meta.cameraMoveAttached === true) return
+  const archetype = archetypeForNode(target)
+  const videoRef = findVideoRefMode(archetype)
+  if (archetype && videoRef) {
+    // P2-B 切模式前先看旧模式是否设了首/尾帧、而目标(video_ref)模式没有该槽 → 会在投影时被静默丢弃。
+    // 留痕告诉用户「模式变了，首帧不再注入」，不静默改。
+    const hadFirstOrLast =
+      (typeof meta.firstFrameUrl === 'string' && meta.firstFrameUrl.trim().length > 0) ||
+      (typeof meta.lastFrameUrl === 'string' && meta.lastFrameUrl.trim().length > 0)
+    // 切到含 video_ref 的模式（已在该模式则 applyArchetypeModeSwitch 幂等）。
+    let nextMeta = applyArchetypeModeSwitch(meta, archetype, videoRef.modeId)
+    const existing = readArchetypeArray(nextMeta, videoRef.metaKey)
+    const referenceVideoUrls = existing.includes(mp4Url) ? existing : [...existing, mp4Url]
+    nextMeta = { ...nextMeta, [videoRef.metaKey]: referenceVideoUrls, cameraMoveAttached: true }
+    const targetMode = archetype.modes.find((m) => m.id === videoRef.modeId)
+    const targetHasFrameSlot = targetMode?.slots.some((s) => s.kind === 'first_frame' || s.kind === 'last_frame') ?? false
+    if (hadFirstOrLast && !targetHasFrameSlot) {
+      toast('已切换到全能参考模式以注入运镜参考视频（该模式无首/尾帧，原首帧不再生效）', 'warning')
+    }
+    const directive = `\n@Video1 跟随这段参考视频的运镜（只参考镜头运动，画面内容由角色参考与文字决定）。`
+    const basePrompt = typeof target.prompt === 'string' ? target.prompt : ''
+    const prompt = basePrompt.includes('@Video1') ? basePrompt : `${basePrompt}${directive}`
+    store.updateNode(targetNodeId, { meta: nextMeta, prompt })
+    return
+  }
+  // 降级：视频节点但模型无视频参考槽 → 只补结构化运镜 prompt 地板（保留模型不变）。
+  const directive = cameraMoveDirective(move)
+  if (!directive) return
+  const basePrompt = typeof target.prompt === 'string' ? target.prompt : ''
+  const prompt = basePrompt.includes('镜头运动：') ? basePrompt : `${basePrompt}${directive}`
+  store.updateNode(targetNodeId, { meta: { ...meta, cameraMoveAttached: true }, prompt })
+}

--- a/src/workbench/generationCanvas/nodes/scene3d/scene3dCameraMovePanel.tsx
+++ b/src/workbench/generationCanvas/nodes/scene3d/scene3dCameraMovePanel.tsx
@@ -2,6 +2,7 @@
 // 点按 = 按当前机位/拍摄目标就地落一段轨迹并追加到时间轴末尾（cameraMovePreset 纯函数），
 // 连点即串联多段；落完仍可去轨迹模式逐点精修。样张：docs/design/mockups/scene3d-camera-directing-upgrade.html。
 import React from 'react'
+import { IconLink, IconMovie, IconPhoto } from '@tabler/icons-react'
 import { cn } from '../../../../utils/cn'
 import { CAMERA_MOVES, CAMERA_MOVE_LABEL, ZOOM_MOVES, type CameraMove } from './cameraMoveVocab'
 import {
@@ -11,6 +12,10 @@ import {
   CAMERA_MOVE_DURATION_MIN,
   type CameraMovePresetSpec,
 } from './cameraMovePreset'
+import {
+  scene3DReferenceTargetLabel,
+  type Scene3DReferenceTargetSummary,
+} from './scene3dReferenceDirector'
 
 const DEFAULT_DURATION = 5 // Seedance 甜区中档（与 CAMERA_SPEED_DURATION.medium 一致）
 const DEFAULT_AMPLITUDE_PERCENT = 60
@@ -19,11 +24,13 @@ export function CameraMovePanel({
   readOnly,
   onApply,
   onExportFrames,
+  referenceTarget,
 }: {
   readOnly: boolean
   onApply: (spec: CameraMovePresetSpec) => void
   /** 把该相机运镜段的首/尾帧各截一张落画布（接 Seedance 首尾帧工作流）。 */
   onExportFrames: () => void
+  referenceTarget?: Scene3DReferenceTargetSummary
 }): JSX.Element {
   const [durationValue, setDurationValue] = React.useState(DEFAULT_DURATION)
   const [amplitudePercent, setAmplitudePercent] = React.useState(DEFAULT_AMPLITUDE_PERCENT)
@@ -36,9 +43,47 @@ export function CameraMovePanel({
     })
   }, [amplitudePercent, durationValue, onApply])
 
+  const target = referenceTarget ?? {
+    state: 'not-connected' as const,
+    currentFrameSupport: { firstFrame: false, lastFrame: false },
+    anyFrameSupport: { firstFrame: false, lastFrame: false },
+  }
+  const videoRouteLabel = target.state === 'video-ref'
+    ? '录 take → video_ref'
+    : target.state === 'prompt-fallback'
+      ? '录 take → 运镜文字'
+      : '待接目标'
+  const frameRouteLabel = target.anyFrameSupport.firstFrame && target.anyFrameSupport.lastFrame
+    ? '首帧 / 尾帧'
+    : target.anyFrameSupport.firstFrame
+      ? '首帧'
+      : '不可接帧槽'
+
   return (
     <div className="grid gap-2 rounded-nomi border border-[var(--nomi-line-soft)] bg-[var(--nomi-paper)] p-2">
       <div className="text-caption font-medium text-[var(--nomi-ink)]">运镜预设</div>
+      <div
+        className="grid gap-2 rounded-nomi-sm border border-[var(--nomi-line-soft)] bg-[var(--nomi-ink-05)] p-2"
+        data-scene3d-reference-panel
+      >
+        <div className="flex min-w-0 items-center gap-1.5 text-caption font-medium text-[var(--nomi-ink)]">
+          <IconLink size={14} stroke={1.6} />
+          <span>参考输出</span>
+        </div>
+        <div className="min-w-0 truncate text-micro text-[var(--nomi-ink-60)]" data-scene3d-reference-target>
+          {scene3DReferenceTargetLabel(target)}
+        </div>
+        <div className="grid grid-cols-2 gap-1.5">
+          <div className="flex min-w-0 items-center gap-1 rounded-nomi-sm bg-[var(--nomi-paper)] px-1.5 py-1 text-micro text-[var(--nomi-ink-60)]">
+            <IconMovie size={13} stroke={1.6} className="shrink-0" />
+            <span className="truncate">{videoRouteLabel}</span>
+          </div>
+          <div className="flex min-w-0 items-center gap-1 rounded-nomi-sm bg-[var(--nomi-paper)] px-1.5 py-1 text-micro text-[var(--nomi-ink-60)]">
+            <IconPhoto size={13} stroke={1.6} className="shrink-0" />
+            <span className="truncate">{frameRouteLabel}</span>
+          </div>
+        </div>
+      </div>
       <div className="grid grid-cols-2 gap-2">
         <label className="grid gap-1">
           <span className="text-micro text-[var(--nomi-ink-60)]">时长（秒）</span>

--- a/src/workbench/generationCanvas/nodes/scene3d/scene3dCharacterActionBar.tsx
+++ b/src/workbench/generationCanvas/nodes/scene3d/scene3dCharacterActionBar.tsx
@@ -170,7 +170,7 @@ export function CharacterActionBar({
 }): JSX.Element {
   return (
     <div
-      className="absolute bottom-5 left-1/2 z-[5] max-w-[calc(100%-32px)] -translate-x-1/2"
+      className="absolute bottom-5 left-1/2 z-[8] max-w-[calc(100%-32px)] -translate-x-1/2"
       aria-label="角色操控动作库"
       onPointerDown={(event) => event.stopPropagation()}
       onWheel={(event) => event.stopPropagation()}
@@ -251,7 +251,7 @@ export function CameraPossessActionBar({
 }): JSX.Element {
   return (
     <div
-      className="absolute bottom-5 left-1/2 z-[5] max-w-[calc(100%-32px)] -translate-x-1/2"
+      className="absolute bottom-5 left-1/2 z-[8] max-w-[calc(100%-32px)] -translate-x-1/2"
       aria-label="镜头操控工具栏"
       onPointerDown={(event) => event.stopPropagation()}
       onWheel={(event) => event.stopPropagation()}

--- a/src/workbench/generationCanvas/nodes/scene3d/scene3dInspector.tsx
+++ b/src/workbench/generationCanvas/nodes/scene3d/scene3dInspector.tsx
@@ -48,6 +48,7 @@ import {
 import { Scene3DEnvironmentPanel } from './scene3dEnvironmentPanel'
 import { CameraMovePanel } from './scene3dCameraMovePanel'
 import type { CameraMovePresetSpec } from './cameraMovePreset'
+import type { Scene3DReferenceTargetSummary } from './scene3dReferenceDirector'
 
 function VectorInputs({
   label,
@@ -446,6 +447,7 @@ export function PropertyPanel({
   onEnvironmentPatch,
   onApplyCameraMove,
   onExportCameraMoveFrames,
+  referenceTarget,
 }: {
   state: Scene3DState
   selection: Scene3DSelection
@@ -455,6 +457,7 @@ export function PropertyPanel({
   onEnvironmentPatch: (patch: Partial<Scene3DState['environment']>) => void
   onApplyCameraMove: (cameraId: string, spec: CameraMovePresetSpec) => void
   onExportCameraMoveFrames: (cameraId: string) => void
+  referenceTarget?: Scene3DReferenceTargetSummary
 }): JSX.Element {
   const selectedObject = selection?.type === 'object'
     ? state.objects.find((object) => object.id === selection.id)
@@ -641,6 +644,7 @@ export function PropertyPanel({
             readOnly={readOnly}
             onApply={(spec) => onApplyCameraMove(selectedCamera.id, spec)}
             onExportFrames={() => onExportCameraMoveFrames(selectedCamera.id)}
+            referenceTarget={referenceTarget}
           />
         </div>
       ) : (

--- a/src/workbench/generationCanvas/nodes/scene3d/scene3dReferenceDirector.test.ts
+++ b/src/workbench/generationCanvas/nodes/scene3d/scene3dReferenceDirector.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest'
+import type { GenerationCanvasEdge, GenerationCanvasNode } from '../../model/generationCanvasTypes'
+import {
+  referenceSlotForScene3DCaptureTitle,
+  scene3DReferenceTargetLabel,
+  shouldAttachScene3DFrameReference,
+  summarizeScene3DReferenceTarget,
+} from './scene3dReferenceDirector'
+
+function node(id: string, kind: GenerationCanvasNode['kind'], patch: Partial<GenerationCanvasNode> = {}): GenerationCanvasNode {
+  return {
+    id,
+    kind,
+    title: id,
+    position: { x: 0, y: 0 },
+    prompt: '',
+    references: [],
+    history: [],
+    status: 'idle',
+    meta: {},
+    ...patch,
+  }
+}
+
+const edge = (source: string, target: string): GenerationCanvasEdge => ({
+  id: `edge-${source}-${target}`,
+  source,
+  target,
+  mode: 'reference',
+})
+
+describe('scene3dReferenceDirector', () => {
+  it('finds the downstream video target and marks Seedance omni as video_ref capable', () => {
+    const scene = node('s3d', 'scene3d')
+    const video = node('shot', 'video', {
+      title: '镜头 01',
+      meta: { archetype: { id: 'seedance-2-apimart', modeId: 'omni' } },
+    })
+
+    const summary = summarizeScene3DReferenceTarget(scene.id, [scene, video], [edge(scene.id, video.id)])
+
+    expect(summary.state).toBe('video-ref')
+    expect(scene3DReferenceTargetLabel(summary)).toBe('video_ref · 镜头 01')
+    expect(summary.currentFrameSupport).toEqual({ firstFrame: true, lastFrame: false })
+    expect(summary.anyFrameSupport).toEqual({ firstFrame: true, lastFrame: true })
+    expect(shouldAttachScene3DFrameReference(summary, 'first_frame')).toBe(true)
+    expect(shouldAttachScene3DFrameReference(summary, 'last_frame')).toBe(true)
+  })
+
+  it('reports prompt fallback when a downstream video node has no video_ref archetype', () => {
+    const scene = node('s3d', 'scene3d')
+    const video = node('shot', 'video', { title: '旧视频节点' })
+
+    const summary = summarizeScene3DReferenceTarget(scene.id, [scene, video], [edge(scene.id, video.id)])
+
+    expect(summary.state).toBe('prompt-fallback')
+    expect(scene3DReferenceTargetLabel(summary)).toBe('prompt · 旧视频节点')
+    expect(shouldAttachScene3DFrameReference(summary, 'first_frame')).toBe(false)
+  })
+
+  it('does not treat non-video downstream nodes as reference video targets', () => {
+    const scene = node('s3d', 'scene3d')
+    const image = node('img', 'image')
+
+    const summary = summarizeScene3DReferenceTarget(scene.id, [scene, image], [edge(scene.id, image.id)])
+
+    expect(summary.state).toBe('not-connected')
+    expect(scene3DReferenceTargetLabel(summary)).toBe('未连接视频镜头')
+  })
+
+  it('maps exported camera move frame capture titles to first/last frame slots', () => {
+    expect(referenceSlotForScene3DCaptureTitle('相机 A · 运镜首帧')).toBe('first_frame')
+    expect(referenceSlotForScene3DCaptureTitle('相机 A · 运镜尾帧')).toBe('last_frame')
+    expect(referenceSlotForScene3DCaptureTitle('相机 A')).toBeNull()
+  })
+})

--- a/src/workbench/generationCanvas/nodes/scene3d/scene3dReferenceDirector.ts
+++ b/src/workbench/generationCanvas/nodes/scene3d/scene3dReferenceDirector.ts
@@ -1,0 +1,127 @@
+import type {
+  GenerationCanvasEdge,
+  GenerationCanvasEdgeMode,
+  GenerationCanvasNode,
+} from '../../model/generationCanvasTypes'
+import { isVideoLikeGenerationNodeKind } from '../../model/generationNodeKinds'
+import { archetypeForNode, findVideoRefMode } from '../../agent/referenceEdgeCapability'
+import { currentArchetypeMode } from '../controls/archetypeMeta'
+
+export type Scene3DReferenceFrameSupport = {
+  firstFrame: boolean
+  lastFrame: boolean
+}
+
+export type Scene3DReferenceTargetSummary =
+  | {
+      state: 'not-connected'
+      targetNodeId?: undefined
+      targetTitle?: undefined
+      videoRefModeId?: undefined
+      videoRefMetaKey?: undefined
+      currentFrameSupport: Scene3DReferenceFrameSupport
+      anyFrameSupport: Scene3DReferenceFrameSupport
+    }
+  | {
+      state: 'video-ref'
+      targetNodeId: string
+      targetTitle: string
+      videoRefModeId: string
+      videoRefMetaKey: string
+      currentFrameSupport: Scene3DReferenceFrameSupport
+      anyFrameSupport: Scene3DReferenceFrameSupport
+    }
+  | {
+      state: 'prompt-fallback'
+      targetNodeId: string
+      targetTitle: string
+      videoRefModeId?: undefined
+      videoRefMetaKey?: undefined
+      currentFrameSupport: Scene3DReferenceFrameSupport
+      anyFrameSupport: Scene3DReferenceFrameSupport
+    }
+
+function emptyFrameSupport(): Scene3DReferenceFrameSupport {
+  return { firstFrame: false, lastFrame: false }
+}
+
+function frameSupportForNode(node: GenerationCanvasNode): {
+  currentFrameSupport: Scene3DReferenceFrameSupport
+  anyFrameSupport: Scene3DReferenceFrameSupport
+} {
+  const archetype = archetypeForNode(node)
+  if (!archetype) {
+    return {
+      currentFrameSupport: emptyFrameSupport(),
+      anyFrameSupport: emptyFrameSupport(),
+    }
+  }
+  const currentMode = currentArchetypeMode(archetype, (node.meta || {}) as Record<string, unknown>)
+  const support = (slots: typeof currentMode.slots): Scene3DReferenceFrameSupport => ({
+    firstFrame: slots.some((slot) => slot.kind === 'first_frame' || slot.kind === 'image_ref'),
+    lastFrame: slots.some((slot) => slot.kind === 'last_frame'),
+  })
+  return {
+    currentFrameSupport: support(currentMode.slots),
+    anyFrameSupport: support(archetype.modes.flatMap((mode) => mode.slots)),
+  }
+}
+
+export function summarizeScene3DReferenceTarget(
+  sourceNodeId: string,
+  nodes: readonly GenerationCanvasNode[],
+  edges: readonly GenerationCanvasEdge[],
+): Scene3DReferenceTargetSummary {
+  const target = edges
+    .filter((edge) => edge.source === sourceNodeId)
+    .map((edge) => nodes.find((node) => node.id === edge.target))
+    .find((node): node is GenerationCanvasNode => Boolean(node && isVideoLikeGenerationNodeKind(node.kind)))
+
+  if (!target) {
+    return {
+      state: 'not-connected',
+      currentFrameSupport: emptyFrameSupport(),
+      anyFrameSupport: emptyFrameSupport(),
+    }
+  }
+
+  const frameSupport = frameSupportForNode(target)
+  const videoRef = findVideoRefMode(archetypeForNode(target))
+  if (videoRef) {
+    return {
+      state: 'video-ref',
+      targetNodeId: target.id,
+      targetTitle: target.title || '视频镜头',
+      videoRefModeId: videoRef.modeId,
+      videoRefMetaKey: videoRef.metaKey,
+      ...frameSupport,
+    }
+  }
+
+  return {
+    state: 'prompt-fallback',
+    targetNodeId: target.id,
+    targetTitle: target.title || '视频镜头',
+    ...frameSupport,
+  }
+}
+
+export function referenceSlotForScene3DCaptureTitle(title: string): Extract<GenerationCanvasEdgeMode, 'first_frame' | 'last_frame'> | null {
+  if (title.includes('运镜首帧')) return 'first_frame'
+  if (title.includes('运镜尾帧')) return 'last_frame'
+  return null
+}
+
+export function shouldAttachScene3DFrameReference(
+  target: Scene3DReferenceTargetSummary,
+  slot: Extract<GenerationCanvasEdgeMode, 'first_frame' | 'last_frame'>,
+): boolean {
+  if (target.state === 'not-connected') return false
+  return slot === 'first_frame' ? target.anyFrameSupport.firstFrame : target.anyFrameSupport.lastFrame
+}
+
+export function scene3DReferenceTargetLabel(target: Scene3DReferenceTargetSummary): string {
+  if (target.state === 'not-connected') return '未连接视频镜头'
+  if (target.state === 'video-ref') return `video_ref · ${target.targetTitle}`
+  return `prompt · ${target.targetTitle}`
+}

--- a/src/workbench/generationCanvas/nodes/scene3d/scene3dTrajectorySurfaces.tsx
+++ b/src/workbench/generationCanvas/nodes/scene3d/scene3dTrajectorySurfaces.tsx
@@ -9,6 +9,7 @@ import { PropertyPanel } from './scene3dInspector'
 import { TrajectoryPanel } from './trajectory/TrajectoryPanel'
 import { TrajectoryTimeline } from './trajectory/TrajectoryTimeline'
 import { TrajectoryPlayback } from './trajectory/TrajectoryPlayback'
+import type { Scene3DReferenceTargetSummary } from './scene3dReferenceDirector'
 
 export type Scene3DRightPanelTab = 'properties' | 'trajectory'
 
@@ -100,6 +101,7 @@ export function Scene3DRightPanelBody({
   onEnvironmentPatch,
   onApplyCameraMove,
   onExportCameraMoveFrames,
+  referenceTarget,
 }: {
   state: Scene3DState
   trajectory: Scene3DTrajectoryEditing
@@ -112,6 +114,7 @@ export function Scene3DRightPanelBody({
   onEnvironmentPatch: (patch: Partial<Scene3DState['environment']>) => void
   onApplyCameraMove: (cameraId: string, spec: CameraMovePresetSpec) => void
   onExportCameraMoveFrames: (cameraId: string) => void
+  referenceTarget?: Scene3DReferenceTargetSummary
 }): JSX.Element {
   return (
     <>
@@ -137,6 +140,7 @@ export function Scene3DRightPanelBody({
           onEnvironmentPatch={onEnvironmentPatch}
           onApplyCameraMove={onApplyCameraMove}
           onExportCameraMoveFrames={onExportCameraMoveFrames}
+          referenceTarget={referenceTarget}
         />
       )}
     </>

--- a/tests/ux/scene3d-reference-pack.walk.mjs
+++ b/tests/ux/scene3d-reference-pack.walk.mjs
@@ -1,0 +1,318 @@
+// 真机走查：3D 导演台参考包出口。
+// 铺好一个 scene3d → Seedance omni 视频镜头的最小画布，然后真实点击：
+// 打开 3D 编辑器 → 选相机 → 点「推近」→ 点「导出运镜首尾帧」。
+// 再真实点击「操控」→「录 take」→ 停止，等本地 mp4 写入目标视频节点 referenceVideoUrls。
+// 硬证据：UI 显示 video_ref 目标；画布 store 里生成首/尾帧图片节点，并自动接到视频节点 first_frame/last_frame；
+// 录 take 出片后目标视频节点拿到 referenceVideoUrls。
+// 零额度：纯本地 3D 截图，不碰任何生成 API。
+// 用法：pnpm run build && node tests/ux/scene3d-reference-pack.walk.mjs
+import { _electron as electron } from 'playwright'
+import { createRequire } from 'node:module'
+import path from 'node:path'
+import os from 'node:os'
+import { fileURLToPath } from 'node:url'
+import { mkdtempSync, mkdirSync } from 'node:fs'
+import { spawn } from 'node:child_process'
+import http from 'node:http'
+import net from 'node:net'
+
+const require = createRequire(import.meta.url)
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..')
+const outDir = path.join(repoRoot, '.scene3d-reference-pack-lab')
+mkdirSync(outDir, { recursive: true })
+const tmp = mkdtempSync(path.join(os.tmpdir(), 'nomi-scene3d-ref-pack-'))
+const projectsDir = path.join(tmp, 'projects')
+mkdirSync(projectsDir, { recursive: true })
+
+function findFreePort() {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer()
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address()
+      const port = typeof address === 'object' && address ? address.port : 0
+      server.close(() => resolve(port))
+    })
+  })
+}
+
+function waitForUrl(url, timeoutMs) {
+  const deadline = Date.now() + timeoutMs
+  return new Promise((resolve, reject) => {
+    const tick = () => {
+      const req = http.get(url, (res) => {
+        res.destroy()
+        resolve(true)
+      })
+      req.on('error', () => {
+        if (Date.now() > deadline) reject(new Error('vite 未就绪'))
+        else setTimeout(tick, 400)
+      })
+      req.setTimeout(1500, () => { req.destroy() })
+    }
+    tick()
+  })
+}
+
+const devPort = await findFreePort()
+const devUrl = `http://127.0.0.1:${devPort}`
+const vite = spawn('node', ['node_modules/vite/bin/vite.js', '--host', '127.0.0.1', '--port', String(devPort), '--strictPort'], {
+  cwd: repoRoot,
+  env: { ...process.env },
+  stdio: 'ignore',
+})
+await waitForUrl(devUrl, 60000)
+
+const app = await electron.launch({
+  executablePath: require('electron'),
+  args: ['.', `--user-data-dir=${path.join(tmp, 'udata')}`],
+  cwd: repoRoot,
+  env: {
+    ...process.env,
+    NOMI_DESKTOP_DEV: '1',
+    VITE_DEV_SERVER_URL: devUrl,
+    NOMI_E2E: '1',
+    NOMI_E2E_SMOKE: '1',
+    NOMI_PROJECTS_DIR: projectsDir,
+  },
+})
+
+const log = (m) => console.log(m)
+const errors = []
+const pass = {
+  projectOpen: false,
+  storeReady: false,
+  injected: false,
+  editorOpen: false,
+  cameraSelected: false,
+  referencePanel: false,
+  moveApplied: false,
+  framesConnected: false,
+  takeVideoRefAttached: false,
+}
+
+async function dismiss(win) {
+  await win.keyboard.press('Escape').catch(() => {})
+  const splashSkip = win.locator('[data-splash-skip="true"]').first()
+  if ((await splashSkip.count()) > 0) await splashSkip.click().catch(() => {})
+  await win.locator('.nomi-splash').first().waitFor({ state: 'detached', timeout: 6000 }).catch(() => {})
+}
+
+async function waitForCanvasStore(win) {
+  for (let i = 0; i < 20; i += 1) {
+    const ready = await win.evaluate(async () => {
+      try {
+        const m = await import('/src/workbench/generationCanvas/store/generationCanvasStore.ts')
+        return Boolean(m.useGenerationCanvasStore?.getState)
+      } catch {
+        return false
+      }
+    }).catch(() => false)
+    if (ready) return true
+    await win.waitForTimeout(500)
+  }
+  return false
+}
+
+try {
+  const win = await app.firstWindow()
+  win.on('console', (m) => { if (m.type() === 'error') errors.push(m.text()) })
+  win.on('pageerror', (e) => errors.push(String(e)))
+  await win.waitForLoadState('domcontentloaded')
+  await win.evaluate(() => {
+    try {
+      localStorage.setItem('__nomiE2E', '1')
+      localStorage.setItem('nomi-color-scheme', 'light')
+    } catch {}
+  })
+  await win.waitForTimeout(1800)
+  await dismiss(win)
+
+  const card = win.locator('[data-project-card]').first()
+  if ((await card.count()) > 0) await card.click()
+  else {
+    const blank = win.getByText('新建空白项目', { exact: false }).first()
+    if ((await blank.count()) > 0) await blank.click()
+  }
+  await win.waitForTimeout(2500)
+  await dismiss(win)
+  pass.projectOpen = /projectId=/.test(win.url()) || (await win.getByRole('button', { name: '生成', exact: false }).count()) > 0
+  log(`  ${pass.projectOpen ? '✓' : '✗'} 进入隔离项目`)
+
+  const genTab = win.getByRole('button', { name: '生成', exact: false }).first()
+  if ((await genTab.count()) > 0) await genTab.click()
+  await win.waitForTimeout(1500)
+  pass.storeReady = await waitForCanvasStore(win)
+  log(`  ${pass.storeReady ? '✓' : '✗'} 画布 E2E store bridge 就绪`)
+  if (!pass.storeReady) throw new Error('画布 store 未暴露')
+
+  const ids = await win.evaluate(async () => {
+    const { useGenerationCanvasStore } = await import('/src/workbench/generationCanvas/store/generationCanvasStore.ts')
+    const state = useGenerationCanvasStore.getState()
+    const scene = state.addNode({
+      kind: 'scene3d',
+      title: '导演参考台',
+      categoryId: 'shots',
+      position: { x: 160, y: 180 },
+      exactPosition: true,
+      select: false,
+    })
+    const target = state.addNode({
+      kind: 'video',
+      title: '镜头 01',
+      prompt: '一名角色在城市街口向镜头走来，保持构图与机位。',
+      categoryId: 'shots',
+      position: { x: 920, y: 180 },
+      exactPosition: true,
+      select: false,
+      meta: {
+        modelVendor: 'apimart',
+        modelKey: 'doubao-seedance-2.0',
+        archetype: { id: 'seedance-2-apimart', modeId: 'omni', variantId: 'standard' },
+      },
+    })
+    state.connectNodes(scene.id, target.id, 'reference')
+    state.setCanvasTransform(1, { x: 0, y: 0 })
+    return { sceneId: scene.id, targetId: target.id }
+  })
+  pass.injected = Boolean(ids?.sceneId && ids?.targetId)
+  log(`  ${pass.injected ? '✓' : '✗'} 注入导演台 + video_ref 目标 (${ids.sceneId} → ${ids.targetId})`)
+
+  const sceneNode = win.locator(`[data-node-id="${ids.sceneId}"]`)
+  await sceneNode.waitFor({ state: 'visible', timeout: 8000 })
+  await win.screenshot({ path: path.join(outDir, '01-canvas-seeded.png') })
+  const openEditor = sceneNode.getByRole('button', { name: '打开 3D 编辑器', exact: false })
+  await openEditor.first().click({ timeout: 5000 })
+  await win.waitForTimeout(4500)
+  pass.editorOpen = (await win.locator('[aria-label="3D 场景编辑器"]').count()) > 0
+  log(`  ${pass.editorOpen ? '✓' : '✗'} 点击打开 3D 编辑器`)
+
+  const cameraRow = win.getByRole('button', { name: '相机1', exact: true }).first()
+  await cameraRow.click({ timeout: 8000 })
+  await win.waitForTimeout(700)
+  pass.cameraSelected = (await win.getByText('FOV', { exact: false }).count()) > 0
+    || (await win.getByText('运镜预设', { exact: true }).count()) > 0
+  log(`  ${pass.cameraSelected ? '✓' : '✗'} 选中相机并显示运镜属性`)
+
+  const referencePanel = win.locator('[data-scene3d-reference-panel]').first()
+  await referencePanel.waitFor({ state: 'attached', timeout: 5000 })
+  await referencePanel.scrollIntoViewIfNeeded({ timeout: 5000 })
+  await win.waitForTimeout(500)
+  await referencePanel.waitFor({ state: 'visible', timeout: 5000 })
+  const targetLabel = await win.locator('[data-scene3d-reference-target]').first().innerText()
+  pass.referencePanel = /video_ref/.test(targetLabel) && /镜头 01/.test(targetLabel)
+  await win.screenshot({ path: path.join(outDir, '02-camera-reference-panel.png') })
+  log(`  ${pass.referencePanel ? '✓' : '✗'} 参考输出面板指向 video_ref (${targetLabel})`)
+
+  const pushIn = win.getByRole('button', { name: '推近', exact: true }).first()
+  await pushIn.click({ timeout: 5000 })
+  await win.waitForTimeout(900)
+  pass.moveApplied = await win.evaluate(async () => {
+    const { useGenerationCanvasStore } = await import('/src/workbench/generationCanvas/store/generationCanvasStore.ts')
+    const nodes = useGenerationCanvasStore.getState().nodes
+    const scene = nodes.find((node) => node.title === '导演参考台')
+    const state = scene?.meta?.scene3dState
+    return Array.isArray(state?.trajectories) && state.trajectories.length > 0
+      && Array.isArray(state?.trajectoryBindings) && state.trajectoryBindings.length > 0
+  })
+  log(`  ${pass.moveApplied ? '✓' : '✗'} 点击「推近」后生成相机轨迹`)
+
+  const exportFrames = win.getByRole('button', { name: '导出运镜首尾帧', exact: true }).first()
+  await exportFrames.click({ timeout: 5000 })
+  await win.waitForTimeout(3500)
+  await win.screenshot({ path: path.join(outDir, '03-after-export-frames.png') })
+  const frameState = await win.evaluate(async (targetId) => {
+    const { useGenerationCanvasStore } = await import('/src/workbench/generationCanvas/store/generationCanvasStore.ts')
+    const state = useGenerationCanvasStore.getState()
+    const incoming = state.edges.filter((edge) => edge.target === targetId)
+    const first = incoming.find((edge) => edge.mode === 'first_frame')
+    const last = incoming.find((edge) => edge.mode === 'last_frame')
+    const imageSources = new Set(state.nodes.filter((node) => node.kind === 'image').map((node) => node.id))
+    return {
+      imageCount: imageSources.size,
+      firstConnected: Boolean(first && imageSources.has(first.source)),
+      lastConnected: Boolean(last && imageSources.has(last.source)),
+      modes: incoming.map((edge) => edge.mode).sort(),
+    }
+  }, ids.targetId)
+  pass.framesConnected = Boolean(frameState.firstConnected && frameState.lastConnected && frameState.imageCount >= 2)
+  log(`  ${pass.framesConnected ? '✓' : '✗'} 首/尾帧图片自动接入视频节点 (${frameState.modes.join(', ')})`)
+
+  const possessCamera = win.getByRole('button', { name: '操控', exact: true }).first()
+  await possessCamera.click({ timeout: 8000 })
+  await win.waitForTimeout(900)
+  const cameraToolbar = win.locator('[aria-label="镜头操控工具栏"]').first()
+  await cameraToolbar.waitFor({ state: 'visible', timeout: 8000 })
+
+  const recBtn = win.locator('[title^="录 take"]').first()
+  await recBtn.click({ timeout: 5000 })
+  await win.waitForTimeout(500)
+  const stopBtn = win.locator('[title="停止录制并生成参考视频"]').first()
+  await stopBtn.waitFor({ state: 'visible', timeout: 5000 })
+  await win.keyboard.down('KeyW')
+  await win.waitForTimeout(2200)
+  await win.keyboard.up('KeyW')
+  await win.waitForTimeout(400)
+  await win.screenshot({ path: path.join(outDir, '04-recording-take.png') })
+  await stopBtn.click({ timeout: 5000 })
+  await win.waitForTimeout(1400)
+
+  let attachedState = null
+  for (let i = 0; i < 45; i += 1) {
+    attachedState = await win.evaluate(async (targetId) => {
+      const { useGenerationCanvasStore } = await import('/src/workbench/generationCanvas/store/generationCanvasStore.ts')
+      const state = useGenerationCanvasStore.getState()
+      const target = state.nodes.find((node) => node.id === targetId)
+      const takeNodes = state.nodes.filter((node) => node.title === '录制走位参考')
+      return {
+        targetVideoUrls: Array.isArray(target?.meta?.referenceVideoUrls) ? target.meta.referenceVideoUrls : [],
+        targetAttached: target?.meta?.cameraMoveAttached === true,
+        targetModeId: target?.meta?.archetype?.modeId,
+        takeCount: takeNodes.length,
+        takeStatuses: takeNodes.map((node) => ({
+          hasAutoCapture: Boolean(node.meta?.cameraMoveAutoCapture),
+          hasVideo: Boolean(node.meta?.cameraMoveVideo),
+        })),
+      }
+    }, ids.targetId)
+    if (attachedState?.targetVideoUrls?.length > 0 && attachedState?.targetAttached) break
+    await win.waitForTimeout(2000)
+  }
+  await win.screenshot({ path: path.join(outDir, '05-after-record-take.png') })
+  pass.takeVideoRefAttached = Boolean(
+    attachedState?.targetVideoUrls?.length > 0 &&
+    attachedState?.targetAttached &&
+    attachedState?.targetModeId === 'omni' &&
+    attachedState?.takeCount > 0,
+  )
+  log(
+    `  ${pass.takeVideoRefAttached ? '✓' : '✗'} 录 take 参考视频写入 video_ref ` +
+    `(urls=${attachedState?.targetVideoUrls?.length ?? 0}, takes=${attachedState?.takeCount ?? 0}, mode=${attachedState?.targetModeId ?? 'n/a'})`,
+  )
+
+  log('\n═══ 结果 ═══')
+  log(`  隔离项目:              ${pass.projectOpen ? '✓' : '✗'}`)
+  log(`  store bridge:          ${pass.storeReady ? '✓' : '✗'}`)
+  log(`  注入画布夹具:          ${pass.injected ? '✓' : '✗'}`)
+  log(`  打开导演台:            ${pass.editorOpen ? '✓' : '✗'}`)
+  log(`  选中相机:              ${pass.cameraSelected ? '✓' : '✗'}`)
+  log(`  UI 显示 video_ref:     ${pass.referencePanel ? '✓' : '✗'}`)
+  log(`  推近运镜落轨迹:        ${pass.moveApplied ? '✓' : '✗'}`)
+  log(`  首尾帧自动连视频槽:    ${pass.framesConnected ? '✓' : '✗'}`)
+  log(`  录 take 写入 video_ref: ${pass.takeVideoRefAttached ? '✓' : '✗'}`)
+  log(errors.length ? `\nconsole errors:\n  ${errors.slice(0, 8).join('\n  ')}` : '\nno console errors')
+
+  const ok = Object.values(pass).every(Boolean)
+  await app.close()
+  vite.kill('SIGTERM')
+  process.exit(ok ? 0 : 1)
+} catch (err) {
+  log(`\nFAIL: ${err?.message || err}`)
+  try {
+    const win = await app.firstWindow()
+    await win.screenshot({ path: path.join(outDir, 'FAIL.png') })
+  } catch {}
+  await app.close().catch(() => undefined)
+  vite.kill('SIGTERM')
+  process.exit(1)
+}


### PR DESCRIPTION
## Summary
- surface Scene3D downstream video targets in the camera move panel with video_ref / prompt fallback routing
- auto-wire exported camera move first/last frames into supported video frame slots
- extract and test recorded-take video_ref attachment, plus real-click E2E for reference frames and recorded take mp4 injection
- add design-system-aligned mockup and implementation plan docs

## Verification
- ./node_modules/.bin/vitest run
- ./node_modules/.bin/eslint . --max-warnings=98
- pnpm run check:filesize && pnpm run check:tokens && pnpm run check:dangling-tokens
- node scripts/build-tailwind.mjs --minify && ./node_modules/.bin/vite build --mode production && ./node_modules/.bin/tsc -p electron/tsconfig.json
- node tests/ux/scene3d-reference-pack.walk.mjs