### PR TITLE
fix(archetypes): 「合计≤12」是 fal 的规矩不是模型的——改钉三家一致的「音频需伴随」

### DIFF
--- a/docs/plan/2026-08-20-seedance-cross-slot-reference-constraint.md
+++ b/docs/plan/2026-08-20-seedance-cross-slot-reference-constraint.md
@@ -1,0 +1,177 @@
+# Seedance 参考槽的跨槽约束：证伪「合计 ≤12」，改钉「音频需伴随」
+
+日期：2026-08-20 · 分支：`claude/magical-tesla-5a9aae`
+
+## 0. 缘起与结论倒置
+
+任务原本是「Seedance 2.0 缺一条官方约束：所有模态参考文件合计不得超过 12 个」，据 fal 模型页
+`https://fal.ai/models/bytedance/seedance-2.0/reference-to-video` 的原文
+`"Total files across all modalities must not exceed 12."`。
+
+按任务自带的判据（`seedance25Contract.test.ts` 头部注释：**三家一致才算模型级能力，才该钉在共享档案上**）
+逐项核实三条我们真正在用的渠道，结论是 **证伪**：
+
+| 来源 | Seedance 2.0 跨模态合计上限 | 原文 |
+|---|---|---|
+| **火山方舟**（字节自家平台，模型的一手出处） | **15**（9图+3视频+3音频） | 「参考素材数量上限 \| Seedance 2.0 \| **15（9张图+3个视频+3个音频）**」 |
+| **APIMart** | 无此条 | 全文只分别写 9/3/3，无任何跨模态合计条款 |
+| **即梦 Dreamina** | 无公开 API 文档 | — |
+| fal（**我们没有这条渠道**） | 12 | `"Total files across all modalities must not exceed 12."` |
+
+出处：
+- 火山方舟 <https://docs.volcengine.com/docs/82379/2607688?lang=zh>（能力概述表，同表并列 2.0/fast/mini/2.5）
+- 火山方舟 <https://docs.volcengine.com/docs/82379/2298881?lang=zh>（使用限制：1~9 张图 / 最多 3 个参考视频 / 最多 3 段参考音频）
+- 火山方舟 <https://docs.volcengine.com/docs/82379/2291680?lang=zh>（Seedance 2.0 系列教程：图片 0~9、视频 0~3、音频 0~3）
+- APIMart <https://docs.apimart.ai/en/api-reference/videos/seedance-2-0/generation.md>
+
+**两点判断：**
+
+1. 字节自己写的 15 **恰好等于 9+3+3**，即合计上限与各槽上限之和相等 → 这条约束**永不咬合**，
+   加了也拦不住任何东西。2.5 同理：方舟写 50 = 30+10+10，fal 也写 50。**两代都不需要「合计上限」这个概念。**
+2. `electron/catalog/` 的 vendor 只有 agnes / apimart / dreamina / modelscope / volcengine，**没有 fal**。
+   那个 12 打不到任何一个 Nomi 用户身上。
+
+若照 12 钉下去，是重演 2026-08-12 的错误（见 `seedance25Contract.test.ts` 头部）：用户放满 9 图 + 3 视频后，
+方舟文档白纸黑字说还能加 3 段音频，我们却在第 12 个就拦死 —— **能力是模型有的，又被我们的档案掐窄。**
+
+→ **不加合计上限。** 但同一次核实挖到一条真的、三家一致、且当前完全没拦的跨槽约束（下节）。
+
+## 1. 真正要修的：Seedance 2.0 的参考音频不能单独用
+
+三家一致 = 模型级契约：
+
+| 来源 | 原文 |
+|---|---|
+| 火山方舟 | 「您可任意组合以下模态内容，**注意不支持"文本+音频"、"纯音频" 输入**」 |
+| APIMart | `"Must be used together with reference images or reference videos"` |
+| fal | `"requires at least one image or video"` |
+
+**而 Seedance 2.5 明确解除了它**：
+- 火山方舟：「Seedance 2.5 **新增支持纯音频参考生成视频**，无需搭配图片或视频素材。」
+- APIMart：`"Reference audio: ≤3, total ≤15s → ≤10, total ≤30s; audio-only OK"`
+
+（fal 的 2.5 页仍写 `"If audio is provided, at least one reference image or video is required."`，
+与字节自家 + APIMart 两家相左 —— 判定 fal 该句为陈旧拷贝，不采信。**一手出处优先于中转转述**。）
+
+一个干净的、按模型分化的能力差异 → 正该由档案声明表达，而不是写死在某处 if。
+
+### 当前缺口（实测，非推断）
+
+`canRunGenerationNode`（`src/workbench/generationCanvas/runner/generationRunController.ts:601`）
+判「视频节点可否生成」只问 `hasArchetypeArrayReferences` = **任一数组槽非空**。
+用户只往 omni 放一段音频 → 判定可生成 → 按钮亮 → 发出去 → 服务商拒。
+全仓 grep `纯音频 / audioOnly / requiresCompanion` 无任何相关逻辑。
+
+这正是原任务描述的病（UI 全程放行、到服务商才被拒），只是触发条件不是 15 个文件，而是 1 段音频。
+
+## 2. 设计
+
+### 2.1 档案层：通用的跨槽依赖声明（不为单个模型开特例，P4）
+
+`src/config/modelArchetypes/types.ts` 的 `ArchetypeReferenceSlot` 新增：
+
+```ts
+/**
+ * 跨槽依赖：本槽有值时，这些 kind 的槽**至少一个**也必须有值，否则该模型不受理。
+ * 缺省 = 无依赖，可单独使用。
+ */
+requiresAnyOf?: ArchetypeReferenceSlotKind[]
+```
+
+- Seedance 2.0 **四**档案的 `audio_ref` 槽声明 `requiresAnyOf: ['image_ref', 'video_ref']`。
+  ⚠️ 任务描述里只列了 apimart / volcengine / dreamina 三个；**实扫 `kind: "audio_ref"` 才发现
+  还有 kie 的 `seedance.ts:78`**，同样是 Seedance 2.0、同样 9/3/3、同样没声明。
+  同一个模型换个中转不会改变「不收纯音频」这件事，四条都得带。
+  这就是 P2 通用性判定要求的「**全仓实扫、给 file:line，扫不猜**」——照着记忆里的清单改就会漏这条。
+- Seedance 2.5 **不声明**（文档已解除），并在注释里写明「2.5 解除了 2.0 的此限制」+ 出处，
+  防止后人"对齐"时手贱补回来。
+
+为什么是 `requiresAnyOf`（任一）而不是 `requiresAll`：三家原文都是「图片**或**视频」，是析取。
+
+### 2.2 拦在哪：**不拦插入，拦生成** —— 且说清为什么
+
+原任务写「要在放进去的那一刻就拦住」。对**容量**类约束（槽满）这是对的，因为后续操作救不回来；
+对**依赖**类约束这是错的：用户先拖音频、再拖图片是完全合理的顺序，在第一步拦死 = 惩罚操作顺序（违反 D1）。
+
+所以：
+- **插入**：放行。音频合法地在那儿，只是还不能单独跑。
+- **生成**：`canRunGenerationNode` 判 false，生成钮置灰，composer 的 title 说人话讲**具体**原因。
+
+考虑过、**没做**的一项：在音频槽下方常驻一行「需搭配至少一张图或一个视频」。
+按 R2「每条信息问『有行动价值吗』」——用户还没放音频时这句没有任何行动价值，
+只是给密度优先的 composer 添一行常驻噪音；真正需要它的那一刻（音频已入、伴随缺失），
+置灰原因已经把话说清楚了。故不加。
+
+### 2.3 「为什么不能生成」的单一真相源（顺带治根，P2）
+
+现状是两条真相源：`canRunGenerationNode` 只返回 `boolean`，
+composer（`NodeGenerationComposer.tsx:683`）再**按 node.kind + acceptsDrop 重猜**一遍原因文案。
+新约束一旦加进来，猜出的文案必然是错的（会说「需要先添加参考素材」，可用户明明加了音频）。
+
+修法：新增纯函数 `unmetReferenceDependency(meta, archetype)` → 返回未满足的依赖（或 null），
+`canRunGenerationNode` 与 composer 的 `disabledReason` **同吃这一个**，不再各猜各的。
+不改 `canRunGenerationNode` 的签名（6 处调用者不动），只加一个并列导出。
+
+### 2.4 文案（R15：走 i18n，zh-CN + en）
+
+- 槽内常驻说明：`需搭配至少一张图或一个视频`
+- 生成钮置灰 title：`参考音频不能单独使用，请再加一张图或一个视频`
+
+## 3. 契约测试
+
+新增 `src/config/modelArchetypes/seedance20Contract.test.ts`，仿 `seedance25Contract.test.ts`，钉住：
+
+1. 三个 2.0 档案的 omni 槽上限 = 9/3/3（三家文档一致）。
+2. 三个 2.0 档案的 `audio_ref.requiresAnyOf` 含 image_ref 与 video_ref。
+3. **2.5 的 audio_ref 不得声明 requiresAnyOf**（负向钉子：文档已解除，别"对齐"回来）。
+4. **两代均不得出现「合计上限」字段**（负向钉子：把本次证伪的结论钉死，
+   附 fal=12 / 方舟=15 的出处，防止后人看到 fal 页面又来加一遍）。
+
+文件头注释按 2.5 的格式，逐条写清出处 URL + 原文 + 核实日期。
+
+## 4. 顺带修（同轮收掉）
+
+`sources.url` 与测试头注释里引的 `https://docs.apimart.ai/cn/api-reference/videos/doubao-seedance-2-5`
+**已 404**（文档搬到 `/en/api-reference/videos/seedance-2-5/generation`）。
+涉及 `seedance25.ts:72`、`seedance25Contract.test.ts:17`、`seedance25ApimartContract.test.ts:2`。
+改成现行 URL 并更新 `checkedAt` 为 2026-08-20。
+
+（`check:archetype-sources` 只查字段在不在，查不到 URL 死没死 —— 如实记在此，不在本轮扩门岗范围。）
+
+## 5. 不动项
+
+- 不加任何形式的「跨模态合计上限」字段（第 0 节已证伪；无咬合场景 = 死代码）。
+- 不动 9/3/3 与 30/10/10 这六个数（本次复核与文档一致）。
+- 不动 2.5 的 resolution 取值。核实中曾疑其被掐窄，但 APIMart 文档里
+  `Resolution: 480p, 720p, 1080p` 一处指的是**输入参考视频**的分辨率，与输出清晰度是两件事；
+  输出侧「2.5 无 4k」的表述需要方舟 + kie 再逐项对账才能下结论，**不在本轮照抄**。
+- 不改 `canRunGenerationNode` 签名（避免 6 处调用点连锁改动）。
+
+## 6. 验收门（已全部完成）
+
+1. ✅ `pnpm run gates` 全过。
+2. ✅ 新契约测试先红后绿：3 条 `requiresAnyOf` 断言红 → 加声明 → 23 条全绿
+   （4 条 2.0 渠道 × 上限/依赖 + 2 条 2.5 渠道的负向钉子 + 合计上限证伪钉子）。
+3. ✅ `referenceDependency.test.ts` 12 条单测（含「切模式后残留值不得误判」「连线来源也算满足」）。
+4. ✅ R13 真机走查 `tests/ux/reference-companion-required.walk.mjs`，8 条断言全过，零额度。
+
+### 走查过程中的两处修正（记下来，不然下次还踩）
+
+- **选择器猜错**：音频 tile **没有** `aria-label="参考音频1"`——只有 characterIndexed 的角色图 tile
+  才带那个属性（为了拖拽重排）。存在性锚点得用它的移除钮 `button[aria-label="移除参考音频1"]`。
+  照角色图的写法猜必然找不到；探真实 DOM 才知道。
+- **肉眼差点结错账**：`01-omni-empty.png` 里我一度把置灰的生成钮看成可点的
+  （800px 缩略图上两种状态几乎同色）。改成机器断言「空 omni → 置灰 + 泛化文案」才定住。
+  **凡是缩略图上分辨不出来的状态，别用"我看着像"结账。**
+
+### 已知限制（诚实标出，D4）
+
+置灰原因只挂在 `title` 上，用户得**悬停才看得到**。这与现有的 `videoReferenceRequired` /
+`imageReferenceRequired` 完全同构（没有引入更差的模式），但「为什么不能生成」整体的可发现性偏弱：
+用户看到一个死按钮，未必想得到去悬停。要改成常驻可见需要动 composer 的信息层级 → 属于 R8
+（先出样张 + 用户拍板）的范围，本轮不擅自动。
+
+## 7. 回滚
+
+单 commit，`git revert` 即可。档案新增字段为可选，旧项目 meta 不受影响；
+未声明 `requiresAnyOf` 的所有其它档案行为完全不变。

--- a/src/config/modelArchetypes/dreaminaSeedance.ts
+++ b/src/config/modelArchetypes/dreaminaSeedance.ts
@@ -43,7 +43,8 @@ const MODES: ModelArchetype["modes"] = [
     slots: [
       { kind: "image_ref", label: "角色参考", min: 0, max: 9, characterIndexed: true, inputKey: "mm_images" },
       { kind: "video_ref", label: "参考视频", min: 0, max: 3, inputKey: "mm_videos" },
-      { kind: "audio_ref", label: "参考音频", min: 0, max: 3, inputKey: "mm_audios" },
+      // 音频不能单独用（即梦跑的就是 Seedance 2.0，模型级契约同方舟/APIMart：不支持纯音频输入）。
+      { kind: "audio_ref", label: "参考音频", min: 0, max: 3, inputKey: "mm_audios", requiresAnyOf: ["image_ref", "video_ref"] },
     ], params: PARAMS_WITH_RATIO,
   },
 ];

--- a/src/config/modelArchetypes/seedance.ts
+++ b/src/config/modelArchetypes/seedance.ts
@@ -75,7 +75,10 @@ const SEEDANCE_2_MODES: ModelArchetype["modes"] = [
     slots: [
       { kind: "image_ref", label: "角色参考", min: 0, max: 9, characterIndexed: true },
       { kind: "video_ref", label: "参考视频", min: 0, max: 3 },
-      { kind: "audio_ref", label: "参考音频", min: 0, max: 3 },
+      // 音频不能单独用。这是**模型级**契约（方舟「不支持"文本+音频"、"纯音频" 输入」/ APIMart
+      // "Must be used together with reference images or reference videos"），与谁做中转无关，
+      // 故 kie 这条渠道同样带上（档案按模型身份认，供应商只管传输）。2.5 已解除此限。
+      { kind: "audio_ref", label: "参考音频", min: 0, max: 3, requiresAnyOf: ["image_ref", "video_ref"] },
     ],
     params: FIRST_MODE_PARAMS,
   },

--- a/src/config/modelArchetypes/seedance20Contract.test.ts
+++ b/src/config/modelArchetypes/seedance20Contract.test.ts
@@ -1,0 +1,129 @@
+// 契约钉子：Seedance 2.0 的参考槽上限、跨槽依赖，以及**「没有跨模态合计上限」这条否定结论**。
+//
+// 2026-08-20 的核实起因：有人照 fal 的模型页
+//   https://fal.ai/models/bytedance/seedance-2.0/reference-to-video
+//   "Total files across all modalities must not exceed 12."
+// 提出「我们的档案漏了合计 ≤12」。按 seedance25Contract.test.ts 头部定下的判据（三家一致才算模型级、
+// 才该钉在共享档案上）逐项核实我们真正在用的三条渠道，结论是**证伪**：
+//
+//   火山方舟（字节自家，模型的一手出处）  https://docs.volcengine.com/docs/82379/2607688?lang=zh
+//     「参考素材数量上限 | Seedance 2.0 | 15（9张图+3个视频+3个音频）」  ← 15，不是 12
+//   APIMart   https://docs.apimart.ai/en/api-reference/videos/seedance-2-0/generation.md
+//     全文只分别写 9/3/3，无任何跨模态合计条款
+//   即梦 Dreamina  无公开 API 文档
+//
+// 两点：① 字节自己写的 15 恰好等于 9+3+3，即合计上限与各槽上限之和相等 —— 这条约束**永不咬合**；
+//       2.5 同理（方舟 50 = 30+10+10）。② electron/catalog 的 vendor 只有 agnes/apimart/dreamina/
+//       modelscope/volcengine，**没有 fal**，那个 12 打不到任何一个 Nomi 用户身上。
+// 照 12 钉下去就是重演 2026-08-12 那次「能力是模型有的、被我们的档案掐窄」：用户放满 9 图 + 3 视频后，
+// 方舟文档白纸黑字说还能加 3 段音频，我们却在第 12 个拦死。所以本文件也把这条**否定结论**钉住，
+// 免得下一个人看到 fal 页面又来加一遍。
+import { describe, expect, it } from 'vitest'
+import { SEEDANCE_2_APIMART_ARCHETYPE } from './seedanceApimart'
+import { SEEDANCE_VOLCENGINE_ARCHETYPE } from './seedanceVolcengine'
+import { DREAMINA_SEEDANCE_ARCHETYPE } from './dreaminaSeedance'
+import { SEEDANCE_2_ARCHETYPE } from './seedance'
+import { SEEDANCE_2_5_ARCHETYPE } from './seedance25'
+import { SEEDANCE_2_5_APIMART_ARCHETYPE } from './seedance25Apimart'
+import type { ModelArchetype } from './types'
+
+/**
+ * 逐项抄自官方文档（2026-08-20 核实）：
+ *   火山方舟 https://docs.volcengine.com/docs/82379/2298881?lang=zh
+ *            「图片数量：seedance 2.0 全模态参考生视频：1~9 张」
+ *            「Seedance 2.0 系列：…最多传入 3 个参考视频，所有视频总时长不超过 15 s」
+ *            「Seedance 2.0 系列：…最多传入 3 段参考音频，所有音频总时长不超过 15 s」
+ *   APIMart  https://docs.apimart.ai/en/api-reference/videos/seedance-2-0/generation.md
+ *            "Maximum of 9 reference images" / "Maximum of 3 reference videos" / "Maximum of 3 reference audio files"
+ * 两家一致 —— 模型级能力，钉在共享档案上是对的。
+ */
+const DOC_LIMITS = { image_ref: 9, video_ref: 3, audio_ref: 3 } as const
+
+/**
+ * **四条**渠道全部走同一套模型级契约（P4 通用第一：档案按模型身份认，供应商只管传输）。
+ * kie 那条（seedance.ts）是 2026-08-20 全仓实扫 `kind: "audio_ref"` 才发现的 —— 起初只盯着
+ * apimart/volcengine/dreamina 三个档案，漏了它。同一个模型换个中转不会改变「不收纯音频」这件事，
+ * 所以四条都得带。**改这里时先扫一遍全仓，别照着记忆里的清单改。**
+ */
+const CHANNELS_2_0: Array<[string, ModelArchetype, string]> = [
+  ['apimart', SEEDANCE_2_APIMART_ARCHETYPE, 'omni'],
+  ['volcengine', SEEDANCE_VOLCENGINE_ARCHETYPE, 'omni'],
+  ['dreamina', DREAMINA_SEEDANCE_ARCHETYPE, 'multimodal'],
+  ['kie', SEEDANCE_2_ARCHETYPE, 'omni'],
+]
+
+/** 2.5 的两条渠道 —— 都**不该**有伴随要求（文档已解除），负向钉子对它们一起生效。 */
+const CHANNELS_2_5: Array<[string, ModelArchetype]> = [
+  ['2.5 kie', SEEDANCE_2_5_ARCHETYPE],
+  ['2.5 apimart', SEEDANCE_2_5_APIMART_ARCHETYPE],
+]
+
+const omniOf = (archetype: ModelArchetype, modeId: string) => archetype.modes.find((mode) => mode.id === modeId)
+
+describe('Seedance 2.0 archetype vs official docs', () => {
+  describe.each(CHANNELS_2_0)('%s', (_vendor, archetype, modeId) => {
+    const omni = omniOf(archetype, modeId)
+
+    it('has the multimodal reference mode', () => {
+      expect(omni).toBeDefined()
+    })
+
+    it.each(Object.entries(DOC_LIMITS))('allows the documented maximum for %s', (kind, max) => {
+      const slot = omni?.slots.find((s) => s.kind === kind)
+      expect(slot, `全能参考模式缺少 ${kind} 槽`).toBeDefined()
+      expect(slot?.max, `${kind} 上限与官方文档不一致`).toBe(max)
+    })
+
+    /**
+     * 三家一致 = 模型级契约：
+     *   火山方舟 https://docs.volcengine.com/docs/82379/2291680?lang=zh
+     *            「您可任意组合以下模态内容，注意不支持"文本+音频"、"纯音频" 输入。」
+     *   APIMart  "Must be used together with reference images or reference videos"
+     *   fal      "requires at least one image or video"
+     * 缺了它 → 用户只放一段音频，UI 判定可生成、发出去被服务商拒（原 canRunGenerationNode 只问
+     * 「任一数组槽非空」）。声明成 requiresAnyOf 而非写死 if，是因为 2.5 已解除此限（见下一个 describe）。
+     */
+    it('requires reference audio to be accompanied by an image or a video', () => {
+      const audio = omni?.slots.find((s) => s.kind === 'audio_ref')
+      expect(audio?.requiresAnyOf, 'audio_ref 未声明跨槽依赖 → 纯音频会被放行到服务商').toBeDefined()
+      expect(audio?.requiresAnyOf).toEqual(expect.arrayContaining(['image_ref', 'video_ref']))
+    })
+  })
+
+  /**
+   * 负向钉子。2.5 **解除**了 2.0 的纯音频限制，别在"对齐两代"时手贱补回来：
+   *   火山方舟 https://docs.volcengine.com/docs/82379/2607688?lang=zh
+   *            「Seedance 2.5 新增支持纯音频参考生成视频，无需搭配图片或视频素材。」
+   *   APIMart  "Reference audio: ≤3, total ≤15s → ≤10, total ≤30s; audio-only OK"
+   * （fal 的 2.5 页仍写 "at least one reference image or video is required"，与字节自家 + APIMart 相左，
+   *  判为陈旧拷贝 —— 一手出处优先于中转转述。）
+   */
+  it.each(CHANNELS_2_5)('does NOT carry the audio companion requirement on %s — the docs lifted it', (_label, archetype) => {
+    const audio = omniOf(archetype, 'omni')?.slots.find((s) => s.kind === 'audio_ref')
+    expect(audio, '2.5 omni 缺少 audio_ref 槽').toBeDefined()
+    expect(audio?.requiresAnyOf, '2.5 支持纯音频参考，不该有伴随要求').toBeUndefined()
+  })
+
+  /**
+   * 负向钉子（本轮证伪的结论）：**两代都不该有「跨模态合计上限」**。
+   * fal 写 2.0=12 / 2.5=50，但字节自家写 2.0=15（=9+3+3）、2.5=50（=30+10+10）——合计恒等于各槽之和，
+   * 永不咬合；且我们没有 fal 渠道。任何形如 maxTotalReferences 的字段出现 = 有人又照 fal 抄了一遍。
+   */
+  it('carries no cross-modality total cap — fal-only, and non-binding even there', () => {
+    const suspects = ['maxTotalReferences', 'maxTotalFiles', 'totalMax', 'maxCombined']
+    const all: Array<[string, ModelArchetype, string]> = [
+      ...CHANNELS_2_0,
+      ...CHANNELS_2_5.map(([label, archetype]): [string, ModelArchetype, string] => [label, archetype, 'omni']),
+    ]
+    for (const [vendor, archetype, modeId] of all) {
+      const omni = omniOf(archetype, modeId)
+      for (const key of suspects) {
+        expect(omni, `${vendor} 缺少全能参考模式`).toBeDefined()
+        expect(Object.hasOwn(omni as object, key), `${vendor} 出现了 ${key}：合计上限已于 2026-08-20 证伪`).toBe(false)
+      }
+      // 各槽上限之和就是文档写的「参考素材数量上限」（2.0=15、2.5=50），不存在更紧的合计约束。
+      const sum = (omni?.slots ?? []).reduce((total, slot) => total + slot.max, 0)
+      expect(sum, `${vendor} 各槽上限之和应等于文档的参考素材数量上限`).toBe(vendor.startsWith('2.5') ? 50 : 15)
+    }
+  })
+})

--- a/src/config/modelArchetypes/seedance25.ts
+++ b/src/config/modelArchetypes/seedance25.ts
@@ -4,7 +4,8 @@ import type { ModelArchetype } from "./types";
 // Seedance 2.5 档案。契约逐项对账自**两家**官方文档（2026-08-12 复核，用户给的链接）：
 //   - kie:     docs.kie.ai/market/bytedance/seedance-2-5 · POST /api/v1/jobs/createTask
 //              input.reference_image_urls / reference_video_urls / reference_audio_urls = 30 / 10 / 10
-//   - apimart: docs.apimart.ai/cn/api-reference/videos/doubao-seedance-2-5 · POST /v1/videos/generations
+//   - apimart: docs.apimart.ai/en/api-reference/videos/seedance-2-5/generation · POST /v1/videos/generations
+//              （原 /cn/.../doubao-seedance-2-5 已 404，2026-08-20 复核后更新为现行路径；30/10/10 未变）
 //              image_urls / video_urls / audio_urls = 30 / 10 / 10（另有 image_with_roles 表达首尾帧）
 //
 // ⚠️ 2026-08-12 修正：此前写 9 图 / 3 视频 / 3 音频、比例默认 16:9——**两处都不是文档里的数**，
@@ -69,8 +70,9 @@ export const SEEDANCE_2_5_ARCHETYPE: ModelArchetype = {
       covers: "POST /api/v1/jobs/createTask；input.reference_image_urls/_video_/_audio_ 上限 30/10/10；aspect_ratio 默认 adaptive；首尾帧与多模态参考互斥",
     },
     {
-      url: "https://docs.apimart.ai/cn/api-reference/videos/doubao-seedance-2-5",
-      checkedAt: "2026-08-12",
+      // 原 /cn/api-reference/videos/doubao-seedance-2-5 已 404（2026-08-20 复核），文档搬到这个路径。
+      url: "https://docs.apimart.ai/en/api-reference/videos/seedance-2-5/generation",
+      checkedAt: "2026-08-20",
       vendorKey: "apimart",
       covers: "POST /v1/videos/generations；image_urls/video_urls/audio_urls 上限 30/10/10；image_with_roles 表首尾帧；首尾帧与参考编辑类提示词下 size 必须 adaptive",
     },
@@ -127,6 +129,9 @@ export const SEEDANCE_2_5_ARCHETYPE: ModelArchetype = {
       slots: [
         { kind: "image_ref", label: "角色参考", min: 0, max: 30, characterIndexed: true },
         { kind: "video_ref", label: "参考视频", min: 0, max: 10 },
+        // **故意不声明 requiresAnyOf**：2.0 的参考音频必须搭配图/视频，2.5 明确解除了
+        // （方舟「Seedance 2.5 新增支持纯音频参考生成视频，无需搭配图片或视频素材」；APIMart "audio-only OK"）。
+        // 别在"对齐两代"时补回来——seedance20Contract.test.ts 有负向钉子拦着。
         { kind: "audio_ref", label: "参考音频", min: 0, max: 10 },
       ],
       params: PARAMS,

--- a/src/config/modelArchetypes/seedanceApimart.ts
+++ b/src/config/modelArchetypes/seedanceApimart.ts
@@ -38,7 +38,9 @@ const SEEDANCE_2_APIMART_MODES: ModelArchetype["modes"] = [
     slots: [
       { kind: "image_ref", label: "角色参考", min: 0, max: 9, characterIndexed: true, inputKey: "image_urls" },
       { kind: "video_ref", label: "参考视频", min: 0, max: 3, inputKey: "video_urls" },
-      { kind: "audio_ref", label: "参考音频", min: 0, max: 3, inputKey: "audio_urls" },
+      // 音频不能单独用（文档原文 "Must be used together with reference images or reference videos"，
+      // 方舟同义：「不支持"文本+音频"、"纯音频" 输入」）。2.5 已解除此限，故声明而非写死（见 types 注释）。
+      { kind: "audio_ref", label: "参考音频", min: 0, max: 3, inputKey: "audio_urls", requiresAnyOf: ["image_ref", "video_ref"] },
     ],
     params: PARAMS,
   },

--- a/src/config/modelArchetypes/seedanceVolcengine.ts
+++ b/src/config/modelArchetypes/seedanceVolcengine.ts
@@ -48,7 +48,9 @@ const MODES: ModelArchetype["modes"] = [
     slots: [
       { kind: "image_ref", label: "角色参考", min: 0, max: 9, characterIndexed: true, inputKey: "volcengine_image_contents" },
       { kind: "video_ref", label: "参考视频", min: 0, max: 3, inputKey: "volcengine_video_contents" },
-      { kind: "audio_ref", label: "参考音频", min: 0, max: 3, inputKey: "volcengine_audio_contents" },
+      // 音频不能单独用：方舟原文「您可任意组合以下模态内容，注意不支持"文本+音频"、"纯音频" 输入。」
+      // （docs.volcengine.com/docs/82379/2291680）。2.5 已解除此限，故声明而非写死（见 types 注释）。
+      { kind: "audio_ref", label: "参考音频", min: 0, max: 3, inputKey: "volcengine_audio_contents", requiresAnyOf: ["image_ref", "video_ref"] },
     ],
     params: PARAMS,
   },

--- a/src/config/modelArchetypes/types.ts
+++ b/src/config/modelArchetypes/types.ts
@@ -38,6 +38,21 @@ export type ArchetypeReferenceSlot = {
    *  仅角色槽为 true（Seedance 全能参考、HappyHorse 角色参考）；普通参考图（如 video-edit 的参考图）为 false。 */
   characterIndexed?: boolean;
   /**
+   * **跨槽依赖**（模型级契约，供应商无关）：本槽有值时，这里列出的 kind 的槽**至少一个**也必须有值，
+   * 否则该模型不受理。缺省 = 无依赖，本槽可单独使用（绝大多数槽如此）。
+   *
+   * 首例：Seedance 2.0 的参考音频不能单独用（火山方舟「不支持"文本+音频"、"纯音频" 输入」/
+   * APIMart "Must be used together with reference images or reference videos"）→
+   * `audio_ref` 声明 `requiresAnyOf: ['image_ref', 'video_ref']`。**Seedance 2.5 已解除此限**
+   * （方舟「新增支持纯音频参考生成视频」）→ 2.5 不声明。正因为同族两代不同，才必须是**声明**而非写死的 if。
+   *
+   * 语义是**析取**（任一即可），因为三家原文都是「图片**或**视频」。判定见 archetypeMeta 的
+   * `unmetReferenceDependency`；它同时喂 canRunGenerationNode 与 composer 的置灰文案（单一真相源）。
+   * 注意这是**依赖**不是**容量**：容量（max）满了就该在放入那一刻拦，依赖不满足只该拦生成 ——
+   * 用户先拖音频再拖图片是合理顺序，在第一步拦死等于惩罚操作顺序。
+   */
+  requiresAnyOf?: ArchetypeReferenceSlotKind[];
+  /**
    * **角色数组合并用**（配合 mode.combineSlotsInto）：该槽在合并出的对象数组里的 `role` 字段值。
    * **缺省由 kind 派生**（first_frame→first_frame、last_frame→last_frame、image_ref→reference_image，
    * 见 archetypeMeta DEFAULT_ROLE_FOR_KIND）——故绝大多数情况不写，避免 role 与 kind 两条平行真相源（P1）。

--- a/src/i18n/locales/generationCommon.ts
+++ b/src/i18n/locales/generationCommon.ts
@@ -550,6 +550,10 @@ export const zhGenerationCommon = {
     rewritePlaceholder: '改写要求…（先在正文里选中要改的文字）',
     replacePlaceholder: '重写要求…（替换整篇）',
     videoReferenceRequired: '需要先添加参考素材（拖入 / 连线 / 点 +）',
+    // 跨槽依赖（档案 slot.requiresAnyOf）。槽名与伴随项都由档案声明 derive，不写死「音频」——
+    // 换个模型声明别的依赖，这句照样说得对。
+    referenceCompanionRequired: '{{slot}}不能单独使用，还需要{{companions}}',
+    companionOr: '或',
     videoFirstFrameRequired: '需要先连接一个图片节点作为首帧',
     promptReferenceUnsupported: '当前模型不支持参考图，已只应用提示词文本',
     imageReferenceRequired: '图生图需要参考图（拖入 / 连线 / 点 +），或切回「文生图」',
@@ -1795,6 +1799,8 @@ export const enGenerationCommon = {
     rewritePlaceholder: 'Describe how to revise… (select text in the document first)',
     replacePlaceholder: 'Describe how to rewrite the entire document…',
     videoReferenceRequired: 'Add a reference first (drag, connect, or click +)',
+    referenceCompanionRequired: '{{slot}} cannot be used on its own — add {{companions}} as well',
+    companionOr: ' or ',
     videoFirstFrameRequired: 'Connect an image node as the first frame',
     promptReferenceUnsupported: 'This model does not accept reference images; only the prompt text was applied',
     imageReferenceRequired:

--- a/src/workbench/generationCanvas/nodes/NodeGenerationComposer.tsx
+++ b/src/workbench/generationCanvas/nodes/NodeGenerationComposer.tsx
@@ -13,7 +13,8 @@ import { useAllProjectAssets } from '../../assets/useAllProjectAssets'
 import { useNodeMentionSource } from './useNodeMentionSource'
 import type { GenerationCanvasNode } from '../model/generationCanvasTypes'
 import { useGenerationCanvasStore } from '../store/generationCanvasStore'
-import { canRunGenerationNode, confirmAndRunNode, confirmAndRunNodeVariants, regenerateNodeInPlace } from '../runner/generationRunController'
+import { canRunGenerationNode, confirmAndRunNode, confirmAndRunNodeVariants, regenerateNodeInPlace, unmetReferenceDependencyForNode } from '../runner/generationRunController'
+import type { UnmetReferenceDependency } from './controls/referenceDependency'
 import { collectUngeneratedReferenceAncestors } from '../runner/referenceAncestors'
 import { buildDependencyWaves } from '../runner/dependencyWaves'
 import { useBatchPlanPreviewStore } from '../components/batchPlanPreview'
@@ -269,6 +270,17 @@ export default function NodeGenerationComposer({ node, visualSize }: Props): JSX
   const canGenerate = useGenerationCanvasStore((state) =>
     canRunGenerationNode(node, { nodes: state.nodes, edges: state.edges }),
   ) && !isGenerating
+  // 跨槽依赖未满足（档案 slot.requiresAnyOf；如 Seedance 2.0 只放了参考音频、缺图/视频）。
+  // 与 canGenerate 同一个判定（unmetReferenceDependencyForNode），composer 不再按 node.kind 重猜原因。
+  // 订阅**字符串**而非对象：对象选择器每帧新引用会破坏 v0.7.2 的 primitive 订阅防抖；
+  // 文案仍留到渲染时用 t() 格式化，保证切语言能实时重渲。
+  const unmetDependencyKey = useGenerationCanvasStore((state) =>
+    JSON.stringify(unmetReferenceDependencyForNode(node, { nodes: state.nodes, edges: state.edges })),
+  )
+  const unmetDependency = React.useMemo(
+    () => JSON.parse(unmetDependencyKey) as UnmetReferenceDependency | null,
+    [unmetDependencyKey],
+  )
   // 自动备齐参考（对话 2026-06-14）：本节点经参考边、尚未出图的上游 id（稳定 key 订阅防抖）。
   // 有则「生成」不裸跑，转而排依赖波次（参考先生成→本节点后生成）走批量确认条。
   const pendingRefKey = useGenerationCanvasStore((state) =>
@@ -680,7 +692,12 @@ export default function NodeGenerationComposer({ node, visualSize }: Props): JSX
           />
         ) : null}
         {(() => {
-          const disabledReason = !canGenerateNow && !isGenerating
+          const disabledReason = unmetDependency
+            ? t('generationCommon.composer.referenceCompanionRequired', {
+                slot: unmetDependency.slotLabel,
+                companions: unmetDependency.companionLabels.join(t('generationCommon.composer.companionOr')),
+              })
+            : !canGenerateNow && !isGenerating
             ? nodeExecutionKind === 'video'
               ? acceptsDrop
                 ? t('generationCommon.composer.videoReferenceRequired')

--- a/src/workbench/generationCanvas/nodes/controls/archetypeMeta.test.ts
+++ b/src/workbench/generationCanvas/nodes/controls/archetypeMeta.test.ts
@@ -131,7 +131,9 @@ describe('C3 全能参考 — 数组槽声明', () => {
     expect(OMNI.slots).toEqual([
       { kind: 'image_ref', label: '角色参考', min: 0, max: 9, characterIndexed: true },
       { kind: 'video_ref', label: '参考视频', min: 0, max: 3 },
-      { kind: 'audio_ref', label: '参考音频', min: 0, max: 3 },
+      // requiresAnyOf：Seedance 2.0 的参考音频不能单独用（三家官方文档一致，2026-08-20 核实；
+      // 2.5 已解除）。判定见 referenceDependency.ts，契约见 seedance20Contract.test.ts。
+      { kind: 'audio_ref', label: '参考音频', min: 0, max: 3, requiresAnyOf: ['image_ref', 'video_ref'] },
     ])
     const arr = archetypeModeArraySlots(OMNI)
     expect(arr.map((s) => [s.metaKey, s.max, s.numbered])).toEqual([

--- a/src/workbench/generationCanvas/nodes/controls/referenceDependency.test.ts
+++ b/src/workbench/generationCanvas/nodes/controls/referenceDependency.test.ts
@@ -1,0 +1,93 @@
+// 跨槽依赖判定（slot.requiresAnyOf）的单元测试。
+// 覆盖的真实缺陷：Seedance 2.0 omni 只放一段参考音频 → 此前 canRunGenerationNode 只问「任一数组槽非空」
+// 判定可生成 → 发出去被服务商拒（方舟「不支持"纯音频"输入」）。
+import { describe, expect, it } from 'vitest'
+import { filledReferenceKinds, nodeUnmetReferenceDependency, unmetReferenceDependency } from './referenceDependency'
+import { SEEDANCE_2_APIMART_ARCHETYPE } from '../../../../config/modelArchetypes/seedanceApimart'
+import { SEEDANCE_2_5_ARCHETYPE } from '../../../../config/modelArchetypes/seedance25'
+import type { ArchetypeMode } from '../../../../config/modelArchetypes'
+
+const omniOf = (archetype: { modes: ArchetypeMode[] }, id: string) =>
+  archetype.modes.find((mode) => mode.id === id) as ArchetypeMode
+
+const OMNI_2_0 = omniOf(SEEDANCE_2_APIMART_ARCHETYPE, 'omni')
+const OMNI_2_5 = omniOf(SEEDANCE_2_5_ARCHETYPE, 'omni')
+const metaFor = (modeId: string, extra: Record<string, unknown> = {}) => ({
+  archetype: { id: SEEDANCE_2_APIMART_ARCHETYPE.id, modeId },
+  ...extra,
+})
+
+describe('unmetReferenceDependency', () => {
+  it('flags audio-only as unmet, naming the slot and its companions', () => {
+    const unmet = unmetReferenceDependency(OMNI_2_0, new Set(['audio_ref']))
+    expect(unmet).not.toBeNull()
+    expect(unmet?.slotLabel).toBe('参考音频')
+    expect(unmet?.companionLabels).toEqual(['角色参考', '参考视频'])
+  })
+
+  it.each([
+    ['an image', 'image_ref'],
+    ['a video', 'video_ref'],
+  ])('is satisfied when audio is accompanied by %s (析取：任一即可)', (_label, companion) => {
+    expect(unmetReferenceDependency(OMNI_2_0, new Set(['audio_ref', companion]))).toBeNull()
+  })
+
+  it('says nothing when the dependent slot itself is empty', () => {
+    // 没放音频 → 依赖无从谈起；只放图片是完全合法的 omni 用法，不能因为「有依赖声明」就报。
+    expect(unmetReferenceDependency(OMNI_2_0, new Set(['image_ref']))).toBeNull()
+    expect(unmetReferenceDependency(OMNI_2_0, new Set())).toBeNull()
+  })
+
+  it('lets 2.5 run on audio alone — the docs lifted that limit', () => {
+    expect(unmetReferenceDependency(OMNI_2_5, new Set(['audio_ref']))).toBeNull()
+  })
+
+  it('is a no-op for modes that declare no dependency at all', () => {
+    const i2v = omniOf(SEEDANCE_2_APIMART_ARCHETYPE, 'i2v')
+    expect(unmetReferenceDependency(i2v, new Set(['image_ref']))).toBeNull()
+  })
+})
+
+describe('filledReferenceKinds', () => {
+  it('counts manual uploads stored in meta', () => {
+    const filled = filledReferenceKinds(metaFor('omni', { referenceAudioUrls: ['nomi-local://a.mp3'] }), OMNI_2_0)
+    expect([...filled]).toEqual(['audio_ref'])
+  })
+
+  it('counts references arriving over canvas edges, not just meta uploads', () => {
+    // 关键：用户**连了**一个图片节点进来，伴随要求就该算满足。只读 meta 会把连线来的图当不存在 → 误拦。
+    const filled = filledReferenceKinds(metaFor('omni', { referenceAudioUrls: ['a.mp3'] }), OMNI_2_0, {
+      referenceImages: ['https://example.com/from-edge.png'],
+    })
+    expect(filled.has('image_ref')).toBe(true)
+    expect(filled.has('audio_ref')).toBe(true)
+  })
+
+  it('ignores empty strings and non-array junk in meta', () => {
+    const filled = filledReferenceKinds(
+      metaFor('omni', { referenceAudioUrls: ['  '], referenceImageUrls: 'not-an-array' }),
+      OMNI_2_0,
+    )
+    expect([...filled]).toEqual([])
+  })
+})
+
+describe('nodeUnmetReferenceDependency', () => {
+  it('blocks audio-only on 2.0 and clears once an edge-borne image arrives', () => {
+    const meta = metaFor('omni', { referenceAudioUrls: ['nomi-local://vo.mp3'] })
+    expect(nodeUnmetReferenceDependency(meta, SEEDANCE_2_APIMART_ARCHETYPE)?.slotLabel).toBe('参考音频')
+    expect(
+      nodeUnmetReferenceDependency(meta, SEEDANCE_2_APIMART_ARCHETYPE, { referenceImages: ['https://x/1.png'] }),
+    ).toBeNull()
+  })
+
+  it('returns null when the node has no archetype (不接管无档案模型)', () => {
+    expect(nodeUnmetReferenceDependency({}, null)).toBeNull()
+  })
+
+  it('does not leak the dependency across modes — t2v has no slots at all', () => {
+    // 参考值全局持久（切模式不清空），所以残留的 referenceAudioUrls 不能让 t2v 被误判成"缺伴随"。
+    const meta = metaFor('t2v', { referenceAudioUrls: ['nomi-local://vo.mp3'] })
+    expect(nodeUnmetReferenceDependency(meta, SEEDANCE_2_APIMART_ARCHETYPE)).toBeNull()
+  })
+})

--- a/src/workbench/generationCanvas/nodes/controls/referenceDependency.ts
+++ b/src/workbench/generationCanvas/nodes/controls/referenceDependency.ts
@@ -1,0 +1,99 @@
+// **跨槽依赖判定的单一真相源**（档案 `slot.requiresAnyOf` 的运行时对应物）。
+//
+// 为什么单独一个模块：这份判断有**两个消费者**——① `canRunGenerationNode` 决定生成钮能不能点、
+// ② composer 决定置灰时说哪句人话。此前 composer 是按 `node.kind + acceptsDrop` **重猜**一遍原因
+// （NodeGenerationComposer 的 disabledReason），跟闸门各算各的；新约束一进来猜出来的必然是错的
+// （会说「需要先添加参考素材」，可用户明明加了音频）。两边同吃这里，杜绝再分家。
+//
+// 判定必须同时看**连线**与**上传**两个来源：用户连了一个图片节点进来，伴随要求就该算满足，
+// 只读 meta（hasArchetypeArrayReferences 的口径）会把连线来的图当不存在 → 误拦。
+import type { ArchetypeMode, ArchetypeReferenceSlotKind, ModelArchetype } from '../../../../config/modelArchetypes'
+import { currentArchetypeMode, readArchetypeArray, referenceSlotStorage } from './archetypeMeta'
+import { translateModelDisplayText } from '../../../../i18n/modelDisplayText'
+
+/** 未满足跨槽依赖的槽 + 它缺的伴随项（析取：任一即可）。标签已本地化，可直接进文案。 */
+export type UnmetReferenceDependency = {
+  /** 有值却缺伴随的那个槽，如「参考音频」。 */
+  slotLabel: string
+  /** 缺的伴随槽标签，如 ['角色参考', '参考视频']；语义是**或**。 */
+  companionLabels: string[]
+}
+
+/** 连线解析出的参考（ResolvedGenerationReferences 的子集，只取本判定要用的几项）。 */
+export type EdgeReferenceCounts = {
+  referenceImages?: readonly string[]
+  referenceVideos?: readonly string[]
+  referenceAudios?: readonly string[]
+  firstFrameUrl?: string | null
+  lastFrameUrl?: string | null
+}
+
+/** 当前模式里「已经有值」的槽 kind 集合（连线 + 上传合并）。 */
+export function filledReferenceKinds(
+  meta: Record<string, unknown> | undefined,
+  mode: ArchetypeMode,
+  fromEdges?: EdgeReferenceCounts,
+): Set<ArchetypeReferenceSlotKind> {
+  const filled = new Set<ArchetypeReferenceSlotKind>()
+  for (const slot of mode.slots) {
+    const storage = referenceSlotStorage(slot)
+    if (!storage) continue
+    const uploaded = storage.isArray
+      ? readArchetypeArray(meta, storage.metaKey).length > 0
+      : typeof meta?.[storage.metaKey] === 'string' && (meta[storage.metaKey] as string).trim().length > 0
+    if (uploaded) {
+      filled.add(slot.kind)
+      continue
+    }
+    // 连线来源：按槽的资产类型取对应那条（image/video/audio 各走各的，别混）。
+    const fromEdge =
+      slot.kind === 'image_ref'
+        ? fromEdges?.referenceImages?.length
+        : slot.kind === 'video_ref' || slot.kind === 'source_video'
+          ? fromEdges?.referenceVideos?.length
+          : slot.kind === 'audio_ref'
+            ? fromEdges?.referenceAudios?.length
+            : slot.kind === 'first_frame'
+              ? (fromEdges?.firstFrameUrl || '').length
+              : slot.kind === 'last_frame'
+                ? (fromEdges?.lastFrameUrl || '').length
+                : 0
+    if (fromEdge) filled.add(slot.kind)
+  }
+  return filled
+}
+
+/**
+ * 当前模式里第一个「自己有值、但伴随项一个都没有」的槽。全部满足（或没有任何依赖声明）→ null。
+ * 纯函数：不碰 store，好测。
+ */
+export function unmetReferenceDependency(
+  mode: ArchetypeMode,
+  filledKinds: ReadonlySet<ArchetypeReferenceSlotKind>,
+): UnmetReferenceDependency | null {
+  for (const slot of mode.slots) {
+    const requires = slot.requiresAnyOf
+    if (!requires?.length) continue
+    if (!filledKinds.has(slot.kind)) continue // 本槽空 → 依赖无从谈起
+    if (requires.some((kind) => filledKinds.has(kind))) continue // 析取：任一满足即可
+    return {
+      slotLabel: translateModelDisplayText(slot.label),
+      companionLabels: requires
+        .map((kind) => mode.slots.find((s) => s.kind === kind)?.label)
+        .filter((label): label is string => Boolean(label))
+        .map(translateModelDisplayText),
+    }
+  }
+  return null
+}
+
+/** 节点级便利入口：解析当前模式 → 算已填 kind → 判依赖。无档案 → null（不接管）。 */
+export function nodeUnmetReferenceDependency(
+  meta: Record<string, unknown> | undefined,
+  archetype: ModelArchetype | null | undefined,
+  fromEdges?: EdgeReferenceCounts,
+): UnmetReferenceDependency | null {
+  if (!archetype) return null
+  const mode = currentArchetypeMode(archetype, meta)
+  return unmetReferenceDependency(mode, filledReferenceKinds(meta, mode, fromEdges))
+}

--- a/src/workbench/generationCanvas/runner/generationRunController.ts
+++ b/src/workbench/generationCanvas/runner/generationRunController.ts
@@ -30,6 +30,10 @@ import {
   currentArchetypeMode,
   hasArchetypeArrayReferences,
 } from '../nodes/controls/archetypeMeta'
+import {
+  nodeUnmetReferenceDependency,
+  type UnmetReferenceDependency,
+} from '../nodes/controls/referenceDependency'
 import { resolveTaskArchetype } from './catalogTaskResolve'
 import type { GenerationNodeKind } from '../model/generationCanvasTypes'
 import i18n from '../../../i18n'
@@ -594,10 +598,28 @@ export function canRunGenerationNode(
   // 有参考槽的模式（i2v/首尾帧/全能参考 omni）→ 需至少一个参考。omni 靠参考数组（referenceImageUrls 等），
   // 单看 resolveGenerationReferences 看不到 → 补一条档案数组判断（否则已放参考的 omni 被误判不可生成）。
   const references = resolveGenerationReferences(node, context)
-  return Boolean(
+  const hasAnyReference = Boolean(
     references.firstFrameUrl ||
     references.lastFrameUrl ||
     references.referenceImages.length > 0 ||
     (archetype && hasArchetypeArrayReferences(meta, archetype)),
   )
+  if (!hasAnyReference) return false
+  // 跨槽依赖（档案 slot.requiresAnyOf）：有参考 ≠ 组合合法。Seedance 2.0 的参考音频必须搭配图或视频
+  // （方舟「不支持"文本+音频"、"纯音频" 输入」/ APIMart "Must be used together with reference images
+  // or reference videos"），只放一段音频此前会被判可生成、发出去才被服务商拒。2.5 已解除，故按档案声明判、
+  // 不写死模型名。置灰文案取同一判定（unmetReferenceDependencyForNode），不让 composer 再猜一遍。
+  return !unmetReferenceDependencyForNode(node, context)
+}
+
+/**
+ * 该节点当前有没有「有值却缺伴随」的参考槽（档案 slot.requiresAnyOf）。
+ * `canRunGenerationNode` 用它决定能不能点，composer 用它决定置灰时说哪句人话 —— **同一个判定**。
+ */
+export function unmetReferenceDependencyForNode(
+  node: GenerationCanvasNode,
+  context: GenerationRunContext = {},
+): UnmetReferenceDependency | null {
+  const meta = node.meta || {}
+  return nodeUnmetReferenceDependency(meta, resolveTaskArchetype(meta), resolveGenerationReferences(node, context))
 }

--- a/tests/ux/reference-companion-required.walk.mjs
+++ b/tests/ux/reference-companion-required.walk.mjs
@@ -1,0 +1,215 @@
+// 穿透走查（规则 13）—— 跨槽依赖：Seedance 2.0 的参考音频不能单独用。**零额度**（全程不点生成）。
+//
+// 覆盖的真实缺陷（2026-08-20）：omni 模式只放一段参考音频时，`canRunGenerationNode` 此前只问
+// 「任一数组槽非空」→ 判定可生成 → 生成钮亮着 → 用户点下去，钱花了、请求被服务商拒。
+// 三家官方文档一致：
+//   火山方舟 https://docs.volcengine.com/docs/82379/2291680 「注意不支持"文本+音频"、"纯音频" 输入」
+//   APIMart  "Must be used together with reference images or reference videos"
+//   fal      "requires at least one image or video"
+// （Seedance 2.5 已解除此限，故做成档案声明 slot.requiresAnyOf，不是写死的 if。）
+//
+// 这份走查验的是**用户真能看见的那一层**，不是断言函数返回值：
+//   ① 只放音频 → 生成钮**真的**置灰（disabled 属性）；
+//   ② 置灰时鼠标悬停给的原因**说人话且说得具体**——「参考音频不能单独使用，还需要角色参考或参考视频」，
+//      而不是泛泛的「需要先添加参考素材」（用户明明加了音频，那句话会把人往沟里带）；
+//   ③ 补一张图 → 立刻可生成（约束是"缺伴随"，不是"音频有毒"）。
+//
+// 用法：pnpm run build && node tests/ux/reference-companion-required.walk.mjs
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { launchNomiApp } from './_launchApp.mjs'
+import { expect, expectVisible, expectAbsent, proveProbe, clickOrFail } from './_assert.mjs'
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
+const shotsDir = path.join(repoRoot, 'tests/ux/shots/reference-companion-required')
+// 每次跑清空产出：上一轮的 PNG 留在盘里会被当成这一轮的产出去对账（眼见链的第一个坑）。
+fs.rmSync(shotsDir, { recursive: true, force: true })
+fs.mkdirSync(shotsDir, { recursive: true })
+
+const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'nomi-companion-'))
+const userDataDir = path.join(tempRoot, 'user-data')
+const projectsDir = path.join(tempRoot, 'projects')
+fs.mkdirSync(projectsDir, { recursive: true })
+
+/** 最小合法 WAV（44 字节头 + 一点 PCM）。真文件，走真上传管线，不是 stub。 */
+function writeTinyWav(target) {
+  const samples = 800 // 8kHz 单声道 16bit ≈ 0.1s
+  const data = Buffer.alloc(samples * 2)
+  const header = Buffer.alloc(44)
+  header.write('RIFF', 0)
+  header.writeUInt32LE(36 + data.length, 4)
+  header.write('WAVE', 8)
+  header.write('fmt ', 12)
+  header.writeUInt32LE(16, 16)
+  header.writeUInt16LE(1, 20) // PCM
+  header.writeUInt16LE(1, 22) // mono
+  header.writeUInt32LE(8000, 24)
+  header.writeUInt32LE(16000, 28)
+  header.writeUInt16LE(2, 32)
+  header.writeUInt16LE(16, 34)
+  header.write('data', 36)
+  header.writeUInt32LE(data.length, 40)
+  fs.writeFileSync(target, Buffer.concat([header, data]))
+}
+
+const { app, win } = await launchNomiApp({
+  name: 'reference-companion-required',
+  userDataDir,
+  settingsDir: userDataDir,
+  projectsDir,
+  args: ['--no-proxy-server'],
+  settleMs: 0,
+})
+
+let passed = 0
+function record(label, detail = '') {
+  passed += 1
+  console.log(`  ✓ ${label}${detail ? ` — ${detail}` : ''}`)
+}
+
+let shotIndex = 0
+async function shot(tag) {
+  shotIndex += 1
+  await win.screenshot({ path: path.join(shotsDir, `${String(shotIndex).padStart(2, '0')}-${tag}.png`) })
+}
+
+const composer = win.locator('.generation-canvas-v2-node__composer')
+const modeGroup = composer.locator('[role="group"][aria-label="生成方式"]')
+const activeMode = modeGroup.locator('button[aria-pressed="true"]')
+/**
+ * 参考 tile 的存在性锚点 = 它的「移除」按钮（`移除参考音频1` / `移除角色参考1`）。
+ * **不用 tile 自身的 aria-label**：只有 characterIndexed 的角色图 tile 才带（要支持拖拽重排），
+ * 音频 tile 根本没有那个属性 —— 探真实 DOM 才发现的，照角色图的写法猜必然找不到（本轮已栽过一次）。
+ */
+const tile = (label) => composer.locator(`button[aria-label="移除${label}"]`)
+/** 生成钮本体（原生 button），以及包着它、承载悬停原因的那层 span[title]。 */
+const generateButton = composer.locator('button[aria-label="生成素材"]')
+// 原因挂在**包着**生成钮的那层 span 的 title 上（悬停时用户看到的就是它），不在按钮自己身上。
+const generateTitle = composer.locator('span[title]:has(button[aria-label="生成素材"])')
+
+async function pickFromSelect(triggerLabel, match, humanLabel) {
+  await clickOrFail(composer.locator(`[aria-label="${triggerLabel}"]`), `${humanLabel}下拉`)
+  const options = win.locator('[role="option"]:visible')
+  await expect(options, `${humanLabel}下拉点开了却一个选项都没有`).not.toHaveCount(0)
+  const texts = (await options.allTextContents()).map((t) => t.trim())
+  const index = texts.findIndex(match)
+  if (index < 0) throw new Error(`WALK FAIL: ${humanLabel}下拉里没有目标选项。实际选项：${JSON.stringify(texts)}`)
+  await options.nth(index).click()
+  return texts[index]
+}
+
+/** 经素材选择器上传一个本地文件到当前节点的参考槽（与 archetype-modebar 同一条真实路径）。 */
+async function addReferenceFile(filePath, humanLabel) {
+  await clickOrFail(composer.locator('button[aria-label="加参考"]'), `omni 的「加参考」（${humanLabel}）`)
+  // 素材选择器里有两个 file input，只有带 aria-label 的那个是「上传本地文件」入口；挑错了会静默什么都不发生。
+  await win.locator('input[type="file"][aria-label="上传本地文件"]').first().setInputFiles(filePath)
+}
+
+try {
+  await win.waitForLoadState('domcontentloaded')
+  await win.waitForTimeout(1200)
+
+  // 占位 key：只为让 Seedance 2.0 进目录。全程不点生成 → 零额度。
+  await win.evaluate(() =>
+    window.nomiDesktop?.modelCatalog?.upsertVendorApiKey('kie', { apiKey: 'nomi-e2e-placeholder', enabled: true }),
+  )
+  await win.reload()
+  await win.waitForLoadState('domcontentloaded')
+  await win.waitForTimeout(1200)
+
+  const browserWindow = await app.browserWindow(win)
+  await browserWindow.evaluate((target) => {
+    target.setBounds({ x: 0, y: 0, width: 1600, height: 1050 })
+    target.center()
+  })
+
+  // ── 进场：新建空白项目 → 生成画布 → 视频节点 → Seedance 2.0 → 全能参考 ──────
+  await clickOrFail(win.locator('button, [role="button"]', { hasText: '新建空白项目' }), '新建空白项目')
+  await clickOrFail(win.getByRole('button', { name: '生成', exact: true }), '顶栏「生成」')
+  await expectVisible(win.locator('.generation-canvas-v2-toolbar'), '生成画布工具栏出现')
+  await clickOrFail(win.locator('.generation-canvas-v2-toolbar button[data-node-kind="video"]'), '工具条「视频」')
+  await expectVisible(composer, '视频节点的浮动 composer 出现')
+
+  const pickedModel = await pickFromSelect('模型', (t) => t.startsWith('Seedance 2.0'), '模型')
+  await expect(composer.locator('[aria-label="模型"]'), '模型芯片没变成 Seedance 2.0').toHaveText(/Seedance 2\.0/)
+  await clickOrFail(modeGroup.locator('button', { hasText: '全能参考' }), '模式「全能参考」')
+  await expect(activeMode, '点了「全能参考」但分段条的选中项没换过去').toHaveText('全能参考')
+  record('进场：新建项目 → 视频节点 → Seedance 2.0 → 全能参考', pickedModel)
+  await shot('omni-empty')
+
+  // 先证探针活着：生成钮在这一屏确实找得到。
+  // 否则后面「它是 disabled」的断言可能只是因为压根没找到这个元素（恒真的空话）。
+  const buttonProof = await proveProbe(generateButton, '全能参考模式下生成钮确实存在')
+  record('探针基线：生成钮在这一屏找得到', buttonProof.label)
+
+  // 基线：**一个参考都没有**的 omni 走的仍是原来那句泛化文案。
+  // 这条钉的是「新约束没有把老路径吃掉」——具体原因只该在它真的适用时替换掉泛化原因。
+  // （顺带：这也是本轮唯一靠肉眼看截图分辨不出来的一处——置灰与否在缩略图上几乎同色，
+  //   所以改成机器断言，别用"我看着像"结账。）
+  await expect(generateButton, '空 omni 本就该置灰（一个参考都没有）').toBeDisabled()
+  await expect(generateTitle, '空 omni 的原因应当是原来那句泛化文案，不该被新约束顶掉')
+    .toHaveAttribute('title', '需要先添加参考素材（拖入 / 连线 / 点 +）')
+  record('基线：空 omni → 置灰 + 泛化文案「需要先添加参考素材」')
+
+  // ── ① 只放一段参考音频 ────────────────────────────────────────────────
+  const tmpWav = path.join(tempRoot, 'voice.wav')
+  writeTinyWav(tmpWav)
+  await addReferenceFile(tmpWav, '音频')
+  await expectVisible(tile('参考音频1'), '上传后参考音频 tile 出现（音频真的进了 audio_ref 槽）')
+  await win.keyboard.press('Escape') // 关掉素材选择器，别盖住 composer
+  record('往 omni 放入一段参考音频（且只有音频）')
+  await shot('audio-only')
+
+  // 断言前先证明「我确实在我以为的现场」：音频进去了、图和视频都还是空的。
+  // 少了这一步，下面的置灰可能是别的原因（比如根本没上传成功 = 一个参考都没有）造成的。
+  //
+  // 用同屏对照物证探针（_assert 的用法②）：`移除X` 这套定位器**在这一屏确实找得到东西**
+  // ——音频 tile 的移除钮就在那。证过之后，「找不到角色参考/参考视频」才是真的没有，
+  // 而不是"这套选择器在本屏根本不生效"。
+  const removeProbeAlive = await proveProbe(tile('参考音频1'), '同屏对照：`移除…` 这套探针在本屏是活的')
+  await expectAbsent(tile('角色参考1'), {
+    provenBy: removeProbeAlive,
+    message: '这一刻不该有任何角色参考图——否则验的就不是"纯音频"了',
+  })
+  await expectAbsent(tile('参考视频1'), {
+    provenBy: removeProbeAlive,
+    message: '这一刻不该有任何参考视频——否则验的就不是"纯音频"了',
+  })
+  record('现场确认：音频已入槽，图/视频两槽都是空的（验的确实是"纯音频"）')
+
+  // ② 生成钮必须置灰
+  await expect(generateButton, '只放参考音频时生成钮仍可点 → 用户会付费发出一个必被拒的请求').toBeDisabled()
+  record('只放参考音频 → 生成钮置灰')
+
+  // ③ 悬停原因要说人话、且说得**具体**（不是泛泛的「需要先添加参考素材」）
+  await expect(generateTitle, '置灰了却不给具体原因，用户只能干瞪眼')
+    .toHaveAttribute('title', '参考音频不能单独使用，还需要角色参考或参考视频')
+  record('置灰原因说人话且具体：「参考音频不能单独使用，还需要角色参考或参考视频」')
+  await shot('audio-only-disabled')
+
+  // ── ④ 补一张图 → 依赖满足，立刻可生成 ─────────────────────────────────
+  // 这一条是"约束是否修得太狠"的反向保险：拦的是**缺伴随**，不是"有音频就不许生成"。
+  const tmpPng = path.join(tempRoot, 'char1.png')
+  fs.writeFileSync(
+    tmpPng,
+    Buffer.from('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==', 'base64'),
+  )
+  await addReferenceFile(tmpPng, '图片')
+  await expectVisible(tile('角色参考1'), '上传后角色图 tile 出现')
+  await win.keyboard.press('Escape')
+  await expect(generateButton, '音频 + 图片已凑齐，生成钮却还灰着 → 约束修过头了').toBeEnabled()
+  record('补一张角色参考图 → 依赖满足，生成钮立刻恢复可点')
+  await shot('audio-plus-image-enabled')
+
+  console.log(`\n✅ reference-companion-required 走查通过（${passed} 条）`)
+  console.log(`   截图：${path.relative(repoRoot, shotsDir)}`)
+} catch (error) {
+  await shot('failure')
+  console.error('\n❌ 走查失败：', error?.message || error)
+  process.exitCode = 1
+} finally {
+  await app.close()
+  fs.rmSync(tempRoot, { recursive: true, force: true })
+}


### PR DESCRIPTION
## 结论倒置：要补的那条约束，核实下来是伪的

原任务是「Seedance 2.0 漏了官方约束：所有模态参考文件合计不得超过 12」，据 fal 模型页原文
`"Total files across all modalities must not exceed 12."`。

按仓库既有判据（`seedance25Contract.test.ts` 头部：**三家一致才算模型级、才该钉在共享档案上**）
逐项核实我们真正在用的渠道：

| 来源 | 2.0 跨模态合计上限 | 原文 |
|---|---|---|
| **火山方舟**（字节自家，模型一手出处） | **15**（9图+3视频+3音频） | 「参考素材数量上限 \| Seedance 2.0 \| **15（9张图+3个视频+3个音频）**」 |
| **APIMart** | 无此条 | 全文只分别写 9/3/3 |
| **即梦 Dreamina** | 无公开 API 文档 | — |
| fal | 12 | 全局约束行 |

出处：[方舟 2607688](https://docs.volcengine.com/docs/82379/2607688?lang=zh)、[方舟 2298881](https://docs.volcengine.com/docs/82379/2298881?lang=zh)、[方舟 2291680](https://docs.volcengine.com/docs/82379/2291680?lang=zh)、[APIMart](https://docs.apimart.ai/en/api-reference/videos/seedance-2-0/generation.md)

两点：① 字节自己写的 15 **恰好等于 9+3+3**，合计上限与各槽之和相等 → **永不咬合**（2.5 同理，50=30+10+10）；
② `electron/catalog/` 的 vendor 只有 agnes/apimart/dreamina/modelscope/volcengine，**没有 fal**。

照 12 钉下去就是重演 2026-08-12 那次「能力是模型有的、被我们的档案掐窄」：
用户放满 9 图 + 3 视频后方舟说还能加 3 段音频，我们却在第 12 个拦死。**故不加合计上限**，
并加负向钉子把这条结论钉住，免得下一个人看到 fal 页面又来补一遍。

## 但同一次核实挖到一条真的、且当前完全没拦的

**Seedance 2.0 的参考音频不能单独用**，必须搭配至少一张图或一个视频——三家一致 = 模型级：

- 方舟：「注意不支持"文本+音频"、"纯音频" 输入」
- APIMart：`"Must be used together with reference images or reference videos"`
- fal：`"requires at least one image or video"`

**而 2.5 明确解除了**（方舟「新增支持纯音频参考生成视频」/ APIMart `"audio-only OK"`）。

缺口是实测的：`canRunGenerationNode` 只问 `hasArchetypeArrayReferences` =「任一数组槽非空」，
只放一段音频 → 判定可生成 → 用户付费发出 → 被服务商拒。跟原任务描述的病同一类，
只是触发条件不是 15 个文件而是 1 段音频。

## 改动

- `types.ts` 新增通用 `slot.requiresAnyOf`（跨槽依赖，析取语义，供应商无关，不为单个模型开特例）
- **四条** 2.0 渠道全部声明。⚠️ kie 那条（`seedance.ts:78`）**任务清单里没列**，
  是全仓实扫 `kind: "audio_ref"` 才发现的——P2 要求「扫，不猜」正是为这个
- 2.5 两条渠道**故意不声明** + 注释写明出处，负向钉子拦住"对齐两代"的手贱
- `referenceDependency.ts`：判定的单一真相源。`canRunGenerationNode` 与 composer 置灰文案**同吃它**
  ——此前 composer 按 `node.kind` 重猜原因，新约束一进来必然猜错成「需要先添加参考素材」
  （用户明明加了音频，那句话会把人往沟里带）
- **拦生成而非拦插入**：容量满了才该在放入那一刻拦；依赖不满足只该拦生成，
  否则「先拖音频再拖图」这个完全合理的顺序会被第一步拦死
- 顺带修 `seedance25` 的 `sources.url`（`docs.apimart.ai/cn/...` 已 404 → 现行路径 + `checkedAt`）

## 验证

- `pnpm run gates` 全过
- 契约测试 `seedance20Contract.test.ts` 23 条，**先红后绿**（3 条 requiresAnyOf 先红）
- 单测 `referenceDependency.test.ts` 12 条（含「切模式后残留值不得误判」「连线来源也算满足」）
- **R13 真机走查** `tests/ux/reference-companion-required.walk.mjs`，8 条断言零额度跑通：
  空 omni → 泛化文案 ／ 只放音频 → 置灰 + 具体文案 ／ 补一张图 → 立刻可生成

走查中两处修正已记进 plan 文档：音频 tile 没有 `aria-label`（得用移除钮当锚点）；
以及缩略图上置灰/可点几乎同色、我一度看错，故改成机器断言而非肉眼结账。

## 已知限制（诚实标出）

置灰原因只挂在 `title` 上，需**悬停**才看得到。与现有 `videoReferenceRequired` 等完全同构，
没引入更差的模式，但「为什么不能生成」的整体可发现性偏弱。要改成常驻可见需动 composer 信息层级
→ 属 R8（样张 + 拍板）范围，本轮不擅自动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)