### PR TITLE
fix(canvas): keep visible media renderable

### DIFF
--- a/docs/plan/2026-08-16-visible-media-scheduler.md
+++ b/docs/plan/2026-08-16-visible-media-scheduler.md
@@ -1,0 +1,59 @@
+# Visible media scheduler
+
+## Problem
+
+Canvas node virtualization is working, but the independent media scheduler treats the first
+viewport intersection as permanent. Media that has since left the viewport can keep queued or
+active image/video slots, while media that is currently visible waits behind it under an opaque
+loading layer. The eight-second slot watchdog only frees concurrency; it does not terminate the
+component state, so the underlying media can remain `opacity-0` indefinitely. Images also pass
+through `NomiImage`'s native lazy-loading decision after the scheduler has admitted them.
+
+## Scope
+
+- Make media eligibility track the real browser viewport continuously.
+- Cancel queued work and release active slots when media leaves that viewport.
+- Reprioritize an existing queued request when its node becomes selected/focused.
+- Model `idle -> queued -> loading -> ready | error | timeout` explicitly.
+- Turn the slot watchdog into a visible, retryable timeout instead of a silent release.
+- Load scheduler-admitted images eagerly while keeping asynchronous decoding.
+- Preserve the last ready media while a replacement is queued/decoded; otherwise keep the
+  existing opaque loading placeholder.
+- Strengthen durable unit and real-user performance checks around visible media settlement.
+
+## Non-scope
+
+- Do not change canvas node virtualization or its 400px render buffer.
+- Do not change the `>80 nodes && zoom <0.55` lightweight node LOD policy.
+- Do not increase image/video concurrency limits (image 4, video 1).
+- Do not change generation, persistence, video transcoding, or media URL resolution.
+- Do not introduce a new visual language; timeout/error feedback reuses existing Nomi tokens,
+  loading surfaces, translations, and action components.
+
+## Interaction contract
+
+1. A rendered node outside the clipped browser viewport does not consume a media slot.
+2. Entering the viewport queues its media after the canvas shell paint.
+3. Visible priority media is ordered before visible normal media, including requests already
+   waiting in the queue.
+4. Leaving the viewport cancels queued work or aborts the active element and releases its slot.
+5. A decoded image or current video frame becomes visible and releases its slot.
+6. Failure or an eight-second timeout removes the transparent loading media, shows an opaque
+   recoverable state, releases the slot, and offers a retry.
+7. Replacing a source keeps the previous ready frame visible until the new source is ready.
+
+## Rollback
+
+Revert the scheduler/component/test commit. No persisted schema, project data, IPC contract, or
+generated asset is changed, so rollback needs no migration.
+
+## Acceptance criteria
+
+- Unit tests prove continuous visibility, offscreen cancellation/release, queued reprioritization,
+  independent concurrency lanes, terminal timeout, and decoded-frame readiness.
+- Component behavior cannot leave timed-out or failed media under `opacity-0`.
+- Scheduler-admitted images use eager browser loading.
+- Existing focused/selected priority behavior remains intact and becomes dynamic while queued.
+- Targeted tests, lint, typecheck, full `pnpm gates`, and production build pass.
+- Real Electron journeys cover initial visible load, pan away/back plus reload, and timeout/error;
+  screenshots are captured and visually inspected.

--- a/src/i18n/resources.ts
+++ b/src/i18n/resources.ts
@@ -38,6 +38,7 @@ export const zhCN = {
     noImage: '无图片',
     imageLoadFailed: '图片加载失败',
     loadFailed: '加载失败',
+    loadTimedOut: '加载超时，请重试',
   },
   brand: {
     name: 'Nomi',
@@ -393,6 +394,7 @@ export const en = {
     noImage: 'No image',
     imageLoadFailed: 'Image failed to load',
     loadFailed: 'Load failed',
+    loadTimedOut: 'Loading timed out. Try again.',
   },
   brand: {
     name: 'Nomi',

--- a/src/workbench/generationCanvas/nodes/DeferredNodeMedia.test.ts
+++ b/src/workbench/generationCanvas/nodes/DeferredNodeMedia.test.ts
@@ -10,6 +10,7 @@ import {
 describe('deferred node media queue', () => {
   afterEach(() => {
     __resetDeferredNodeMediaQueueForTests()
+    vi.useRealTimers()
     vi.unstubAllGlobals()
   })
 
@@ -71,6 +72,58 @@ describe('deferred node media queue', () => {
     expect(activated).toEqual(['active', 'priority'])
   })
 
+  it('reprioritizes media that is already waiting in the queue', () => {
+    __setDeferredNodeMediaLimitForTests('image', 1)
+    const activated: string[] = []
+    let releaseActive = () => {}
+
+    requestDeferredNodeMediaSlot('image', (release) => {
+      activated.push('active')
+      releaseActive = release
+    })
+    requestDeferredNodeMediaSlot('image', () => {
+      activated.push('normal-first')
+    })
+    const promoted = requestDeferredNodeMediaSlot('image', () => {
+      activated.push('promoted')
+    })
+
+    promoted.setPriority(true)
+    releaseActive()
+
+    expect(activated).toEqual(['active', 'promoted'])
+  })
+
+  it('cancels active offscreen media and immediately releases its slot', () => {
+    __setDeferredNodeMediaLimitForTests('video', 1)
+    const activated: string[] = []
+
+    const offscreen = requestDeferredNodeMediaSlot('video', () => {
+      activated.push('offscreen')
+    })
+    requestDeferredNodeMediaSlot('video', () => {
+      activated.push('visible')
+    })
+
+    offscreen.cancel()
+
+    expect(activated).toEqual(['offscreen', 'visible'])
+  })
+
+  it('turns the active-slot watchdog into an observable timeout', () => {
+    vi.useFakeTimers()
+    const onTimeout = vi.fn()
+    const activated: string[] = []
+
+    __setDeferredNodeMediaLimitForTests('image', 1)
+    requestDeferredNodeMediaSlot('image', () => activated.push('timed-out'), false, onTimeout)
+    requestDeferredNodeMediaSlot('image', () => activated.push('next'))
+    vi.advanceTimersByTime(8000)
+
+    expect(onTimeout).toHaveBeenCalledTimes(1)
+    expect(activated).toEqual(['timed-out', 'next'])
+  })
+
   it('keeps video activation on its own lower concurrency lane', () => {
     __setDeferredNodeMediaLimitForTests('image', 2)
     __setDeferredNodeMediaLimitForTests('video', 1)
@@ -89,7 +142,7 @@ describe('deferred node media queue', () => {
     expect(activated).toEqual(['video-1', 'image-1'])
   })
 
-  it('waits for IntersectionObserver visibility before activating media', () => {
+  it('tracks IntersectionObserver visibility until cleanup', () => {
     let observerCallback: IntersectionObserverCallback | null = null
     const disconnect = vi.fn()
     const observe = vi.fn()
@@ -102,33 +155,43 @@ describe('deferred node media queue', () => {
       disconnect = disconnect
     }
     vi.stubGlobal('window', { IntersectionObserver: FakeIntersectionObserver })
-    const onVisible = vi.fn()
+    const onVisibilityChange = vi.fn()
     const element = {} as Element
 
-    const cleanup = observeDeferredNodeMediaVisibility(element, onVisible)
+    const cleanup = observeDeferredNodeMediaVisibility(element, onVisibilityChange)
 
     expect(observe).toHaveBeenCalledWith(element)
-    expect(onVisible).not.toHaveBeenCalled()
+    expect(onVisibilityChange).not.toHaveBeenCalled()
 
-    observerCallback?.([{ isIntersecting: false, intersectionRatio: 0 } as IntersectionObserverEntry], {} as IntersectionObserver)
-    expect(onVisible).not.toHaveBeenCalled()
+    observerCallback?.(
+      [{ isIntersecting: false, intersectionRatio: 0 } as IntersectionObserverEntry],
+      {} as IntersectionObserver,
+    )
+    expect(onVisibilityChange).toHaveBeenLastCalledWith(false)
 
-    observerCallback?.([{ isIntersecting: true, intersectionRatio: 0 } as IntersectionObserverEntry], {} as IntersectionObserver)
-    expect(onVisible).toHaveBeenCalledTimes(1)
-    expect(disconnect).toHaveBeenCalledTimes(1)
+    observerCallback?.(
+      [{ isIntersecting: true, intersectionRatio: 0 } as IntersectionObserverEntry],
+      {} as IntersectionObserver,
+    )
+    expect(onVisibilityChange).toHaveBeenLastCalledWith(true)
+    expect(disconnect).not.toHaveBeenCalled()
 
-    observerCallback?.([{ isIntersecting: true, intersectionRatio: 1 } as IntersectionObserverEntry], {} as IntersectionObserver)
-    expect(onVisible).toHaveBeenCalledTimes(1)
+    observerCallback?.(
+      [{ isIntersecting: false, intersectionRatio: 0 } as IntersectionObserverEntry],
+      {} as IntersectionObserver,
+    )
+    expect(onVisibilityChange).toHaveBeenLastCalledWith(false)
 
     cleanup()
+    expect(disconnect).toHaveBeenCalledTimes(1)
   })
 
   it('falls back to immediate activation when IntersectionObserver is unavailable', () => {
     vi.stubGlobal('window', {})
-    const onVisible = vi.fn()
+    const onVisibilityChange = vi.fn()
 
-    observeDeferredNodeMediaVisibility({} as Element, onVisible)
+    observeDeferredNodeMediaVisibility({} as Element, onVisibilityChange)
 
-    expect(onVisible).toHaveBeenCalledTimes(1)
+    expect(onVisibilityChange).toHaveBeenCalledWith(true)
   })
 })

--- a/src/workbench/generationCanvas/nodes/DeferredNodeMedia.tsx
+++ b/src/workbench/generationCanvas/nodes/DeferredNodeMedia.tsx
@@ -1,19 +1,68 @@
 import React from 'react'
+import { useTranslation } from 'react-i18next'
+import { IconRefresh } from '@tabler/icons-react'
+import { WorkbenchButton } from '../../../design'
 import { NomiImage, type NomiImageProps } from '../../../design/media'
 import { cn } from '../../../utils/cn'
-import { isDeferredVideoFrameReady, useDeferredNodeMediaSrc } from './deferredNodeMediaQueue'
+import {
+  isDeferredVideoFrameReady,
+  type DeferredNodeMediaState,
+  useDeferredNodeMediaSrc,
+} from './deferredNodeMediaQueue'
 
 export const DeferredNodeMediaPlaceholder = React.forwardRef<HTMLDivElement, { className?: string }>(
   function DeferredNodeMediaPlaceholder({ className }, ref): JSX.Element {
+    return <div ref={ref} className={cn('generation-canvas-v2-node__media-loading', className)} aria-hidden="true" />
+  },
+)
+
+function DeferredNodeMediaViewportAnchor({
+  state,
+  anchorRef,
+}: {
+  state: DeferredNodeMediaState
+  anchorRef: React.RefCallback<HTMLDivElement>
+}): JSX.Element {
   return (
     <div
-      ref={ref}
-      className={cn('generation-canvas-v2-node__media-loading', className)}
+      ref={anchorRef}
+      className="absolute inset-0 pointer-events-none"
+      data-node-media-state={state}
       aria-hidden="true"
     />
   )
-  },
-)
+}
+
+function DeferredNodeMediaFailure({
+  state,
+  onRetry,
+}: {
+  state: 'error' | 'timeout'
+  onRetry: () => void
+}): JSX.Element {
+  const { t } = useTranslation()
+  const message = state === 'timeout' ? t('media.loadTimedOut') : t('media.loadFailed')
+  return (
+    <div
+      role="alert"
+      className="absolute inset-0 z-[2] flex flex-col items-center justify-center gap-2 bg-nomi-ink-05 p-3 text-center"
+      data-node-media-failure={state}
+    >
+      <span className="text-caption leading-snug text-nomi-ink-60">{message}</span>
+      <WorkbenchButton
+        size="sm"
+        onPointerDown={(event) => event.stopPropagation()}
+        onClick={(event) => {
+          event.stopPropagation()
+          onRetry()
+        }}
+      >
+        <IconRefresh />
+        {t('common.retry')}
+      </WorkbenchButton>
+    </div>
+  )
+}
 
 export type DeferredNodeImageProps = Omit<NomiImageProps, 'src'> & {
   src: string
@@ -31,14 +80,31 @@ export function DeferredNodeImage({
   ...props
 }: DeferredNodeImageProps): JSX.Element {
   const media = useDeferredNodeMediaSrc({ src, kind: 'image', priority })
+  const retainedSrc = media.readySrc && media.readySrc !== media.activeSrc ? media.readySrc : null
   return (
     <>
-      {media.loading ? <DeferredNodeMediaPlaceholder ref={media.placeholderRef} className={placeholderClassName} /> : null}
-      {media.deferredSrc ? (
+      <DeferredNodeMediaViewportAnchor state={media.state} anchorRef={media.placeholderRef} />
+      {media.loading && !media.readySrc ? <DeferredNodeMediaPlaceholder className={placeholderClassName} /> : null}
+      {retainedSrc ? (
         <NomiImage
           {...props}
-          src={media.deferredSrc}
-          className={cn(className, media.loading && 'opacity-0')}
+          key={retainedSrc}
+          src={retainedSrc}
+          eager
+          className={cn(className, media.activeSrc && 'absolute inset-0')}
+        />
+      ) : null}
+      {media.activeSrc ? (
+        <NomiImage
+          {...props}
+          key={media.loadKey}
+          src={media.activeSrc}
+          eager
+          className={cn(
+            className,
+            retainedSrc && 'absolute inset-0',
+            media.state === 'loading' && 'opacity-0 pointer-events-none',
+          )}
           onLoad={(event) => {
             media.markLoaded()
             onLoad?.(event)
@@ -48,6 +114,9 @@ export function DeferredNodeImage({
             onError?.(event)
           }}
         />
+      ) : null}
+      {media.state === 'error' || media.state === 'timeout' ? (
+        <DeferredNodeMediaFailure state={media.state} onRetry={media.retry} />
       ) : null}
     </>
   )
@@ -70,6 +139,15 @@ function releaseVideoElement(video: HTMLVideoElement | null): void {
   }
 }
 
+function ManagedDeferredNodeVideo({
+  mediaKey,
+  ...props
+}: React.VideoHTMLAttributes<HTMLVideoElement> & { mediaKey: string }): JSX.Element {
+  const videoRef = React.useRef<HTMLVideoElement | null>(null)
+  React.useEffect(() => () => releaseVideoElement(videoRef.current), [])
+  return <video {...props} key={mediaKey} ref={videoRef} />
+}
+
 export function DeferredNodeVideo({
   src,
   priority = false,
@@ -81,27 +159,32 @@ export function DeferredNodeVideo({
   ...props
 }: DeferredNodeVideoProps): JSX.Element {
   const media = useDeferredNodeMediaSrc({ src, kind: 'video', priority })
-  const videoRef = React.useRef<HTMLVideoElement | null>(null)
-  const setVideoRef = React.useCallback((element: HTMLVideoElement | null) => {
-    if (videoRef.current && videoRef.current !== element) {
-      releaseVideoElement(videoRef.current)
-    }
-    videoRef.current = element
-  }, [])
-
-  React.useEffect(() => {
-    return () => releaseVideoElement(videoRef.current)
-  }, [])
+  const retainedSrc = media.readySrc && media.readySrc !== media.activeSrc ? media.readySrc : null
 
   return (
     <>
-      {media.loading ? <DeferredNodeMediaPlaceholder ref={media.placeholderRef} className={placeholderClassName} /> : null}
-      {media.deferredSrc ? (
-        <video
+      <DeferredNodeMediaViewportAnchor state={media.state} anchorRef={media.placeholderRef} />
+      {media.loading && !media.readySrc ? <DeferredNodeMediaPlaceholder className={placeholderClassName} /> : null}
+      {retainedSrc ? (
+        <ManagedDeferredNodeVideo
           {...props}
-          ref={setVideoRef}
-          src={media.deferredSrc}
-          className={cn(className, media.loading && 'opacity-0')}
+          key={retainedSrc}
+          mediaKey={retainedSrc}
+          src={retainedSrc}
+          className={cn(className, media.activeSrc && 'absolute inset-0')}
+        />
+      ) : null}
+      {media.activeSrc ? (
+        <ManagedDeferredNodeVideo
+          {...props}
+          key={media.loadKey}
+          mediaKey={media.loadKey}
+          src={media.activeSrc}
+          className={cn(
+            className,
+            retainedSrc && 'absolute inset-0',
+            media.state === 'loading' && 'opacity-0 pointer-events-none',
+          )}
           onLoadedMetadata={(event) => {
             onLoadedMetadata?.(event)
           }}
@@ -114,6 +197,9 @@ export function DeferredNodeVideo({
             onError?.(event)
           }}
         />
+      ) : null}
+      {media.state === 'error' || media.state === 'timeout' ? (
+        <DeferredNodeMediaFailure state={media.state} onRetry={media.retry} />
       ) : null}
     </>
   )

--- a/src/workbench/generationCanvas/nodes/deferredNodeMediaQueue.ts
+++ b/src/workbench/generationCanvas/nodes/deferredNodeMediaQueue.ts
@@ -28,8 +28,15 @@ type DeferredMediaQueueEntry = {
   activate: (release: () => void) => void
   activated: boolean
   cancelled: boolean
+  priority: boolean
+  onTimeout?: () => void
   release: (() => void) | null
   autoReleaseTimer: ReturnType<typeof setTimeout> | null
+}
+
+export type DeferredNodeMediaSlotRequest = {
+  cancel: () => void
+  setPriority: (priority: boolean) => void
 }
 
 let nextMediaQueueId = 1
@@ -42,6 +49,13 @@ function removeQueuedEntry(entry: DeferredMediaQueueEntry): void {
   const queue = mediaQueues[entry.kind]
   const index = queue.indexOf(entry)
   if (index >= 0) queue.splice(index, 1)
+}
+
+function sortDeferredMediaQueue(kind: DeferredNodeMediaKind): void {
+  mediaQueues[kind].sort((left, right) => {
+    if (left.priority !== right.priority) return left.priority ? -1 : 1
+    return left.id - right.id
+  })
 }
 
 function drainDeferredMediaQueue(kind: DeferredNodeMediaKind): void {
@@ -63,10 +77,18 @@ function drainDeferredMediaQueue(kind: DeferredNodeMediaKind): void {
       }
       activeMediaEntries.delete(entry)
       activeMediaCounts[kind] = Math.max(0, activeMediaCounts[kind] - 1)
+      entry.release = null
       drainDeferredMediaQueue(kind)
     }
     entry.release = release
-    entry.autoReleaseTimer = setTimeout(release, MEDIA_SLOT_AUTO_RELEASE_MS)
+    entry.autoReleaseTimer = setTimeout(() => {
+      if (entry.cancelled) return
+      try {
+        entry.onTimeout?.()
+      } finally {
+        release()
+      }
+    }, MEDIA_SLOT_AUTO_RELEASE_MS)
     entry.activate(release)
   }
 }
@@ -75,24 +97,34 @@ export function requestDeferredNodeMediaSlot(
   kind: DeferredNodeMediaKind,
   activate: (release: () => void) => void,
   priority = false,
-): () => void {
+  onTimeout?: () => void,
+): DeferredNodeMediaSlotRequest {
   const entry: DeferredMediaQueueEntry = {
     id: nextMediaQueueId,
     kind,
     activate,
     activated: false,
     cancelled: false,
+    priority,
+    onTimeout,
     release: null,
     autoReleaseTimer: null,
   }
   nextMediaQueueId += 1
-  if (priority) mediaQueues[kind].unshift(entry)
-  else mediaQueues[kind].push(entry)
+  mediaQueues[kind].push(entry)
+  sortDeferredMediaQueue(kind)
   drainDeferredMediaQueue(kind)
-  return () => {
-    entry.cancelled = true
-    if (!entry.activated) removeQueuedEntry(entry)
-    entry.release?.()
+  return {
+    cancel: () => {
+      entry.cancelled = true
+      if (!entry.activated) removeQueuedEntry(entry)
+      entry.release?.()
+    },
+    setPriority: (nextPriority) => {
+      if (entry.cancelled || entry.priority === nextPriority) return
+      entry.priority = nextPriority
+      if (!entry.activated) sortDeferredMediaQueue(kind)
+    },
   }
 }
 
@@ -117,9 +149,12 @@ export function scheduleAfterCanvasShellPaint(callback: () => void): () => void 
   const run = () => {
     if (cancelled) return
     if (typeof idleWindow.requestIdleCallback === 'function') {
-      idleHandle = idleWindow.requestIdleCallback(() => {
-        if (!cancelled) callback()
-      }, { timeout: 350 })
+      idleHandle = idleWindow.requestIdleCallback(
+        () => {
+          if (!cancelled) callback()
+        },
+        { timeout: 350 },
+      )
       return
     }
     fallbackTimer = setTimeout(() => {
@@ -148,22 +183,17 @@ type IntersectionObserverCapableWindow = Window & {
 
 export function observeDeferredNodeMediaVisibility(
   element: Element | null,
-  onVisible: () => void,
+  onVisibilityChange: (visible: boolean) => void,
 ): () => void {
   const win = typeof window === 'undefined' ? null : (window as IntersectionObserverCapableWindow)
   if (!element || !win?.IntersectionObserver) {
-    onVisible()
+    onVisibilityChange(true)
     return () => {}
   }
 
-  let done = false
   const observer = new win.IntersectionObserver(
     (entries) => {
-      if (done) return
-      if (!entries.some((entry) => entry.isIntersecting || entry.intersectionRatio > 0)) return
-      done = true
-      observer.disconnect()
-      onVisible()
+      onVisibilityChange(entries.some((entry) => entry.isIntersecting || entry.intersectionRatio > 0))
     },
     {
       root: null,
@@ -173,10 +203,11 @@ export function observeDeferredNodeMediaVisibility(
   )
   observer.observe(element)
   return () => {
-    done = true
     observer.disconnect()
   }
 }
+
+export type DeferredNodeMediaState = 'idle' | 'queued' | 'loading' | 'ready' | 'error' | 'timeout'
 
 export function useDeferredNodeMediaSrc({
   src,
@@ -187,19 +218,36 @@ export function useDeferredNodeMediaSrc({
   kind: DeferredNodeMediaKind
   priority?: boolean
 }): {
-  deferredSrc: string | null
+  activeSrc: string | null
+  readySrc: string | null
+  state: DeferredNodeMediaState
   loading: boolean
   placeholderRef: React.RefCallback<HTMLDivElement>
-  markLoaded: () => void
-  markFailed: () => void
+  loadKey: string
+  markLoaded: () => boolean
+  markFailed: () => boolean
+  retry: () => void
 } {
-  const [deferredSrc, setDeferredSrc] = React.useState<string | null>(null)
-  const [loadedSrc, setLoadedSrc] = React.useState<string | null>(null)
-  const [visibleSrc, setVisibleSrc] = React.useState<string | null>(null)
+  const [activeSrc, setActiveSrc] = React.useState<string | null>(null)
+  const [readySrc, setReadySrc] = React.useState<string | null>(null)
+  const [state, setState] = React.useState<DeferredNodeMediaState>('idle')
+  const [isVisible, setIsVisible] = React.useState(false)
+  const [retryToken, setRetryToken] = React.useState(0)
   const [placeholderElement, setPlaceholderElement] = React.useState<HTMLDivElement | null>(null)
   const releaseRef = React.useRef<(() => void) | null>(null)
+  const requestRef = React.useRef<DeferredNodeMediaSlotRequest | null>(null)
+  const stateRef = React.useRef<DeferredNodeMediaState>('idle')
+  const readySrcRef = React.useRef<string | null>(null)
+  const activeSrcRef = React.useRef<string | null>(null)
   const priorityRef = React.useRef(priority)
+  readySrcRef.current = readySrc
+  activeSrcRef.current = activeSrc
   priorityRef.current = priority
+
+  const transitionTo = React.useCallback((nextState: DeferredNodeMediaState) => {
+    stateRef.current = nextState
+    setState(nextState)
+  }, [])
 
   const releaseSlot = React.useCallback(() => {
     releaseRef.current?.()
@@ -208,25 +256,33 @@ export function useDeferredNodeMediaSrc({
 
   React.useEffect(() => {
     releaseSlot()
-    setDeferredSrc(null)
-    setLoadedSrc(null)
-    setVisibleSrc(null)
-    if (!src) return
-  }, [kind, releaseSlot, src])
+    requestRef.current?.cancel()
+    requestRef.current = null
+    setActiveSrc(readySrcRef.current === src ? (src ?? null) : null)
+    transitionTo(src && readySrcRef.current === src ? 'ready' : 'idle')
+  }, [kind, releaseSlot, src, transitionTo])
 
   React.useEffect(() => {
-    if (!src || loadedSrc === src || deferredSrc === src || visibleSrc === src) return undefined
-    if (!placeholderElement) return undefined
-    return observeDeferredNodeMediaVisibility(placeholderElement, () => setVisibleSrc(src))
-  }, [deferredSrc, loadedSrc, placeholderElement, src, visibleSrc])
+    if (!src || !placeholderElement) {
+      setIsVisible(false)
+      return undefined
+    }
+    return observeDeferredNodeMediaVisibility(placeholderElement, setIsVisible)
+  }, [placeholderElement, src])
 
   React.useEffect(() => {
-    if (!src || visibleSrc !== src) return undefined
+    requestRef.current?.setPriority(priority)
+  }, [priority])
+
+  React.useEffect(() => {
+    if (!src || !isVisible || readySrc === src) return undefined
+    if (stateRef.current === 'error' || stateRef.current === 'timeout') return undefined
     let cancelled = false
-    let cancelQueuedSlot: (() => void) | null = null
+    let queuedRequest: DeferredNodeMediaSlotRequest | null = null
+    transitionTo('queued')
     const cancelPaintWait = scheduleAfterCanvasShellPaint(() => {
       if (cancelled) return
-      cancelQueuedSlot = requestDeferredNodeMediaSlot(
+      queuedRequest = requestDeferredNodeMediaSlot(
         kind,
         (release) => {
           if (cancelled) {
@@ -234,40 +290,78 @@ export function useDeferredNodeMediaSrc({
             return
           }
           releaseRef.current = release
-          setDeferredSrc(src)
+          setActiveSrc(src)
+          transitionTo('loading')
         },
         priorityRef.current,
+        () => {
+          if (cancelled || activeSrcRef.current !== src) return
+          releaseRef.current = null
+          setActiveSrc(null)
+          transitionTo('timeout')
+        },
       )
+      requestRef.current = queuedRequest
     })
 
     return () => {
       cancelled = true
       cancelPaintWait()
-      cancelQueuedSlot?.()
+      queuedRequest?.cancel()
+      if (requestRef.current === queuedRequest) requestRef.current = null
       releaseSlot()
     }
-  }, [kind, releaseSlot, src, visibleSrc])
+  }, [isVisible, kind, readySrc, releaseSlot, retryToken, src, transitionTo])
+
+  React.useEffect(() => {
+    if (isVisible || !src || readySrc === src) return
+    setActiveSrc(null)
+    if (stateRef.current === 'queued' || stateRef.current === 'loading') transitionTo('idle')
+  }, [isVisible, readySrc, src, transitionTo])
 
   const placeholderRef = React.useCallback((element: HTMLDivElement | null) => {
     setPlaceholderElement(element)
   }, [])
 
   const markLoaded = React.useCallback(() => {
-    setLoadedSrc(deferredSrc)
+    const loadedSrc = activeSrcRef.current
+    if (!loadedSrc || loadedSrc !== src || stateRef.current !== 'loading') return false
+    setReadySrc(loadedSrc)
+    transitionTo('ready')
     releaseSlot()
-  }, [deferredSrc, releaseSlot])
+    return true
+  }, [releaseSlot, src, transitionTo])
 
   const markFailed = React.useCallback(() => {
-    setLoadedSrc(deferredSrc)
+    const failedSrc = activeSrcRef.current
+    if (!failedSrc || failedSrc !== src || (stateRef.current !== 'loading' && stateRef.current !== 'ready'))
+      return false
+    setActiveSrc(null)
+    if (readySrcRef.current === failedSrc) setReadySrc(null)
+    transitionTo('error')
     releaseSlot()
-  }, [deferredSrc, releaseSlot])
+    return true
+  }, [releaseSlot, src, transitionTo])
+
+  const retry = React.useCallback(() => {
+    requestRef.current?.cancel()
+    requestRef.current = null
+    releaseSlot()
+    setActiveSrc(null)
+    transitionTo('idle')
+    setRetryToken((current) => current + 1)
+  }, [releaseSlot, transitionTo])
 
   return {
-    deferredSrc,
-    loading: Boolean(src && loadedSrc !== src),
+    activeSrc,
+    readySrc,
+    state,
+    loading: Boolean(src && readySrc !== src && state !== 'error' && state !== 'timeout'),
     placeholderRef,
+    loadKey: `${src ?? ''}:${retryToken}`,
     markLoaded,
     markFailed,
+    retry,
   }
 }
 

--- a/tests/ux/canvas-performance-benchmark.e2e.mjs
+++ b/tests/ux/canvas-performance-benchmark.e2e.mjs
@@ -27,11 +27,12 @@ const argValue = (name) => {
   return index >= 0 ? args[index + 1] : undefined
 }
 const hasArg = (name) => args.includes(name)
+const captureScreenshots = hasArg('--screenshots')
 if (hasArg('--help') || hasArg('-h')) {
   console.log('用法：node tests/ux/canvas-performance-benchmark.e2e.mjs <label> [--scale L] [--runs 5]')
   console.log(`scale：${Object.keys(CANVAS_PERF_SCALES).join(' / ')}`)
   console.log(
-    'scenario：all / cold-open / blank-pan / node-drag-image / node-drag-video / marquee-select / click-select / wheel-zoom / pan-zoom-mix / resize / media-reveal / video-hover / reload-heavy',
+    'scenario：all / cold-open / blank-pan / node-drag-image / node-drag-video / marquee-select / click-select / wheel-zoom / pan-zoom-mix / resize / media-reveal / media-error / video-hover / reload-heavy',
   )
   process.exit(0)
 }
@@ -61,6 +62,7 @@ const allScenarios = [
   'pan-zoom-mix',
   'resize',
   'media-reveal',
+  'media-error',
   'video-hover',
   'reload-heavy',
 ]
@@ -242,6 +244,22 @@ async function pageSnapshot(page) {
     const images = Array.from(document.querySelectorAll('img'))
     const nodeElements = Array.from(document.querySelectorAll('.generation-canvas-v2-node'))
     const media = [...images, ...videos]
+    const stageRect = document.querySelector('.generation-canvas-v2__stage')?.getBoundingClientRect()
+    const visibleMediaStates = stageRect
+      ? Array.from(document.querySelectorAll('[data-node-media-state]'))
+          .filter((element) => {
+            const rect = element.getBoundingClientRect()
+            return (
+              rect.width > 2 &&
+              rect.height > 2 &&
+              rect.bottom > stageRect.top &&
+              rect.top < stageRect.bottom &&
+              rect.right > stageRect.left &&
+              rect.left < stageRect.right
+            )
+          })
+          .map((element) => element.getAttribute('data-node-media-state'))
+      : []
     const memory = performance.memory
     return {
       domNodes: document.querySelectorAll('*').length,
@@ -263,6 +281,9 @@ async function pageSnapshot(page) {
       }).length,
       loadedImages: images.filter((image) => image.complete && image.naturalWidth > 0).length,
       loadedVideos: videos.filter((video) => video.readyState >= 1).length,
+      visibleMediaNodes: visibleMediaStates.length,
+      visibleMediaPending: visibleMediaStates.filter((state) => ['idle', 'queued', 'loading'].includes(state)).length,
+      visibleMediaFailures: visibleMediaStates.filter((state) => state === 'error' || state === 'timeout').length,
       activeVideos: videos.filter((video) => !video.paused && !video.ended).length,
       resourceCount: performance.getEntriesByType('resource').filter((entry) => entry.name.includes('/assets/')).length,
       jsHeapUsedMB: memory ? Math.round((memory.usedJSHeapSize / 1024 / 1024) * 10) / 10 : null,
@@ -274,6 +295,26 @@ async function pageSnapshot(page) {
       })(),
     }
   })
+}
+
+async function waitForVisibleMediaSettlement(page, { expectMedia = true, timeout = 30_000 } = {}) {
+  const deadline = Date.now() + timeout
+  let stableReads = 0
+  let previousTransform = ''
+  let snapshot = null
+  while (Date.now() < deadline) {
+    snapshot = await pageSnapshot(page)
+    const transform = JSON.stringify(snapshot.transform)
+    const mediaPresent = !expectMedia || snapshot.visibleMediaNodes > 0
+    if (mediaPresent && snapshot.visibleMediaPending === 0 && transform === previousTransform) stableReads += 1
+    else stableReads = 0
+    if (stableReads >= 3) return snapshot
+    previousTransform = transform
+    await sleep(page, 250)
+  }
+  throw new Error(
+    `当前视口媒体未稳定：visible=${snapshot?.visibleMediaNodes ?? 0}, pending=${snapshot?.visibleMediaPending ?? 0}`,
+  )
 }
 
 function diffMetrics(before, after) {
@@ -448,27 +489,18 @@ async function openProject(app, page, fixture) {
   const firstCanvasMs = Date.now() - startedAt
   const settleStartedAt = Date.now()
   await page.waitForFunction(
-    ({ nodeCount, imageCount, videoCount }) => {
+    ({ nodeCount }) => {
       const mountedNodes = document.querySelectorAll('.generation-canvas-v2-node').length
       const nodesReady = nodeCount === 0 || mountedNodes > 0
       const virtualizationReady = nodeCount <= 50 || mountedNodes < nodeCount
-      const loadedImages = Array.from(document.querySelectorAll('img')).filter(
-        (image) => image.complete && image.naturalWidth > 0,
-      ).length
-      const loadedVideos = Array.from(document.querySelectorAll('video')).filter(
-        (video) => video.readyState >= 1,
-      ).length
-      return (
-        nodesReady && virtualizationReady && (!imageCount || loadedImages >= 2) && (!videoCount || loadedVideos >= 2)
-      )
+      return nodesReady && virtualizationReady
     },
-    {
-      nodeCount: fixture.summary.nodes,
-      imageCount: fixture.summary.imageNodes,
-      videoCount: fixture.summary.videoNodes,
-    },
+    { nodeCount: fixture.summary.nodes },
     { timeout: 20_000 },
   )
+  await waitForVisibleMediaSettlement(page, {
+    expectMedia: fixture.summary.imageNodes + fixture.summary.videoNodes > 0,
+  })
   let stableReads = 0
   let previousKey = ''
   for (let attempt = 0; attempt < 20 && stableReads < 3; attempt += 1) {
@@ -745,7 +777,22 @@ async function runAction(page, scenario, fixture) {
       await sleep(page, 220)
       snapshots.push(await pageSnapshot(page))
     }
-    return { snapshots }
+    return {
+      snapshots,
+      settled: await waitForVisibleMediaSettlement(page, {
+        expectMedia: fixture.summary.imageNodes + fixture.summary.videoNodes > 0,
+      }),
+    }
+  }
+  if (scenario === 'media-error') {
+    const failure = page.locator('[data-node-media-failure="error"]').first()
+    await failure.waitFor({ timeout: 10_000 })
+    await failure.getByRole('button', { name: '重试' }).click()
+    await failure.waitFor({ timeout: 10_000 })
+    return {
+      explicitFailures: await page.locator('[data-node-media-failure="error"]').count(),
+      retryCompleted: true,
+    }
   }
   if (scenario === 'video-hover') {
     const nodes = page.locator('.generation-canvas-v2-node[data-kind="video"]')
@@ -778,6 +825,9 @@ async function runAction(page, scenario, fixture) {
         { nodeCount: fixture.summary.nodes },
         { timeout: 20_000 },
       )
+      await waitForVisibleMediaSettlement(page, {
+        expectMedia: fixture.summary.imageNodes + fixture.summary.videoNodes > 0,
+      })
       reloadDurationsMs.push(Date.now() - startedAt)
       await installProbe(page)
       await page.evaluate(() => window.__canvasPerformanceProbe.start())
@@ -808,6 +858,15 @@ async function runScenario({ scale, scenario, runIndex, rootDir }) {
     projectId: `project-canvas-perf-${scale.toLowerCase()}-${scenario}-${runIndex}`,
     projectName: `ZZ Canvas 性能 ${scale} ${scenario} ${runIndex}`,
   })
+  if (scenario === 'media-error') {
+    const imageNode = fixture.record.payload.generationCanvas.nodes.find((node) => node.kind === 'image')
+    if (imageNode?.result) {
+      const missingUrl = `nomi-local://asset/${encodeURIComponent(fixture.record.id)}/assets/generated/canvas-performance/missing.png`
+      imageNode.result.url = missingUrl
+      imageNode.result.thumbnailUrl = missingUrl
+      fs.writeFileSync(path.join(fixture.projectRoot, '.nomi', 'project.json'), JSON.stringify(fixture.record, null, 1))
+    }
+  }
   let app = null
   let page = null
   const pageErrors = []
@@ -815,7 +874,8 @@ async function runScenario({ scale, scenario, runIndex, rootDir }) {
   const attachDiagnostics = (candidate) => {
     candidate.on('pageerror', (error) => pageErrors.push(String(error)))
     candidate.on('console', (message) => {
-      if (message.type() === 'error') consoleErrors.push(message.text())
+      const expectedMissingFixture = scenario === 'media-error' && message.text().includes('404 (Not Found)')
+      if (message.type() === 'error' && !expectedMissingFixture) consoleErrors.push(message.text())
     })
   }
   const startedAt = Date.now()
@@ -857,6 +917,12 @@ async function runScenario({ scale, scenario, runIndex, rootDir }) {
     await prepareScenario(page, scenario)
     if (scenario === 'marquee-select') await sleep(page, 500)
     const beforePage = await pageSnapshot(page)
+    if (captureScreenshots) {
+      fs.mkdirSync(path.join(outputDir, `canvas-${label}-shots`), { recursive: true })
+      await page.screenshot({
+        path: path.join(outputDir, `canvas-${label}-shots`, `${scale}-${scenario}-${runIndex}-before.png`),
+      })
+    }
     if (scenario === 'cold-open') {
       return {
         scale,
@@ -885,6 +951,11 @@ async function runScenario({ scale, scenario, runIndex, rootDir }) {
       : combineProbeSummaries(actionDetails?.reloadProbes || [])
     const cdpAfter = await getCdpMetrics(cdp)
     const afterPage = await pageSnapshot(page)
+    if (captureScreenshots) {
+      await page.screenshot({
+        path: path.join(outputDir, `canvas-${label}-shots`, `${scale}-${scenario}-${runIndex}-after.png`),
+      })
+    }
     const nodeIdentity = probeSurvivesAction ? await readNodeIdentity(page, actionDetails?.nodeId) : null
     return {
       scale,
@@ -959,6 +1030,17 @@ function sampleHardFailures(sample) {
   if (sample.probe?.maxLoadingVideos > 1) failures.push(`video activation peak ${sample.probe.maxLoadingVideos} > 1`)
   if (sample.probe?.maxActiveVideos > 1)
     failures.push(`simultaneously playing videos ${sample.probe.maxActiveVideos} > 1`)
+  if (sample.scenario === 'media-error' && sample.actionDetails?.explicitFailures < 1)
+    failures.push('media failure did not remain explicit after retry')
+  const settledSnapshots = [sample.cold?.settled, sample.actionDetails?.settled]
+    .filter(Boolean)
+    .concat(sample.scenario === 'reload-heavy' ? sample.actionDetails?.snapshots || [] : [])
+  for (const snapshot of settledSnapshots) {
+    if (snapshot.visibleMediaPending > 0) {
+      failures.push(`${snapshot.visibleMediaPending} visible media nodes never reached a visible terminal state`)
+      break
+    }
+  }
   return failures
 }
 
@@ -980,6 +1062,9 @@ function summarizeScenario(samples) {
     ['layoutDurationMs', (sample) => sample.cdpDelta?.LayoutDurationMs],
     ['jsHeapUsedMB', (sample) => sample.page?.jsHeapUsedMB],
     ['visibleMedia', (sample) => sample.page?.visibleMedia],
+    ['visibleMediaNodes', (sample) => sample.page?.visibleMediaNodes],
+    ['visibleMediaPending', (sample) => sample.page?.visibleMediaPending],
+    ['visibleMediaFailures', (sample) => sample.page?.visibleMediaFailures],
     ['loadedImages', (sample) => sample.page?.loadedImages],
     ['loadedVideos', (sample) => sample.page?.loadedVideos],
     ['activeVideos', (sample) => sample.page?.activeVideos],
@@ -1084,8 +1169,7 @@ try {
   )
   results.runtimeVersions = results.results.find((sample) => sample.runtimeVersions)?.runtimeVersions || null
   results.pass =
-    results.warmupFailures.length === 0 &&
-    Object.values(results.summary).every((summary) => summary.verdict.pass)
+    results.warmupFailures.length === 0 && Object.values(results.summary).every((summary) => summary.verdict.pass)
   const outputPath = writeResults(results, label)
   console.log(`\n✅ 画布性能 benchmark 完成：${outputPath}`)
   if (results.warmupFailures.length) console.log(`⚠ warmup 失败 ${results.warmupFailures.length} 次，结果标记为不可靠`)


### PR DESCRIPTION
## 根因

- 媒体第一次进入视口后 `IntersectionObserver` 就断开，之后离开视口不会取消排队或加载。
- 历史媒体持续占用图片 4、视频 1 的并发槽，当前视口媒体被堵在队尾并保持 `opacity-0`。
- 8 秒 watchdog 过去只释放调度槽，不结束组件加载状态；图片获准后还会被原生 lazy loading 二次延迟。

## 修复

- 持续跟踪真实浏览器视口，离屏时取消排队/活动任务并立即释放槽位。
- 支持已排队媒体动态提升 selected/focused 优先级。
- 引入 `idle -> queued -> loading -> ready | error | timeout` 显式状态；超时或失败显示不透明、可重试终态。
- 调度器放行后的图片使用 eager 加载；媒体替换时保留上一份已就绪画面直到新媒体解码。
- 保持原有 LOD、400px 节点渲染缓冲区和图片 4/视频 1 并发限制不变。
- 扩展单元测试和 Electron 画布性能脚本，检查当前视口媒体是否全部结束排队/加载。

## 验证

- `pnpm gates` 通过：585 个测试文件通过、1 个跳过；5057 个测试通过、1 个跳过；production build、Electron typecheck 通过。
- deferred media 定向测试 9/9 通过，覆盖动态提权、离屏释放、超时终态、后续任务继续执行、连续可见性和独立并发车道。
- Electron S 夹具（24 图片 + 24 视频）：冷启动、平移进入新区域、连续三次 reload 后，当前视口 pending 均为 0。
- 故意注入 404 时保持明确失败面板，可重试，其他媒体正常；媒体 hard failures 为 0。
- 本机 30fps 下既有 `frameGapP95 <= 33ms` 性能预算偶发超出 1-13ms；该指标不属于媒体正确性失败，也不在仓库全量 gates 内。