### PR TITLE
fix(dreamina): 即梦 CLI 强制直连——梯子把即梦分流到海外导致会员识别失败

### DIFF
--- a/electron/catalog/dreaminaCli.test.ts
+++ b/electron/catalog/dreaminaCli.test.ts
@@ -1,0 +1,44 @@
+// buildDreaminaEnv 回归：即梦是国内服务，子进程必须强制直连——抹掉一切出站代理变量 + NO_PROXY=*。
+// 防的是「有人日后清理 spawn env 时，把 ...process.env 原样透传回去」这种静默复发（青阳的梯子 bug 根因）。
+import { describe, it, expect } from "vitest";
+import { buildDreaminaEnv } from "./dreaminaCli";
+
+describe("dreamina 子进程强制直连（buildDreaminaEnv）", () => {
+  const proxied: NodeJS.ProcessEnv = {
+    HTTP_PROXY: "http://127.0.0.1:7897",
+    http_proxy: "http://127.0.0.1:7897",
+    HTTPS_PROXY: "http://127.0.0.1:7897",
+    https_proxy: "http://127.0.0.1:7897",
+    ALL_PROXY: "socks5://127.0.0.1:7897",
+    all_proxy: "socks5://127.0.0.1:7897",
+    NO_PROXY: "localhost,127.0.0.1",
+    PATH: "/usr/bin:/bin",
+    HOME: "/Users/tester",
+  };
+
+  it("六个出站代理变量（大小写）全被抹掉", () => {
+    const env = buildDreaminaEnv(proxied);
+    for (const key of ["HTTP_PROXY", "http_proxy", "HTTPS_PROXY", "https_proxy", "ALL_PROXY", "all_proxy"]) {
+      expect(env[key], `${key} 应被删除`).toBeUndefined();
+    }
+  });
+
+  it("NO_PROXY / no_proxy 被强制成 *（兜底：代理若从别处冒出来也绕开即梦）", () => {
+    const env = buildDreaminaEnv(proxied);
+    expect(env.NO_PROXY).toBe("*");
+    expect(env.no_proxy).toBe("*");
+  });
+
+  it("无关变量保留；原 PATH 并入且补上 ~/.local/bin 兜底目录", () => {
+    const env = buildDreaminaEnv(proxied);
+    expect(env.HOME).toBe("/Users/tester");        // 无关变量不动
+    expect(env.PATH).toContain("/usr/bin");         // 原 PATH 保留
+    expect(env.PATH).toContain(".local/bin");       // GUI Electron 极简 PATH 的兜底
+  });
+
+  it("不改传入对象（返回新 env，不污染 process.env）", () => {
+    const snapshot = { ...proxied };
+    buildDreaminaEnv(proxied);
+    expect(proxied).toEqual(snapshot);
+  });
+});

--- a/electron/catalog/dreaminaCli.ts
+++ b/electron/catalog/dreaminaCli.ts
@@ -28,6 +28,38 @@ function extraPathDirs(): string[] {
     : [path.join(home, ".local", "bin"), "/usr/local/bin", "/opt/homebrew/bin", path.join(home, "bin")];
 }
 
+/** 出站代理环境变量名（大小写各一份）。dreamina 子进程要抹掉这些 → 见 buildDreaminaEnv。 */
+const PROXY_ENV_KEYS = [
+  "HTTP_PROXY", "http_proxy",
+  "HTTPS_PROXY", "https_proxy",
+  "ALL_PROXY", "all_proxy",
+] as const;
+
+/**
+ * dreamina 子进程的 env：补 PATH 兜底 + **强制直连**（抹掉继承来的出站代理变量 + NO_PROXY=*）。
+ *
+ * 病根：dreamina 是 Go 程序，HTTP 栈只认环境变量代理（HTTP(S)_PROXY / NO_PROXY，见其内置
+ * golang.org/x/net/http/httpproxy）；而即梦（jimeng.jianying.com）是中国大陆服务、按来源 IP 认会员。
+ * 用户为访问海外 AI API 开的梯子若把 HTTP(S)_PROXY 泄进本子进程，dreamina 的 user_credit / login /
+ * 生成就会经代理出站——代理只要把即梦分流到海外（就是青阳机器上 clash 的行为），即梦即当成非本土
+ * 流量 → 会员识别失败 / 静默拒绝（现象：得关掉梯子才能用）。app 自身 fetch 该走代理（systemProxy.ts
+ * 管，为的是海外 API）；即梦 CLI 恰恰相反——永远直连。故给子进程一份抹掉代理的 env。
+ *
+ * 实测（2026-07-04，本机 clash 开着、把代理指向死端口验证）：带代理 →
+ * `proxyconnect tcp ... connection refused` 直接挂；删掉代理变量 或 NO_PROXY=* → user_credit 正常返回。
+ * 两条都灵，这里双保险（删变量治「梯子经 env 泄进来」，NO_PROXY=* 兜底「代理从别处冒出来」）。
+ * 注：clash「TUN / 增强模式」在网络层透明改道，env 层拦不住——那种只能在梯子里给
+ * jimeng.jianying.com 配直连分流规则，非本进程能修。
+ */
+export function buildDreaminaEnv(base: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv {
+  const mergedPath = [...extraPathDirs(), base.PATH || ""].filter(Boolean).join(path.delimiter);
+  const env: NodeJS.ProcessEnv = { ...base, PATH: mergedPath };
+  for (const key of PROXY_ENV_KEYS) delete env[key];
+  env.NO_PROXY = "*";
+  env.no_proxy = "*";
+  return env;
+}
+
 /**
  * 解析 dreamina 真实可执行路径：env 覆盖 → 已知安装位逐个探。返回 "" 表示未安装（调用方负责引导安装）。
  * 不做 `which`（GUI PATH 不可靠），直接探文件存在性。
@@ -59,9 +91,8 @@ export function runDreaminaCli(args: string[], opts: { timeoutMs?: number; bin?:
     );
   }
   const timeoutMs = opts.timeoutMs ?? 120_000;
-  const mergedPath = [...extraPathDirs(), process.env.PATH || ""].filter(Boolean).join(path.delimiter);
   return new Promise<DreaminaRunResult>((resolve, reject) => {
-    const child = spawn(bin, args, { windowsHide: true, env: { ...process.env, PATH: mergedPath } });
+    const child = spawn(bin, args, { windowsHide: true, env: buildDreaminaEnv() });
     let stdout = "";
     let stderr = "";
     let settled = false;

--- a/electron/catalog/dreaminaLoginIpc.ts
+++ b/electron/catalog/dreaminaLoginIpc.ts
@@ -75,7 +75,8 @@ export function dreaminaInstall(): Promise<DreaminaInstallResult> {
     return Promise.resolve({ ok: false, message: "Windows 暂请在 WSL 或手动安装即梦 CLI（curl -fsSL https://jimeng.jianying.com/cli | bash）。" });
   }
   return new Promise<DreaminaInstallResult>((resolve) => {
-    const child = spawn("/bin/bash", ["-lc", "curl -fsSL https://jimeng.jianying.com/cli | bash"], { windowsHide: true });
+    // 即梦是国内服务：curl 强制 --noproxy '*' 直连，别让梯子把安装源分流到海外（与 dreaminaCli.buildDreaminaEnv 同理）。
+    const child = spawn("/bin/bash", ["-lc", "curl --noproxy '*' -fsSL https://jimeng.jianying.com/cli | bash"], { windowsHide: true });
     let out = "";
     const timer = setTimeout(() => { try { child.kill("SIGKILL"); } catch { /* gone */ } resolve({ ok: false, message: "安装超时，请稍后重试或终端手动安装。" }); }, 120_000);
     child.stdout?.on("data", (c) => { out += String(c); });


### PR DESCRIPTION
## 问题
即梦会员在代理(梯子)模式下用不了、得关掉梯子才行(青阳反馈)。

## 根因
`dreamina` CLI 是 Go 程序,其 HTTP 栈只认**环境变量代理**(`HTTP(S)_PROXY` / `NO_PROXY`,内置 `golang.org/x/net/http/httpproxy`)。`runDreaminaCli` spawn 子进程时透传了整份 `process.env`(含梯子的 `HTTP(S)_PROXY`),于是即梦(`jimeng.jianying.com`,中国大陆服务、按来源 IP 认会员)的 `user_credit` / `login` / 生成请求都经代理出站。代理只要把即梦分流到海外,即梦即当成非本土流量 → 会员识别失败 / 静默拒绝。app 自身 fetch 该走代理(`systemProxy.ts` 管,为的是海外 AI API);即梦 CLI 恰恰相反——必须永远直连。

## 改动
- 新增 `buildDreaminaEnv()`:给 dreamina 子进程一份**抹掉 6 个出站代理变量(大小写) + `NO_PROXY=*`** 的 env(双保险);`runDreaminaCli` 统一走它,一次覆盖 **识别 / 登录 / 退登 / 生成** 全路径。
- 一键安装的 `curl` 补 `--noproxy '*'`,别让梯子把安装源分流到海外。
- 补 `buildDreaminaEnv` 单测 4 例。

## 实测
本机 clash 开着、把代理指向死端口验证:
- 带代理、不绕过 → `proxyconnect tcp ... connection refused`(复现 bug);
- 带代理 + `NO_PROXY=*` → `user_credit` 正常返回;
- 抹掉代理变量 → 正常返回。

`tsc` + `vitest`(23 例,含新增 4 例)全绿。

## 边界
clash「TUN / 增强模式」在网络层透明改道,env 层拦不住——那种需在梯子里给 `jimeng.jianying.com` 配直连分流规则,非本进程能修。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
