### PR TITLE
fix(release): unblock v0.20.0 promotion

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -84,6 +84,8 @@ jobs:
           RC_SHA: ${{ steps.manifest.outputs.sha }}
         shell: bash
         run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           if git rev-parse "refs/tags/$RELEASE_TAG" >/dev/null 2>&1; then
             test "$(git rev-list -n 1 "$RELEASE_TAG")" = "$RC_SHA"
           else

--- a/docs/plan/2026-08-17-v0.20.0-promotion-hotfix.md
+++ b/docs/plan/2026-08-17-v0.20.0-promotion-hotfix.md
@@ -1,0 +1,25 @@
+# Nomi v0.20.0 promotion hotfix
+
+## Scope
+
+- Configure the Git identity used to create the immutable annotated release tag in GitHub Actions.
+- Add a workflow regression assertion for the release bot identity.
+- Add an explicit post-publish checklist for website and GitHub direct installer downloads.
+
+## Out of scope
+
+- No rebuild or mutation of RC run `32013206070` artifacts.
+- No product runtime, installer contents, release notes, or version changes.
+- No direct push to `main` and no replacement of a published tag.
+
+## Rollback
+
+- Revert this hotfix PR before rerunning promotion if its checks fail.
+- Keep the validated RC artifacts unchanged and do not create the stable tag manually.
+
+## Acceptance
+
+1. The release workflow configures `github-actions[bot]` before creating the annotated tag.
+2. The focused release-contract test passes and guards the Git identity configuration.
+3. The same validated RC run can be promoted without rebuilding.
+4. Post-publish checks prove the website and GitHub latest-download URLs request the three current installers directly, without stopping on a Releases page.

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -95,7 +95,22 @@ RC 验收通过后：
 
 正式发布不会重新构建。
 
-## 6. GitHub 仓库设置
+## 6. 发布后直链验收
+
+正式 Release 公开后、对外宣布版本前，必须完成以下检查。不能只检查 HTML 里存在链接，必须真实发起请求并确认没有停在 Releases 页面。
+
+1. 确认 `https://github.com/aqm857886159/Nomi/releases/latest` 指向刚发布的 tag。
+2. 分别请求以下 GitHub 直链，跟随重定向后必须返回安装包内容，不能落到 `/releases/latest` 或 `/releases/tag/...` 页面：
+   - `https://github.com/aqm857886159/Nomi/releases/latest/download/Nomi-mac-arm64.dmg`
+   - `https://github.com/aqm857886159/Nomi/releases/latest/download/Nomi-mac-intel.dmg`
+   - `https://github.com/aqm857886159/Nomi/releases/latest/download/Nomi-windows-setup.exe`
+3. 在 `https://nomiaqm.com/` 和 `https://nomiaqm.com/en/` 实测下载按钮：已知平台应直接请求对应的 `releases/latest/download/...` 安装包；无法判断 Mac 芯片时应在站内提供三个直链选项，不能把用户送到 Releases 列表。
+4. 实测应用更新入口 `https://nomiaqm.com/?download=1&source=app-update&platform=darwin&arch=arm64`，确认只触发一次对应 DMG 下载，并清除一次性查询参数。
+5. 检查 `latest-mac.yml`、`latest.yml` 和三个稳定安装包别名都属于本次版本，文件大小非零，下载响应不是 `text/html`。
+
+任一检查失败都不宣布发布完成；先修复 Release 资产或官网路由，再重新执行整套直链验收。
+
+## 7. GitHub 仓库设置
 
 在仓库设置中完成一次性配置：
 
@@ -104,7 +119,7 @@ RC 验收通过后：
 3. 创建 `desktop-preview` label。
 4. 不允许 force-push 或删除 release tag。
 
-## 7. macOS 官网直接下载
+## 8. macOS 官网直接下载
 
 未签名 macOS 版本无法在应用内直接替换。Nomi 会打开：
 

--- a/scripts/release-contract.test.mjs
+++ b/scripts/release-contract.test.mjs
@@ -155,6 +155,8 @@ describe('release contract', () => {
       '--draft',
       'verify-release-assets',
       '--draft=false',
+      'git config user.name "github-actions[bot]"',
+      'git config user.email "41898282+github-actions[bot]@users.noreply.github.com"',
     ]) {
       expect(release, token).toContain(token)
     }


### PR DESCRIPTION
## Summary

- configure the GitHub Actions tagger identity before creating the immutable annotated tag
- guard the identity configuration in the release-contract test
- add mandatory post-publish website and GitHub direct-download checks

## Verification

- `pnpm exec vitest run scripts/release-contract.test.mjs`
- `pnpm run gates` (592 test files passed, 5131 tests passed, production build passed)

## Release context

Desktop Release run 32016285194 validated RC run 32013206070 and prepared all assets, then failed only because the annotated tag step had no Git identity. This PR keeps the RC artifacts unchanged.