### PR TITLE
fix(comfyui): 修复 ComfyUI 本地视频预览、导出 URL 与时间轴时长不一致问题

### DIFF
--- a/docs/plan/2026-07-24-comfyui-video-preview-range.md
+++ b/docs/plan/2026-07-24-comfyui-video-preview-range.md
@@ -1,0 +1,31 @@
+# ComfyUI Video Preview, Export, and Timeline Duration Fix
+
+## Scope
+
+- Fix `nomi-local://asset/...` local asset serving so Chromium video playback can read byte ranges.
+- Keep existing image/file behavior unchanged for non-Range requests.
+- Add protocol-level regression tests.
+- Preserve generated video file extensions during task asset localization so WebM/MOV outputs are not saved as misleading `.mp4` files.
+- Carry probed media duration from localized video/audio assets into task results when the main process can read the persisted file.
+- Reuse the existing generation result URL resolver so newly created timeline clips prefer persisted `nomi-local://` assets over stale/private ComfyUI provider URLs.
+- Resolve existing timeline preview/export URLs through the source generation node so old clips that still store a ComfyUI `providerUrl` use the node's persisted local result instead.
+- Before inserting a generated video into the timeline, probe the current media file duration in the renderer and use that duration even when `result.durationSeconds` is stale.
+- Keep drag payloads compatible while adding `nodeId`, so drop handlers can resolve the latest generation node from the canvas store instead of relying on a serialized drag snapshot.
+
+## Non-Goals
+
+- Do not change ComfyUI workflow import or result parsing.
+- Do not transcode generated video files.
+- Do not change timeline editing or trimming behavior beyond the initial inserted video duration and playback/export URL resolution.
+- Do not add a new duration metadata schema to generation node `meta`.
+
+## Acceptance
+
+- `Range: bytes=0-0` returns `206`, `Content-Range`, `Accept-Ranges`, and one byte.
+- Full requests still return the whole file with CORS headers.
+- Invalid ranges return `416`.
+- Existing timeline clips that still store a ComfyUI `providerUrl` preview/export via the node's persisted `nomi-local://` result URL.
+- A generated 3.0625s video with asset duration in the task result normalizes to `result.durationSeconds = 3.0625`.
+- A generated video whose result still has stale duration uses the current media file duration when inserted into the timeline; for example, a 7s file at 30fps inserts as 210 frames even if `result.durationSeconds` says 5s.
+- Drag/drop insertion resolves the latest canvas node by `nodeId` instead of trusting the serialized drag payload snapshot.
+- Electron typecheck and focused tests pass.

--- a/electron/protocol/localProtocol.test.ts
+++ b/electron/protocol/localProtocol.test.ts
@@ -1,0 +1,75 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+vi.mock("electron", () => ({
+  protocol: { handle: vi.fn() },
+  net: {
+    fetch: vi.fn(async (url: string) => {
+      const filePath = new URL(url).pathname.replace(/^\/([A-Za-z]:)/, "$1");
+      const bytes = fs.readFileSync(decodeURIComponent(filePath));
+      return new Response(bytes, { headers: { "Content-Type": "video/mp4" } });
+    }),
+  },
+}));
+
+let projectRoot = "";
+let assetPath = "";
+
+vi.mock("../projects/repository", () => ({
+  resolveProjectRelativePath: vi.fn((_projectId: string, relativePath: string) => path.join(projectRoot, relativePath)),
+}));
+
+import { handleNomiLocalRequest } from "./localProtocol";
+
+beforeAll(() => {
+  projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), "nomi-local-protocol-"));
+  assetPath = path.join(projectRoot, "assets", "generated", "clip.mp4");
+  fs.mkdirSync(path.dirname(assetPath), { recursive: true });
+  fs.writeFileSync(assetPath, Buffer.from("0123456789"));
+});
+
+afterAll(() => {
+  if (projectRoot) fs.rmSync(projectRoot, { recursive: true, force: true });
+});
+
+function assetUrl(relativePath = "assets/generated/clip.mp4"): string {
+  return `nomi-local://asset/project-a/${relativePath}`;
+}
+
+describe("handleNomiLocalRequest", () => {
+  it("serves byte ranges for video playback", async () => {
+    const response = await handleNomiLocalRequest(new Request(assetUrl(), { headers: { Range: "bytes=0-0" } }));
+
+    expect(response.status).toBe(206);
+    expect(response.headers.get("Accept-Ranges")).toBe("bytes");
+    expect(response.headers.get("Content-Range")).toBe("bytes 0-0/10");
+    expect(response.headers.get("Content-Length")).toBe("1");
+    expect(await response.text()).toBe("0");
+  });
+
+  it("serves suffix ranges", async () => {
+    const response = await handleNomiLocalRequest(new Request(assetUrl(), { headers: { Range: "bytes=-3" } }));
+
+    expect(response.status).toBe(206);
+    expect(response.headers.get("Content-Range")).toBe("bytes 7-9/10");
+    expect(await response.text()).toBe("789");
+  });
+
+  it("rejects unsatisfiable ranges", async () => {
+    const response = await handleNomiLocalRequest(new Request(assetUrl(), { headers: { Range: "bytes=20-30" } }));
+
+    expect(response.status).toBe(416);
+    expect(response.headers.get("Content-Range")).toBe("bytes */10");
+  });
+
+  it("keeps full-file responses working", async () => {
+    const response = await handleNomiLocalRequest(new Request(assetUrl()));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Accept-Ranges")).toBe("bytes");
+    expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*");
+    expect(await response.text()).toBe("0123456789");
+  });
+});

--- a/electron/protocol/localProtocol.ts
+++ b/electron/protocol/localProtocol.ts
@@ -1,39 +1,98 @@
 import { net, protocol } from "electron";
+import fs from "node:fs";
 import { pathToFileURL } from "node:url";
+import { contentTypeFromPath } from "../assets/assetPaths";
 import { resolveProjectRelativePath } from "../projects/repository";
 
-export function registerLocalProtocol(): void {
-  protocol.handle("nomi-local", async (request) => {
-    try {
-      const url = new URL(request.url);
-      if (url.hostname !== "asset") {
-        return new Response("Unsupported nomi-local host", { status: 404 });
+function withLocalAssetHeaders(headers?: HeadersInit): Headers {
+  const next = new Headers(headers);
+  // canvas.toDataURL() 需要 CORS 头，否则 crossOrigin='anonymous' 加载的图片会污染画布
+  // 导致九宫格/裁切等操作静默失败（SecurityError 被吞掉）。
+  next.set("Access-Control-Allow-Origin", "*");
+  next.set("Cross-Origin-Resource-Policy", "cross-origin");
+  next.set("Accept-Ranges", "bytes");
+  return next;
+}
+
+function assetPathFromUrl(rawUrl: string): string | null {
+  const url = new URL(rawUrl);
+  if (url.hostname !== "asset") return null;
+  // 解码与 localAssetUrl 的「逐段 encodeURIComponent」对称：先按 "/" 切段、再逐段 decode。
+  // （此前先整体 decode 再 split，文件名若含被编码的 %2F 会让段边界错位 → 路径错位 404。）
+  const segments = url.pathname
+    .replace(/^\/+/, "")
+    .split("/")
+    .map((seg) => {
+      try {
+        return decodeURIComponent(seg);
+      } catch {
+        return seg;
       }
-      // 解码与 localAssetUrl 的「逐段 encodeURIComponent」对称：先按 "/" 切段、再逐段 decode。
-      // （此前先整体 decode 再 split，文件名若含被编码的 %2F 会让段边界错位 → 路径错位 404。）
-      const segments = url.pathname
-        .replace(/^\/+/, "")
-        .split("/")
-        .map((seg) => {
-          try {
-            return decodeURIComponent(seg);
-          } catch {
-            return seg;
-          }
-        });
-      const [projectId, ...relativeParts] = segments;
-      const relativePath = relativeParts.join("/");
-      const filePath = resolveProjectRelativePath(projectId, relativePath);
-      const fileResponse = await net.fetch(pathToFileURL(filePath).toString());
-      // canvas.toDataURL() 需要 CORS 头，否则 crossOrigin='anonymous' 加载的图片会污染画布
-      // 导致九宫格/裁切等操作静默失败（SecurityError 被吞掉）。
-      const corsHeaders = new Headers(fileResponse.headers);
-      corsHeaders.set("Access-Control-Allow-Origin", "*");
-      corsHeaders.set("Cross-Origin-Resource-Policy", "cross-origin");
-      return new Response(fileResponse.body, { status: fileResponse.status, headers: corsHeaders });
-    } catch (error) {
-      const message = error instanceof Error ? error.message : "local asset not found";
-      return new Response(message, { status: 404 });
-    }
+    });
+  const [projectId, ...relativeParts] = segments;
+  return resolveProjectRelativePath(projectId, relativeParts.join("/"));
+}
+
+type ByteRange = { start: number; end: number };
+
+function parseRangeHeader(rangeHeader: string, size: number): ByteRange | null {
+  const match = /^bytes=(\d*)-(\d*)$/i.exec(rangeHeader.trim());
+  if (!match || size <= 0) return null;
+  const [, rawStart, rawEnd] = match;
+  if (!rawStart && !rawEnd) return null;
+
+  if (!rawStart) {
+    const suffixLength = Number.parseInt(rawEnd, 10);
+    if (!Number.isFinite(suffixLength) || suffixLength <= 0) return null;
+    return { start: Math.max(0, size - suffixLength), end: size - 1 };
+  }
+
+  const start = Number.parseInt(rawStart, 10);
+  const end = rawEnd ? Number.parseInt(rawEnd, 10) : size - 1;
+  if (!Number.isFinite(start) || !Number.isFinite(end) || start < 0 || end < start || start >= size) return null;
+  return { start, end: Math.min(end, size - 1) };
+}
+
+function streamRange(filePath: string, range: ByteRange, size: number, method: string): Response {
+  const contentLength = range.end - range.start + 1;
+  const headers = withLocalAssetHeaders({
+    "Content-Type": contentTypeFromPath(filePath),
+    "Content-Length": String(contentLength),
+    "Content-Range": `bytes ${range.start}-${range.end}/${size}`,
   });
+  const body = method === "HEAD" ? null : fs.createReadStream(filePath, { start: range.start, end: range.end });
+  return new Response(body as BodyInit | null, { status: 206, headers });
+}
+
+function rangeNotSatisfiable(size: number): Response {
+  return new Response(null, {
+    status: 416,
+    headers: withLocalAssetHeaders({ "Content-Range": `bytes */${size}` }),
+  });
+}
+
+export async function handleNomiLocalRequest(request: Request): Promise<Response> {
+  try {
+    const filePath = assetPathFromUrl(request.url);
+    if (!filePath) {
+      return new Response("Unsupported nomi-local host", { status: 404 });
+    }
+    const rangeHeader = request.headers.get("range") || "";
+    if (rangeHeader) {
+      const stat = fs.statSync(filePath);
+      const range = parseRangeHeader(rangeHeader, stat.size);
+      if (!range) return rangeNotSatisfiable(stat.size);
+      return streamRange(filePath, range, stat.size, request.method);
+    }
+    const fileResponse = await net.fetch(pathToFileURL(filePath).toString());
+    const corsHeaders = withLocalAssetHeaders(fileResponse.headers);
+    return new Response(request.method === "HEAD" ? null : fileResponse.body, { status: fileResponse.status, headers: corsHeaders });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "local asset not found";
+    return new Response(message, { status: 404 });
+  }
+}
+
+export function registerLocalProtocol(): void {
+  protocol.handle("nomi-local", handleNomiLocalRequest);
 }

--- a/electron/runtime.assets.test.ts
+++ b/electron/runtime.assets.test.ts
@@ -2,8 +2,16 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { createProject, importRemoteAsset, listProjectAssets } from "./runtime";
+import { createProject, importRemoteAsset, listProjectAssets, localizeTaskAsset, localizedTaskAssetFileName } from "./runtime";
 import { importLocalFile } from "./assets/localFileImport";
+
+vi.mock("./export/mediaProbe", () => ({
+  probeMediaMetadata: vi.fn(async () => ({ kind: "video", hasAudio: false, durationSeconds: 3.0625 })),
+}));
+
+vi.mock("./review/reviewTrace", () => ({
+  scheduleTechnicalReview: vi.fn(),
+}));
 
 type AssetRecord = {
   data: {
@@ -58,6 +66,32 @@ function createWorkspace(): { id: string; rootPath: string } {
 }
 
 describe("runtime workspace asset storage", () => {
+  it("keeps provider video filename extensions when localizing task assets", () => {
+    expect(
+      localizedTaskAssetFileName(
+        "video",
+        "http://127.0.0.1:8188/view?filename=ComfyUI_00123_.webm&subfolder=&type=output",
+        123,
+      ),
+    ).toBe("video-123.webm");
+    expect(localizedTaskAssetFileName("video", "https://cdn.example.com/result.mov", 123)).toBe("video-123.mov");
+    expect(localizedTaskAssetFileName("video", "https://cdn.example.com/result", 123)).toBe("video-123.mp4");
+  });
+
+  it("includes probed video duration when localizing task assets", async () => {
+    const workspace = createWorkspace();
+
+    const asset = await localizeTaskAsset(
+      workspace.id,
+      "data:video/mp4;base64,aGVsbG8=",
+      "video",
+      "node-1",
+    );
+
+    expect(asset.url).toContain("nomi-local://asset/");
+    expect(asset.durationSeconds).toBe(3.0625);
+  });
+
   it("writes generated remote assets under assets/generated/YYYY-MM-DD", async () => {
     const workspace = createWorkspace();
 

--- a/electron/runtime.ts
+++ b/electron/runtime.ts
@@ -10,6 +10,7 @@ import { chatImageFallbackOperation } from "./catalog/imageRouteFallback";
 import { buildNormalizedRecipe, buildTaskProvenance } from "./vendor/provenance";
 import { traceVendorCompleted, traceVendorRequested } from "./events/vendorCallTrace";
 import { scheduleTechnicalReview } from "./review/reviewTrace";
+import { probeMediaMetadata } from "./export/mediaProbe";
 import {
   type AuthType,
   authHeaders as buildAuthHeaders,
@@ -43,6 +44,30 @@ import {
 // 公共 API：main.ts 仍从 "./runtime" 消费这些 —— re-export 保持其 import 不变。
 export { createProject, deleteProject, listProjects, readProject, resolveProjectRelativePath, saveProject };
 export { importRemoteAsset, listProjectAssets, moveAssetFile, writeAsset } from "./assets/projectAssetStore";
+
+const DEFAULT_ASSET_EXTENSIONS: Record<"image" | "video" | "audio" | "model3d", string> = {
+  image: "png",
+  video: "mp4",
+  audio: "mp3",
+  model3d: "glb",
+};
+
+function extensionFromAssetUrl(assetUrl: string): string {
+  try {
+    const parsed = new URL(assetUrl);
+    const filename = parsed.searchParams.get("filename") || parsed.pathname;
+    const match = /\.([a-z0-9]{1,8})(?:$|[?#])/i.exec(filename);
+    return match?.[1]?.toLowerCase() || "";
+  } catch {
+    const match = /\.([a-z0-9]{1,8})(?:$|[?#])/i.exec(assetUrl);
+    return match?.[1]?.toLowerCase() || "";
+  }
+}
+
+export function localizedTaskAssetFileName(type: "image" | "video" | "audio" | "model3d", assetUrl: string, now = Date.now()): string {
+  const ext = extensionFromAssetUrl(assetUrl) || DEFAULT_ASSET_EXTENSIONS[type];
+  return `${type}-${now}.${ext}`;
+}
 
 // 任务执行复用 catalog 状态（readCatalog + extractVendorExtraHeaders 纯函数）；
 // catalogStore 反向复用本文件任务引擎 → 运行期循环引用（CommonJS 安全）。
@@ -136,6 +161,7 @@ export type TaskResult = {
     assetName?: string | null;
     /** 原始 CDN URL（https://...）。供后续生成直接用，无需上传。可能过期，过期后退回本地字节。 */
     providerUrl?: string | null;
+    durationSeconds?: number;
   }>;
   raw: unknown;
   /**
@@ -204,8 +230,17 @@ export async function localizeTaskAsset(
     url: assetUrl,
     kind: "generated",
     ownerNodeId: nodeId || null,
-    fileName: `${type}-${Date.now()}.${type === "image" ? "png" : type === "video" ? "mp4" : type === "model3d" ? "glb" : "mp3"}`,
+    fileName: localizedTaskAssetFileName(type, assetUrl),
   }, { trustedPrivateOrigin: trustedLocalOutputOrigin(vendor) || undefined })) as { id?: string; name?: string; data?: { url?: string; absolutePath?: string } };
+  let durationSeconds: number | undefined;
+  if ((type === "video" || type === "audio") && imported.data?.absolutePath) {
+    try {
+      const probe = await probeMediaMetadata(imported.data.absolutePath);
+      durationSeconds = probe.durationSeconds;
+    } catch {
+      // 时长探测失败不影响生成成功；renderer 仍会回退到参数时长 / 默认时长。
+    }
+  }
   if (type === "image" || type === "video")
     scheduleTechnicalReview({
       projectId,
@@ -220,6 +255,7 @@ export async function localizeTaskAsset(
     thumbnailUrl: type === "image" ? String(imported.data?.url || assetUrl) : null,
     assetId: imported.id || null,
     assetName: imported.name || null,
+    ...(durationSeconds !== undefined ? { durationSeconds } : {}),
     // 原始 CDN URL 留存：任何 vendor 都能直接使用，不需要再上传或转 base64。
     providerUrl: /^https?:\/\//i.test(assetUrl) ? assetUrl : null,
   };

--- a/src/workbench/api/taskApi.ts
+++ b/src/workbench/api/taskApi.ts
@@ -23,6 +23,7 @@ export type TaskAssetDto = {
   assetId?: string | null
   assetRefId?: string | null
   assetName?: string | null
+  durationSeconds?: number
   /** 原始 CDN URL（https://...）。供后续生成直接用，任何 vendor 都能接受，无需上传或转 base64。 */
   providerUrl?: string | null
 }

--- a/src/workbench/export/exportApi.test.ts
+++ b/src/workbench/export/exportApi.test.ts
@@ -4,6 +4,13 @@ import type { TimelineState } from '../timeline/timelineTypes'
 const exportTimelineToWebmMock = vi.fn()
 const downloadTimelineBlobMock = vi.fn()
 
+type ExportProgressEvent = {
+  jobId: string
+  snapshot: {
+    progress: { ratio: number; stage: string; message: string }
+  }
+}
+
 vi.mock('./timelineWebmExport', () => ({
   createTimelineExportFilename: vi.fn(() => 'fallback.webm'),
   downloadTimelineBlob: downloadTimelineBlobMock,
@@ -227,12 +234,79 @@ describe('exportTimelineToMp4', () => {
     expect(payload.manifest.diagnostics.warnings.join('\n')).toMatch(/unsupported tracks|timeline model/i)
   })
 
+  it('resolves old ComfyUI providerUrl clips to local assets before starting the desktop export job', async () => {
+    const startJob = vi.fn().mockResolvedValue({ jobId: 'job-1', backend: 'filtergraph' })
+    const finishTempInput = vi.fn().mockResolvedValue({
+      absolutePath: '/tmp/out.mp4',
+      relativePath: 'exports/out.mp4',
+      size: 4,
+    })
+    const providerUrl = 'http://192.168.10.2:8188/view?filename=ComfyUI_00025_.mp4&subfolder=video&type=output'
+    const localUrl = 'nomi-local://asset/project-1/assets/generated/video.mp4'
+    const timeline: TimelineState = {
+      ...makeTimeline(),
+      tracks: [
+        {
+          id: 'videoTrack',
+          type: 'video',
+          label: '视频轨',
+          clips: [
+            {
+              id: 'clip-1',
+              type: 'video',
+              sourceNodeId: 'node-1',
+              label: 'clip',
+              startFrame: 0,
+              endFrame: 30,
+              frameCount: 30,
+              offsetStartFrame: 0,
+              offsetEndFrame: 0,
+              url: providerUrl,
+            },
+          ],
+        },
+      ],
+    }
+
+    vi.stubGlobal('window', {
+      nomiDesktop: {
+        exports: {
+          startJob,
+          writeTempInput: vi.fn(),
+          finishTempInput,
+        },
+      },
+    })
+
+    const { exportTimelineToMp4 } = await import('./exportApi')
+
+    await exportTimelineToMp4({
+      projectId: 'project-1',
+      timeline,
+      aspectRatio: '16:9',
+      generationNodes: [
+        {
+          id: 'node-1',
+          kind: 'video',
+          title: 'clip',
+          position: { x: 0, y: 0 },
+          status: 'idle',
+          result: { id: 'result-1', type: 'video', url: localUrl, providerUrl, createdAt: 1 },
+        },
+      ],
+    })
+
+    const payload = startJob.mock.calls[0][0]
+    expect(payload.manifest.assets['node-1'].url).toBe(localUrl)
+    expect(payload.manifest.assets['node-1'].url).not.toBe(providerUrl)
+  })
+
   it('subscribes to matching job progress events and unsubscribes after export completes', async () => {
     const startJob = vi.fn().mockResolvedValue({ jobId: 'job-1' })
     const writeTempInput = vi.fn().mockResolvedValue({ ok: true, size: 4 })
     const unsubscribe = vi.fn()
-    let listener: ((event: any) => void) | null = null
-    const onEvent = vi.fn((callback: (event: any) => void) => {
+    let listener: ((event: ExportProgressEvent) => void) | null = null
+    const onEvent = vi.fn((callback: (event: ExportProgressEvent) => void) => {
       listener = callback
       return unsubscribe
     })

--- a/src/workbench/export/exportApi.ts
+++ b/src/workbench/export/exportApi.ts
@@ -4,10 +4,12 @@ import type { DesktopMp4ExportResult } from '../../desktop/bridge'
 import i18n from '../../i18n'
 import type { TimelineState } from '../timeline/timelineTypes'
 import type { PreviewAspectRatio } from '../workbenchTypes'
+import type { GenerationCanvasNode } from '../generationCanvas/model/generationCanvasTypes'
 import { createTimelineExportFilename, downloadTimelineBlob, exportTimelineToWebm } from './timelineWebmExport'
 import type { ExportQuality } from './exportTypes'
 import { buildRenderManifestRequest } from './renderManifest'
 import { renderTextOverlays } from './textOverlayPng'
+import { resolveTimelinePlaybackUrls } from '../timeline/timelinePlaybackUrl'
 
 const MP4_WEBM_IPC_CHUNK_BYTES = 1024 * 1024
 
@@ -18,6 +20,7 @@ export type ExportTimelineToMp4Options = {
   outputName?: string
   resolution?: '720p' | '1080p'
   quality?: ExportQuality
+  generationNodes?: GenerationCanvasNode[]
   onProgress?: (progress: { status: 'preparing' | 'recording' | 'converting' | 'done'; ratio: number }) => void
 }
 
@@ -30,16 +33,17 @@ export async function startTimelineMp4ExportJob(options: StartTimelineMp4ExportJ
   }
   const projectId = (options.projectId || getDesktopActiveProjectId()).trim()
   if (!projectId) throw new Error(i18n.t('runtime.export.missingProjectId'))
+  const exportTimeline = resolveTimelinePlaybackUrls(options.timeline, options.generationNodes || [])
 
   const manifest = buildRenderManifestRequest({
     projectId,
-    timeline: options.timeline,
+    timeline: exportTimeline,
     aspectRatio: options.aspectRatio,
     resolution: options.resolution || '1080p',
     quality: options.quality || 'standard',
     preset: 'publish',
   })
-  manifest.textOverlays = renderTextOverlays(options.timeline, manifest.profile.width, manifest.profile.height)
+  manifest.textOverlays = renderTextOverlays(exportTimeline, manifest.profile.width, manifest.profile.height)
 
   return desktop.exports.startJob({
     projectId,
@@ -57,15 +61,16 @@ export async function exportTimelineToMp4(options: ExportTimelineToMp4Options): 
   if (!projectId) throw new Error(i18n.t('runtime.export.missingProjectId'))
   const resolution = options.resolution || '1080p'
   const quality = options.quality || 'standard'
+  const exportTimeline = resolveTimelinePlaybackUrls(options.timeline, options.generationNodes || [])
   const manifest = buildRenderManifestRequest({
     projectId,
-    timeline: options.timeline,
+    timeline: exportTimeline,
     aspectRatio: options.aspectRatio,
     resolution,
     quality,
     preset: 'publish',
   })
-  manifest.textOverlays = renderTextOverlays(options.timeline, manifest.profile.width, manifest.profile.height)
+  manifest.textOverlays = renderTextOverlays(exportTimeline, manifest.profile.width, manifest.profile.height)
   const { jobId, backend } = await desktop.exports.startJob({
     projectId,
     outputName: options.outputName,
@@ -93,7 +98,7 @@ export async function exportTimelineToMp4(options: ExportTimelineToMp4Options): 
 
     // 降级路径：资产无法本地解析 → 录 canvas WebM 上传，主进程转码。
     webmBlob = await exportTimelineToWebm({
-      timeline: options.timeline,
+      timeline: exportTimeline,
       aspectRatio: options.aspectRatio,
       width: options.resolution === '720p' ? 1280 : 1920,
       autoDownload: false,

--- a/src/workbench/generationCanvas/model/buildClipFromGenerationNode.test.ts
+++ b/src/workbench/generationCanvas/model/buildClipFromGenerationNode.test.ts
@@ -16,18 +16,18 @@ function makeNode(result: Partial<GenerationNodeResult> | null): GenerationCanva
   }
 }
 
-describe('buildClipFromGenerationNode URL 口径（providerUrl 优先）', () => {
+describe('buildClipFromGenerationNode URL 口径（本地 url 优先）', () => {
   it('只有 providerUrl（url/thumbnail 都空）也能成 clip——这是修复前会被静默丢的坑', () => {
     const clip = buildClipFromGenerationNode(makeNode({ providerUrl: 'https://cdn.example.com/a.png' }))
     expect(clip).not.toBeNull()
     expect(clip?.url).toBe('https://cdn.example.com/a.png')
   })
 
-  it('providerUrl 优先于 url', () => {
+  it('url 优先于 providerUrl，避免时间轴播放 ComfyUI 私网源被 CSP 拦截', () => {
     const clip = buildClipFromGenerationNode(
       makeNode({ providerUrl: 'https://cdn.example.com/a.png', url: 'nomi-local://a.png' }),
     )
-    expect(clip?.url).toBe('https://cdn.example.com/a.png')
+    expect(clip?.url).toBe('nomi-local://a.png')
   })
 
   it('无 providerUrl 时退回 url', () => {

--- a/src/workbench/generationCanvas/model/buildClipFromGenerationNode.ts
+++ b/src/workbench/generationCanvas/model/buildClipFromGenerationNode.ts
@@ -1,6 +1,7 @@
 import type { TimelineClip, TimelineClipType } from '../../timeline/timelineTypes'
 import type { GenerationCanvasNode, GenerationNodeResult } from './generationCanvasTypes'
 import { getGenerationNodeExecutionKind } from './generationNodeKinds'
+import { resultUrl } from '../runner/referenceUrl'
 
 const DEFAULT_IMAGE_SECONDS = 3
 const DEFAULT_VIDEO_SECONDS = 5
@@ -13,16 +14,6 @@ type BuildClipOptions = {
 
 function readString(value: unknown): string {
   return typeof value === 'string' ? value.trim() : ''
-}
-
-/**
- * clip 播放 URL 口径：providerUrl > url > thumbnailUrl。
- * 与 runner/referenceUrl.resultUrl 同序，但**不过 vendor 严格白名单**——
- * clip.url 是本地 <video>/<img> 播放用，file:// / nomi-local:// 等本地 scheme 都合法，
- * 不能像「喂 vendor」那样被 asUrl 收紧。这里只修「漏读 providerUrl」的真坑（记忆 url-priority-inconsistency）。
- */
-function pickClipUrl(result: GenerationNodeResult | null | undefined): string {
-  return readString(result?.providerUrl) || readString(result?.url) || readString(result?.thumbnailUrl)
 }
 
 function readPositiveNumber(value: unknown): number | null {
@@ -87,8 +78,8 @@ export function buildClipFromGenerationNode(node: GenerationCanvasNode, options?
   const startFrame = normalizeFrame(options?.startFrame)
   const type = resolveClipType(node, result)
   const label = readString(node.title) || readString(node.prompt) || node.id
-  // providerUrl 优先（不再只读 result.url）——否则只有 providerUrl 的产物会被静默丢、拖不进轨。
-  const url = pickClipUrl(result)
+  // 复用 referenceUrl.resultUrl：本地持久文件优先，providerUrl 只在无本地拷贝时兜底。
+  const url = resultUrl(result || undefined)
   const thumbnailUrl = readString(result?.thumbnailUrl) || (type === 'image' ? url : '')
 
   // v0.7.1: image / video / audio 都要求有 url（生成或上传后才允许拖）
@@ -116,7 +107,7 @@ export function buildClipFromGenerationNode(node: GenerationCanvasNode, options?
  * 把「重生成后的新产物」回填进一条已存在的 clip（C0 回填闸的纯函数核）。
  * 铁律（评审挖出的三个坑）：
  *  - 位置不变：startFrame 保持（"位置不变 = 起点不变"，时长真变了 endFrame 才变）。
- *  - URL 口径：providerUrl > url > thumbnailUrl（复用 resultUrl）。
+ *  - URL 口径：本地 url > providerUrl > thumbnailUrl（复用 referenceUrl.resultUrl）。
  *  - trim 越界夹取：新产物时长可能变短/变长，offset 夹进新 frameCount，保可见 ≥1 帧。
  * image clip 的时长是用户设的、与产物无关 → 只换 URL；video/audio 才按新 durationSeconds 重算。
  * 无可用产物（url 空）→ 原样返回（防御，不破坏既有 clip）。
@@ -126,7 +117,7 @@ export function applyRegeneratedResultToClip(
   result: GenerationNodeResult | null,
   fps?: number,
 ): TimelineClip {
-  const url = pickClipUrl(result)
+  const url = resultUrl(result || undefined)
   if (!url) return clip
   const thumbnailUrl = readString(result?.thumbnailUrl) || (clip.type === 'image' ? url : clip.thumbnailUrl || '')
 

--- a/src/workbench/generationCanvas/nodes/BaseGenerationNode.tsx
+++ b/src/workbench/generationCanvas/nodes/BaseGenerationNode.tsx
@@ -35,7 +35,7 @@ import { useWorkbenchStore } from '../../workbenchStore'
 import { useGenerationCanvasStore } from '../store/generationCanvasStore'
 import { encodeTimelineGenerationNodeDragPayload, TIMELINE_GENERATION_NODE_DRAG_MIME } from '../../timeline/timelineDragPayload'
 import { getTrackTypeForClipType } from '../../timeline/timelineTypes'
-import { buildClipFromGenerationNode } from '../model/buildClipFromGenerationNode'
+import { buildGenerationNodeTimelineClip } from '../../timeline/buildGenerationNodeTimelineClip'
 import { toast } from '../../../ui/toast'
 import { canRunGenerationNode, confirmAndRunNode } from '../runner/generationRunController'
 import { retryLocalAssetImport } from '../adapters/assetImportAdapter'
@@ -148,16 +148,18 @@ function BaseGenerationNodeImpl({
     event.preventDefault()
     event.stopPropagation()
     const timeline = useWorkbenchStore.getState().timeline
+    const liveNode = useGenerationCanvasStore.getState().nodes.find((candidate) => candidate.id === node.id) || node
     const startFrame = timeline.playheadFrame
-    const clip = buildClipFromGenerationNode(node, {
+    void buildGenerationNodeTimelineClip(liveNode, {
       fps: timeline.fps,
       startFrame,
+    }).then((clip) => {
+      if (!clip) {
+        toast(t('generationCommon.node.generateFirst'), 'info')
+        return
+      }
+      useWorkbenchStore.getState().addTimelineClipAtFrame(clip, getTrackTypeForClipType(clip.type), startFrame)
     })
-    if (!clip) {
-      toast(t('generationCommon.node.generateFirst'), 'info')
-      return
-    }
-    useWorkbenchStore.getState().addTimelineClipAtFrame(clip, getTrackTypeForClipType(clip.type), startFrame)
   }
 
   const updateMediaDimensions = (width: number, height: number, durationSeconds?: number) => {

--- a/src/workbench/generationCanvas/nodes/useNodeDragResize.ts
+++ b/src/workbench/generationCanvas/nodes/useNodeDragResize.ts
@@ -6,7 +6,7 @@ import { useGenerationCanvasStore } from '../store/generationCanvasStore'
 import { useWorkbenchStore } from '../../workbenchStore'
 import { clientXToFrame } from '../../timeline/timelineEdit'
 import { getTrackTypeForClipType } from '../../timeline/timelineTypes'
-import { buildClipFromGenerationNode } from '../model/buildClipFromGenerationNode'
+import { buildGenerationNodeTimelineClip } from '../../timeline/buildGenerationNodeTimelineClip'
 import { toast } from '../../../ui/toast'
 import { emitCanvasGesture } from '../events/canvasEventEmitter'
 import i18n from '../../../i18n'
@@ -301,10 +301,11 @@ export function useNodeDragResize({
     }
     if (timelineDropTarget) {
       const timeline = useWorkbenchStore.getState().timeline
+      const liveNode = useGenerationCanvasStore.getState().nodes.find((candidate) => candidate.id === node.id) || node
       const rect = timelineDropTarget.getBoundingClientRect()
       const startFrame = clientXToFrame(event.clientX, rect.left, timeline.scale)
-      const clip = buildClipFromGenerationNode(node, { fps: timeline.fps, startFrame })
-      if (clip) {
+      void buildGenerationNodeTimelineClip(liveNode, { fps: timeline.fps, startFrame }).then((clip) => {
+        if (!clip) return
         useWorkbenchStore.getState().addTimelineClipAtFrame(clip, getTrackTypeForClipType(clip.type), startFrame)
         if (!dragStart?.multi) {
           moveNode(
@@ -316,7 +317,7 @@ export function useNodeDragResize({
             { persist: false, emit: false },
           )
         }
-      }
+      })
     }
     if (dragStart?.dragging || hadResize) {
       if (dragStart?.dragging) emitDragSettled(dragStart.multi)

--- a/src/workbench/generationCanvas/runner/catalogTaskActions.test.ts
+++ b/src/workbench/generationCanvas/runner/catalogTaskActions.test.ts
@@ -14,6 +14,10 @@ function imageNode(): GenerationCanvasNode {
   return { id: 'n2', kind: 'image', title: '', position: { x: 0, y: 0 }, meta: { modelKey: 'sd' } }
 }
 
+function generatedVideoNode(): GenerationCanvasNode {
+  return { id: 'v1', kind: 'video', title: '', position: { x: 0, y: 0 }, meta: { modelKey: 'comfyui-local-video' } }
+}
+
 function chatResult(raw: unknown, status: TaskResultDto['status'] = 'succeeded'): TaskResultDto {
   return { id: 'task-1', kind: 'chat', status, assets: [], raw }
 }
@@ -422,6 +426,40 @@ describe('normalizeCatalogTaskResult — image path unaffected', () => {
     )
     expect(result.type).toBe('image')
     expect(result.url).toBe('https://x/y.png')
+  })
+})
+
+describe('normalizeCatalogTaskResult — generated video duration', () => {
+  it('uses localized asset duration before the canvas metadata fallback', () => {
+    const node = generatedVideoNode()
+    const result = normalizeCatalogTaskResult(
+      {
+        id: 't-video',
+        kind: 'text_to_video',
+        status: 'succeeded',
+        assets: [{ type: 'video', url: 'nomi-local://asset/p/video.mp4', durationSeconds: 3.0625 }],
+        raw: {},
+      },
+      { ...node, meta: { ...node.meta, videoDuration: 5 } },
+    )
+
+    expect(result.durationSeconds).toBe(3.0625)
+  })
+
+  it('does not freeze a previous video metadata duration into a newly generated result', () => {
+    const node = generatedVideoNode()
+    const result = normalizeCatalogTaskResult(
+      {
+        id: 't-video',
+        kind: 'text_to_video',
+        status: 'succeeded',
+        assets: [{ type: 'video', url: 'nomi-local://asset/p/new-video.mp4' }],
+        raw: {},
+      },
+      { ...node, meta: { ...node.meta, videoDuration: 8 } },
+    )
+
+    expect(result.durationSeconds).toBeUndefined()
   })
 })
 

--- a/src/workbench/generationCanvas/runner/catalogTaskResultParse.ts
+++ b/src/workbench/generationCanvas/runner/catalogTaskResultParse.ts
@@ -88,9 +88,8 @@ function describeTaskFailure(result: TaskResultDto): string {
   return suffix ? `${prefix} (${suffix})` : prefix
 }
 
-function readDurationSeconds(node: GenerationCanvasNode): number | undefined {
-  const meta = node.meta || {}
-  return asFiniteNumber(meta.durationSeconds) ?? asFiniteNumber(meta.videoDuration)
+function readDurationSeconds(asset: { durationSeconds?: unknown } | null | undefined): number | undefined {
+  return asFiniteNumber(asset?.durationSeconds)
 }
 
 export function normalizeCatalogTaskResult(
@@ -134,7 +133,7 @@ export function normalizeCatalogTaskResult(
     thumbnailUrl: asset.thumbnailUrl || undefined,
     ...(asset.providerUrl ? { providerUrl: asset.providerUrl } : {}),
     model: selectedModelKey(node) || undefined,
-    durationSeconds: type === 'video' ? readDurationSeconds(node) : undefined,
+    durationSeconds: type === 'video' ? readDurationSeconds(asset) : undefined,
     taskId: result.id,
     taskKind: type,
     assetId: asset.assetId || undefined,

--- a/src/workbench/preview/TimelinePreview.tsx
+++ b/src/workbench/preview/TimelinePreview.tsx
@@ -26,6 +26,8 @@ import { describeVideoPlaybackFailure, diagnoseVideoPlaybackFailure, logVideoPla
 import { computeTimelineDuration } from '../timeline/timelineMath'
 import { getDesktopBridge } from '../../desktop/bridge'
 import { getDesktopActiveProjectId } from '../../desktop/activeProject'
+import { useGenerationCanvasStore } from '../generationCanvas/store/generationCanvasStore'
+import { resolveTimelineClipPlaybackUrl } from '../timeline/timelinePlaybackUrl'
 
 type TimelinePreviewProps = {
   activeClips: TimelineClip[]
@@ -79,13 +81,14 @@ export default function TimelinePreview({ activeClips, aspectRatio, fps, playhea
   const playing = useWorkbenchStore((state) => state.timelinePlaying)
   const setTimelinePlaying = useWorkbenchStore((state) => state.setTimelinePlaying)
   const setTimelinePlayhead = useWorkbenchStore((state) => state.setTimelinePlayhead)
+  const generationNodes = useGenerationCanvasStore((state) => state.nodes)
   const videoClip = findClip(activeClips, 'video')
   const imageClip = findClip(activeClips, 'image')
   const audioClip = findClip(activeClips, 'audio')
-  const videoUrl = videoClip?.url || ''
+  const videoUrl = resolveTimelineClipPlaybackUrl(videoClip, generationNodes)
   const videoPlaybackUrl = videoUrl ? buildVideoPlaybackUrl(videoUrl) : ''
   const activeRatio = PREVIEW_RATIOS.find((ratio) => ratio.value === aspectRatio) || PREVIEW_RATIOS[0]
-  const activeMediaKey = videoClip?.url || imageClip?.url || ''
+  const activeMediaKey = videoUrl || imageClip?.url || ''
   const hasMedia = Boolean(activeMediaKey)
   // 取景 per-clip（P0-5）：控件作用于主媒体 clip（视频优先，z-2 在上）；渲染时各媒体用自己的 framing。
   const framingClipId = (videoClip ?? imageClip)?.id ?? ''
@@ -111,13 +114,13 @@ export default function TimelinePreview({ activeClips, aspectRatio, fps, playhea
   // 放宽阈值只在 scrub 这种「大跳」时纠正，避免每帧把 currentTime 往回拽造成抖动。
   React.useEffect(() => {
     const video = videoRef.current
-    if (!video || !videoClip?.url) return
+    if (!video || !videoClip || !videoUrl) return
     const nextTime = resolveVideoClipMediaTimeSeconds({ clip: videoClip, playheadFrame, fps })
     if (!Number.isFinite(nextTime)) return
     const threshold = playing ? 0.3 : 0.04
     if (Math.abs(video.currentTime - nextTime) < threshold) return
     video.currentTime = nextTime
-  }, [fps, playheadFrame, videoClip, playing])
+  }, [fps, playheadFrame, videoClip, videoUrl, playing])
 
   // 音量/静音应用到 <video>（video 每个 clip 重挂，故 videoUrl 变也要重设）。
   React.useEffect(() => {
@@ -150,7 +153,7 @@ export default function TimelinePreview({ activeClips, aspectRatio, fps, playhea
 
   React.useEffect(() => {
     const video = videoRef.current
-    if (!video || !videoClip?.url) return
+    if (!video || !videoClip || !videoUrl) return
     if (playing) {
       setPlaybackError('')
       void video.play().catch((error: unknown) => {
@@ -167,7 +170,7 @@ export default function TimelinePreview({ activeClips, aspectRatio, fps, playhea
         // jsdom does not implement media controls; browsers do.
       }
     }
-  }, [playing, setTimelinePlaying, videoClip?.url, t])
+  }, [playing, setTimelinePlaying, videoClip, videoUrl, t])
 
   React.useEffect(() => {
     setPlaybackError('')
@@ -255,6 +258,7 @@ export default function TimelinePreview({ activeClips, aspectRatio, fps, playhea
         projectId,
         resolution: '1080p',
         quality: 'standard',
+        generationNodes,
         onProgress: (progress: Parameters<NonNullable<ExportTimelineToMp4Options['onProgress']>>[0]) => {
           setExportStatus(progress.status)
           setExportRatio(progress.ratio)
@@ -273,7 +277,7 @@ export default function TimelinePreview({ activeClips, aspectRatio, fps, playhea
       cancelJobIdRef.current = ''
       setCanCancelExport(false)
     }
-  }, [aspectRatio, exportBusy, timeline, t])
+  }, [aspectRatio, exportBusy, generationNodes, timeline, t])
 
   // 导出进行中订阅导出事件，捕获当前项目在跑 job 的 id（供「取消」按钮）。
   // exportApi 内部生成 jobId 不回传 UI；per-project 单 active 锁保证相关性可靠。

--- a/src/workbench/timeline/TimelineTrack.tsx
+++ b/src/workbench/timeline/TimelineTrack.tsx
@@ -1,8 +1,10 @@
 import React from 'react'
 import { useTranslation } from 'react-i18next'
 import { useWorkbenchStore } from '../workbenchStore'
+import { useGenerationCanvasStore } from '../generationCanvas/store/generationCanvasStore'
 import { cn } from '../../utils/cn'
 import { buildClipFromGenerationNode } from '../generationCanvas/model/buildClipFromGenerationNode'
+import { buildGenerationNodeTimelineClip } from './buildGenerationNodeTimelineClip'
 import { tryAddAudioAssetFromDragData } from './dropAudioAssetToTimeline'
 import { ASSET_LIBRARY_DRAG_MIME } from '../assets/assetLibraryDrag'
 import { clientXToFrame } from './timelineEdit'
@@ -65,8 +67,12 @@ function TimelineTrack({ track, variant = 'primary' }: TimelineTrackProps): JSX.
         event.dataTransfer.getData(TIMELINE_GENERATION_NODE_DRAG_MIME),
       )
       if (!generationNodePayload) return null
+      const liveNode = useGenerationCanvasStore
+        .getState()
+        .nodes.find((node) => node.id === generationNodePayload.nodeId)
+      const generationNode = liveNode || generationNodePayload.node
       const startFrame = resolveFrame(event.clientX)
-      const clip = buildClipFromGenerationNode(generationNodePayload.node, {
+      const clip = buildClipFromGenerationNode(generationNode, {
         fps,
         startFrame,
         resultId: generationNodePayload.resultId,
@@ -112,9 +118,27 @@ function TimelineTrack({ track, variant = 'primary' }: TimelineTrackProps): JSX.
         toast(preview.reason || t('timelineEditor.track.unavailable'), 'warning')
         return
       }
-      addTimelineClipAtFrame(preview.clip, getTrackTypeForClipType(preview.clip.type), preview.startFrame)
+      const generationNodePayload = decodeTimelineGenerationNodeDragPayload(
+        event.dataTransfer.getData(TIMELINE_GENERATION_NODE_DRAG_MIME),
+      )
+      if (!generationNodePayload) {
+        addTimelineClipAtFrame(preview.clip, getTrackTypeForClipType(preview.clip.type), preview.startFrame)
+        return
+      }
+      const liveNode = useGenerationCanvasStore
+        .getState()
+        .nodes.find((node) => node.id === generationNodePayload.nodeId)
+      const generationNode = liveNode || generationNodePayload.node
+      void buildGenerationNodeTimelineClip(generationNode, {
+        fps,
+        startFrame: preview.startFrame,
+        resultId: generationNodePayload.resultId,
+      }).then((clip) => {
+        const nextClip = clip || preview.clip
+        addTimelineClipAtFrame(nextClip, getTrackTypeForClipType(nextClip.type), preview.startFrame)
+      })
     },
-    [handleAssetAudioDrop, addTimelineClipAtFrame, dragPreview, resolveDropPreview, t],
+    [handleAssetAudioDrop, addTimelineClipAtFrame, dragPreview, resolveDropPreview, fps, t],
   )
 
   return (

--- a/src/workbench/timeline/buildGenerationNodeTimelineClip.test.ts
+++ b/src/workbench/timeline/buildGenerationNodeTimelineClip.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { GenerationCanvasNode } from '../generationCanvas/model/generationCanvasTypes'
+import { buildGenerationNodeTimelineClip } from './buildGenerationNodeTimelineClip'
+
+vi.mock('../../media/videoDurationProbe', () => ({
+  readVideoDurationSeconds: vi.fn(async () => 7),
+}))
+
+function videoNode(overrides: Partial<GenerationCanvasNode> = {}): GenerationCanvasNode {
+  return {
+    id: 'node-1',
+    kind: 'video',
+    title: 'shot',
+    position: { x: 0, y: 0 },
+    result: { id: 'result-1', type: 'video', url: 'nomi-local://asset/project/video.mp4', createdAt: 1 },
+    ...overrides,
+  }
+}
+
+describe('buildGenerationNodeTimelineClip', () => {
+  it('probes a generated video duration before inserting when result duration is missing', async () => {
+    const clip = await buildGenerationNodeTimelineClip(videoNode(), { fps: 30, startFrame: 10 })
+
+    expect(clip?.frameCount).toBe(210)
+    expect(clip?.startFrame).toBe(10)
+    expect(clip?.endFrame).toBe(220)
+  })
+
+  it('prefers the current media file duration even when result duration is already available', async () => {
+    const clip = await buildGenerationNodeTimelineClip(
+      videoNode({ result: { id: 'result-1', type: 'video', url: 'nomi-local://asset/project/video.mp4', durationSeconds: 3, createdAt: 1 } }),
+      { fps: 30, startFrame: 0 },
+    )
+
+    expect(clip?.frameCount).toBe(210)
+    expect(clip?.endFrame).toBe(210)
+  })
+
+  it('prefers the current media file duration over a stale result duration', async () => {
+    const clip = await buildGenerationNodeTimelineClip(
+      videoNode({ result: { id: 'result-1', type: 'video', url: 'nomi-local://asset/project/video.mp4', durationSeconds: 5, createdAt: 1 } }),
+      { fps: 30, startFrame: 0 },
+    )
+
+    expect(clip?.frameCount).toBe(210)
+    expect(clip?.endFrame).toBe(210)
+  })
+})

--- a/src/workbench/timeline/buildGenerationNodeTimelineClip.ts
+++ b/src/workbench/timeline/buildGenerationNodeTimelineClip.ts
@@ -1,0 +1,33 @@
+import { readVideoDurationSeconds } from '../../media/videoDurationProbe'
+import { buildClipFromGenerationNode } from '../generationCanvas/model/buildClipFromGenerationNode'
+import type { GenerationCanvasNode } from '../generationCanvas/model/generationCanvasTypes'
+import type { TimelineClip } from './timelineTypes'
+
+type BuildOptions = {
+  fps?: number
+  startFrame?: number
+  resultId?: string
+}
+
+function withVideoDuration(clip: TimelineClip, durationSeconds: number, fps: number): TimelineClip {
+  const frameCount = Math.max(1, Math.round(durationSeconds * Math.max(1, fps)))
+  return {
+    ...clip,
+    frameCount,
+    endFrame: clip.startFrame + frameCount,
+    offsetStartFrame: 0,
+    offsetEndFrame: 0,
+  }
+}
+
+export async function buildGenerationNodeTimelineClip(
+  node: GenerationCanvasNode,
+  options: BuildOptions = {},
+): Promise<TimelineClip | null> {
+  const clip = buildClipFromGenerationNode(node, options)
+  if (!clip || clip.type !== 'video' || !clip.url) return clip
+
+  const durationSeconds = await readVideoDurationSeconds(clip.url)
+  if (!durationSeconds) return clip
+  return withVideoDuration(clip, durationSeconds, options.fps || 30)
+}

--- a/src/workbench/timeline/timelineDragPayload.test.ts
+++ b/src/workbench/timeline/timelineDragPayload.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import type { GenerationCanvasNode } from '../generationCanvas/model/generationCanvasTypes'
+import { decodeTimelineGenerationNodeDragPayload, encodeTimelineGenerationNodeDragPayload } from './timelineDragPayload'
+
+function node(overrides: Partial<GenerationCanvasNode> = {}): GenerationCanvasNode {
+  return {
+    id: 'node-1',
+    kind: 'video',
+    title: 'shot',
+    position: { x: 0, y: 0 },
+    result: { id: 'old-result', type: 'video', url: 'nomi-local://old.mp4', durationSeconds: 5, createdAt: 1 },
+    ...overrides,
+  }
+}
+
+describe('timeline generation node drag payload', () => {
+  it('carries nodeId separately so drop handlers can resolve the latest store node', () => {
+    const decoded = decodeTimelineGenerationNodeDragPayload(encodeTimelineGenerationNodeDragPayload(node(), 'result-1'))
+
+    expect(decoded?.nodeId).toBe('node-1')
+    expect(decoded?.node.id).toBe('node-1')
+    expect(decoded?.resultId).toBe('result-1')
+  })
+
+  it('keeps compatibility with old payloads that only serialized node.id', () => {
+    const decoded = decodeTimelineGenerationNodeDragPayload(JSON.stringify({ kind: 'generationNode', node: node() }))
+
+    expect(decoded?.nodeId).toBe('node-1')
+    expect(decoded?.node.id).toBe('node-1')
+  })
+})

--- a/src/workbench/timeline/timelineDragPayload.ts
+++ b/src/workbench/timeline/timelineDragPayload.ts
@@ -10,6 +10,7 @@ export type TimelineClipDragPayload = {
 
 export type TimelineGenerationNodeDragPayload = {
   kind: 'generationNode'
+  nodeId: string
   node: GenerationCanvasNode
   resultId?: string
 }
@@ -23,8 +24,10 @@ function parseJsonPayload(value: string): unknown {
 }
 
 export function encodeTimelineGenerationNodeDragPayload(node: GenerationCanvasNode, resultId?: string): string {
+  const nodeId = String(node.id || '').trim()
   return JSON.stringify({
     kind: 'generationNode',
+    nodeId,
     node,
     ...(resultId ? { resultId } : {}),
   } satisfies TimelineGenerationNodeDragPayload)
@@ -33,13 +36,18 @@ export function encodeTimelineGenerationNodeDragPayload(node: GenerationCanvasNo
 export function decodeTimelineGenerationNodeDragPayload(value: string): TimelineGenerationNodeDragPayload | null {
   const parsed = parseJsonPayload(value)
   if (!parsed || typeof parsed !== 'object') return null
-  const payload = parsed as { kind?: unknown; node?: unknown; resultId?: unknown }
+  const payload = parsed as { kind?: unknown; nodeId?: unknown; node?: unknown; resultId?: unknown }
   if (payload.kind !== 'generationNode' || !payload.node || typeof payload.node !== 'object') return null
   const node = payload.node as GenerationCanvasNode
-  const id = typeof node.id === 'string' ? node.id.trim() : ''
+  const id = typeof payload.nodeId === 'string' && payload.nodeId.trim()
+    ? payload.nodeId.trim()
+    : typeof node.id === 'string'
+      ? node.id.trim()
+      : ''
   if (!id) return null
   return {
     kind: 'generationNode',
+    nodeId: id,
     node: {
       ...node,
       id,

--- a/src/workbench/timeline/timelinePlaybackUrl.test.ts
+++ b/src/workbench/timeline/timelinePlaybackUrl.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest'
+import type { GenerationCanvasNode } from '../generationCanvas/model/generationCanvasTypes'
+import type { TimelineClip, TimelineState } from './timelineTypes'
+import { resolveTimelineClipPlaybackUrl, resolveTimelinePlaybackUrls } from './timelinePlaybackUrl'
+
+function clip(url: string): TimelineClip {
+  return {
+    id: 'clip-1',
+    type: 'video',
+    sourceNodeId: 'node-1',
+    label: '镜头',
+    startFrame: 0,
+    endFrame: 30,
+    frameCount: 30,
+    offsetStartFrame: 0,
+    offsetEndFrame: 0,
+    url,
+  }
+}
+
+function node(): GenerationCanvasNode {
+  return {
+    id: 'node-1',
+    kind: 'video',
+    title: '镜头',
+    position: { x: 0, y: 0 },
+    status: 'idle',
+    result: {
+      id: 'result-1',
+      type: 'video',
+      url: 'nomi-local://asset/project/assets/generated/video.mp4',
+      providerUrl: 'http://192.168.10.2:8188/view?filename=ComfyUI_00025_.mp4&subfolder=video&type=output',
+      createdAt: 1,
+    },
+  }
+}
+
+describe('resolveTimelineClipPlaybackUrl', () => {
+  it('rewrites an old providerUrl timeline clip back to the local persisted asset', () => {
+    expect(resolveTimelineClipPlaybackUrl(clip(node().result!.providerUrl!), [node()])).toBe(
+      'nomi-local://asset/project/assets/generated/video.mp4',
+    )
+  })
+
+  it('keeps the clip url when it does not match the source node result', () => {
+    expect(resolveTimelineClipPlaybackUrl(clip('https://cdn.example.com/other.mp4'), [node()])).toBe(
+      'https://cdn.example.com/other.mp4',
+    )
+  })
+})
+
+describe('resolveTimelinePlaybackUrls', () => {
+  it('returns an export-safe timeline without mutating the original clip url', () => {
+    const providerUrl = node().result!.providerUrl!
+    const timeline: TimelineState = {
+      fps: 30,
+      scale: 1,
+      playheadFrame: 0,
+      tracks: [{ id: 'video', type: 'video', label: 'Video', clips: [clip(providerUrl)] }],
+      textClips: [],
+    }
+
+    const resolved = resolveTimelinePlaybackUrls(timeline, [node()])
+
+    expect(resolved.tracks[0]?.clips[0]?.url).toBe('nomi-local://asset/project/assets/generated/video.mp4')
+    expect(timeline.tracks[0]?.clips[0]?.url).toBe(providerUrl)
+  })
+})

--- a/src/workbench/timeline/timelinePlaybackUrl.ts
+++ b/src/workbench/timeline/timelinePlaybackUrl.ts
@@ -1,0 +1,52 @@
+import type { GenerationCanvasNode, GenerationNodeResult } from '../generationCanvas/model/generationCanvasTypes'
+import { resultUrl } from '../generationCanvas/runner/referenceUrl'
+import type { TimelineClip, TimelineState } from './timelineTypes'
+
+function readString(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function resultUrlCandidates(result: GenerationNodeResult | null | undefined): string[] {
+  return [readString(result?.url), readString(result?.providerUrl), readString(result?.thumbnailUrl)].filter(Boolean)
+}
+
+function findSourceNode(nodes: GenerationCanvasNode[], clip: TimelineClip | null | undefined): GenerationCanvasNode | null {
+  if (!clip?.sourceNodeId) return null
+  return nodes.find((node) => node.id === clip.sourceNodeId) || null
+}
+
+export function resolveTimelineClipPlaybackUrl(
+  clip: TimelineClip | null | undefined,
+  nodes: GenerationCanvasNode[],
+): string {
+  const clipUrl = readString(clip?.url)
+  if (!clip) return ''
+
+  const sourceNode = findSourceNode(nodes, clip)
+  if (!sourceNode) return clipUrl
+
+  const matchingHistory = (sourceNode.history || []).find((result) => resultUrlCandidates(result).includes(clipUrl))
+  const historicalUrl = resultUrl(matchingHistory)
+  if (historicalUrl) return historicalUrl
+
+  const currentUrl = resultUrl(sourceNode.result)
+  if (currentUrl && (!clipUrl || resultUrlCandidates(sourceNode.result).includes(clipUrl))) return currentUrl
+
+  return clipUrl
+}
+
+export function resolveTimelinePlaybackUrls(timeline: TimelineState, nodes: GenerationCanvasNode[]): TimelineState {
+  let changed = false
+  const tracks = timeline.tracks.map((track) => {
+    let trackChanged = false
+    const clips = track.clips.map((clip) => {
+      const nextUrl = resolveTimelineClipPlaybackUrl(clip, nodes)
+      if (!nextUrl || nextUrl === clip.url) return clip
+      trackChanged = true
+      changed = true
+      return { ...clip, url: nextUrl }
+    })
+    return trackChanged ? { ...track, clips } : track
+  })
+  return changed ? { ...timeline, tracks } : timeline
+}


### PR DESCRIPTION
**描述**

本次修复解决 ComfyUI 生成视频在 Nomi 中的三个相关问题：

1. 本地视频预览失败  
   `nomi-local://asset/...` 现在支持 Chromium 视频播放需要的 byte range 请求，避免视频元素因无法读取分片而播放失败。

2. 预览和导出仍使用 ComfyUI 本地服务地址  
   时间轴预览和导出现在会优先使用已持久化的 `nomi-local://` 本地资源地址，避免继续请求 `http://192.168.x.x:8188/view?...` 这类 ComfyUI provider URL。

3. 重新生成视频后时间轴时长沿用旧值  
   视频拖入时间轴前会重新探测当前媒体文件真实时长，并覆盖可能过期的 `result.durationSeconds`，避免 7s 视频显示成 5s、3s 视频仍显示旧时长的问题。

**主要改动**

- 为 Electron 本地资源协议增加 Range 请求支持。
- 本地化 ComfyUI 结果资源时保留原始视频扩展名，并写入探测到的媒体时长。
- 新增时间轴播放 URL 解析逻辑，让旧 clip 也能从 generation node 找回本地持久化资源。
- 新增入轨前视频时长探测逻辑，统一应用到拖拽、节点操作和时间轴 drop 入口。
- 拖拽 payload 增加 `nodeId`，drop 时优先读取最新 canvas node，避免使用序列化快照里的旧结果。
- 更新修复计划文档并补充回归测试。

**验证**

- `pnpm vitest run src/workbench/timeline/buildGenerationNodeTimelineClip.test.ts src/workbench/timeline/timelineDragPayload.test.ts src/workbench/generationCanvas/model/buildClipFromGenerationNode.test.ts src/workbench/generationCanvas/runner/catalogTaskActions.test.ts electron/runtime.assets.test.ts src/workbench/timeline/timelinePlaybackUrl.test.ts src/workbench/export/exportApi.test.ts electron/protocol/localProtocol.test.ts`
  - 8 个测试文件通过
  - 165 个测试通过
- `pnpm run typecheck`
  - 通过