### PR TITLE
feat(browser): add minimal reference capture window

### DIFF
--- a/electron/assets/assetPaths.test.ts
+++ b/electron/assets/assetPaths.test.ts
@@ -86,6 +86,7 @@ describe("assetBucketFromMeta", () => {
     expect(assetBucketFromMeta({ kind: "upload" })).toBe("imported");
     expect(assetBucketFromMeta({ kind: "imported" })).toBe("imported");
     expect(assetBucketFromMeta({ kind: "local" })).toBe("imported");
+    expect(assetBucketFromMeta({ kind: "browser-capture" })).toBe("imported");
     expect(assetBucketFromMeta({ kind: "generated" })).toBe("generated");
     expect(assetBucketFromMeta({})).toBe("generated");
   });

--- a/electron/assets/assetPaths.ts
+++ b/electron/assets/assetPaths.ts
@@ -50,5 +50,5 @@ export function stableAssetId(projectId: string, relativePath: string): string {
 
 export function assetBucketFromMeta(meta: JsonRecord): "generated" | "imported" {
   const kind = String(meta.kind || "").toLowerCase();
-  return kind === "upload" || kind === "imported" || kind === "local" ? "imported" : "generated";
+  return kind === "upload" || kind === "imported" || kind === "local" || kind === "browser-capture" ? "imported" : "generated";
 }

--- a/electron/browserCapture/browserCaptureMedia.test.ts
+++ b/electron/browserCapture/browserCaptureMedia.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from "vitest";
+import { browserCaptureContentType, browserCaptureFileName, browserCaptureMediaTarget } from "./browserCaptureMedia";
+
+describe("browser capture media helpers", () => {
+  it("extracts right-click image and video targets from Electron context menu params", () => {
+    expect(browserCaptureMediaTarget({ mediaType: "image", srcURL: "https://cdn.example.com/a.png", suggestedFilename: "a.png" })).toEqual({
+      kind: "image",
+      url: "https://cdn.example.com/a.png",
+      suggestedName: "a.png",
+    });
+    expect(browserCaptureMediaTarget({ mediaType: "video", srcURL: "data:video/mp4;base64,AAAA", suggestedFilename: "" })).toMatchObject({
+      kind: "video",
+      url: "data:video/mp4;base64,AAAA",
+    });
+  });
+
+  it("rejects non-media and blob targets so capture stays on downloadable bytes", () => {
+    expect(browserCaptureMediaTarget({ mediaType: "canvas", srcURL: "https://x/canvas", suggestedFilename: "" })).toBeNull();
+    expect(browserCaptureMediaTarget({ mediaType: "image", srcURL: "blob:https://x/id", suggestedFilename: "" })).toBeNull();
+    expect(browserCaptureMediaTarget({ mediaType: "image", srcURL: "", suggestedFilename: "" })).toBeNull();
+  });
+
+  it("builds a safe file name from suggestion, URL, or content type", () => {
+    vi.spyOn(Date, "now").mockReturnValue(123);
+    expect(browserCaptureFileName({ url: "https://x/assets/cat", contentType: "image/webp", fallbackKind: "image" })).toBe("cat.webp");
+    expect(browserCaptureFileName({ url: "https://x/a", contentType: "video/mp4", suggestedName: "clip", fallbackKind: "video" })).toBe("clip.mp4");
+    expect(browserCaptureFileName({ url: "not-a-url", contentType: "image/png", fallbackKind: "image" })).toBe("browser-capture-123.png");
+  });
+
+  it("normalizes content type to image or video families", () => {
+    expect(browserCaptureContentType({ responseType: "image/png; charset=utf-8", fileName: "x.bin", fallbackKind: "image" })).toBe("image/png");
+    expect(browserCaptureContentType({ responseType: "application/octet-stream", fileName: "movie.webm", fallbackKind: "video" })).toBe("video/webm");
+    expect(browserCaptureContentType({ responseType: "application/octet-stream", fileName: "x.bin", fallbackKind: "image" })).toBe("image/png");
+  });
+});

--- a/electron/browserCapture/browserCaptureMedia.ts
+++ b/electron/browserCapture/browserCaptureMedia.ts
@@ -1,0 +1,56 @@
+import path from "node:path";
+import type { ContextMenuParams } from "electron";
+import { contentTypeFromPath, extensionFromMime, extensionFromUrl } from "../assets/assetPaths";
+import { sanitizeName } from "../projects/repository";
+
+export type BrowserCaptureMediaKind = "image" | "video";
+
+export type BrowserCaptureMediaTarget = {
+  kind: BrowserCaptureMediaKind;
+  url: string;
+  suggestedName: string;
+};
+
+export function browserCaptureMediaTarget(params: Pick<ContextMenuParams, "mediaType" | "srcURL" | "suggestedFilename">): BrowserCaptureMediaTarget | null {
+  if (params.mediaType !== "image" && params.mediaType !== "video") return null;
+  const url = String(params.srcURL || "").trim();
+  if (!url || (!/^https?:\/\//i.test(url) && !url.startsWith("data:"))) return null;
+  return {
+    kind: params.mediaType,
+    url,
+    suggestedName: String(params.suggestedFilename || "").trim(),
+  };
+}
+
+export function browserCaptureFileName(input: {
+  url: string;
+  contentType: string;
+  suggestedName?: string;
+  fallbackKind: BrowserCaptureMediaKind;
+}): string {
+  const fromSuggestion = String(input.suggestedName || "").trim();
+  const fromUrl = (() => {
+    try {
+      return path.basename(new URL(input.url).pathname);
+    } catch {
+      return "";
+    }
+  })();
+  const fallbackExt = input.fallbackKind === "video" ? "mp4" : "png";
+  const ext = extensionFromMime(input.contentType, extensionFromUrl(input.url) || fallbackExt);
+  const rawName = fromSuggestion || fromUrl || `browser-capture-${Date.now()}.${ext}`;
+  const safeName = sanitizeName(rawName, `browser-capture.${ext}`);
+  return path.extname(safeName) ? safeName : `${safeName}.${ext}`;
+}
+
+export function browserCaptureContentType(input: {
+  responseType: string;
+  fileName: string;
+  fallbackKind: BrowserCaptureMediaKind;
+}): string {
+  const responseType = String(input.responseType || "").split(";")[0].trim().toLowerCase();
+  if (responseType.startsWith("image/") || responseType.startsWith("video/")) return responseType;
+  const fromName = contentTypeFromPath(input.fileName);
+  if (fromName.startsWith("image/") || fromName.startsWith("video/")) return fromName;
+  return input.fallbackKind === "video" ? "video/mp4" : "image/png";
+}

--- a/electron/browserCapture/browserCaptureWindow.ts
+++ b/electron/browserCapture/browserCaptureWindow.ts
@@ -1,0 +1,286 @@
+import { BrowserWindow, Menu, WebContentsView, ipcMain, shell, session } from "electron";
+import type { BrowserWindowConstructorOptions, Rectangle, Session } from "electron";
+import path from "node:path";
+import { parseDataUrl } from "../assets/assetBytes";
+import { importLocalFile } from "../assets/localFileImport";
+import { browserCaptureContentType, browserCaptureFileName, browserCaptureMediaTarget, type BrowserCaptureMediaKind } from "./browserCaptureMedia";
+
+type CaptureState = {
+  url: string;
+  title: string;
+  loading: boolean;
+  canGoBack: boolean;
+  canGoForward: boolean;
+  status: string;
+  error: string | null;
+};
+
+type CaptureRecord = {
+  projectId: string;
+  window: BrowserWindow;
+  view: WebContentsView;
+};
+
+const BROWSER_CAPTURE_PARTITION = "persist:nomi-browser-capture";
+const BROWSER_CAPTURE_SHELL_PARTITION = "persist:nomi-browser-capture-shell";
+const TOOLBAR_HEIGHT = 44;
+let captureRecord: CaptureRecord | null = null;
+let captureSessionHardened = false;
+
+function normalizeCaptureUrl(raw: unknown): string {
+  const text = String(raw || "").trim();
+  if (!text) throw new Error("请输入网址");
+  const withProtocol = /^[a-zA-Z][a-zA-Z\d+.-]*:/.test(text) ? text : `https://${text}`;
+  const url = new URL(withProtocol);
+  if (url.protocol !== "http:" && url.protocol !== "https:") throw new Error("只支持 http(s) 网页");
+  return url.toString();
+}
+
+function captureShellHtml(): string {
+  return `<!doctype html><html><head><meta charset="utf-8"><title>Nomi 参考捕捞</title><style>
+*{box-sizing:border-box}html,body{margin:0;width:100%;height:100%;overflow:hidden;background:#f6f3ee;color:#2b2823;font-family:Inter,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif}
+.bar{height:${TOOLBAR_HEIGHT}px;display:grid;grid-template-columns:auto auto minmax(0,1fr) auto;gap:6px;align-items:center;padding:6px 10px;border-bottom:1px solid rgba(43,40,35,.12);background:#fffdfa}
+button{height:30px;min-width:30px;border:1px solid transparent;border-radius:6px;background:transparent;color:#4c453d;font:600 13px/1 inherit;cursor:pointer}
+button:hover:not(:disabled){background:rgba(43,40,35,.06)}button:disabled{opacity:.38;cursor:default}
+form{display:flex;min-width:0;gap:6px}input{height:30px;min-width:0;flex:1;border:1px solid rgba(43,40,35,.16);border-radius:6px;background:#f6f3ee;padding:0 10px;color:#2b2823;font:500 13px/30px inherit;outline:none}
+input:focus{border-color:rgba(75,108,86,.55);background:#fff}.status{height:20px;min-width:140px;text-align:right;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:rgba(43,40,35,.55);font-size:12px}
+.hint{position:absolute;left:0;right:0;top:44px;height:28px;display:none;align-items:center;justify-content:center;background:rgba(75,108,86,.94);color:white;font-size:12px;font-weight:650;z-index:2}.hint[data-open="true"]{display:flex}
+</style></head><body>
+<div class="bar">
+  <button id="back" title="后退" aria-label="后退">‹</button>
+  <button id="forward" title="前进" aria-label="前进">›</button>
+  <form id="form"><input id="url" spellcheck="false" autocomplete="off" placeholder="输入参考网页地址" /></form>
+  <div class="status" id="status">右键图片或视频捕捞进素材库</div>
+</div>
+<div class="hint" id="hint"></div>
+<script>
+const api = window.nomiDesktop && window.nomiDesktop.browserCapture;
+const form = document.getElementById('form');
+const input = document.getElementById('url');
+const back = document.getElementById('back');
+const forward = document.getElementById('forward');
+const status = document.getElementById('status');
+const hint = document.getElementById('hint');
+let hintTimer = 0;
+function showHint(text, danger) {
+  window.clearTimeout(hintTimer);
+  hint.textContent = text;
+  hint.style.background = danger ? 'rgba(159,57,45,.94)' : 'rgba(75,108,86,.94)';
+  hint.dataset.open = 'true';
+  hintTimer = window.setTimeout(() => { hint.dataset.open = 'false'; }, 2200);
+}
+form.addEventListener('submit', (event) => {
+  event.preventDefault();
+  api && api.navigate(input.value).catch((error) => showHint(error && error.message ? error.message : String(error), true));
+});
+back.addEventListener('click', () => api && api.back());
+forward.addEventListener('click', () => api && api.forward());
+api && api.onState((state) => {
+  if (document.activeElement !== input) input.value = state.url || '';
+  back.disabled = !state.canGoBack;
+  forward.disabled = !state.canGoForward;
+  status.textContent = state.error || state.status || (state.loading ? '加载中' : '右键图片或视频捕捞进素材库');
+});
+api && api.onCaptureResult((result) => showHint(result.ok ? '已捕捞到素材库：' + result.name : result.error, !result.ok));
+</script></body></html>`;
+}
+
+function shellOptions(parent?: BrowserWindow | null): BrowserWindowConstructorOptions {
+  return {
+    width: 1120,
+    height: 760,
+    minWidth: 760,
+    minHeight: 520,
+    title: "Nomi 参考捕捞",
+    backgroundColor: "#f6f3ee",
+    ...(parent ? { parent } : {}),
+    webPreferences: {
+      preload: path.join(__dirname, "../preload.js"),
+      contextIsolation: true,
+      nodeIntegration: false,
+      sandbox: false,
+      partition: BROWSER_CAPTURE_SHELL_PARTITION,
+    },
+  };
+}
+
+function hardenCaptureSession(viewSession: Session): void {
+  if (captureSessionHardened) return;
+  captureSessionHardened = true;
+  viewSession.setPermissionCheckHandler(() => false);
+  viewSession.setPermissionRequestHandler((_contents, _permission, callback) => callback(false));
+  viewSession.setDisplayMediaRequestHandler((_request, callback) => callback({}));
+}
+
+function viewBounds(bounds: Rectangle): Rectangle {
+  return { x: 0, y: TOOLBAR_HEIGHT, width: bounds.width, height: Math.max(0, bounds.height - TOOLBAR_HEIGHT) };
+}
+
+function sendState(record: CaptureRecord, patch: Partial<CaptureState> = {}): void {
+  const contents = record.view.webContents;
+  const state: CaptureState = {
+    url: contents.getURL(),
+    title: contents.getTitle(),
+    loading: contents.isLoading(),
+    canGoBack: contents.canGoBack(),
+    canGoForward: contents.canGoForward(),
+    status: "",
+    error: null,
+    ...patch,
+  };
+  if (!record.window.isDestroyed()) record.window.webContents.send("nomi:browser-capture:state", state);
+}
+
+function notifyAssetImported(projectId: string): void {
+  for (const win of BrowserWindow.getAllWindows()) {
+    if (!win.isDestroyed()) win.webContents.send("nomi:browser-capture:asset-imported", { projectId });
+  }
+}
+
+async function bytesForTarget(record: CaptureRecord, target: { url: string; kind: BrowserCaptureMediaKind; pageUrl: string; suggestedName: string }): Promise<{
+  bytes: Buffer;
+  contentType: string;
+  fileName: string;
+}> {
+  if (target.url.startsWith("data:")) {
+    const parsed = parseDataUrl(target.url);
+    const fileName = browserCaptureFileName({ url: target.url, contentType: parsed.contentType, suggestedName: target.suggestedName, fallbackKind: target.kind });
+    return { bytes: parsed.bytes, contentType: parsed.contentType, fileName };
+  }
+  const response = await record.view.webContents.session.fetch(target.url, {
+    headers: target.pageUrl ? { Referer: target.pageUrl } : undefined,
+  });
+  if (!response.ok) throw new Error(`下载失败：HTTP ${response.status}`);
+  const responseType = response.headers.get("content-type") || "";
+  const firstName = browserCaptureFileName({ url: target.url, contentType: responseType, suggestedName: target.suggestedName, fallbackKind: target.kind });
+  const contentType = browserCaptureContentType({ responseType, fileName: firstName, fallbackKind: target.kind });
+  const fileName = browserCaptureFileName({ url: target.url, contentType, suggestedName: firstName, fallbackKind: target.kind });
+  return { bytes: Buffer.from(await response.arrayBuffer()), contentType, fileName };
+}
+
+async function importCaptureTarget(record: CaptureRecord, target: { url: string; kind: BrowserCaptureMediaKind; pageUrl: string; suggestedName: string }): Promise<void> {
+  try {
+    sendState(record, { status: "正在捕捞素材" });
+    const media = await bytesForTarget(record, target);
+    const asset = await importLocalFile({
+      projectId: record.projectId,
+      bytes: media.bytes,
+      contentType: media.contentType,
+      fileName: media.fileName,
+      kind: "browser-capture",
+    }) as { name?: string };
+    record.window.webContents.send("nomi:browser-capture:result", { ok: true, name: asset.name || media.fileName });
+    notifyAssetImported(record.projectId);
+    sendState(record, { status: "已捕捞到素材库" });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    record.window.webContents.send("nomi:browser-capture:result", { ok: false, error: message });
+    sendState(record, { status: "", error: message });
+  }
+}
+
+function installViewHandlers(record: CaptureRecord): void {
+  const contents = record.view.webContents;
+  contents.setWindowOpenHandler(({ url }) => {
+    if (/^https?:\/\//i.test(url)) {
+      void contents.loadURL(url);
+    } else {
+      void shell.openExternal(url);
+    }
+    return { action: "deny" };
+  });
+  contents.on("did-start-loading", () => sendState(record, { status: "加载中" }));
+  contents.on("did-stop-loading", () => sendState(record));
+  contents.on("did-navigate", () => sendState(record));
+  contents.on("did-navigate-in-page", () => sendState(record));
+  contents.on("page-title-updated", () => sendState(record));
+  contents.on("did-fail-load", (_event, code, description, failedUrl, isMainFrame) => {
+    if (isMainFrame) sendState(record, { error: `${description || "加载失败"} (${code})`, url: failedUrl });
+  });
+  contents.on("context-menu", (event, params) => {
+    event.preventDefault();
+    const target = browserCaptureMediaTarget(params);
+    const template: Electron.MenuItemConstructorOptions[] = [];
+    if (target) {
+      template.push({
+        label: target.kind === "video" ? "捕捞视频到素材库" : "捕捞图片到素材库",
+        click: () => void importCaptureTarget(record, {
+          url: target.url,
+          kind: target.kind,
+          pageUrl: params.pageURL || contents.getURL(),
+          suggestedName: target.suggestedName,
+        }),
+      });
+      template.push({ type: "separator" });
+    }
+    template.push(
+      { label: "后退", enabled: contents.canGoBack(), click: () => contents.goBack() },
+      { label: "前进", enabled: contents.canGoForward(), click: () => contents.goForward() },
+      { label: "刷新", click: () => contents.reload() },
+    );
+    Menu.buildFromTemplate(template).popup({ window: record.window, x: params.x, y: params.y, sourceType: params.menuSourceType });
+  });
+}
+
+function ensureCaptureRecord(projectId: string, owner?: BrowserWindow | null): CaptureRecord {
+  if (captureRecord && !captureRecord.window.isDestroyed()) {
+    captureRecord.projectId = projectId;
+    captureRecord.window.show();
+    captureRecord.window.focus();
+    sendState(captureRecord);
+    return captureRecord;
+  }
+  const viewSession = session.fromPartition(BROWSER_CAPTURE_PARTITION);
+  hardenCaptureSession(viewSession);
+  const window = new BrowserWindow(shellOptions(owner));
+  const view = new WebContentsView({
+    webPreferences: {
+      contextIsolation: true,
+      nodeIntegration: false,
+      sandbox: true,
+      session: viewSession,
+    },
+  });
+  const record: CaptureRecord = { projectId, window, view };
+  captureRecord = record;
+  window.contentView.addChildView(view);
+  view.setBounds(viewBounds(window.getContentBounds()));
+  window.on("resize", () => view.setBounds(viewBounds(window.getContentBounds())));
+  window.on("closed", () => {
+    if (captureRecord === record) captureRecord = null;
+    if (!view.webContents.isDestroyed()) view.webContents.close();
+  });
+  installViewHandlers(record);
+  void window.loadURL(`data:text/html;charset=utf-8,${encodeURIComponent(captureShellHtml())}`);
+  return record;
+}
+
+export function registerBrowserCaptureIpc(): void {
+  ipcMain.handle("nomi:browser-capture:open", async (event, payload: { projectId?: unknown; url?: unknown } | null) => {
+    const projectId = String(payload?.projectId || "").trim();
+    if (!projectId) throw new Error("projectId is required");
+    const owner = BrowserWindow.fromWebContents(event.sender);
+    const record = ensureCaptureRecord(projectId, owner);
+    if (payload?.url) await record.view.webContents.loadURL(normalizeCaptureUrl(payload.url));
+    sendState(record);
+    return { ok: true };
+  });
+  ipcMain.handle("nomi:browser-capture:navigate", async (_event, payload: { url?: unknown } | null) => {
+    if (!captureRecord || captureRecord.window.isDestroyed()) throw new Error("参考捕捞窗未打开");
+    await captureRecord.view.webContents.loadURL(normalizeCaptureUrl(payload?.url));
+    sendState(captureRecord);
+    return { ok: true };
+  });
+  ipcMain.handle("nomi:browser-capture:back", () => {
+    if (captureRecord?.view.webContents.canGoBack()) captureRecord.view.webContents.goBack();
+  });
+  ipcMain.handle("nomi:browser-capture:forward", () => {
+    if (captureRecord?.view.webContents.canGoForward()) captureRecord.view.webContents.goForward();
+  });
+  ipcMain.handle("nomi:browser-capture:reload", () => {
+    captureRecord?.view.webContents.reload();
+  });
+  ipcMain.handle("nomi:browser-capture:close", () => {
+    captureRecord?.window.close();
+  });
+}

--- a/electron/catalog/dreaminaCli.test.ts
+++ b/electron/catalog/dreaminaCli.test.ts
@@ -19,6 +19,10 @@ type FakeChild = EventEmitter & {
 const mockSpawn = vi.mocked(spawn);
 let envSnapshot: NodeJS.ProcessEnv;
 
+function normalizePathForAssert(value: unknown): string {
+  return String(value || "").replace(/\\/g, "/");
+}
+
 function restoreEnv(snapshot: NodeJS.ProcessEnv): void {
   for (const key of Object.keys(process.env)) delete process.env[key];
   Object.assign(process.env, snapshot);
@@ -89,7 +93,7 @@ describe("dreamina 子进程强制直连（buildDreaminaEnv）", () => {
     const env = buildDreaminaEnv(proxied);
     expect(env.HOME).toBe("/Users/tester");        // 无关变量不动
     expect(env.PATH).toContain("/usr/bin");         // 原 PATH 保留
-    expect(env.PATH).toContain(".local/bin");       // GUI Electron 极简 PATH 的兜底
+    expect(normalizePathForAssert(env.PATH)).toContain(".local/bin");       // GUI Electron 极简 PATH 的兜底
   });
 
   it("不改传入对象（返回新 env，不污染 process.env）", () => {
@@ -112,7 +116,7 @@ describe("runDreaminaCli", () => {
     expect(options?.env?.HTTPS_PROXY).toBeUndefined();
     expect(options?.env?.ALL_PROXY).toBeUndefined();
     expect(options?.env?.NO_PROXY).toBe("*");
-    expect(options?.env?.PATH).toContain(".local/bin");
+    expect(normalizePathForAssert(options?.env?.PATH)).toContain(".local/bin");
   });
 
   it("网络超时结果自动重试一次后返回成功结果", async () => {

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -45,6 +45,7 @@ import { registerOnboardingIpc } from "./ai/onboarding/onboardingIpc";
 import { registerUpdaterIpc } from "./update/autoUpdater";
 import { setRendererTarget } from "./capabilityCore/rendererBridge";
 import { readMcpInfo, installMcp, uninstallMcp } from "./capabilityCore/mcpConfig";
+import { registerBrowserCaptureIpc } from "./browserCapture/browserCaptureWindow";
 
 // 尽早安装：捕获引导阶段起的 uncaughtException / unhandledRejection，落盘到 app logs（P0-8）。
 installCrashHandlers();
@@ -636,6 +637,7 @@ function registerIpc(): void {
   registerPromptLibraryIpc();
   registerOnboardingIpc();
   registerUpdaterIpc();
+  registerBrowserCaptureIpc();
   // S4-1 评测安全铁律:事件落盘前,已配置的 vendor key 精确匹配脱敏(形态兜底之外的地基)。
   setEventLogSecretsProvider(catalogSecretsProvider);
 }

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -56,6 +56,29 @@ contextBridge.exposeInMainWorld("nomiDesktop", {
         path?: string;
       }>,
   },
+  browserCapture: {
+    open: (payload: unknown) => ipcRenderer.invoke("nomi:browser-capture:open", payload),
+    navigate: (url: string) => ipcRenderer.invoke("nomi:browser-capture:navigate", { url }),
+    back: () => ipcRenderer.invoke("nomi:browser-capture:back"),
+    forward: () => ipcRenderer.invoke("nomi:browser-capture:forward"),
+    reload: () => ipcRenderer.invoke("nomi:browser-capture:reload"),
+    close: () => ipcRenderer.invoke("nomi:browser-capture:close"),
+    onState: (callback: (state: unknown) => void) => {
+      const listener = (_event: unknown, payload: unknown) => callback(payload);
+      ipcRenderer.on("nomi:browser-capture:state", listener);
+      return () => ipcRenderer.removeListener("nomi:browser-capture:state", listener);
+    },
+    onCaptureResult: (callback: (result: unknown) => void) => {
+      const listener = (_event: unknown, payload: unknown) => callback(payload);
+      ipcRenderer.on("nomi:browser-capture:result", listener);
+      return () => ipcRenderer.removeListener("nomi:browser-capture:result", listener);
+    },
+    onAssetImported: (callback: (event: unknown) => void) => {
+      const listener = (_event: unknown, payload: unknown) => callback(payload);
+      ipcRenderer.on("nomi:browser-capture:asset-imported", listener);
+      return () => ipcRenderer.removeListener("nomi:browser-capture:asset-imported", listener);
+    },
+  },
   video: {
     extractFrame: (payload: unknown) =>
       ipcRenderer.invoke("nomi:video:extract-frame", payload) as Promise<{ url: string }>,

--- a/electron/workspace/workspaceRegistry.concurrency.test.ts
+++ b/electron/workspace/workspaceRegistry.concurrency.test.ts
@@ -7,10 +7,10 @@ import { listRecentWorkspaces } from "./workspaceRegistry";
 
 // poison「项目不存在」根因回归：注册表无锁 read-modify-write，多进程并发建项目时后写覆盖先写丢条目。
 // 确定性复现（修前两进程各写 N 条→丢约一半）。本测起两个真子进程并发猛写，断言一条不丢（锁生效）。
-const tsxBin = path.resolve(__dirname, "../../node_modules/.bin/tsx");
+const tsxCli = path.resolve(__dirname, "../../node_modules/tsx/dist/cli.mjs");
 
 describe("注册表并发写不丢条目（poison 根因回归）", () => {
-  it.skipIf(!fs.existsSync(tsxBin))("两进程各写 40 条 → 全留存（无锁会丢约一半）", async () => {
+  it.skipIf(!fs.existsSync(tsxCli))("两进程各写 40 条 → 全留存（无锁会丢约一半）", async () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), "nomi-registry-race-"));
     const N = 40;
     const worker = path.join(root, "worker.ts");
@@ -21,9 +21,13 @@ describe("注册表并发写不丢条目（poison 根因回归）", () => {
         `for (let i = 0; i < ${N}; i++) rememberWorkspace(root, { id: p + "-" + i, name: p + "-" + i, lastKnownRootPath: root });\n`,
     );
     const run = (prefix: string) =>
-      new Promise<void>((resolve) =>
-        spawn(tsxBin, [worker, prefix], { env: { ...process.env, RR: root }, stdio: "ignore" }).on("exit", () => resolve()),
-      );
+      new Promise<void>((resolve, reject) => {
+        const child = spawn(process.execPath, [tsxCli, worker, prefix], { env: { ...process.env, RR: root }, stdio: ["ignore", "ignore", "pipe"] });
+        let stderr = "";
+        child.stderr?.on("data", (chunk) => { stderr += String(chunk); });
+        child.on("error", reject);
+        child.on("exit", (code) => code === 0 ? resolve() : reject(new Error(`worker ${prefix} exited ${code}: ${stderr}`)));
+      });
     await Promise.all([run("A"), run("B")]);
     const listed = new Set(listRecentWorkspaces(root).map((e) => e.id));
     let lost = 0;

--- a/electron/workspace/workspaceRegistry.ts
+++ b/electron/workspace/workspaceRegistry.ts
@@ -23,12 +23,21 @@ function writeRecentWorkspaces(settingsRoot: string, entries: RecentWorkspaceEnt
  * 跨进程锁：把注册表的「读→改→写」串行化。根因（2026-06-30 钉死，确定性复现：两进程各写 60 条→丢 60 条）——
  * rememberWorkspace 是无锁 read-modify-write，多个 headless host / app 同时建项目时各读旧表、各写自己那条 →
  * 后写覆盖先写 → 条目丢 → readProject 找不到 →「项目不存在」。多 agent 并发驱动 + app 同时跑必中。
- * 用原子 mkdir 做锁（跨进程有效），自旋退避；3s 上限 + 陈旧锁兜底，绝不死等（最坏退化回原无锁行为）。
+ * 用原子 mkdir 做锁（跨进程有效），自旋退避；只清理足够陈旧的锁，避免慢机器上误删活锁后退回无锁覆盖。
  */
+const REGISTRY_LOCK_STALE_MS = 30_000;
+
+function isStaleRegistryLock(lockDir: string): boolean {
+  try {
+    return Date.now() - fs.statSync(lockDir).mtimeMs > REGISTRY_LOCK_STALE_MS;
+  } catch {
+    return false;
+  }
+}
+
 function withRegistryLock<T>(settingsRoot: string, fn: () => T): T {
   const lockDir = `${recentWorkspacesPath(settingsRoot)}.lock`;
   const spin = new Int32Array(new SharedArrayBuffer(4));
-  const deadline = Date.now() + 3000;
   let locked = false;
   for (;;) {
     try {
@@ -37,16 +46,14 @@ function withRegistryLock<T>(settingsRoot: string, fn: () => T): T {
       break;
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== "EEXIST") break; // 锁机制异常→不阻塞，退化回无锁
-      if (Date.now() > deadline) {
-        // 陈旧锁兜底：持锁进程崩溃残留 → 超时夺锁，绝不永久死等。
+      if (isStaleRegistryLock(lockDir)) {
+        // 陈旧锁兜底：持锁进程崩溃残留 → 仅在锁目录真的过旧时清掉，避免误删活锁。
         try {
           fs.rmSync(lockDir, { recursive: true, force: true });
-          fs.mkdirSync(lockDir);
-          locked = true;
         } catch {
-          /* 夺锁失败也继续（最坏=退化回原行为，不卡死） */
+          /* 其他进程可能刚释放/接手；继续自旋 */
         }
-        break;
+        continue;
       }
       Atomics.wait(spin, 0, 0, 10); // 同步退避 10ms 再抢
     }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "gen:archetype-defaults": "tsx scripts/gen-archetype-wire-defaults.ts",
     "build:handbook": "tsx scripts/build-handbook-html.mjs",
     "check:audit": "node ./scripts/check-audit-cadence.mjs && node ./scripts/check-eval-cadence.mjs",
-    "gates": "pnpm run check:filesize && pnpm run check:tokens && pnpm run check:dangling-tokens && pnpm run check:archetype-defaults && pnpm run lint:ci && pnpm run typecheck && pnpm run test && pnpm run build && mkdir -p .claude && touch .claude/.gates-ok && echo '✅ 全门通过，已盖 .claude/.gates-ok（push 闸放行）'",
+    "gates": "pnpm run check:filesize && pnpm run check:tokens && pnpm run check:dangling-tokens && pnpm run check:archetype-defaults && pnpm run lint:ci && pnpm run typecheck && pnpm run test && pnpm run build && node -e \"const fs=require('fs'); fs.mkdirSync('.claude',{recursive:true}); fs.closeSync(fs.openSync('.claude/.gates-ok','a')); console.log('✅ 全门通过，已盖 .claude/.gates-ok（push 闸放行）');\"",
     "typecheck": "tsc -p tsconfig.app.json && tsc -p electron/tsconfig.json",
     "lint": "eslint .",
     "lint:ci": "eslint . --max-warnings=98",

--- a/src/desktop/bridge.ts
+++ b/src/desktop/bridge.ts
@@ -81,6 +81,24 @@ export type DesktopUpdateEvent =
   | { type: 'downloaded'; version: string }
   | { type: 'error'; message: string }
 
+export type DesktopBrowserCaptureState = {
+  url: string
+  title: string
+  loading: boolean
+  canGoBack: boolean
+  canGoForward: boolean
+  status: string
+  error: string | null
+}
+
+export type DesktopBrowserCaptureResult =
+  | { ok: true; name: string }
+  | { ok: false; error: string }
+
+export type DesktopBrowserCaptureAssetEvent = {
+  projectId: string
+}
+
 export type DesktopBridge = {
   platform: string
   /** 窗口控制（Windows 自绘标题栏用；mac 原生 chrome 时不调用）。老 preload 可能无此口。 */
@@ -140,6 +158,17 @@ export type DesktopBridge = {
       url: string
       suggestedName?: string
     }) => Promise<{ ok: boolean; canceled?: boolean; path?: string }>
+  }
+  browserCapture?: {
+    open: (payload: { projectId: string; url?: string }) => Promise<{ ok: boolean }>
+    navigate: (url: string) => Promise<{ ok: boolean }>
+    back: () => Promise<void>
+    forward: () => Promise<void>
+    reload: () => Promise<void>
+    close: () => Promise<void>
+    onState: (callback: (state: DesktopBrowserCaptureState) => void) => () => void
+    onCaptureResult: (callback: (result: DesktopBrowserCaptureResult) => void) => () => void
+    onAssetImported: (callback: (event: DesktopBrowserCaptureAssetEvent) => void) => () => void
   }
   video: {
     /** 视频抽帧（首/尾帧/指定秒）→ 项目素材 nomi-local:// URL。通用基建，见 electron/video/extractVideoFrame.ts。 */

--- a/src/ui/app-shell/NomiAppBar.tsx
+++ b/src/ui/app-shell/NomiAppBar.tsx
@@ -1,10 +1,13 @@
 import React from 'react'
-import { IconBooks, IconDownload, IconPhoto, IconPlugConnected, IconBulb } from '@tabler/icons-react'
+import { IconBooks, IconDownload, IconPhoto, IconPlugConnected, IconBulb, IconWorld } from '@tabler/icons-react'
 import type { WorkspaceMode } from '../../workbench/workbenchStore'
 import { NomiBrand, NomiStepper, WorkbenchButton } from '../../design'
 import { OnboardingChecklist } from '../../workbench/onboarding/OnboardingChecklist'
 import { AboutNomiPopover } from './AboutNomiPopover'
 import { cn } from '../../utils/cn'
+import { getDesktopActiveProjectId } from '../../desktop/activeProject'
+import { getDesktopBridge } from '../../desktop/bridge'
+import { toast } from '../toast'
 
 // 平台分流：win32 下品牌/关于 + 上手清单都让位给 WorkbenchShell 的自绘标题栏（windowbar），
 // 本栏不重复渲染；非 win32（mac/Linux）保持原生窗口，品牌与清单仍住这里——两平台都有家、不丢失、不重复。
@@ -14,6 +17,22 @@ const isWindows = window.nomiDesktop?.platform === 'win32'
 // 上传已移进面板内部，AppBar 只负责发开面板事件（仿 nomi-open-model-catalog）。
 function openAssetLibrary(): void {
   window.dispatchEvent(new CustomEvent('nomi-open-asset-library'))
+}
+
+function openBrowserCapture(): void {
+  const projectId = getDesktopActiveProjectId()
+  const browserCapture = getDesktopBridge()?.browserCapture
+  if (!projectId) {
+    toast('先打开一个项目，再捕捞网页参考', 'warning')
+    return
+  }
+  if (!browserCapture) {
+    toast('当前运行环境不支持参考捕捞窗', 'error')
+    return
+  }
+  void browserCapture.open({ projectId }).catch((error) => {
+    toast(error instanceof Error ? error.message : '参考捕捞窗打开失败', 'error')
+  })
 }
 
 // 「提示词库」点击 → 打开提示词库面板（仿素材库的事件驱动开法）。
@@ -203,6 +222,24 @@ export default function NomiAppBar({ workspaceMode, onWorkspaceModeChange, proje
         {/* 上手 4 步引导入口：非 win32 住这里（始终高/不遮画布，4/4 自动消失）。
             win32 已移进 WorkbenchShell 自绘标题栏，本栏不重复渲染——两平台都有家、不丢 mac 清单。 */}
         {!isWindows ? <OnboardingChecklist /> : null}
+        <WorkbenchButton
+          className={cn(
+            'nomi-appbar__ghost',
+            'app-no-drag',
+            'inline-flex items-center gap-1.5 h-[30px] px-2.5',
+            'border border-transparent rounded-[var(--nomi-radius-sm)]',
+            'bg-transparent text-[var(--nomi-ink-80)] font-inherit text-body-sm',
+            'transition-[background,color] duration-[var(--nomi-transition-fast)]',
+            'hover:bg-[var(--nomi-ink-05)] hover:text-[var(--nomi-ink)]',
+            'max-[1400px]:w-[30px] max-[1400px]:h-[30px] max-[1400px]:justify-center max-[1400px]:p-0',
+          )}
+          aria-label="打开参考捕捞窗"
+          title="参考捕捞"
+          onClick={openBrowserCapture}
+        >
+          <IconWorld size={15} stroke={1.7} />
+          <span className={cn('nomi-appbar__action-text', 'max-[1400px]:hidden')}>参考捕捞</span>
+        </WorkbenchButton>
         <WorkbenchButton
           className={cn(
             'nomi-appbar__ghost',

--- a/src/workbench/assets/AssetLibraryPanel.tsx
+++ b/src/workbench/assets/AssetLibraryPanel.tsx
@@ -22,6 +22,7 @@ import { AssetThumb } from './AssetTile'
 import { DesignEmptyState, DesignSearchInput } from '../../design'
 import { acceptAttrForKinds, mediaKindFromExtension } from '../../../electron/assets/mediaTypes'
 import { toast } from '../../ui/toast'
+import { getDesktopBridge } from '../../desktop/bridge'
 
 const GRID_COLS = 3
 const ESTIMATED_ROW_HEIGHT = 121
@@ -150,6 +151,14 @@ export function AssetLibraryPanel({ opened, onClose, projectId }: Props): JSX.El
   const [query, setQuery] = React.useState('')
 
   const { assets, refresh } = useAssetPool(projectId)
+
+  React.useEffect(() => {
+    const browserCapture = getDesktopBridge()?.browserCapture
+    if (!opened || !projectId || !browserCapture?.onAssetImported) return undefined
+    return browserCapture.onAssetImported((event) => {
+      if (event.projectId === projectId) refresh()
+    })
+  }, [opened, projectId, refresh])
 
   const visible = React.useMemo(
     () => filterAssets(assets, { query, accept: filter === 'all' ? undefined : [filter] }),

--- a/src/workbench/generationCanvas/store/canvasNodeActions.ts
+++ b/src/workbench/generationCanvas/store/canvasNodeActions.ts
@@ -8,16 +8,16 @@ import { CLIPBOARD_OFFSET, createClipboardNodeId, createNodeId } from './canvasI
 import { bumpPersistRevision, isCategoryId, shouldPersistCanvasMutation } from './canvasGuards'
 import { getHistoryFlags, pushUndoSnapshot } from '../events/canvasUndoJournal'
 import { emitCanvasGesture } from '../events/canvasEventEmitter'
-import { useWorkbenchStore } from '../../workbenchStore'
+import { reconcileTimelineForDeletedCanvasNodes } from '../../timeline/timelineNodeReconcileBridge'
 import type { CanvasNodeActions, CanvasSliceCreator } from './canvasStoreTypes'
 
 // 删节点 → 时间轴对账(数据一致性):clip 创建时把节点产物 url 快照冻结、无 node→clip 同步,
 // 删了节点时间轴仍引用悬空/过期素材(导出会渲染已删节点的旧帧)。删完节点单向通知 workbenchStore
-// 移除引用该 sourceNodeId 的 clip。跨 store 最小耦合:只在 action 运行时取 getState()(live binding,
-// 不在模块初始化期触碰,避免 workbenchStore→genStore→canvasNodeActions→workbenchStore 循环初始化)。
+// 移除引用该 sourceNodeId 的 clip。跨 store 最小耦合:经 timeline bridge 调运行时注册的 reconciler,
+// 避免 canvasNodeActions 静态 import workbenchStore 形成初始化回环。
 // 调用方缺失/无悬空 clip 时是 no-op,绝不影响画布删除本身。
 function reconcileTimelineForDeletedNodes(nodeIds: readonly string[]): void {
-  useWorkbenchStore.getState().reconcileTimelineForDeletedNodes(nodeIds)
+  reconcileTimelineForDeletedCanvasNodes(nodeIds)
 }
 
 // 编辑突发(burst)粒度的撤销点:提示词/参数是逐键连续写入,原先完全不打 barrier →

--- a/src/workbench/timeline/timelineNodeReconcileBridge.ts
+++ b/src/workbench/timeline/timelineNodeReconcileBridge.ts
@@ -1,0 +1,11 @@
+type DeletedNodeReconciler = (nodeIds: readonly string[]) => void
+
+let deletedNodeReconciler: DeletedNodeReconciler | null = null
+
+export function registerTimelineDeletedNodeReconciler(reconciler: DeletedNodeReconciler): void {
+  deletedNodeReconciler = reconciler
+}
+
+export function reconcileTimelineForDeletedCanvasNodes(nodeIds: readonly string[]): void {
+  deletedNodeReconciler?.(nodeIds)
+}

--- a/src/workbench/workbenchStore.ts
+++ b/src/workbench/workbenchStore.ts
@@ -37,6 +37,7 @@ import type { StoryboardPlan } from './generationCanvas/agent/storyboardPlan'
 import type { ComposerAttachment } from './ai/composer/composerAttachmentTypes'
 import { createConversationBuckets } from './aiConversationBuckets'
 import { abandonCreationTurn } from './creation/creationTurnController'
+import { registerTimelineDeletedNodeReconciler } from './timeline/timelineNodeReconcileBridge'
 
 // 创作面板会话「会话域」per-project 桶(S1 治串台)。
 // 注:messages 已迁出本桶,改由 conversationThreads 模型按项目寻址(会话历史,2026-06-14);
@@ -762,3 +763,7 @@ export const useWorkbenchStore = create<WorkbenchState>()(subscribeWithSelector(
     })
   },
 })))
+
+registerTimelineDeletedNodeReconciler((nodeIds) => {
+  useWorkbenchStore.getState().reconcileTimelineForDeletedNodes(nodeIds)
+})


### PR DESCRIPTION
## Summary

把原先的大浏览器面收窄成「参考捕捞窗」最小闭环：单 WebContentsView + 地址栏 + 原生右键捕捞 → 既有素材库。

- 不再做多标签、书签、搜索引擎、推荐站点或 DOM hover 注入
- 使用 Electron 原生 context-menu 读取 `srcURL` 捕捞图片/视频
- 第三方页面放入独立 session，并 deny-by-default 处理权限请求
- 捕捞字节通过 `browser-capture` kind 复用 electron assets 索引，落入 imported bucket
- 不写 `originalUrl` sidecar，避免需要 Referer/cookie 的图床离站 403
- 素材库保持磁盘/项目目录为真相源，捕捞完成后只触发面板刷新
- 顺手修掉 `createCanvasNodeActions` 初始化 TDZ：拆掉 canvasNodeActions -> workbenchStore 静态回环

## Gates

- `pnpm run gates`

## Notes

为保证 Windows 本机门岗真实可跑，同时修了几个门岗相关的跨平台/并发边界：`gates` 尾部写 `.claude/.gates-ok` 改为 Node 写法，Dreamina PATH 断言归一化，workspace registry 并发锁不再 3s 误删活锁。