### PR TITLE
fix(test): 素材走查数的是 tab 不是素材（假绿修复）

### DIFF
--- a/tests/ux/asset-surface-convergence.walk.mjs
+++ b/tests/ux/asset-surface-convergence.walk.mjs
@@ -142,7 +142,15 @@ try {
   if (await allTab.count()) await allTab.click({ timeout: 2000 }).catch(() => {})
   await win.waitForTimeout(900)
   // compact 侧栏格子不渲染文件名（tooltip 才有）,数瓦片：3 张落盘图（含「曾被软删.png」）全在=软删层解散。
-  const allTileCount = await win.locator('section[aria-label="素材库"] [aria-selected]').count()
+  //
+  // 2026-08-18 修假绿：这里原本数的是 `[aria-selected]`——那个属性在**来源 tab**（role=tab）和
+  // **种类过滤项**（role=option）身上都有，而瓦片的 aria-selected 是 `selectable ? selected : undefined`，
+  // 侧栏里根本不渲染这个属性。也就是说它**从来没数到过素材**：以前恰好有 3 个来源 tab
+  // （全部/项目/智能分组）让 `>= 3` 蒙混通过，智能分组一删就只剩 2 个、当场露馅。
+  // 改数瓦片自己的图片元素（每张素材渲染一个带 alt 的 img），这才是「素材可见」的真判据。
+  const tiles = win.locator('section[aria-label="素材库"] img[alt]')
+  await tiles.first().waitFor({ state: 'visible', timeout: 15000 }).catch(() => {})
+  const allTileCount = await tiles.count()
   check('三张落盘素材全部可见（含曾软删,软删层解散预期）', allTileCount >= 3, `tiles=${allTileCount}`)
   await snap(win, '05-asset-library-all-assets')
 


### PR DESCRIPTION
在跑 v0.20.0 → main 的测试清单时发现的。

## 现象

删掉「智能分组」（`3bf20664`）后，`asset-surface-convergence.walk.mjs` 的
「三张落盘素材全部可见」转红，`tiles=2`。

看着像回归 —— **但不是**。

## 根因：这条断言从来没数到过素材

它数的是 `section[aria-label="素材库"] [aria-selected]`，而这个属性长在：

- 来源 tab（[AssetLibraryPanel.tsx:539](src/workbench/assets/AssetLibraryPanel.tsx:539) `role="tab"`）
- 种类过滤项（[AssetLibraryPanelParts.tsx:80](src/workbench/assets/AssetLibraryPanelParts.tsx:80) `role="option"`）

而瓦片自己的 `aria-selected` 是 `selectable ? selected : undefined` —— 侧栏 compact 模式下**压根不渲染这个属性**。

所以它一直在数**来源 tab**：以前恰好 3 个（全部 / 项目 / 智能分组）让 `>= 3` 蒙混通过；智能分组一删只剩 2 个，当场露馅。

## 产品侧是正常的

三张瓦片都在，截图已亲眼核对：`tests/ux/shots/asset-surface-convergence/05-asset-library-all-assets.png`。

## 修法

改成数瓦片自己的图片元素（每张素材渲染一个带 `alt` 的 `img`）—— 这才是「素材可见」的真判据：素材真被藏起来时会读到 **0**，而不是读到 tab 数。

修完 **14/14 通过**，`tiles=3`。

这正是 `eec02cd6` 走查加固要治的那一类：**断言架在与被测对象无关的计数上，数字凑巧对得上就报绿**。

门禁全过，走查棘轮基线未动（`dead-selector=0`，`sleep-as-done-signal=113` 不变）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)