### PR TITLE
fix(test): isolate settings and harden Electron startup

### DIFF
--- a/electron/export/exportJobs.ts
+++ b/electron/export/exportJobs.ts
@@ -439,7 +439,6 @@ export function showExportInFolder(payload: unknown): { ok: true } {
   const resolved = resolveProjectRelativePath(projectId, normalized);
   if (!fs.existsSync(resolved)) throw new Error("打开导出位置失败：导出文件不存在");
   // Lazy require keeps runtime.ts usable in tests that do not initialize Electron shell.
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
   const { shell } = require("electron") as typeof import("electron");
   shell.showItemInFolder(resolved);
   return { ok: true };

--- a/electron/export/ffmpegRunner.ts
+++ b/electron/export/ffmpegRunner.ts
@@ -186,7 +186,6 @@ type ResolveFfmpegPathOptions = {
 function resolveBundledFfmpegPath(): string {
   try {
     // @ffmpeg-installer/ffmpeg resolves to the platform-specific binary shipped with the app.
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
     const bundled = require("@ffmpeg-installer/ffmpeg") as { path?: unknown };
     return typeof bundled.path === "string" ? bundled.path : "";
   } catch {

--- a/electron/settings/settingsRoot.test.ts
+++ b/electron/settings/settingsRoot.test.ts
@@ -1,0 +1,44 @@
+// 根因回归：设置根必须是**绝对**目录，否则一切 path.join(getSettingsRoot(), 文件名)
+// 都会退化成相对路径、静默写进 process.cwd()（开发/测试时 = 仓库根目录）。
+//
+// 真实事故：electron 桩的 getPath() 返回 ""，providerAdapter/onboardingRoundtrip 的真实
+// 往返里 executeProfileOperation → readCatalog() 首次读不到就落一份默认 catalog，于是每跑
+// 一次 `pnpm run test` 仓库根就多一个未跟踪的 model-catalog.json。修在这一层（而不是
+// .gitignore、也不是给那个测试再加个 mock）才管得住整类：getSettingsRoot() 目前有十余个
+// 调用点，每个都是 join 出文件名，任何一个都能把文件写到不该去的地方。
+//
+// 本文件**故意不 vi.mock("electron")** —— 要验的正是「其它测试默认拿到的那个桩」是否忠实。
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { getSettingsRoot, SETTINGS_ROOT_ENV } from "./settingsRoot";
+
+const previousSettingsRoot = process.env[SETTINGS_ROOT_ENV];
+afterEach(() => {
+  if (previousSettingsRoot === undefined) delete process.env[SETTINGS_ROOT_ENV];
+  else process.env[SETTINGS_ROOT_ENV] = previousSettingsRoot;
+});
+
+describe("getSettingsRoot", () => {
+  it("默认（无 env 覆盖）给出绝对目录，且不在仓库里 —— 单测不得往仓库根写文件", () => {
+    delete process.env[SETTINGS_ROOT_ENV];
+    const root = getSettingsRoot();
+
+    expect(path.isAbsolute(root)).toBe(true);
+    // 仓库根 = vitest 的 root = 相对路径会落到的地方。设置根落在这下面，
+    // 就意味着任何一次写盘都会在 git status 里冒出未跟踪垃圾。
+    const repoRoot = process.cwd();
+    expect(path.relative(repoRoot, root).startsWith("..")).toBe(true);
+  });
+
+  it("env 覆盖是绝对路径时原样返回", () => {
+    const absolute = path.join(path.sep, "tmp", "nomi-settings-root-test");
+    process.env[SETTINGS_ROOT_ENV] = absolute;
+    expect(getSettingsRoot()).toBe(absolute);
+  });
+
+  it("拿到相对路径时当场抛错，而不是静默写进 process.cwd()", () => {
+    process.env[SETTINGS_ROOT_ENV] = "relative-settings-dir";
+    expect(() => getSettingsRoot()).toThrow(/absolute/i);
+  });
+});

--- a/electron/settings/settingsRoot.ts
+++ b/electron/settings/settingsRoot.ts
@@ -1,12 +1,28 @@
 import { app } from "electron";
+import path from "node:path";
 
 /** 评测/测试隔离：覆盖固定设置根，防临时项目污染真实 userData。 */
 export const SETTINGS_ROOT_ENV = "NOMI_SETTINGS_DIR";
 
 /**
  * 应用设置的固定根目录。它不能依赖可自定义的项目位置，否则项目位置设置会形成自举环。
+ *
+ * **绝对路径是硬不变量**：全项目十余处都写成 `path.join(getSettingsRoot(), 文件名)`，
+ * 根一旦是空串或相对路径，join 出来就还是相对路径 —— 落到 `process.cwd()`：开发/测试时
+ * 即仓库根目录（单测曾因此在仓库里写出 model-catalog.json），打包运行时则是启动进程时
+ * 碰巧所在的任意目录。这类故障**静默**：文件确实写成功了，只是写错了地方。
+ * 故这里当场炸掉，而不是让每个调用点各自去防 —— 真实来源（Electron 的 userData、
+ * main.ts 启动时注入的 NOMI_ELECTRON_USER_DATA_DIR、各 e2e 的 NOMI_SETTINGS_DIR）
+ * 全都是绝对路径，能走到这个分支就说明接线本身错了。
  */
 export function getSettingsRoot(): string {
   const configured = String(process.env[SETTINGS_ROOT_ENV] || "").trim();
-  return configured || app.getPath("userData");
+  const root = configured || app.getPath("userData");
+  if (!path.isAbsolute(root)) {
+    throw new Error(
+      `[nomi] settings root must be an absolute directory, got ${JSON.stringify(root)}. ` +
+        `Set ${SETTINGS_ROOT_ENV} to an absolute path, or make sure Electron's userData path is available before this runs.`,
+    );
+  }
+  return root;
 }

--- a/electron/tasks/unpollableTaskQuery.test.ts
+++ b/electron/tasks/unpollableTaskQuery.test.ts
@@ -19,8 +19,10 @@ vi.mock("../runtime", async () => {
 });
 
 // 第二个（也是唯一另一个）边界桩：catalog 的磁盘读。真 readCatalog() 首次调用会**落盘**
-// （electron 桩的 getPath() 返回 ""，于是 model-catalog.json 写进仓库根目录）。这里只有
-// 「create 已带产物」那条分支会读它（取 vendor 提示给 SSRF 白名单），返回空 vendors 即可。
+// （落 electron 桩给的按进程临时 userData 目录 —— 从前桩的 getPath() 返回 ""，那会写进
+// 仓库根目录，见 settings/settingsRoot.test.ts 钉的绝对路径不变量）。桩掉是为了不让本
+// 用例依赖磁盘状态：这里只有「create 已带产物」那条分支会读它（取 vendor 提示给 SSRF
+// 白名单），返回空 vendors 即可。
 vi.mock("../catalog/catalogStore", async () => {
   const actual = await vi.importActual<typeof import("../catalog/catalogStore")>("../catalog/catalogStore");
   return { ...actual, readCatalog: () => ({ vendors: [], models: [], mappings: [] }) };

--- a/scripts/start-electron.mjs
+++ b/scripts/start-electron.mjs
@@ -4,10 +4,15 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { installChildProcessLifecycle } from "./child-process-lifecycle.mjs";
+import { ensureElectronSignature } from "./ensure-electron-signature.mjs";
 
 const require = createRequire(import.meta.url);
 const electron = require("electron");
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+// Match `pnpm dev`: launching a revoked dev Electron lets XProtect delete the
+// bundle, so repair its local signature before the first spawn.
+ensureElectronSignature(electron, { log: (msg) => console.log(msg) });
 
 // Auto-load the onboarding agent LLM (dm-fox gpt-5.5) from .secrets/agent.key so
 // model onboarding works without manual `export`s. Already-set env vars win.

--- a/tests/stubs/electron.ts
+++ b/tests/stubs/electron.ts
@@ -10,11 +10,36 @@
 // 运行时；真正需要 electron 行为的测试各自注入自己的假实现。桩只需"存在且不抛"。
 // 真实 app 构建走 vite.config.ts，不受此 alias 影响。
 
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
 const noop = (): undefined => undefined;
 
+// getPath() 必须给**绝对**目录 —— 真 Electron 永远如此（main.ts 启动时还会
+// app.setPath("userData", …) 再注入一次）。桩从前返回 ""，于是遍布代码的
+// `path.join(getSettingsRoot(), 文件名)` 全退化成相对路径，落进 process.cwd()
+// = 仓库根目录：跑一次 `pnpm run test` 就在仓库里拉出一个未跟踪的
+// model-catalog.json（真发生过，由 providerAdapter/onboardingRoundtrip 触发）。
+// 不忠实的替身 = 生产代码里发现不了的一整类 bug，故这里按进程给一份真临时
+// userData 根：每个 vitest worker 各一份、互不串味，进程退出即清。
+// 需要检查落盘内容的测试仍各自 vi.mock("electron") 指向自己的临时目录。
+const TEST_APP_DATA_ROOT = path.join(os.tmpdir(), "nomi-vitest-userdata", String(process.pid));
+
+process.on("exit", () => {
+  try {
+    fs.rmSync(TEST_APP_DATA_ROOT, { recursive: true, force: true });
+  } catch {
+    // 尽力而为：临时目录留下无害，绝不能因清理失败影响测试结果
+  }
+});
+
 export const app = {
-  getPath: (_name?: string): string => "",
-  getAppPath: (): string => "",
+  // 真 Electron 的各 name（userData / temp / documents / downloads…）是不同目录，
+  // 这里同样分开，免得「项目默认目录」之类的东西被塞进 userData 里。
+  getPath: (name?: string): string => path.join(TEST_APP_DATA_ROOT, name || "userData"),
+  // 开发态下 getAppPath() 就是仓库根（既有各测试的自备 mock 也都这么写）。
+  getAppPath: (): string => process.cwd(),
   getName: (): string => "Nomi",
   getVersion: (): string => "0.0.0-test",
   on: noop,

--- a/tests/stubs/electron.ts
+++ b/tests/stubs/electron.ts
@@ -14,30 +14,26 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
+const globalScope = globalThis as { __nomiElectronStubRoot?: string };
+
+// 真 Electron 的 getPath() 永远返回绝对路径。测试桩按 worker 进程提供独立临时根，
+// 并在首次使用时清掉同 pid 的旧内容。缓存必须挂在 globalThis：Vitest 的模块隔离会
+// 重新求值本文件，模块级缓存会在同一轮测试中反复清目录，破坏别的测试刚写入的数据。
+function runtimeRoot(): string {
+  const existing = globalScope.__nomiElectronStubRoot;
+  if (existing) return existing;
+  const root = path.join(os.tmpdir(), `nomi-vitest-${process.pid}`);
+  fs.rmSync(root, { recursive: true, force: true });
+  globalScope.__nomiElectronStubRoot = root;
+  return root;
+}
+
 const noop = (): undefined => undefined;
-
-// getPath() 必须给**绝对**目录 —— 真 Electron 永远如此（main.ts 启动时还会
-// app.setPath("userData", …) 再注入一次）。桩从前返回 ""，于是遍布代码的
-// `path.join(getSettingsRoot(), 文件名)` 全退化成相对路径，落进 process.cwd()
-// = 仓库根目录：跑一次 `pnpm run test` 就在仓库里拉出一个未跟踪的
-// model-catalog.json（真发生过，由 providerAdapter/onboardingRoundtrip 触发）。
-// 不忠实的替身 = 生产代码里发现不了的一整类 bug，故这里按进程给一份真临时
-// userData 根：每个 vitest worker 各一份、互不串味，进程退出即清。
-// 需要检查落盘内容的测试仍各自 vi.mock("electron") 指向自己的临时目录。
-const TEST_APP_DATA_ROOT = path.join(os.tmpdir(), "nomi-vitest-userdata", String(process.pid));
-
-process.on("exit", () => {
-  try {
-    fs.rmSync(TEST_APP_DATA_ROOT, { recursive: true, force: true });
-  } catch {
-    // 尽力而为：临时目录留下无害，绝不能因清理失败影响测试结果
-  }
-});
 
 export const app = {
   // 真 Electron 的各 name（userData / temp / documents / downloads…）是不同目录，
   // 这里同样分开，免得「项目默认目录」之类的东西被塞进 userData 里。
-  getPath: (name?: string): string => path.join(TEST_APP_DATA_ROOT, name || "userData"),
+  getPath: (name = "userData"): string => path.join(runtimeRoot(), name),
   // 开发态下 getAppPath() 就是仓库根（既有各测试的自备 mock 也都这么写）。
   getAppPath: (): string => process.cwd(),
   getName: (): string => "Nomi",

--- a/tests/ux/_launchApp.mjs
+++ b/tests/ux/_launchApp.mjs
@@ -22,6 +22,7 @@ import os from 'node:os'
 import path from 'node:path'
 import { createRequire } from 'node:module'
 import { fileURLToPath } from 'node:url'
+import { ensureElectronSignature } from '../../scripts/ensure-electron-signature.mjs'
 
 const require = createRequire(import.meta.url)
 
@@ -101,7 +102,12 @@ export async function launchNomiApp(options = {}) {
   // 开发 electron 二进制要靠 `.` 指到仓库根去加载 dist-electron；**打包好的 .app 自带产物**，
   // 再塞个 `.` 反而会被当成「要打开的路径」参数。所以这两件事都跟着「是不是开发构建」走。
   const isDevElectron = executablePath === require('electron')
-  if (isDevElectron) assertBuilt()
+  if (isDevElectron) {
+    assertBuilt()
+    // Apple 会在首次启动时直接删除已吊销公证的 Electron.app。走查必须在 spawn 前复用
+    // dev 启动器的静态探测与重签，否则表现为 60s 超时且一张截图也产不出来。
+    ensureElectronSignature(executablePath)
+  }
 
   // isolate:false = 用用户**真实** profile 起（交互式 dev driver ui-driver.mjs 才这么用：
   // 它要能打开已有/示例项目，这是它注释里写明的既定设计，不是漏配）。此时不传 --user-data-dir、


### PR DESCRIPTION
## Summary

- require the settings root to be absolute so tests and runtime cannot silently write configuration into the repository
- give each Vitest worker an isolated Electron stub data root
- repair a revoked local Electron signature before development and walkthrough startup
- remove two dead lint-disable directives

## Scope

The original launcher commit also touched Scene3D walkthroughs. Those files are intentionally excluded from this PR and remain assigned to the later Scene3D delivery.

## Verification

- targeted settings and launcher tests: 3 files / 11 tests passed
- pnpm gates
- 525 test files passed, 1 skipped
- 4631 tests passed, 1 skipped
- lint: 95 warnings, 0 errors