### PR TITLE
修复提示词编辑卡片继承拖拽光标

### DIFF
--- a/src/workbench/generationCanvas/nodes/NodeGenerationComposer.tsx
+++ b/src/workbench/generationCanvas/nodes/NodeGenerationComposer.tsx
@@ -538,6 +538,9 @@ export default function NodeGenerationComposer({ node, visualSize }: Props): JSX
         ...(flipUp
           ? { bottom: `calc(100% + ${composerLayout.gap + aboveClearance}px)` }
           : { top: `calc(100% + ${composerLayout.gap}px)` }),
+        cursor: 'default',
+        userSelect: 'auto',
+        touchAction: 'auto',
       }}
       onPointerDown={(event) => event.stopPropagation()}
       {...(acceptsDrop ? dropHandlers : {})}
@@ -553,7 +556,7 @@ export default function NodeGenerationComposer({ node, visualSize }: Props): JSX
           'transition-[outline-color] duration-150',
           isDragOver && 'outline-2 outline-dashed outline-nomi-accent outline-offset-[-2px]',
         )}
-        style={{ maxHeight: composerLayout.maxHeight }}
+        style={{ maxHeight: composerLayout.maxHeight, cursor: 'default', userSelect: 'auto', touchAction: 'auto' }}
       >
       {hasReferenceControls || hasPromptPickerButton ? (
         <div className={cn('flex w-0 min-w-full items-start gap-3')}>

--- a/src/workbench/generationCanvas/nodes/NodeGenerationComposer.tsx
+++ b/src/workbench/generationCanvas/nodes/NodeGenerationComposer.tsx
@@ -639,7 +639,10 @@ export default function NodeGenerationComposer({ node, visualSize }: Props): JSX
         // ⚠️ 别再往里套「无高度约束的内层块 + overflow-y-auto」：那样内层块按内容长到全高、滚动永不触发，
         // 整片 prompt 下溢盖住底栏（= 截图里「文字太长盖住 选择模型/优化」的根因）。滚动容器必须自己有界。
         // 用 overflow-y-auto 而非 overflow-auto：卡宽已被 w-0 min-w-full 锁死、prompt 在卡宽内换行，横向永不溢出，明确关掉横向滚动条。
-        <div className={cn('relative flex-1 min-h-[72px] w-0 min-w-full overflow-y-auto')}>
+        <div
+          className={cn('relative flex-1 min-h-[72px] w-0 min-w-full overflow-y-auto')}
+          style={{ cursor: node.locked ? 'default' : 'text', userSelect: node.locked ? 'auto' : 'text' }}
+        >
           <PromptEditor
             className={cn('min-h-[72px]')}
             value={node.prompt || ''}


### PR DESCRIPTION
## 背景

画布节点外层使用 `cursor-grab` 表示节点可拖拽。提示词编辑卡片渲染在节点内部，因此会继承外层节点的拖拽光标。

结果是鼠标移动到弹出的提示词编辑卡片上时，即使不是拖拽节点区域，也会显示拖拽手套光标，和实际交互语义不一致。

## 修复

只在 `NodeGenerationComposer` 的弹出卡片边界重置光标相关样式：

- 外层 composer 定位容器使用 `cursor: default`
- composer 卡片本体使用 `cursor: default`
- 同时恢复 `userSelect: auto` 和 `touchAction: auto`，避免继承节点层拖拽交互状态

这次修复不改全局 `PromptEditor`，也不提交 `tailwind.generated.css`。根因是弹出卡片继承了节点容器的拖拽光标，所以修复范围只放在最外层弹出卡片。

## 影响范围

- 只修改 `src/workbench/generationCanvas/nodes/NodeGenerationComposer.tsx`
- 不影响其他提示词编辑器
- 不影响待生成节点卡片

## 验证

- `pnpm exec eslint src\workbench\generationCanvas\nodes\NodeGenerationComposer.tsx`
- `pnpm run typecheck`