### PR TITLE
fix(mcp): 付费确认别再折腾用户——问对地方 + 别反复问

### DIFF
--- a/electron/capabilityCore/gateway.ts
+++ b/electron/capabilityCore/gateway.ts
@@ -64,6 +64,29 @@ export function withPreApprovedPlan(gateway: ProjectGateway): ProjectGateway {
   }
 }
 
+/**
+ * 付费已在**调用方客户端**经 elicitation 得到真人确认 → 包一层直铸令牌，不再弹应用内确认卡（免双问）。
+ * 其余读写/方案确认原样透传。
+ *
+ * 为什么确认可以不发生在 Nomi 窗口里：判据是「谁能替我们问到真人」。请求经 MCP 进来说明人在调用方那头，
+ * 客户端声明 elicitation 就是它能弹真对话框；窗口开着 ≠ 用户注意力在 Nomi。协议层只在收到客户端
+ * `action:'accept' + confirm:true` 后才置这个位（mcpProtocol.ts），模型自己伪造不了那一帧
+ * ——spendGrant.ts 写死的威胁模型（「Nomi 的 AI 触发不了未确认的付费生成」）不破。
+ *
+ * ⚠️ 代价说清楚（2026-08-18 用户拍板接受）：本模式经 loopback RPC 过线后，能读 `~/.nomi/capability-core/token`
+ * 的本地进程可借它静默烧额度——此前那条路会弹卡、用户看得见能拒。换来的是「Claude 里点一次就行，
+ * 不必为了确认跑去 Nomi」。**边界仅放宽到这里**：令牌仍只在主进程铸、`assertAndConsumeSpendGrant` 仍逐次硬校验，
+ * 且导出等其余硬边界一律不得复制本模式。
+ */
+export function withPreApprovedSpend(gateway: ProjectGateway): ProjectGateway {
+  return {
+    readDoc: gateway.readDoc,
+    apply: gateway.apply,
+    confirmSpend: async (info) => mintSpendGrant({ nodeIds: [info.nodeId] }),
+    confirmPlan: gateway.confirmPlan,
+  }
+}
+
 function readDiskSnapshot(projectId: string): CanvasSnapshot {
   const record = readProject(projectId)
   if (!record) throw new Error(`项目不存在: ${projectId}`)

--- a/electron/capabilityCore/mcpProtocol.ts
+++ b/electron/capabilityCore/mcpProtocol.ts
@@ -5,8 +5,8 @@
 // 配置后实时驱动 Nomi。**这是唯一的 MCP server 实现**——打包/dev 都由 app 自身二进制以 NOMI_MCP_STDIO
 // 模式拉起 mcpStdioServer.ts，后者把本模块接到 stdin/stdout + 进程内 invoke（取代旧 scripts/nomi-mcp.mjs，P1）。
 //
-// 传输经 McpTransport 注入：send（服务端→客户端帧）/ invoke（调能力核）/ isAppOpen（Nomi 开着没，决定
-// 付费确认走应用内卡片还是 Claude 侧 elicitation）。本模块不 import electron → 协议握手可纯逻辑单测。
+// 传输经 McpTransport 注入：send（服务端→客户端帧）/ invoke（调能力核）/ isAppOpen（Nomi 开着没 = 还有没有
+// 应用内确认卡这条兜底问法；**不用来猜用户注意力在哪**）。本模块不 import electron → 协议握手可纯逻辑单测。
 //
 // MCP Apps（GUI 宿主内嵌活 widget，扩展 id io.modelcontextprotocol/ui，Stable 2026-01-26）：
 // nomi_generate 挂 _meta.ui.resourceUri → 指向 ui:// 资源（widget HTML，经 resources/read 取）；
@@ -44,7 +44,10 @@ export interface McpTransport {
   send(message: unknown): void
   /** 调一次能力核方法。spendConfirmed=真人已在 Claude 侧确认付费 → 透传给传输层放行本次。 */
   invoke(method: string, params: Record<string, unknown>, options?: McpInvokeOptions): Promise<unknown>
-  /** Nomi 是否开着（有活实例）。开着→付费确认走应用内卡，关着→走 elicitation。 */
+  /**
+   * Nomi 是否开着（有活实例）= **「应用内确认卡这条问法还在不在」**，不是「用户注意力在不在 Nomi」。
+   * 确认优先弹在调用方（客户端声明 elicitation 即可）；本标志只用于回答「客户端问不了时，还有谁能问」。
+   */
   isAppOpen(): boolean
   /** 结果/进度文案语言（可选；缺省 zh-CN，跟 App 语言设置走）。 */
   getLocale?(): ResultLocale
@@ -376,6 +379,11 @@ export function createMcpProtocol(transport: McpTransport) {
         // 且 App 开着时，把确认递进聊天问一次而非让人跑去 App 点弹窗；批准记会话级信任、同项目后续不再问。
         // 不满足（单节点 / 不声明 elicitation / headless）→ 落到下面原样 invoke，走既有 gateway.confirmPlan
         //（App 弹窗 / headless 自动放行），逐字节不变。headless 即便声明 elicitation 也不问——它本就是无人值守自动放行。
+        //
+        // ⚠️ 这里的 isAppOpen() 与付费路那条**不是同一个意思**，别跟着一起删：付费路曾用它猜「用户在不在
+        // Nomi 边上」（错的，已改判据）；这里它问的是「不这么做的话，会不会弹出一张应用内方案卡」——
+        // 本分支的价值就是把那张卡搬进聊天。App 关着时 confirmPlan 恒 true（免费可撤、无人值守自动放行，
+        // 见 createDiskGateway），没有卡可替代，去掉这个条件只会凭空多问一次 → 与「少让用户点」正相反。
         if (
           tool.name === 'nomi_add_nodes'
           && clientSupportsElicitation
@@ -399,26 +407,33 @@ export function createMcpProtocol(transport: McpTransport) {
           reply(id, buildToolResultPayload(tool.name, args, result))
           return
         }
-        // 付费生成 + Nomi 没开（无应用内确认卡可弹）→ 在 Claude 这一侧弹 elicitation 让真人确认。
-        // 真人确认才以 spendConfirmed 授权本次生成；enforcement 仍在主进程硬闸。
-        // app 开着则照常走——由应用内确认卡处理（用户人在 Nomi 边上）。
-        if (tool.name === 'nomi_generate' && !transport.isAppOpen()) {
-          const costHint = describeSpend(args)
-          const confirm = await elicitSpendConfirm(`Nomi 未打开。${costHint}\n确认现在生成吗？`)
-          if (!confirm.supported) {
+        // 付费生成必须有真人确认。**判据是「谁能替我们问到真人」，不是「Nomi 窗口开着没」**：
+        // 请求经 MCP 进来，本身就证明人正坐在调用方那头（Claude/Codex/Cursor）；窗口开着 ≠ 注意力在 Nomi
+        // （用户桌面上常年挂着 Nomi）。按窗口路由 → 只要 Nomi 开着就把人赶去 App 点一下，白跑一趟。
+        //  ① 客户端声明 elicitation → 就地弹在调用方（**不管 App 开没开**），真人 accept 才带 spendConfirmed 放行；
+        //  ② 客户端问不了、App 开着 → 落到下面原样 invoke，由应用内确认卡兜底（唯一还能问到人的地方）；
+        //  ③ 两者都没有 → 无处问真人 → 诚实报错，绝不静默花钱。
+        // elicitSpendConfirm 在客户端没声明 elicitation 时返回 supported:false，故它就是①/②的唯一判据
+        // （不另读 clientSupportsElicitation，免两处能力判断漂移）。enforcement 仍在主进程硬闸。
+        if (tool.name === 'nomi_generate') {
+          const confirm = await elicitSpendConfirm(`${describeSpend(args)}\n确认现在生成吗？`)
+          if (confirm.supported) {
+            if (!confirm.confirmed) {
+              reply(id, { content: [{ type: 'text', text: '已取消：你未确认这次付费生成，未生成、未消耗额度。' }], isError: true })
+              return
+            }
+            const result = await transport.invoke(tool.method, built, { spendConfirmed: true })
+            reply(id, buildToolResultPayload(tool.name, args, result))
+            return
+          }
+          if (!transport.isAppOpen()) {
             reply(id, {
-              content: [{ type: 'text', text: '已暂停：Nomi 未打开，且当前客户端不支持弹确认。请打开 Nomi 后再触发生成（或在 Nomi 里确认）。节点/提示词若已通过其它工具写入则已保存。' }],
+              content: [{ type: 'text', text: '已暂停：当前客户端不支持弹确认，Nomi 也没打开——没有地方能确认这次付费生成。请打开 Nomi 后再触发生成。节点/提示词若已通过其它工具写入则已保存。' }],
               isError: true,
             })
             return
           }
-          if (!confirm.confirmed) {
-            reply(id, { content: [{ type: 'text', text: '已取消：你未确认这次付费生成，未生成、未消耗额度。' }], isError: true })
-            return
-          }
-          const result = await transport.invoke(tool.method, built, { spendConfirmed: true })
-          reply(id, buildToolResultPayload(tool.name, args, result))
-          return
+          // App 开着但客户端问不了 → 落到下面原样 invoke，走应用内确认卡。
         }
         const result = await transport.invoke(tool.method, built)
         reply(id, buildToolResultPayload(tool.name, args, result))

--- a/electron/capabilityCore/mcpStdioServer.ts
+++ b/electron/capabilityCore/mcpStdioServer.ts
@@ -10,10 +10,9 @@ import readline from 'node:readline'
 import { app, session } from 'electron'
 import { createMcpProtocol, type McpInvokeOptions } from './mcpProtocol'
 import { getDesktopLocale, setDesktopLocale } from '../i18n'
-import { createDiskGateway, type ProjectGateway, type SpendConfirmInfo } from './gateway'
+import { createDiskGateway, withPreApprovedSpend, type ProjectGateway } from './gateway'
 import { readLiveInstance, type InstanceAdvertisement } from './lockfile'
 import { runTask, fetchTaskResult } from '../runtime'
-import { mintSpendGrant } from '../spendGrant'
 import { applySystemProxy } from '../systemProxy'
 import { getProductionRunService } from '../productionRun/productionRunRuntime'
 import { startArtifactPreviewHttpServer, withAssetPreview } from '../productionRun/artifactPreviewHttpServer'
@@ -45,15 +44,13 @@ function transportTimeoutMs(): number {
   return Number.isFinite(raw) && raw > 0 ? raw : 360_000
 }
 
-/** 付费已确认（elicitation 真人点了）→ 直铸令牌放行本次生成。仅在 elicit confirmed 后用，不碰全局 env。 */
+/**
+ * 付费已确认（elicitation 真人点了）→ 直铸令牌放行本次生成。仅在 elicit confirmed 后用，不碰全局 env。
+ * 「预批付费」这层只此一份定义（gateway.withPreApprovedSpend），App 开着走 RPC 的那条路复用同一份
+ * ——两条路的钱路语义不会各写各的、漂移开（rpcServer.ts 读 body.spendConfirmed 处）。
+ */
 function makeConfirmedGateway(projectId: string): ProjectGateway {
-  const disk = createDiskGateway(projectId)
-  return {
-    readDoc: disk.readDoc,
-    apply: disk.apply,
-    confirmSpend: async (info: SpendConfirmInfo) => mintSpendGrant({ nodeIds: [info.nodeId] }),
-    confirmPlan: disk.confirmPlan, // 方案门免费可撤，headless 直放行（与 disk 一致）
-  }
+  return withPreApprovedSpend(createDiskGateway(projectId))
 }
 
 async function callViaRpc(
@@ -80,8 +77,15 @@ async function callViaRpc(
             }
           : {}),
       },
-      // planConfirmed 跨 RPC 到渲染层网关：方案已在聊天里批准 → App 不再弹方案卡（免双问）。付费不透传（钱路留 App）。
-      body: JSON.stringify({ method, params, ...(options?.planConfirmed ? { planConfirmed: true } : {}) }),
+      // planConfirmed / spendConfirmed 跨 RPC 到渲染层网关：已在调用方客户端经 elicitation 被真人确认过
+      // → App 不再弹第二次卡（免双问）。**没有这一行，App 开着时用户会在 Claude 点一次、再被叫去 Nomi 点一次。**
+      // 钱路为何敢过线、代价是什么：见 gateway.withPreApprovedSpend 与 rpcServer 读 body.spendConfirmed 处。
+      body: JSON.stringify({
+        method,
+        params,
+        ...(options?.planConfirmed ? { planConfirmed: true } : {}),
+        ...(options?.spendConfirmed ? { spendConfirmed: true } : {}),
+      }),
       signal: controller.signal,
     })
   } catch (error) {

--- a/electron/capabilityCore/nomiMcpElicitation.test.ts
+++ b/electron/capabilityCore/nomiMcpElicitation.test.ts
@@ -1,10 +1,12 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { createMcpProtocol, type McpTransport } from './mcpProtocol'
 
-// MCP 协议层的 elicitation 付费确认握手（B 模式：Nomi 没开）。
+// MCP 协议层的 elicitation 付费确认握手。
 // 验证手搓双向 JSON-RPC：服务端能发 elicitation/create 给客户端、按 id 路由响应、按确认结果放行/拦截。
-// 直接驱动纯协议层 mcpProtocol.ts（注入假 transport）——不 spawn 任何进程、不触发真实生成，
-// 只覆盖 decline / 不支持 两条不调 invoke 的路径（取代旧的 spawn `node scripts/nomi-mcp.mjs`）。
+// 直接驱动纯协议层 mcpProtocol.ts（注入假 transport）——不 spawn 任何进程、不触发真实生成。
+//
+// 路由判据 = 「谁能替我们问到真人」，**不是「Nomi 窗口开着没」**（2026-08-18 修：窗口开着 ≠ 用户注意力
+// 在 Nomi，旧判据害得人从 Claude 跑回 App 点一下）。下面 4 条锁死 {支持 elicitation × App 开/关} 全矩阵。
 
 type RpcMessage = { jsonrpc?: string; id?: unknown; method?: string; params?: Record<string, unknown>; result?: unknown; error?: { code?: number; message?: string } }
 
@@ -70,23 +72,28 @@ afterEach(() => {
   harness = null
 })
 
-describe('nomi-mcp · 付费 elicitation 握手（B 模式）', () => {
-  it('客户端支持 elicitation：generate → 弹确认 → decline → 拦截不生成', async () => {
+describe('nomi-mcp · 付费确认按「谁能问到真人」路由', () => {
+  const GENERATE_ARGS = { projectId: 'p', vendor: 'apimart', modelKey: 'doubao-seedance-2.0', intent: 'video', prompt: '巷口回头' }
+  const callGenerate = (h: ProtocolHarness) =>
+    h.send({ jsonrpc: '2.0', id: 2, method: 'tools/call', params: { name: 'nomi_generate', arguments: GENERATE_ARGS } })
+  /** 生成成功的 invoke 桩：只有「真人确认过」的路径才该走到这里。 */
+  const generateOk = async (method: string) => {
+    if (method === 'generate') return { nodeId: 'n1', assetPath: '/tmp/a.mp4' }
+    throw new Error(`unexpected invoke: ${method}`)
+  }
+
+  it('① 支持 elicitation + App 关：弹在调用方 → decline → 拦截不生成', async () => {
     harness = new ProtocolHarness(false)
     await harness.initialize(true)
-    harness.send({
-      jsonrpc: '2.0',
-      id: 2,
-      method: 'tools/call',
-      params: { name: 'nomi_generate', arguments: { projectId: 'p', vendor: 'apimart', modelKey: 'doubao-seedance-2.0', intent: 'video', prompt: '巷口回头' } },
-    })
+    callGenerate(harness)
     // 服务端应先发 elicitation/create 请求给客户端。
     const elicit = await harness.next()
     expect(elicit.method).toBe('elicitation/create')
     expect(typeof elicit.id).toBe('string')
     const params = elicit.params as { message?: string }
-    expect(params.message).toContain('Nomi 未打开')
     expect(params.message).toContain('doubao-seedance-2.0')
+    // 旧文案硬编码了「Nomi 未打开。」开头；改判据后 App 开着也走这条，那句话不再成立 → 必须已删。
+    expect(params.message).not.toContain('Nomi 未打开')
     // 真人点了取消 → decline。
     harness.send({ jsonrpc: '2.0', id: elicit.id, result: { action: 'decline' } })
     const toolRes = await harness.next()
@@ -97,29 +104,52 @@ describe('nomi-mcp · 付费 elicitation 握手（B 模式）', () => {
     expect(harness.invoke).not.toHaveBeenCalled()
   })
 
+  it('② 支持 elicitation + App 开：仍弹在调用方（不赶人回 Nomi），accept 才带 spendConfirmed 放行', async () => {
+    // 这条就是本次修复的核心：旧判据下 App 一开就跳过 elicitation、把人赶去点应用内卡片。
+    harness = new ProtocolHarness(true, generateOk)
+    await harness.initialize(true)
+    callGenerate(harness)
+    const elicit = await harness.next()
+    expect(elicit.method).toBe('elicitation/create')
+    expect((elicit.params as { message?: string }).message).not.toContain('Nomi 未打开')
+    harness.send({ jsonrpc: '2.0', id: elicit.id, result: { action: 'accept', content: { confirm: true } } })
+    const toolRes = await harness.next()
+    expect(toolRes.id).toBe(2)
+    expect(toolRes.result).not.toMatchObject({ isError: true })
+    // 真人在调用方确认过 → 必须带 spendConfirmed 过线，否则 App 会再弹一次卡（双问）。
+    expect(harness.invoke).toHaveBeenCalledWith('generate', expect.anything(), { spendConfirmed: true })
+  })
+
+  it('③ 不支持 elicitation + App 开：不弹、原样 invoke（由应用内确认卡兜底），绝不自带 spendConfirmed', async () => {
+    harness = new ProtocolHarness(true, generateOk)
+    await harness.initialize(false)
+    callGenerate(harness)
+    const toolRes = await harness.next()
+    expect(toolRes.id).toBe(2)
+    expect(toolRes.result).not.toMatchObject({ isError: true })
+    // 没人替我们问过真人 → 这次 invoke 不许预批付费，确认权留给应用内卡片。
+    expect(harness.invoke).toHaveBeenCalledTimes(1)
+    expect(harness.invoke.mock.calls[0][2]).not.toMatchObject({ spendConfirmed: true })
+  })
+
+  it('④ 不支持 elicitation + App 关：无处问真人 → 诚实报错，不生成', async () => {
+    harness = new ProtocolHarness(false)
+    await harness.initialize(false)
+    callGenerate(harness)
+    const toolRes = await harness.next()
+    expect(toolRes.id).toBe(2)
+    const result = toolRes.result as { content: Array<{ text: string }>; isError?: boolean }
+    expect(result.isError).toBe(true)
+    expect(result.content[0].text).toContain('不支持弹确认')
+    expect(harness.invoke).not.toHaveBeenCalled()
+  })
+
   it('握手回显客户端请求的协议版本（兼容只讲老协议的客户端，如 Codex/Cursor 早期）', async () => {
     harness = new ProtocolHarness(false)
     // 老客户端只讲 2025-03-26（elicitation 之前的修订）。
     const res = await harness.initialize(false, '2025-03-26')
     const result = res.result as { protocolVersion?: string }
     expect(result.protocolVersion).toBe('2025-03-26')
-  })
-
-  it('客户端不支持 elicitation：generate → 不弹、回可操作错误', async () => {
-    harness = new ProtocolHarness(false)
-    await harness.initialize(false)
-    harness.send({
-      jsonrpc: '2.0',
-      id: 2,
-      method: 'tools/call',
-      params: { name: 'nomi_generate', arguments: { projectId: 'p', vendor: 'apimart', modelKey: 'sora-2', intent: 'video', prompt: 'x' } },
-    })
-    const toolRes = await harness.next()
-    expect(toolRes.id).toBe(2)
-    const result = toolRes.result as { content: Array<{ text: string }>; isError?: boolean }
-    expect(result.isError).toBe(true)
-    expect(result.content[0].text).toContain('Nomi 未打开')
-    expect(harness.invoke).not.toHaveBeenCalled()
   })
 })
 

--- a/electron/capabilityCore/rpcServer.test.ts
+++ b/electron/capabilityCore/rpcServer.test.ts
@@ -15,6 +15,7 @@ let openProjectId = ''
 // 模拟渲染层在线 + 付费确认应答（测 hybrid 网关：窗口活着但项目没在前台）。
 let rendererUp = false
 let spendReply: { confirmed?: boolean } = { confirmed: true }
+let planReply: { confirmed?: boolean } = { confirmed: true }
 let rendererOps: string[] = []
 // 捕获最后一次 runTask 请求,断言 grantId 是否随请求下传(=付费确认是否真路由+铸令牌)。
 let lastRunTaskReq: { extras?: Record<string, unknown> } | null = null
@@ -31,6 +32,7 @@ vi.mock('./rendererBridge', () => ({
   requestRenderer: async (op: string) => {
     rendererOps.push(op)
     if (op === 'spend.confirm') return spendReply
+    if (op === 'plan.confirm') return planReply
     // hybrid 网关读写应走盘,绝不该把 canvas.* 转给渲染层——命中即测试失败。
     throw new Error(`hybrid 不应调用渲染层 op: ${op}`)
   },
@@ -62,6 +64,16 @@ async function rpc(
   return { status: res.status, body: (await res.json()) as { ok: boolean; result?: unknown; error?: string } }
 }
 
+/** 发原始请求体：用于测顶层旁路标志（planConfirmed / spendConfirmed），它们不在 params 里。 */
+async function rpcRaw(body: Record<string, unknown>) {
+  const res = await fetch(`http://127.0.0.1:${server!.port}/rpc`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', authorization: `Bearer ${token}` },
+    body: JSON.stringify(body),
+  })
+  return { status: res.status, body: (await res.json()) as { ok: boolean; result?: unknown; error?: string } }
+}
+
 beforeEach(async () => {
   mockedDocumentsRoot = makeTempDir('nomi-rpc-documents-')
   mockedUserDataRoot = makeTempDir('nomi-rpc-user-data-')
@@ -69,6 +81,7 @@ beforeEach(async () => {
   openProjectId = ''
   rendererUp = false
   spendReply = { confirmed: true }
+  planReply = { confirmed: true }
   rendererOps = []
   lastRunTaskReq = null
   token = ensureToken()
@@ -174,6 +187,40 @@ describe('capabilityCore/rpcServer', () => {
     expect(rendererOps.filter((op) => op.startsWith('canvas'))).toHaveLength(0)
     // 真人(模拟)确认 → 铸了令牌随请求下传 runTask(主进程硬闸据此核验消费)。
     expect(lastRunTaskReq?.extras?.grantId).toBeTruthy()
+  })
+
+  it('spendConfirmed 过线：已在调用方客户端确认过 → App 不再弹第二张卡，直接铸令牌下传', async () => {
+    // 2026-08-18 修双问：协议层已在 Claude/Codex 侧经 elicitation 拿到真人 accept。若这个信号不过 RPC 线，
+    // 渲染层会再弹一次 spend.confirm → 用户点两次（比修之前更糟）。锁死：不弹卡 + 仍有令牌。
+    rendererUp = true
+    spendReply = { confirmed: false } // 卡真被弹到就会拒 → grantId 缺失,双重保险坐实「没走弹卡这条」
+    const created = await rpc('project.create', { name: '已在客户端确认' })
+    const projectId = (created.body.result as { id: string }).id
+    const gen = await rpcRaw({
+      method: 'generate',
+      params: { projectId, intent: 'image', prompt: 'robot', vendor: 'v', modelKey: 'm' },
+      spendConfirmed: true,
+    })
+    expect(gen.body.ok).toBe(true)
+    expect(rendererOps).not.toContain('spend.confirm')
+    // 付费硬闸不松：仍必须有令牌随请求下传,runTask 侧 assertAndConsumeSpendGrant 照常逐次核验。
+    expect(lastRunTaskReq?.extras?.grantId).toBeTruthy()
+  })
+
+  it('安全：spendConfirmed 只预批付费,不顺手预批方案门(confirmPlan 仍要真人)', async () => {
+    // 防「一个 flag 顺走一串权限」：预批范围必须恰好是付费确认本身。
+    rendererUp = true
+    openProjectId = ''
+    const created = await rpc('project.create', { name: '预批范围' })
+    const projectId = (created.body.result as { id: string }).id
+    const added = await rpcRaw({
+      method: 'canvas.addNodes',
+      params: { projectId, nodes: [{ kind: 'text', prompt: 'a' }, { kind: 'text', prompt: 'b' }] },
+      spendConfirmed: true,
+    })
+    expect(added.body.ok).toBe(true)
+    // hybrid 网关的 confirmPlan 仍走渲染层问真人——没被 spendConfirmed 带着一起放行。
+    expect(rendererOps).toContain('plan.confirm')
   })
 
   it('安全：付费确认被拒(confirmed:false) → 不铸令牌,请求不带 grantId(runTask 硬闸会拦)', async () => {

--- a/electron/capabilityCore/rpcServer.ts
+++ b/electron/capabilityCore/rpcServer.ts
@@ -12,7 +12,7 @@ import type { AddressInfo } from 'node:net'
 
 import type { FetchTaskResultFn, RunTaskFn } from './core'
 import { RpcError } from './dispatcher'
-import { createDiskGateway, createHybridGateway, createRendererGateway, type ProjectGateway } from './gateway'
+import { createDiskGateway, createHybridGateway, createRendererGateway, withPreApprovedSpend, type ProjectGateway } from './gateway'
 import { isRendererAvailable } from './rendererBridge'
 import { resolveMcpOrigin, verifyToken } from './security'
 import { getProductionRunService } from '../productionRun/productionRunRuntime'
@@ -93,7 +93,7 @@ export function startRpcServer(options: RpcServerOptions): Promise<RpcServerHand
         if (req.method !== 'POST' || req.url !== '/rpc') throw new RpcError('仅支持 POST /rpc', 404)
         if (!verifyToken(bearerToken(req))) throw new RpcError('鉴权失败：token 无效', 401)
         const raw = await readBody(req)
-        let parsed: { method?: unknown; params?: unknown; planConfirmed?: unknown }
+        let parsed: { method?: unknown; params?: unknown; planConfirmed?: unknown; spendConfirmed?: unknown }
         try {
           parsed = JSON.parse(raw || '{}')
         } catch {
@@ -105,12 +105,27 @@ export function startRpcServer(options: RpcServerOptions): Promise<RpcServerHand
           firstHeader(req.headers['x-nomi-mcp-client']),
           firstHeader(req.headers['x-nomi-mcp-client-proof']),
         )
+        // 付费已在**调用方客户端**经 elicitation 被真人确认（协议层 mcpProtocol.ts 只在收到
+        // `action:'accept' + confirm:true` 后才置位）→ 预批准付费门，App 不再弹第二张确认卡。
+        //
+        // 这条曾**刻意不过线**，注释写着「永远不预批 confirmSpend」。2026-08-18 用户拍板放开，理由与代价：
+        // · 为什么放开——旧判据是「Nomi 窗口开着没」，它跟「用户注意力在不在 Nomi」没有因果关系（桌面上常年
+        //   挂着 Nomi）。结果：人在 Claude 里驱动生成，却被赶回 Nomi 点一下。若信号不过线，协议层弹完
+        //   elicitation 这边照样弹卡 → 变成点两次，比原来更糟。
+        // · 为什么仍守得住 spendGrant.ts 写死的威胁模型（「Nomi 的 AI 触发不了未确认的付费生成」）——模型只能
+        //   吐 tool-call/文本，伪造不了客户端写进 server stdin 的 elicitation 响应帧；且 App 关着时这条一模一样的
+        //   信任链早已在用（makeConfirmedGateway）。
+        // · 代价（已知并接受）——能读 `~/.nomi/capability-core/token` 的本地进程可借此静默烧额度；此前它触发生成
+        //   会弹卡、用户看得见能拒。这是把「防本地攻击者」这层纵深换成「少跑一趟」，不是「防 AI」那道红线松了。
+        // ⚠️ 边界仅放宽到付费确认这一处：令牌仍只在主进程铸、assertAndConsumeSpendGrant 仍逐次硬校验、
+        // 导出等其余硬边界一律不得复制本模式（那些是抗伪造红线，客户端一个 flag 不足以过）。
+        const preApprovedSpend = parsed.spendConfirmed === true
         // 交付②④：dispatch + 生成结果富化收口在 dispatchAndEnrich（0a）——传输里没有 bare dispatch 可调，
         // 缩略图 base64 / 签名预览链的富化在结构上不可能被忘（此进程有 nativeImage，launcher bare node 做不了）。
         const result = await dispatchAndEnrich(method, params, {
           runTask: options.runTask,
           fetchTaskResult: options.fetchTaskResult,
-          makeGateway,
+          makeGateway: preApprovedSpend ? (projectId: string) => withPreApprovedSpend(makeGateway(projectId)) : makeGateway,
           productionRuns,
           origin: { host: origin },
           // 画布方案已在聊天里确认（协议层 elicitation-first）→ addNodes 预批准方案门、渲染层不再弹卡（免双问）。
@@ -118,9 +133,7 @@ export function startRpcServer(options: RpcServerOptions): Promise<RpcServerHand
           // 为什么这里敢信客户端传的 planConfirmed（对比 origin「never trust」的硬边界）：方案门守的是
           // 「模型的决定要过真人」这道软闸，不是抗伪造令牌的红线——加节点免费、可撤销，且持有本 RPC token
           // 的进程在 headless 下 confirmPlan 本就恒 true，客户端「预批」拿不到它本来拿不到的权限。协议层也只
-          // 在真人 accept 之后才置这个位。**它只能预批 confirmPlan，永远不预批 confirmSpend**——花钱那条硬边界
-          // 刻意不过线（spendConfirmed 不跨 RPC，令牌只在主进程真人点卡后铸）。⚠️ 禁止把本模式复制到
-          // spend/export 等硬边界：那些是「抗伪造」红线，客户端一个 flag 不足以过。
+          // 在真人 accept 之后才置这个位。
           ...(parsed.planConfirmed === true ? { planConfirmed: true } : {}),
         })
         send(200, { ok: true, result })

--- a/tests/ux/spend-elicit-app-open.walk.mjs
+++ b/tests/ux/spend-elicit-app-open.walk.mjs
@@ -1,0 +1,220 @@
+// R16 走查（付费确认路由）：**Nomi 开着**时，外部 MCP agent 触发付费生成，确认要弹在**调用方**
+// （Claude/Codex 的 elicitation），而不是把人赶回 Nomi 点应用内卡片。
+//
+// 为什么必须真机走查、单测不够：双问 bug 不在协议层，而在**传输层**——协议层弹完 elicitation 后，
+// spendConfirmed 若不跟着跨 loopback RPC 进 GUI 主进程，渲染层会照旧再弹一次卡（用户点两次，比修之前更糟）。
+// 只有「真 GUI + 真 stdio 子进程 + 真 RPC」这一条链跑通，才证明得了它。
+//
+// 两条腿（缺一不可，A 是 B 的基线）：
+//  · A 客户端**不声明** elicitation（= Claude Code 当下的真实能力）→ App 必须照旧弹应用内确认卡。
+//    这条既是回归保护（别把还在用卡的客户端修坏），也给 B 的「卡没出现」提供 proveProbe 基线——
+//    否则「没看到卡」和「选择器写错了」在观测上完全一样（见 _assert.mjs 的血泪注释）。
+//  · B 客户端**声明** elicitation（Codex/Cursor）→ 确认弹在调用方，App 全程不弹卡，生成照跑。
+//
+// 链路：起真 GUI app（写 instance 广告）→ 另起 stdio MCP 子进程（同 NOMI_CAPABILITY_DIR → 探到运行中的
+// GUI，经 RPC 转发）。全程 mock vendor，**零额度**。
+// 用法：pnpm run build && node tests/ux/spend-elicit-app-open.walk.mjs
+import { launchNomiApp, repoRoot, withLinuxNoSandbox } from './_launchApp.mjs'
+import { startMockVendorServer, writeIsolatedCatalog, parseToolResult } from './_mcpJourney.mjs'
+import { clickOrFail, expectAbsent, proveProbe } from './_assert.mjs'
+import { createRequire } from 'node:module'
+import { spawn } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import readline from 'node:readline'
+import path from 'node:path'
+
+const require = createRequire(import.meta.url)
+const shotsDir = path.join(repoRoot, 'tests/ux/shots/spend-elicit-app-open')
+fs.rmSync(shotsDir, { recursive: true, force: true })
+fs.mkdirSync(shotsDir, { recursive: true })
+
+const base = fs.mkdtempSync(path.join(os.tmpdir(), 'nomi-spendelicit-'))
+const settingsDir = path.join(base, 'settings')
+const projectsDir = path.join(base, 'projects')
+const capDir = path.join(base, 'capability-core')
+for (const d of [settingsDir, projectsDir, capDir]) fs.mkdirSync(d, { recursive: true })
+
+const sharedEnv = {
+  NOMI_E2E: '1',
+  NOMI_E2E_ALLOW_MULTI_INSTANCE: '1',
+  NOMI_ELECTRON_USER_DATA_DIR: settingsDir,
+  NOMI_SETTINGS_DIR: settingsDir,
+  NOMI_PROJECTS_DIR: projectsDir,
+  NOMI_CAPABILITY_DIR: capDir,
+  // 刻意不设 NOMI_LOOP_SPEND_OK：付费必须靠真人确认走通，不许走 env 逃生口。
+}
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms))
+let passed = 0
+const ok = (c, l) => { if (!c) throw new Error(`FAIL: ${l}`); passed += 1; console.log(`  ✓ ${l}`) }
+
+const mockVendor = await startMockVendorServer()
+writeIsolatedCatalog(settingsDir, mockVendor.origin)
+
+const { app } = await launchNomiApp({
+  name: 'spend-elicit-app-open',
+  userDataDir: settingsDir,
+  settingsDir,
+  projectsDir,
+  env: { NOMI_CAPABILITY_DIR: capDir },
+  args: ['--disable-gpu', '--disable-software-rasterizer'],
+  settleMs: 0,
+})
+
+/**
+ * 起一个 stdio MCP 子进程当外部 agent。capabilities 决定它是「能替我们问真人」的客户端还是不能的。
+ * elicitation/create **不自动应答**——要趁它挂起时去 GUI 抓现行，看有没有第二张卡。
+ */
+function spawnAgent({ capabilities, clientName }) {
+  const pending = new Map()
+  const elicitInbox = []
+  let elicitWaiter = null
+  let seq = 0
+  const child = spawn(require('electron'), withLinuxNoSandbox([repoRoot, '--disable-gpu']), {
+    cwd: repoRoot,
+    env: { ...process.env, ...sharedEnv, NOMI_MCP_STDIO: '1' },
+    stdio: ['pipe', 'pipe', 'inherit'],
+  })
+  readline.createInterface({ input: child.stdout }).on('line', (line) => {
+    const t = line.trim(); if (!t.startsWith('{')) return
+    let msg; try { msg = JSON.parse(t) } catch { return }
+    if (msg.method === 'elicitation/create' && msg.id != null) {
+      if (elicitWaiter) { const w = elicitWaiter; elicitWaiter = null; w(msg) } else elicitInbox.push(msg)
+      return
+    }
+    if (msg.id != null && pending.has(msg.id)) { const { resolve, timer } = pending.get(msg.id); clearTimeout(timer); pending.delete(msg.id); resolve(msg) }
+  })
+  const rpc = (method, params, timeoutMs = 30000) => {
+    const id = (seq += 1)
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => { pending.delete(id); reject(new Error(`RPC 超时: ${method}`)) }, timeoutMs)
+      pending.set(id, { resolve, timer })
+      child.stdin.write(JSON.stringify({ jsonrpc: '2.0', id, method, params }) + '\n')
+    })
+  }
+  return {
+    child,
+    rpc,
+    async callTool(name, args, timeoutMs = 90000) {
+      const res = (await rpc('tools/call', { name, arguments: args }, timeoutMs)).result
+      const parsed = parseToolResult(res)
+      if (parsed.isError) throw new Error(`工具 ${name} 失败：${parsed.text.slice(0, 200)}`)
+      return parsed
+    },
+    async start() {
+      let init = null
+      for (let i = 0; i < 20 && !init; i++) {
+        try { init = await rpc('initialize', { protocolVersion: '2025-11-25', capabilities, clientInfo: { name: clientName } }, 4000) } catch { await sleep(1000) }
+      }
+      return init
+    },
+    waitForElicit(timeoutMs = 30000) {
+      if (elicitInbox.length) return Promise.resolve(elicitInbox.shift())
+      return new Promise((resolve, reject) => {
+        const timer = setTimeout(() => { elicitWaiter = null; reject(new Error('没等到 elicitation/create')) }, timeoutMs)
+        elicitWaiter = (msg) => { clearTimeout(timer); resolve(msg) }
+      })
+    },
+    answerElicit(id, confirm) {
+      child.stdin.write(JSON.stringify({ jsonrpc: '2.0', id, result: confirm ? { action: 'accept', content: { confirm: true } } : { action: 'decline' } }) + '\n')
+    },
+    elicitCount: () => elicitInbox.length,
+  }
+}
+
+let agents = []
+let exitCode = 0
+try {
+  const win = app.windows().filter((w) => !w.isClosed()).slice(-1)[0]
+  win.on('pageerror', (e) => console.log('  [pageerror]', e.message.slice(0, 160)))
+  await win.waitForLoadState('domcontentloaded')
+  await sleep(1500)
+  await win.evaluate(() => { for (const k of ['nomi:splash:v1', 'nomi:journey-tour:v1', 'nomi:canvas-gesture-hint:v1']) window.localStorage.setItem(k, 'seen') })
+  await win.reload(); await sleep(1500)
+  for (let i = 0; i < 5; i++) { const s = win.locator('button,[role="button"],a', { hasText: /跳过|开始创作|进入|完成/ }).first(); if (await s.count()) await s.click({ timeout: 1000 }).catch(() => {}); await win.keyboard.press('Escape').catch(() => {}); await sleep(300) }
+  await win.screenshot({ path: path.join(shotsDir, '01-app-ready.png') })
+
+  // 应用内付费确认卡（i18n runtime.capability.spendTitle = 「AI 助手想生成{{intent}}」）。
+  const spendCard = win.locator('div.fixed.inset-0').filter({ hasText: /AI 助手想生成/ })
+
+  // ── 前置：证明 App 真被认成「开着」——否则整条走查会退回 headless 路、测的是旧行为 ──
+  const advertFiles = fs.readdirSync(capDir).filter((f) => f.startsWith('instance'))
+  ok(advertFiles.length > 0, `GUI 写出了 instance 广告（${advertFiles.join(',')}）= isAppOpen() 为真`)
+  const advert = JSON.parse(fs.readFileSync(path.join(capDir, advertFiles[0]), 'utf8'))
+  const capToken = fs.readFileSync(path.join(capDir, 'token'), 'utf8').trim()
+  const pingRes = await fetch(`http://127.0.0.1:${advert.port}/rpc`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', authorization: `Bearer ${capToken}` },
+    body: JSON.stringify({ method: 'ping', params: {} }),
+  }).then((r) => r.json()).catch(() => null)
+  ok(pingRes?.ok === true, `GUI 的 RPC server 活着（port=${advert.port}）= 生成会经 RPC 转发进 GUI 主进程`)
+
+  // ══ A 腿 · 基线：客户端不声明 elicitation（Claude Code 当下）→ App 必须照旧弹卡 ══
+  console.log('\n  ── A 腿：客户端问不了真人 → 应用内确认卡兜底（也是 B 腿的探针基线）──')
+  const plainAgent = spawnAgent({ capabilities: {}, clientName: 'claude-code' })
+  agents.push(plainAgent)
+  ok(Boolean((await plainAgent.start())?.result), 'stdio MCP 起来了（不声明 elicitation）')
+  const projA = await plainAgent.callTool('nomi_create_project', { name: '付费确认-兜底腿' })
+  const projectIdA = projA.json?.projectId || projA.json?.id
+  ok(projectIdA, `建项目（${projectIdA}）`)
+
+  const genA = plainAgent.callTool('nomi_generate', {
+    projectId: projectIdA, vendor: 'nomi-mock', modelKey: 'nomi-mock-image', intent: 'image', prompt: '兜底腿：巷口回头',
+  })
+  // 探针基线：这一屏卡**确实会浮**。expectAbsent 只认这个证明。
+  const cardProof = await proveProbe(spendCard, '客户端不支持 elicitation 时，App 确实会弹付费确认卡', 30_000)
+  await win.screenshot({ path: path.join(shotsDir, '02-fallback-card-shown.png') })
+  ok(true, '不声明 elicitation + App 开着 → 应用内确认卡照旧弹出（没修坏兜底路）')
+  await clickOrFail(spendCard.locator('button').last(), '确认生成')
+  const resA = await genA
+  ok(resA.json?.status === 'succeeded', `点了卡之后生成跑完（status=${resA.json?.status}）`)
+  plainAgent.child.kill('SIGTERM')
+
+  // ══ B 腿 · 修复本体：客户端声明 elicitation → 确认弹在调用方，App 不再弹卡 ══
+  console.log('\n  ── B 腿：客户端能问真人 → 确认弹在调用方，Nomi 不该再要一次点击 ──')
+  const elicitAgent = spawnAgent({ capabilities: { elicitation: {} }, clientName: 'codex' })
+  agents.push(elicitAgent)
+  ok(Boolean((await elicitAgent.start())?.result), 'stdio MCP 起来了（声明 elicitation）')
+  const projB = await elicitAgent.callTool('nomi_create_project', { name: '付费确认-调用方腿' })
+  const projectIdB = projB.json?.projectId || projB.json?.id
+  ok(projectIdB, `建项目（${projectIdB}）`)
+
+  const genB = elicitAgent.callTool('nomi_generate', {
+    projectId: projectIdB, vendor: 'nomi-mock', modelKey: 'nomi-mock-image', intent: 'image', prompt: '调用方腿：巷口回头',
+  })
+  const elicit = await elicitAgent.waitForElicit(30_000)
+  ok(true, 'App 开着，付费确认仍弹在**调用方**（收到 elicitation/create）——不再赶用户回 Nomi')
+  const msgText = elicit.params?.message || ''
+  console.log('  · 确认文案：', msgText.replace(/\n+/g, ' ').slice(0, 120))
+  ok(msgText.includes('nomi-mock-image'), '确认文案点名了要花钱的模型（用户看得懂在批什么）')
+  ok(!msgText.includes('Nomi 未打开'), '文案没再谎称「Nomi 未打开」（App 明明开着）')
+
+  // 趁 elicitation 挂起去 GUI 抓现行——带 A 腿的基线，「没看到卡」才算数。
+  await sleep(2000)
+  await win.screenshot({ path: path.join(shotsDir, '03-during-elicit-no-card.png') })
+  await expectAbsent(spendCard, { provenBy: cardProof, message: '确认已在调用方问过，App 不该再弹第二张卡' })
+  ok(true, 'elicitation 挂起期间 App **没有**弹付费确认卡（无双问，基线已证卡是能被看见的）')
+
+  elicitAgent.answerElicit(elicit.id, true)
+  const resB = await genB
+  ok(resB.json?.status === 'succeeded', `调用方确认后生成直接跑完（status=${resB.json?.status}）——没碰过 Nomi 窗口`)
+  const assetUrl = resB.json?.assets?.[0]?.url || ''
+  ok(String(assetUrl).startsWith('nomi-local://'), `真落了资产（${String(assetUrl).slice(0, 46)}）= 付费令牌确实铸出来了`)
+
+  await sleep(1000)
+  await win.screenshot({ path: path.join(shotsDir, '04-after-generate.png') })
+  await expectAbsent(spendCard, { provenBy: cardProof, message: '生成结束后也不该补问一次' })
+  ok(true, '生成结束后 App 依然没冒出确认卡（确认没被补问）')
+  ok(mockVendor.hits.length >= 2, `两腿都真跑了生成管线，打的是 mock vendor（${mockVendor.hits.length} 次，零额度）`)
+
+  console.log(`\nSPEND-ELICIT PASS: ${passed} 断言——问得到真人的客户端就地问，问不到的照旧走 App 卡。`)
+  console.log('  截图 →', shotsDir)
+} catch (err) {
+  console.log(`✗ ${err?.message || err}`)
+  exitCode = 1
+} finally {
+  for (const a of agents) a.child.kill('SIGTERM')
+  await mockVendor.close().catch(() => undefined)
+  await app.close().catch(() => undefined)
+  setTimeout(() => process.exit(exitCode), 300)
+}


### PR DESCRIPTION
## 问题

用户从 Claude / Codex / Cursor 经 MCP 驱动 Nomi 生成时，**只要 Nomi 开着，付费确认一律被送去 App 卡片**，人得离开正在用的软件跑去 Nomi 点一下。2026-08-18 用户当面反馈：「那这样反复去软件确认 不是太麻烦了」。

根因是判据错了：`!transport.isAppOpen()`。请求经 MCP 进来本身就证明人在调用方那头，而「窗口开着」跟「注意力在 Nomi」没有因果关系——用户桌面上常年挂着 Nomi。

## 改法

判据换成「**谁能替我们问到真人**」：

| 客户端支持 elicitation | App | 行为 |
|---|---|---|
| ✅ | 开/关 | 弹在调用方（就地确认，不用回 Nomi） |
| ❌ | 开 | 照旧走应用内确认卡 |
| ❌ | 关 | 诚实报错，绝不静默花钱 |

顺带删掉硬编码的「Nomi 未打开。」前缀——改完 App 开着也走这条，那句话不成立了。

## ⚠️ 这里有一半是传输层的事，请重点看

只改协议层会**变成点两次**（比改之前更糟）：协议层弹完 elicitation，`spendConfirmed` 若不跟着跨 loopback RPC 进 GUI 主进程，渲染层照旧再弹一张卡。已实测坐实——去掉那一行转发，真机走查直接报「缺少授权令牌」。

所以 `spendConfirmed` 现在会过 RPC 线。`rpcServer.ts` 里原本有条明写的红队禁令「**永远不预批 confirmSpend**」，**按用户拍板放开，注释改写而非删除**，写清三件事：

- **为什么放开** —— 不放开就是双问，比原来更糟。
- **为什么仍守得住** —— `spendGrant.ts` 写死的威胁模型是「Nomi 的 AI 触发不了未确认的付费生成」。模型只能吐 tool-call/文本，伪造不了客户端写进 server stdin 的 elicitation 响应帧；且 App 关着时这条一模一样的信任链早已在用。
- **代价（已知并接受）** —— 能读 `~/.nomi/capability-core/token` 的本地进程可借此静默烧额度；此前它触发生成会弹卡、用户看得见能拒。这是把「防本地攻击者」这层纵深换成「少跑一趟」，不是「防 AI」那道红线松了。

`assertAndConsumeSpendGrant` **一字未动**，令牌仍逐次硬校验；导出等其余硬边界明令不得复制本模式。

## `nomi_add_nodes` 那处 isAppOpen()：判断后保留

它与付费路**不同义**——付费路曾用它猜「用户在不在 Nomi 边上」（错的）；这里它问的是「不这么做会不会弹出一张应用内方案卡」。App 关着时 `confirmPlan` 恒放行（免费可撤、无人值守），没有卡可替代，去掉只会**凭空多问一次**，与「少让用户点」正相反。已在代码里写明，防后人跟着一起删。

## 验证

- **单测**覆盖 `{支持 elicitation × App 开/关}` 全矩阵。其中「App 开着仍弹在调用方」和文案两条，经 stash 实测确认**在旧代码下会失败**——不是恒真的假绿。
- **rpcServer 两条**：`spendConfirmed` 过线不再弹第二张卡；且它只预批付费、**不顺手预批方案门**。
- **新增真机走查** `tests/ux/spend-elicit-app-open.walk.mjs`（真 GUI + 真 stdio 子进程 + 真 RPC，mock vendor **零额度**），16 断言：
  - **A 腿**不声明 elicitation（= Claude Code 当下）→ App 照旧弹卡。既是回归保护，也给 B 腿的「卡没出现」提供 `proveProbe` 基线。
  - **B 腿**声明 elicitation → 确认弹在调用方，App 全程无卡，生成照跑。
  - 截图人眼核对过：A 腿卡确实浮出（`AI 助手想生成一张画面`），B 腿同一时刻同一个活窗口干干净净。
- `pnpm run gates` 全过；`check:walkthroughs` 的 `absence-without-baseline` 保持 70 未增（absence 断言都带了基线）。

## 已知范围

**Claude Code 当下不声明 elicitation 能力**（2026-08-18 实测），所以这个修复对它暂不生效，走的是 A 腿的应用内卡片。受益的是 Codex / Cursor 等已支持 elicitation 的客户端，以及将来支持了的 Claude Code。别把「改完 Claude Code 里还是弹不出来」当成修复失败。

🤖 Generated with [Claude Code](https://claude.com/claude-code)