### PR TITLE
fix(ai): 拆镜头输出被截断——停止编造 max_tokens，截断错误说真话

### DIFF
--- a/electron/ai/agentChatV2.ts
+++ b/electron/ai/agentChatV2.ts
@@ -535,6 +535,9 @@ export async function runAgentChatV2(
   const messages: CoreMessage[] = [...priorMessages, userMessage];
 
   const abortController = createLinkedAbortController(hooks.abortSignal);
+  // 单轮输出上限：只认目录 meta.maxOutputTokens（用户/档案数据）——有则透传，没有就不发 max_tokens、
+  // 用服务商该模型自身的默认。代码不编造上限（旧 fallback 注 4096 曾把拆镜头整份方案 JSON 拦腰截断）。
+  const metaMaxOutputTokens = Number((model.meta as Record<string, unknown> | undefined)?.maxOutputTokens);
   // 统一循环内核（S0）：maxSteps(skill)/retry/repair/prompt 缓存全在 agentLoop 一处。
   const result = runAgentLoop(
     {
@@ -544,6 +547,7 @@ export async function runAgentChatV2(
       tools,
       isAnthropic: normalizeProviderKind(vendor.providerKind) === "anthropic",
       temperature: typeof payload.temperature === "number" ? payload.temperature : 0.7,
+      ...(Number.isFinite(metaMaxOutputTokens) && metaMaxOutputTokens > 0 ? { maxTokens: Math.floor(metaMaxOutputTokens) } : {}),
       skillKey: resolvedSkillKey,
       abortSignal: abortController.signal,
     },

--- a/electron/ai/agentError.ts
+++ b/electron/ai/agentError.ts
@@ -73,12 +73,12 @@ export type EmptyReplyModelInfo = {
  */
 export function describeEmptyAgentReply(finishReason: string, info: EmptyReplyModelInfo): string {
   const reason = String(finishReason || "").toLowerCase();
-  const guide = "建议换用通用对话模型（如 GPT-4o / Claude / Gemini）来跑创作助手——它们做 Agent 工具调用更稳。";
   if (reason === "length") {
     const parts = [`模型「${info.modelLabel}」这一轮达到了输出长度上限，内容被截断，没能完整返回。`];
     if (info.agentNote) parts.push(info.agentNote);
     else if (info.agentSuitability === "poor") parts.push("该模型做 Agent 工具调用本就不可靠。");
-    parts.push(guide);
+    // 截断是确定性的——原样重试必再撞。给真动作：缩短这轮任务，或换单轮输出上限更大的模型。
+    parts.push("原样重试会再次截断。请缩短这一轮的任务量（如剧本分段拆镜头、减少镜头数），或换用单轮输出上限更大的模型（如 GPT-4o / Claude / Gemini）。");
     return parts.join("\n");
   }
   if (reason === "content-filter") {

--- a/electron/ai/modelProfiles.test.ts
+++ b/electron/ai/modelProfiles.test.ts
@@ -38,7 +38,6 @@ describe("modelProfiles.getModelProfile", () => {
   it("falls back to acceptable for unknown models", () => {
     const p = getModelProfile("some-new-model");
     expect(p.agentSuitability).toBe("acceptable");
-    expect(p.defaultMaxTokens).toBe(4096);
   });
 });
 
@@ -49,16 +48,16 @@ describe("modelProfiles.applyProfileToRequestBody", () => {
     expect(applyProfileToRequestBody(body, profile)).toMatchObject({ temperature: 1 });
   });
 
-  it("does not override caller-set max_tokens", () => {
-    const body = { max_tokens: 8000 };
-    const profile = { defaultMaxTokens: 4096 };
-    expect(applyProfileToRequestBody(body, profile).max_tokens).toBe(8000);
+  it("never invents max_tokens（单轮输出上限是模型属性，不由代码编造——2026-07-15 拆镜头截断事故）", () => {
+    const body = { messages: [] };
+    const profile = getModelProfile("some-unknown-relay-model");
+    expect(applyProfileToRequestBody(body, profile).max_tokens).toBeUndefined();
   });
 
-  it("sets default max_tokens when caller didn't", () => {
-    const body = {};
-    const profile = { defaultMaxTokens: 4096 };
-    expect(applyProfileToRequestBody(body, profile).max_tokens).toBe(4096);
+  it("preserves caller-set max_tokens untouched", () => {
+    const body = { max_tokens: 8000 };
+    const profile = getModelProfile("gpt-4o");
+    expect(applyProfileToRequestBody(body, profile).max_tokens).toBe(8000);
   });
 
   it("merges extraBody", () => {

--- a/electron/ai/modelProfiles.ts
+++ b/electron/ai/modelProfiles.ts
@@ -17,8 +17,10 @@
 export type ModelQuirks = {
   /** Required fixed temperature value (e.g. some reasoning models require exactly 1). */
   requireTemperature?: number;
-  /** Default max_tokens if caller didn't set one (some providers default too low). */
-  defaultMaxTokens?: number;
+  // 注意：这里**没有** defaultMaxTokens——单轮输出上限是模型自身属性（4k~64k+ 差异巨大，且多数
+  // 服务商对超限值直接 400 不 clamp），不由代码编造。旧 fallback 注入的 max_tokens:4096 曾把
+  // 拆镜头这类「单发整份大 JSON」的轮次拦腰截断（2026-07-15 Mimo/Deepseek 真实事故，根因见
+  // agentError.ts）。需要上限时走目录 meta.maxOutputTokens（用户数据）→ agentChatV2 透传。
   /** Extra body fields to merge into every request (e.g. `enable_thinking: false`). */
   extraBody?: Record<string, unknown>;
   /** Whether this model is known to truncate tool-call JSON arguments mid-stream. */
@@ -41,13 +43,11 @@ const PROFILES: ProfileEntry[] = [
     description: "OpenAI reasoning models (o1, o3) require temperature: 1",
     match: (id) => /^(o1|o3)(-|$)/i.test(id),
     requireTemperature: 1,
-    defaultMaxTokens: 8192,
     agentSuitability: "good",
   },
   {
     description: "OpenAI GPT-4o / GPT-5 family — reliable agent",
     match: (id) => /^gpt-(4o|5)/i.test(id),
-    defaultMaxTokens: 4096,
     agentSuitability: "good",
   },
 
@@ -55,7 +55,6 @@ const PROFILES: ProfileEntry[] = [
   {
     description: "Anthropic Claude — reliable agent",
     match: (id) => /^claude-/i.test(id),
-    defaultMaxTokens: 8192,
     agentSuitability: "good",
   },
 
@@ -63,7 +62,6 @@ const PROFILES: ProfileEntry[] = [
   {
     description: "Google Gemini — reliable agent",
     match: (id) => /^(gemini-|models\/gemini-)/i.test(id),
-    defaultMaxTokens: 8192,
     agentSuitability: "good",
   },
 
@@ -87,7 +85,6 @@ const PROFILES: ProfileEntry[] = [
   {
     description: "Moonshot v1 (moonshot-v1-*, kimi-latest) — unreliable tool-call JSON",
     match: (id) => /^(moonshot-v1|kimi-latest|kimi-thinking)/i.test(id),
-    defaultMaxTokens: 4096,
     unreliableToolJson: true,
     agentSuitability: "poor",
     agentNote:
@@ -96,7 +93,6 @@ const PROFILES: ProfileEntry[] = [
 ];
 
 const FALLBACK_PROFILE: ModelQuirks = {
-  defaultMaxTokens: 4096,
   agentSuitability: "acceptable",
 };
 
@@ -126,9 +122,6 @@ export function applyProfileToRequestBody(
   const next: Record<string, unknown> = { ...body };
   if (profile.requireTemperature !== undefined) {
     next.temperature = profile.requireTemperature;
-  }
-  if (profile.defaultMaxTokens !== undefined && next.max_tokens == null) {
-    next.max_tokens = profile.defaultMaxTokens;
   }
   if (profile.extraBody) {
     Object.assign(next, profile.extraBody);

--- a/src/workbench/generationCanvas/nodes/fencedCanvas.invariant.test.ts
+++ b/src/workbench/generationCanvas/nodes/fencedCanvas.invariant.test.ts
@@ -25,7 +25,8 @@ describe('FencedCanvas 不变量', () => {
       const text = readFileSync(file, 'utf8')
       if (!text.includes("from '@react-three/fiber'")) continue
       if (!/<Canvas[\s>]/.test(text)) continue
-      const rel = path.relative(WORKBENCH_ROOT, file)
+      // Windows path.relative 产 `\`，白名单按 `/` 记——统一成 POSIX 再比对（跨平台）。
+      const rel = path.relative(WORKBENCH_ROOT, file).split(path.sep).join('/')
       if (!ALLOWED.has(rel)) offenders.push(rel)
     }
     expect(offenders, '裸 <Canvas> 会在初始化 suspend 时把宿主表面整棵 display:none，改用 FencedCanvas').toEqual([])

--- a/src/workbench/generationCanvas/runner/classifyGenerationError.test.ts
+++ b/src/workbench/generationCanvas/runner/classifyGenerationError.test.ts
@@ -40,6 +40,13 @@ describe('classifyGenerationError — 已知分类', () => {
     expect(r.hint).not.toMatch(/网络/)
   })
 
+  it('输出截断(agent length 签名)不落 unknown 的「稍等重试」误导(2026-07-15 拆镜头事故)', () => {
+    const r = classifyGenerationError('模型「Mimo v2.5」这一轮达到了输出长度上限，内容被截断，没能完整返回。')
+    expect(r.reason).toBe('输出超长被截断')
+    expect(r.hint).toMatch(/分段|减少镜头|输出上限/)
+    expect(r.hint).not.toMatch(/临时故障|稍等重试/)
+  })
+
   it('模型未开通(火山 404,真实 structured IPC 形态):不当成「服务商临时故障」,指向控制台开通', () => {
     const upstreamMsg =
       'Your account 2126482930 has not activated the model doubao-seedream-4-5-251128. Please activate the model service in the Ark Console.'

--- a/src/workbench/observability/classifyError.ts
+++ b/src/workbench/observability/classifyError.ts
@@ -75,6 +75,9 @@ const STRUCTURED_KINDS: readonly GenerationErrorKind[] = ['auth', 'balance', 'qu
 /** legacy 字符串 → 类别(老项目持久化的 node.error / 非 vendor 错误的兜底识别;文案不在这里)。 */
 function detectLegacyErrorKind(raw: string): GenerationErrorKind | null {
   const lower = raw.toLowerCase()
+  // 输出截断（agentError.describeEmptyAgentReply 的 length 签名）最先判——它是确定性失败，
+  // 落进 unknown 会给出「稍等重试」的误导（重试必再撞）。短语来自我们自己的文案，单一来源。
+  if (raw.includes('输出长度上限') || raw.includes('内容被截断')) return 'output-truncated'
   if (lower.includes('api key') || lower.includes('apikey') || lower.includes('unauthorized') || lower.includes('401')) return 'auth'
   // 余额不足要和限流分开——用户动作不同(充值 vs 等待)。只匹配明确指向余额/欠费的词,
   // 避免把 OpenAI 的 insufficient_quota(配额)误判成余额。

--- a/src/workbench/observability/narrate.ts
+++ b/src/workbench/observability/narrate.ts
@@ -61,6 +61,7 @@ export type GenerationErrorKind =
   | 'content-policy'
   | 'server'
   | 'input'
+  | 'output-truncated'
   | 'unknown'
 
 const NARRATE_ERROR: Record<GenerationErrorKind, { reason: string; hint: string }> = {
@@ -86,6 +87,12 @@ const NARRATE_ERROR: Record<GenerationErrorKind, { reason: string; hint: string 
   'content-policy': { reason: '提示词被拦截', hint: '提示词触发了安全策略，请修改后重试。' },
   server: { reason: '服务商故障', hint: '服务商服务异常，请稍后重试，或换一个模型。' },
   input: { reason: '参数不被接受', hint: '服务商拒绝了请求参数，请检查比例/尺寸等设置，或换一个模型。' },
+  // 输出截断是**确定性**的（这轮要返回的内容超过模型单轮输出上限）——绝不能落 unknown 的
+  // 「稍等重试」误导（原样重试必再撞，2026-07-15 拆镜头 Mimo→Deepseek 连撞两次就是这么来的）。
+  'output-truncated': {
+    reason: '输出超长被截断',
+    hint: '这一轮要返回的内容超过了模型的单轮输出上限，原样重试只会再次截断。请缩短这轮任务（如剧本分段拆镜头、减少镜头数），或换单轮输出上限更大的模型。',
+  },
   unknown: { reason: '生成失败', hint: '可能是服务商临时故障或额度问题，建议稍等重试，或换一个模型。' },
 }
 

--- a/tests/ux/helpers/electronFixture.test.mjs
+++ b/tests/ux/helpers/electronFixture.test.mjs
@@ -1,15 +1,17 @@
+import path from "node:path";
 import { describe, expect, test } from "vitest";
 import { isolatedElectronLaunchOptions } from "./electronFixture.mjs";
 
 describe("isolatedElectronLaunchOptions", () => {
   test("isolates every writable desktop path and bypasses the single-instance lock", () => {
     const options = isolatedElectronLaunchOptions("/repo", "/tmp/case", {});
-    expect(options.args).toContain("--user-data-dir=/tmp/case/user-data");
+    // 期望值经 path.join 派生：不变量是「路径都隔离在 tempRoot 下」，分隔符跟平台走（Windows 为 `\`）。
+    expect(options.args).toContain(`--user-data-dir=${path.join("/tmp/case", "user-data")}`);
     expect(options.env).toMatchObject({
       NOMI_E2E: "1",
       NOMI_E2E_ALLOW_MULTI_INSTANCE: "1",
-      NOMI_SETTINGS_DIR: "/tmp/case/settings",
-      NOMI_PROJECTS_DIR: "/tmp/case/projects",
+      NOMI_SETTINGS_DIR: path.join("/tmp/case", "settings"),
+      NOMI_PROJECTS_DIR: path.join("/tmp/case", "projects"),
     });
   });
 });


### PR DESCRIPTION
## 问题

拆镜头连续失败（Mimo v2.5 → 换 Deepseek v4 Pro 再撞）：「模型这一轮达到了输出长度上限，内容被截断」，且错误提示误导用户「可能是服务商临时故障，建议稍等重试」——而截断是确定性的，重试必再撞。

## 根因

1. fallback 模型档案给**所有未登记模型**注入 `max_tokens: 4096`（`modelProfiles.ts` FALLBACK_PROFILE，经 `buildAiSdkModel` 的 profiled fetch 写进每个请求体）。
2. 拆镜头契约要求单发整份方案 JSON（`propose_storyboard_plan`，最多 24 锚 + 24 镜含详细中文 prompt），轻松 4k-8k tokens。
3. Mimo/Deepseek 是推理模型，thinking tokens 还计入 max_tokens → 更早撞线。
4. 撞线后 finish_reason=length、工具调用 JSON 拦腰断 → 空响应报错；渲染层分类不认识这个错误 → 落 `unknown`「服务商临时故障」误导。

## 修法（derive 不 hardcode）

- **删掉 `defaultMaxTokens` 整个机制**：单轮输出上限是模型属性（4k~64k+ 差异巨大，超限值多数服务商直接 400 不 clamp），代码不编造；不发 `max_tokens` 时用服务商该模型自身默认。
- **目录 `meta.maxOutputTokens`（用户数据）→ agentChatV2 有则透传**：个别服务商默认输出真的低时，在模型条目 meta 里填，决定权给数据不给代码。
- **截断错误诚实分类**：narrate/classifyError 新增 `output-truncated` 词条——说明截断是确定性的 + 给真动作（分段拆镜头/减少镜头数/换长输出模型）；`agentError` length 分支同步改为对症建议。

## 附带

`test(windows)`: 新基线两个测试把路径断言写死 POSIX 分隔符、Windows 上红（挡五门）——期望值改经 `path.join` 派生 / `path.relative` 结果归一 POSIX 再比白名单，不变量本身不变。

## 验证

- 全部门禁通过（filesize/tokens/dangling-tokens/archetype-defaults/lint/typecheck/test/build），全量单测 2665 项通过
- 新增回归测试：`classifyGenerationError` 截断签名归 `output-truncated` 且不出现「稍等重试」；`modelProfiles` 断言不再发明 max_tokens
- 真机端到端重试需真实模型 Key：重启后用之前失败的剧本重拆即可确认；若某中转仍截断（其服务端默认输出确实低），给该模型 meta 填 `maxOutputTokens` 即解

🤖 Generated with [Claude Code](https://claude.com/claude-code)