### PR TITLE
feat: P4 S1 multi-shot plan schema and shot addressing

### DIFF
--- a/electron/productionRun/productionGenerationSubmission.ts
+++ b/electron/productionRun/productionGenerationSubmission.ts
@@ -33,6 +33,11 @@ export type GenerationSubmissionStartInput = {
   definitelyNotSubmitted?: boolean;
   /** Explicitly selected attempt; omitted means the latest durable attempt. */
   attempt?: number;
+  /**
+   * P4 S1 shot addressing: which shot's sub-contract to submit. Omitted = the default (single) shot,
+   * behaving exactly as the P1–P3 single-shot chain (top-level plan contract). Backward compatible.
+   */
+  shotId?: string;
 };
 
 export type GenerationSubmissionResult = {
@@ -91,6 +96,8 @@ export type GenerationNewAttemptInput = {
   projectId: string;
   operationId: string;
   reason: "submission_unknown" | "needs_attention";
+  /** P4 S1: which shot to re-attempt. Omitted = the default (single) shot — today's chain. */
+  shotId?: string;
 };
 
 export type GenerationNewAttemptResult = {
@@ -154,20 +161,38 @@ function requiredRun(repository: ProductionRunRepository, projectId: string, run
   return run;
 }
 
-function requiredContract(run: ProductionRun): ExecutionContractV1 {
+/**
+ * P4 S1: resolve the sub-contract this call addresses.
+ * - No shotId → the default (single) shot: top-level plan contract + plan-level receipt (today's chain).
+ * - shotId → that shot's sealed sub-contract + the shot's own receipt approval.
+ * Either way the plan must be sealed/submitted and the addressed unit must be approved before submit.
+ */
+function requiredContract(run: ProductionRun, shotId?: string): ExecutionContractV1 {
   const plan = run.generationPlan;
-  if (!plan?.contract || !plan.approvedReceiptId || (plan.state !== "sealed" && plan.state !== "submitted")) {
+  if (!plan || (plan.state !== "sealed" && plan.state !== "submitted")) {
     throw new Error("Seal and confirm the generation plan before starting");
   }
+  if (shotId) {
+    const shot = (plan.shots ?? []).find((candidate) => candidate.shotId === shotId);
+    if (!shot?.contract || !shot.approvedReceiptId) throw new Error("Seal and confirm the generation plan before starting");
+    return shot.contract;
+  }
+  if (!plan.contract || !plan.approvedReceiptId) throw new Error("Seal and confirm the generation plan before starting");
   return plan.contract;
 }
 
-function jobIdFor(runId: string, contractHash: string, attempt = 1): string {
-  return `generation-${runId}-${contractHash.slice(0, 16)}${attempt > 1 ? `-attempt-${attempt}` : ""}`;
+/**
+ * P4 S1 identity: shotId is part of the jobId so two shots with identical parameters (equal contract
+ * hash) never collide. The default shot keeps the legacy prefix (`generation-<run>-<hash16>`) so
+ * durable Runs and single-shot callers are byte-compatible; a named shot inserts `-<shotId>` after it.
+ */
+function jobIdFor(runId: string, contractHash: string, attempt = 1, shotId?: string): string {
+  const shotSegment = shotId ? `-${shotId}` : "";
+  return `generation-${runId}${shotSegment}-${contractHash.slice(0, 16)}${attempt > 1 ? `-attempt-${attempt}` : ""}`;
 }
 
-function latestGenerationAttempt(run: ProductionRun, contractHash: string): number {
-  const prefix = `generation-${run.runId}-${contractHash.slice(0, 16)}`;
+function latestGenerationAttempt(run: ProductionRun, contractHash: string, shotId?: string): number {
+  const prefix = jobIdFor(run.runId, contractHash, 1, shotId).replace(/-attempt-\d+$/, "");
   return run.jobs
     .filter((job) => job.jobId === prefix || job.jobId.startsWith(`${prefix}-attempt-`))
     .reduce((latest, job) => Math.max(latest, job.attempt), 0);
@@ -185,7 +210,12 @@ function isFailedProviderStatus(status: string): boolean {
   return ["failed", "error", "cancelled", "canceled", "rejected"].includes(status.trim().toLowerCase());
 }
 
-function ensureBinding(deps: ProductionGenerationSubmissionDependencies, run: ProductionRun, contract: ExecutionContractV1, jobId: string, attempt: number, fencingEpoch: number): ProductionExecutionBinding {
+/**
+ * The binding's `shotId` is the addressed shot (default shot → its jobId, keeping single-shot bindings
+ * byte-identical). The providerIdempotencyKey MUST include the shotId so two shots that hash identically
+ * derive different keys (#5): a two-shot batch with equal parameters must not collapse to one provider task.
+ */
+function ensureBinding(deps: ProductionGenerationSubmissionDependencies, run: ProductionRun, contract: ExecutionContractV1, jobId: string, attempt: number, fencingEpoch: number, shotId?: string): ProductionExecutionBinding {
   const existing = run.jobs.find((job) => job.jobId === jobId)?.executionBinding;
   if (existing) {
     if (existing.contractHash !== contract.contractHash || existing.providerNamespace !== contract.providerId) {
@@ -193,6 +223,9 @@ function ensureBinding(deps: ProductionGenerationSubmissionDependencies, run: Pr
     }
     return existing;
   }
+  // The default shot keeps the jobId as its shot identity (single-shot binding unchanged); a named shot
+  // uses its stable shotId. Both feed the idempotency key so identical-parameter shots stay distinct.
+  const bindingShotId = shotId ?? jobId;
   const runtimeTaskId = deps.runtimeTaskId?.({ runId: run.runId, contractHash: contract.contractHash, attempt })
     || `runtime-${run.runId}-${contract.contractHash.slice(0, 16)}-attempt-${attempt}`;
   const requestFingerprint = sha256({
@@ -208,11 +241,11 @@ function ensureBinding(deps: ProductionGenerationSubmissionDependencies, run: Pr
     immutableProjectUuid: deps.immutableProjectUuid,
     projectGeneration: deps.projectGeneration,
     runId: run.runId,
-    shotId: jobId,
+    shotId: bindingShotId,
     contractHash: contract.contractHash,
     runtimeTaskId,
     providerNamespace: contract.providerId,
-    providerIdempotencyKey: `generation:${run.runId}:${contract.contractHash}:attempt-${attempt}`,
+    providerIdempotencyKey: `generation:${run.runId}:${bindingShotId}:${contract.contractHash}:attempt-${attempt}`,
     requestFingerprint,
     runtimeEnvelopeRef: envelopeRefFor(run.runId, jobId),
     fencingEpoch,
@@ -249,7 +282,7 @@ export function createProductionGenerationSubmission(deps: ProductionGenerationS
     }).run;
   }
 
-  function prepare(run: ProductionRun, contract: ExecutionContractV1, binding: ProductionExecutionBinding, jobId: string, attempt: number): { run: ProductionRun; envelope: ReturnType<typeof createProductionRunRuntimeEnvelope> } {
+  function prepare(run: ProductionRun, contract: ExecutionContractV1, binding: ProductionExecutionBinding, jobId: string, attempt: number, shotId?: string): { run: ProductionRun; envelope: ReturnType<typeof createProductionRunRuntimeEnvelope> } {
     let current = run;
     const existingJob = current.jobs.find((job) => job.jobId === jobId);
     const addedJob = !existingJob;
@@ -267,10 +300,14 @@ export function createProductionGenerationSubmission(deps: ProductionGenerationS
         providerIdempotencyKey: binding.providerIdempotencyKey,
         runtimeEnvelopeRef: binding.runtimeEnvelopeRef,
         taskKind: contract.mode,
+        // P4 S1: stamp the shot lineage so per-shot attempt monotonicity survives replay (reducer reads
+        // metadata.shotId). Default shot omits it → the reducer treats it as the single default lineage.
+        ...(shotId ? { metadata: { shotId } } : {}),
         createdAt: now(),
         updatedAt: now(),
       };
-      current = command(current, "job.add", { job }, "job-add");
+      // #4 commandId: the suffix must carry jobId or a second job in the same Run is silently deduped.
+      current = command(current, "job.add", { job }, `job-add:${jobId}`);
     }
     const approvalId = `approval:generation:${current.runId}:${contract.contractHash}:${jobId}`;
     const existingApproval = deps.repository.readApprovals(current.projectId, current.runId).find((approval) => approval.approvalId === approvalId);
@@ -301,9 +338,11 @@ export function createProductionGenerationSubmission(deps: ProductionGenerationS
     if (addedJob) {
       if (current.budget.authorized < 0) throw new Error("Invalid generation budget authorization");
       if (current.budget.authorized === 0 && current.budget.reserved === 0 && current.budget.actual === 0 && current.budget.unsettled === 0) {
+        // #4 commandId: without jobId, a second shot's authorize reuses the first's commandId and is
+        // deduped into a stale-revision result. The billingEntryId already embeds jobId (via approvalId).
         current = command(current, "budget.entry", {
           entry: { billingEntryId: `${approvalId}:authorize`, kind: "authorize", amount: 0, occurredAt: now() },
-        }, "budget-authorize");
+        }, `budget-authorize:${jobId}`);
       }
     }
     const resolved = resolveExecutionContract(contract, binding);
@@ -321,11 +360,12 @@ export function createProductionGenerationSubmission(deps: ProductionGenerationS
   }
 
   async function start(input: GenerationSubmissionStartInput): Promise<GenerationSubmissionResult> {
+    const shotId = input.shotId;
     let run = requiredRun(deps.repository, input.projectId, input.operationId);
-    const contract = requiredContract(run);
-    const attempt = input.attempt ?? Math.max(1, latestGenerationAttempt(run, contract.contractHash));
+    const contract = requiredContract(run, shotId);
+    const attempt = input.attempt ?? Math.max(1, latestGenerationAttempt(run, contract.contractHash, shotId));
     if (!Number.isInteger(attempt) || attempt < 1) throw new Error("Generation attempt is invalid");
-    let jobId = jobIdFor(run.runId, contract.contractHash, attempt);
+    let jobId = jobIdFor(run.runId, contract.contractHash, attempt, shotId);
     const existingJob = run.jobs.find((job) => job.jobId === jobId);
     if (existingJob?.status === "provider_accepted" && existingJob.providerTaskId) {
       if (run.generationPlan?.state !== "submitted") run = command(run, "generation.submit", {}, "plan-submit");
@@ -339,12 +379,12 @@ export function createProductionGenerationSubmission(deps: ProductionGenerationS
     const runLock = lock(run.runId);
     return runLock.withLock(async (lease) => {
       run = requiredRun(deps.repository, input.projectId, input.operationId);
-      const lockedContract = requiredContract(run);
+      const lockedContract = requiredContract(run, shotId);
       if (lockedContract.contractHash !== contract.contractHash) throw new Error("Generation contract changed while waiting for the Run lock");
-      const lockedAttempt = input.attempt ?? Math.max(1, latestGenerationAttempt(run, lockedContract.contractHash));
-      jobId = jobIdFor(run.runId, lockedContract.contractHash, lockedAttempt);
-      const binding = ensureBinding(deps, run, lockedContract, jobId, lockedAttempt, lease.fencingEpoch);
-      const prepared = prepare(run, lockedContract, binding, jobId, lockedAttempt);
+      const lockedAttempt = input.attempt ?? Math.max(1, latestGenerationAttempt(run, lockedContract.contractHash, shotId));
+      jobId = jobIdFor(run.runId, lockedContract.contractHash, lockedAttempt, shotId);
+      const binding = ensureBinding(deps, run, lockedContract, jobId, lockedAttempt, lease.fencingEpoch, shotId);
+      const prepared = prepare(run, lockedContract, binding, jobId, lockedAttempt, shotId);
       run = prepared.run;
       const log = intentLog(run.runId);
       let rawReceipt: unknown;
@@ -397,10 +437,11 @@ export function createProductionGenerationSubmission(deps: ProductionGenerationS
   }
 
   async function poll(input: GenerationSubmissionStartInput): Promise<GenerationSubmissionPollResult> {
+    const shotId = input.shotId;
     const run = requiredRun(deps.repository, input.projectId, input.operationId);
-    const contract = requiredContract(run);
-    const attempt = input.attempt ?? Math.max(1, latestGenerationAttempt(run, contract.contractHash));
-    const jobId = jobIdFor(run.runId, contract.contractHash, attempt);
+    const contract = requiredContract(run, shotId);
+    const attempt = input.attempt ?? Math.max(1, latestGenerationAttempt(run, contract.contractHash, shotId));
+    const jobId = jobIdFor(run.runId, contract.contractHash, attempt, shotId);
     const job = run.jobs.find((candidate) => candidate.jobId === jobId);
     if (!job?.providerTaskId) throw new SubmissionReconciliationRequiredError("A provider task id is required before polling");
 
@@ -433,10 +474,11 @@ export function createProductionGenerationSubmission(deps: ProductionGenerationS
   }
 
   async function materialize(input: GenerationSubmissionStartInput): Promise<GenerationSubmissionMaterializeResult> {
+    const shotId = input.shotId;
     let run = requiredRun(deps.repository, input.projectId, input.operationId);
-    const contract = requiredContract(run);
-    const attempt = input.attempt ?? Math.max(1, latestGenerationAttempt(run, contract.contractHash));
-    const jobId = jobIdFor(run.runId, contract.contractHash, attempt);
+    const contract = requiredContract(run, shotId);
+    const attempt = input.attempt ?? Math.max(1, latestGenerationAttempt(run, contract.contractHash, shotId));
+    const jobId = jobIdFor(run.runId, contract.contractHash, attempt, shotId);
     let job = run.jobs.find((candidate) => candidate.jobId === jobId);
     if (!job?.providerTaskId) throw new GenerationMaterializationError("A provider task id is required before materialization");
     const providerTaskId = job.providerTaskId;
@@ -487,21 +529,22 @@ export function createProductionGenerationSubmission(deps: ProductionGenerationS
   }
 
   async function createNewAttempt(input: GenerationNewAttemptInput): Promise<GenerationNewAttemptResult> {
+    const shotId = input.shotId;
     let run = requiredRun(deps.repository, input.projectId, input.operationId);
-    const contract = requiredContract(run);
-    const previousAttempt = Math.max(1, latestGenerationAttempt(run, contract.contractHash));
-    const previousJob = run.jobs.find((job) => job.jobId === jobIdFor(run.runId, contract.contractHash, previousAttempt));
+    const contract = requiredContract(run, shotId);
+    const previousAttempt = Math.max(1, latestGenerationAttempt(run, contract.contractHash, shotId));
+    const previousJob = run.jobs.find((job) => job.jobId === jobIdFor(run.runId, contract.contractHash, previousAttempt, shotId));
     if (!previousJob || previousJob.status !== input.reason) throw new SubmissionReconciliationRequiredError("A new attempt is only available after the selected submission issue is recorded");
     const runLock = lock(run.runId);
     return runLock.withLock(async (lease) => {
       run = requiredRun(deps.repository, input.projectId, input.operationId);
-      const lockedContract = requiredContract(run);
-      const lockedPreviousAttempt = Math.max(1, latestGenerationAttempt(run, lockedContract.contractHash));
-      const lockedPreviousJob = run.jobs.find((job) => job.jobId === jobIdFor(run.runId, lockedContract.contractHash, lockedPreviousAttempt));
+      const lockedContract = requiredContract(run, shotId);
+      const lockedPreviousAttempt = Math.max(1, latestGenerationAttempt(run, lockedContract.contractHash, shotId));
+      const lockedPreviousJob = run.jobs.find((job) => job.jobId === jobIdFor(run.runId, lockedContract.contractHash, lockedPreviousAttempt, shotId));
       if (!lockedPreviousJob || lockedPreviousJob.status !== input.reason) throw new SubmissionReconciliationRequiredError("The submission state changed; reconcile it before creating a new attempt");
       const nextAttempt = lockedPreviousAttempt + 1;
-      const jobId = jobIdFor(run.runId, lockedContract.contractHash, nextAttempt);
-      const binding = ensureBinding(deps, run, lockedContract, jobId, nextAttempt, lease.fencingEpoch);
+      const jobId = jobIdFor(run.runId, lockedContract.contractHash, nextAttempt, shotId);
+      const binding = ensureBinding(deps, run, lockedContract, jobId, nextAttempt, lease.fencingEpoch, shotId);
       const job: ProductionJob = {
         jobId,
         stageId: "generate",
@@ -515,10 +558,12 @@ export function createProductionGenerationSubmission(deps: ProductionGenerationS
         providerIdempotencyKey: binding.providerIdempotencyKey,
         runtimeEnvelopeRef: binding.runtimeEnvelopeRef,
         taskKind: lockedContract.mode,
+        // P4 S1: carry the shot lineage so the reducer scopes attempt monotonicity + approval reset.
+        ...(shotId ? { metadata: { shotId } } : {}),
         createdAt: now(),
         updatedAt: now(),
       };
-      run = command(run, "generation.new_attempt", { job }, `new-attempt-${nextAttempt}`);
+      run = command(run, "generation.new_attempt", { job, ...(shotId ? { shotId } : {}) }, `new-attempt-${shotId ? `${shotId}-` : ""}${nextAttempt}`);
       return {
         operationId: run.runId,
         runId: run.runId,
@@ -533,10 +578,11 @@ export function createProductionGenerationSubmission(deps: ProductionGenerationS
   }
 
   async function resume(input: GenerationSubmissionStartInput): Promise<GenerationSubmissionResumeResult> {
+    const shotId = input.shotId;
     let run = requiredRun(deps.repository, input.projectId, input.operationId);
-    const contract = requiredContract(run);
-    const attempt = input.attempt ?? Math.max(1, latestGenerationAttempt(run, contract.contractHash));
-    const jobId = jobIdFor(run.runId, contract.contractHash, attempt);
+    const contract = requiredContract(run, shotId);
+    const attempt = input.attempt ?? Math.max(1, latestGenerationAttempt(run, contract.contractHash, shotId));
+    const jobId = jobIdFor(run.runId, contract.contractHash, attempt, shotId);
     const job = run.jobs.find((candidate) => candidate.jobId === jobId);
     if (!job) return { operationId: run.runId, action: "attention", reason: "invalid_recovery_state", nextAction: "attention" };
     const currentEnvelope = envelope(run.runId, jobId).read();
@@ -545,8 +591,9 @@ export function createProductionGenerationSubmission(deps: ProductionGenerationS
       const committed = intentLog(run.runId).list().some((intent) => intent.key === `${run.runId}:${jobId}:${job.attempt}` && intent.status === "committed");
       if (committed) return { operationId: run.runId, action: "reconcile", reason: "submission_receipt_unknown", nextAction: "reconcile" };
       if (currentEnvelope.state === "submitted_unknown") envelope(run.runId, jobId).markDefinitelyNotSubmitted();
-      run = command(run, "job.status", { jobId, status: "submit_intent_persisted", patch: {} }, "explicit-retry");
-      return { ...(await start({ projectId: run.projectId, operationId: run.runId, definitelyNotSubmitted: true })), action: "dispatch", nextAction: "dispatch" };
+      // Suffix carries jobId so a per-shot explicit retry never dedupes against a sibling shot.
+      run = command(run, "job.status", { jobId, status: "submit_intent_persisted", patch: {} }, `explicit-retry:${jobId}`);
+      return { ...(await start({ projectId: run.projectId, operationId: run.runId, definitelyNotSubmitted: true, ...(shotId ? { shotId } : {}) })), action: "dispatch", nextAction: "dispatch" };
     }
     const decision = classifyGenerationResume({ jobStatus: job.status, providerTaskId: job.providerTaskId, envelopeState: currentEnvelope.state, definitelyNotSubmitted: input.definitelyNotSubmitted });
     if (decision.action === "poll") return { operationId: run.runId, ...decision, nextAction: "poll", providerTaskId: job.providerTaskId };

--- a/electron/productionRun/productionMultiShotSchema.test.ts
+++ b/electron/productionRun/productionMultiShotSchema.test.ts
@@ -1,0 +1,392 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { compileExecutionContract, type PlanCandidate } from "../capabilityCore/executionContract";
+import { createModuleRegistry } from "../capabilityCore/moduleRegistry";
+import { applyProductionCommand } from "./productionRunReducer";
+import { createProductionGenerationSubmission } from "./productionGenerationSubmission";
+import { createProductionRunRepository } from "./productionRunRepository";
+import type { ProductionGenerationShot, ProductionRun } from "./productionRunTypes";
+
+// P4 S1: multi-shot generationPlan schema + shot addressing.
+// TDD: these lock the contract that S1 must satisfy — shot-grained keys never collide, legacy
+// single-shot snapshots replay unchanged, per-shot new attempts don't touch sibling shots, and
+// attempt monotonicity is scoped to one shot's lineage.
+
+const roots: string[] = [];
+
+const registry = createModuleRegistry([{
+  moduleId: "generation.single-shot",
+  version: "1.0.0",
+  inputKinds: ["text"],
+  outputKinds: ["image"],
+  modes: ["text-to-image"],
+  parameterSchema: { aspectRatio: { type: "string" } },
+  assetInputSchema: { references: { kind: "image", max: 4 } },
+  providers: [{
+    providerId: "fixture-provider",
+    models: [{
+      modelId: "fixture-model",
+      modes: ["text-to-image"],
+      parameterSchema: {},
+      capabilities: { submitIdempotency: true, query: true, reconcile: true, cancel: true },
+    }],
+  }],
+}]);
+
+function candidate(candidateId: string, prompt: string): PlanCandidate {
+  return {
+    candidateId,
+    revision: 1,
+    moduleId: "generation.single-shot",
+    providerId: "fixture-provider",
+    modelId: "fixture-model",
+    mode: "text-to-image",
+    prompt,
+    parameters: { aspectRatio: "16:9" },
+    references: [],
+  };
+}
+
+/** A single-shot draft, sealed + approved, exactly like today's chain. */
+function setupSingleShot() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "nomi-multishot-single-"));
+  roots.push(root);
+  const repository = createProductionRunRepository({
+    projectDirResolver: (projectId) => (projectId === "project-1" ? root : null),
+    now: () => "2026-08-24T00:00:00.000Z",
+    randomId: (() => { let n = 0; return () => `id-${++n}`; })(),
+  });
+  const planCandidate = candidate("candidate-1", "A paper boat on a quiet lake");
+  const contract = compileExecutionContract(planCandidate, registry);
+  repository.createGenerationDraft({
+    operationId: "op-1",
+    projectId: "project-1",
+    origin: { host: "semantic-mcp" },
+    candidate: planCandidate,
+    policy: {
+      trustedHosts: ["semantic-mcp"],
+      allowedProviders: ["fixture-provider"],
+      allowedModels: ["fixture-model"],
+      maxSpend: 0,
+      maxAttemptsPerJob: 2,
+    },
+  });
+  repository.execute("project-1", "op-1", {
+    commandId: "generation.seal:op-1",
+    expectedRevision: 0,
+    type: "generation.seal",
+    payload: { contract },
+    issuedAt: "2026-08-24T00:00:00.000Z",
+  });
+  repository.execute("project-1", "op-1", {
+    commandId: "generation.approve:op-1:receipt-fixture",
+    expectedRevision: 1,
+    type: "generation.approve",
+    payload: { receiptId: "receipt-fixture", contractHash: contract.contractHash },
+    issuedAt: "2026-08-24T00:00:00.000Z",
+  });
+  return { root, repository, contract };
+}
+
+function submission(root: string, repository: ReturnType<typeof createProductionRunRepository>, submit: ReturnType<typeof vi.fn>, now = "2026-08-24T00:00:00.000Z") {
+  return createProductionGenerationSubmission({
+    repository,
+    projectRoot: root,
+    immutableProjectUuid: "project-uuid-1",
+    projectGeneration: 1,
+    intentMacKey: "test-intent-key",
+    provider: {
+      providerId: "fixture-provider",
+      capabilities: { submitIdempotency: true, query: true, reconcile: true, cancel: true },
+      buildRequest: (input) => input,
+      submit,
+    },
+    now: () => now,
+  });
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
+});
+
+describe("P4 S1 multi-shot generation plan schema", () => {
+  it("keeps the legacy single-shot snapshot (no shots[]) readable and submittable unchanged", async () => {
+    const { root, repository, contract } = setupSingleShot();
+    // The legacy snapshot has no shots[]. Reading it must expose the top-level plan as before.
+    const beforeSubmit = repository.read("project-1", "op-1");
+    expect(beforeSubmit?.generationPlan).toMatchObject({ state: "sealed", contract: { contractHash: contract.contractHash } });
+    expect(beforeSubmit?.generationPlan?.shots).toBeUndefined();
+
+    const submit = vi.fn(async () => ({ providerTaskId: "provider-task-1", raw: { accepted: true } }));
+    const runner = submission(root, repository, submit);
+    // A start() with no shotId must address the default (legacy) shot and behave exactly as today.
+    await expect(runner.start({ projectId: "project-1", operationId: "op-1" })).resolves.toMatchObject({
+      operationId: "op-1",
+      providerTaskId: "provider-task-1",
+      nextAction: "observe",
+    });
+    expect(submit).toHaveBeenCalledTimes(1);
+    const run = repository.read("project-1", "op-1");
+    expect(run?.jobs).toHaveLength(1);
+    expect(run?.jobs[0]).toMatchObject({ status: "provider_accepted", providerTaskId: "provider-task-1" });
+    // Default-shot jobId keeps the legacy prefix so old callers/tests still match.
+    expect(run?.jobs[0]?.jobId).toMatch(/^generation-op-1-/);
+  });
+
+  it("gives two shots with identical parameters distinct jobId / providerIdempotencyKey / commandId", async () => {
+    // Build a two-shot sealed plan where both shots share the SAME contract hash (identical params).
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "nomi-multishot-collide-"));
+    roots.push(root);
+    const repository = createProductionRunRepository({
+      projectDirResolver: (projectId) => (projectId === "project-1" ? root : null),
+      now: () => "2026-08-24T00:00:00.000Z",
+      randomId: (() => { let n = 0; return () => `id-${++n}`; })(),
+    });
+    // The realistic collision: the SAME candidate (same id/revision/params/prompt) applied to two
+    // shots → identical contract hashes. The old identity keyed only on contractHash would collapse
+    // both shots onto one jobId / one provider task. shotId in the derivation must keep them distinct.
+    const shotACandidate = candidate("candidate-shared", "Identical shot");
+    const shotBCandidate = candidate("candidate-shared", "Identical shot");
+    const shotAContract = compileExecutionContract(shotACandidate, registry);
+    const shotBContract = compileExecutionContract(shotBCandidate, registry);
+    expect(shotAContract.contractHash).toBe(shotBContract.contractHash);
+
+    repository.createGenerationDraft({
+      operationId: "op-multi",
+      projectId: "project-1",
+      origin: { host: "semantic-mcp" },
+      candidate: shotACandidate,
+      policy: {
+        trustedHosts: ["semantic-mcp"],
+        allowedProviders: ["fixture-provider"],
+        allowedModels: ["fixture-model"],
+        maxSpend: 0,
+        maxAttemptsPerJob: 2,
+      },
+    });
+    // Seal a two-shot plan. The reducer variant must accept per-shot sealed contracts.
+    const shots: ProductionGenerationShot[] = [
+      { shotId: "shot-a", candidate: { ...shotACandidate, sealedContractHash: shotAContract.contractHash }, contract: shotAContract, updatedAt: "2026-08-24T00:00:00.000Z" },
+      { shotId: "shot-b", candidate: { ...shotBCandidate, sealedContractHash: shotBContract.contractHash }, contract: shotBContract, updatedAt: "2026-08-24T00:00:00.000Z" },
+    ];
+    repository.execute("project-1", "op-multi", {
+      commandId: "generation.seal:op-multi",
+      expectedRevision: 0,
+      type: "generation.seal",
+      payload: { contract: shotAContract, shots, planHash: "plan-hash-multi" },
+      issuedAt: "2026-08-24T00:00:00.000Z",
+    });
+    repository.execute("project-1", "op-multi", {
+      commandId: "generation.approve:op-multi:receipt-multi",
+      expectedRevision: 1,
+      type: "generation.approve",
+      payload: { receiptId: "receipt-multi", contractHash: "plan-hash-multi" },
+      issuedAt: "2026-08-24T00:00:00.000Z",
+    });
+
+    const submit = vi.fn(async () => ({ providerTaskId: `task-${submit.mock.calls.length}` }));
+    const runner = submission(root, repository, submit);
+    await runner.start({ projectId: "project-1", operationId: "op-multi", shotId: "shot-a" });
+    await runner.start({ projectId: "project-1", operationId: "op-multi", shotId: "shot-b" });
+
+    const run = repository.read("project-1", "op-multi")!;
+    const jobs = run.jobs;
+    expect(jobs).toHaveLength(2);
+    const [jobA, jobB] = jobs;
+    // #5 identity: two shots with identical parameters must not collide on any derived key.
+    expect(jobA.jobId).not.toBe(jobB.jobId);
+    expect(jobA.providerIdempotencyKey).toBeDefined();
+    expect(jobA.providerIdempotencyKey).not.toBe(jobB.providerIdempotencyKey);
+    expect(jobA.executionBinding?.shotId).not.toBe(jobB.executionBinding?.shotId);
+    expect(submit).toHaveBeenCalledTimes(2);
+
+    // #4 commandId: the second shot's job.add / budget.authorize must not be swallowed by dedupe.
+    // Both provider submissions landed distinct provider tasks → both jobs reached provider_accepted.
+    expect(jobA).toMatchObject({ status: "provider_accepted" });
+    expect(jobB).toMatchObject({ status: "provider_accepted" });
+    expect(jobA.providerTaskId).not.toBe(jobB.providerTaskId);
+  });
+});
+
+describe("P4 S1 reducer shot addressing", () => {
+  const now = "2026-08-24T00:00:00.000Z";
+
+  function sealedTwoShotRun(): ProductionRun {
+    const shotACandidate = candidate("cand-a", "shot a");
+    const shotBCandidate = candidate("cand-b", "shot b differs");
+    const shotAContract = compileExecutionContract(shotACandidate, registry);
+    const shotBContract = compileExecutionContract(shotBCandidate, registry);
+    return {
+      schemaVersion: 1, runId: "op-x", projectId: "project-1", revision: 5,
+      status: "draft", stageId: "generate", playbook: { name: "generation.single-shot", version: "1.0.0" },
+      origin: { host: "semantic-mcp" },
+      policy: { mode: "balanced", trustedHosts: [], allowedProviders: [], allowedModels: [], maxSpend: null, maxAttemptsPerJob: 2, minimizeUploads: true },
+      budget: { currency: "CNY", authorized: 0, reserved: 0, actual: 0, unsettled: 0 },
+      planVersion: 1, snapshotCursor: 5, stages: [], gates: [], jobs: [], artifacts: [],
+      generationPlan: {
+        operationId: "op-x",
+        state: "sealed",
+        candidate: { ...shotACandidate, sealedContractHash: shotAContract.contractHash },
+        contract: shotAContract,
+        planHash: "plan-hash-x",
+        approvedReceiptId: "receipt-x",
+        shots: [
+          { shotId: "shot-a", candidate: { ...shotACandidate, sealedContractHash: shotAContract.contractHash }, contract: shotAContract, approvedReceiptId: "receipt-x", attemptCount: 1, updatedAt: now },
+          { shotId: "shot-b", candidate: { ...shotBCandidate, sealedContractHash: shotBContract.contractHash }, contract: shotBContract, approvedReceiptId: "receipt-x", attemptCount: 1, updatedAt: now },
+        ],
+        updatedAt: now,
+      },
+      createdAt: now, updatedAt: now,
+    };
+  }
+
+  it("a per-shot new attempt keeps the plan-level receipt and the sibling shot untouched", () => {
+    const run = sealedTwoShotRun();
+    const shotAContract = run.generationPlan!.shots![0].contract!;
+    const job = {
+      jobId: "generation-op-x-shot-a-a-attempt-2", stageId: "generate", status: "authorized" as const, attempt: 2,
+      provider: "fixture-provider", model: "fixture-model", idempotencyKey: "generation:op-x:shot-a:some:attempt-2",
+      taskKind: "text-to-image", createdAt: now, updatedAt: now,
+    };
+    const effect = applyProductionCommand(run, {
+      commandId: "new-attempt-shot-a", expectedRevision: 5, type: "generation.new_attempt",
+      payload: { job, shotId: "shot-a" }, issuedAt: now,
+    }, now);
+
+    // Plan-level receipt approval is preserved (not cleared by a per-shot attempt).
+    expect(effect.run.generationPlan?.approvedReceiptId).toBe("receipt-x");
+    // Only shot-a's per-shot approval is reset; shot-b keeps its receipt.
+    const shotA = effect.run.generationPlan?.shots?.find((s) => s.shotId === "shot-a");
+    const shotB = effect.run.generationPlan?.shots?.find((s) => s.shotId === "shot-b");
+    expect(shotA?.approvedReceiptId).toBeUndefined();
+    expect(shotA?.attemptCount).toBe(2);
+    expect(shotB?.approvedReceiptId).toBe("receipt-x");
+    expect(shotB?.attemptCount).toBe(1);
+    expect(effect.run.jobs.map((j) => j.jobId)).toContain(job.jobId);
+    void shotAContract;
+  });
+
+  it("scopes attempt monotonicity to the shot lineage: shot A attempt 2 does not block shot B attempt 2", () => {
+    // shot A already has an attempt-2 job for the same provider/model/stage.
+    const run = sealedTwoShotRun();
+    const withShotAAttempt2: ProductionRun = {
+      ...run,
+      jobs: [
+        { jobId: "generation-op-x-shot-a-a-attempt-2", stageId: "generate", status: "provider_accepted", attempt: 2, provider: "fixture-provider", model: "fixture-model", idempotencyKey: "k-a-2", createdAt: now, updatedAt: now },
+      ],
+    };
+    const shotBJob = {
+      jobId: "generation-op-x-shot-b-b-attempt-2", stageId: "generate", status: "authorized" as const, attempt: 2,
+      provider: "fixture-provider", model: "fixture-model", idempotencyKey: "generation:op-x:shot-b:x:attempt-2",
+      taskKind: "text-to-image", createdAt: now, updatedAt: now,
+    };
+    // Same provider/model/stage AND same attempt number as shot A's job — but a DIFFERENT shot.
+    // The global comparison would reject this; the shot-scoped check must allow it.
+    expect(() => applyProductionCommand(withShotAAttempt2, {
+      commandId: "new-attempt-shot-b", expectedRevision: 5, type: "generation.new_attempt",
+      payload: { job: shotBJob, shotId: "shot-b" }, issuedAt: now,
+    }, now)).not.toThrow();
+  });
+
+  it("still rejects a stale attempt within the SAME shot lineage", () => {
+    const run = sealedTwoShotRun();
+    const withShotAAttempt2: ProductionRun = {
+      ...run,
+      jobs: [
+        { jobId: "generation-op-x-shot-a-a-attempt-2", stageId: "generate", status: "provider_accepted", attempt: 2, provider: "fixture-provider", model: "fixture-model", idempotencyKey: "k-a-2", metadata: { shotId: "shot-a" }, createdAt: now, updatedAt: now },
+      ],
+    };
+    // A second attempt-2 job for the SAME shot must still be rejected (monotonicity within lineage).
+    const dupShotAJob = {
+      jobId: "generation-op-x-shot-a-a-attempt-2-dup", stageId: "generate", status: "authorized" as const, attempt: 2,
+      provider: "fixture-provider", model: "fixture-model", idempotencyKey: "generation:op-x:shot-a:y:attempt-2",
+      metadata: { shotId: "shot-a" }, taskKind: "text-to-image", createdAt: now, updatedAt: now,
+    };
+    expect(() => applyProductionCommand(withShotAAttempt2, {
+      commandId: "new-attempt-shot-a-dup", expectedRevision: 5, type: "generation.new_attempt",
+      payload: { job: dupShotAJob, shotId: "shot-a" }, issuedAt: now,
+    }, now)).toThrow(/attempt/);
+  });
+
+  it("patches one shot's candidate + included flag without touching sibling shots (draft)", () => {
+    const shotACandidate = candidate("cand-a", "shot a");
+    const shotBCandidate = candidate("cand-b", "shot b");
+    const draft: ProductionRun = {
+      schemaVersion: 1, runId: "op-patch", projectId: "project-1", revision: 3,
+      status: "draft", stageId: "generate", playbook: { name: "generation.single-shot", version: "1.0.0" },
+      origin: { host: "semantic-mcp" },
+      policy: { mode: "balanced", trustedHosts: [], allowedProviders: [], allowedModels: [], maxSpend: null, maxAttemptsPerJob: 2, minimizeUploads: true },
+      budget: { currency: "CNY", authorized: 0, reserved: 0, actual: 0, unsettled: 0 },
+      planVersion: 1, snapshotCursor: 3, stages: [], gates: [], jobs: [], artifacts: [],
+      generationPlan: {
+        operationId: "op-patch", state: "draft", candidate: shotACandidate,
+        shots: [
+          { shotId: "shot-a", candidate: shotACandidate, updatedAt: now },
+          { shotId: "shot-b", candidate: shotBCandidate, updatedAt: now },
+        ],
+        updatedAt: now,
+      },
+      createdAt: now, updatedAt: now,
+    };
+    const effect = applyProductionCommand(draft, {
+      commandId: "patch-shot-a", expectedRevision: 3, type: "generation.patch",
+      payload: { shotId: "shot-a", patch: { prompt: "shot a revised" }, included: false }, issuedAt: now,
+    }, now);
+    const shotA = effect.run.generationPlan?.shots?.find((s) => s.shotId === "shot-a");
+    const shotB = effect.run.generationPlan?.shots?.find((s) => s.shotId === "shot-b");
+    expect(shotA?.candidate.prompt).toBe("shot a revised");
+    expect(shotA?.candidate.revision).toBe(2);
+    expect(shotA?.included).toBe(false);
+    // Sibling shot untouched.
+    expect(shotB?.candidate.prompt).toBe("shot b");
+    expect(shotB?.candidate.revision).toBe(1);
+    expect(shotB?.included).toBeUndefined();
+  });
+
+  it("seals only the included shots into per-shot contracts", () => {
+    // A draft plan with three shots, one of them excluded (included: false).
+    const shotACandidate = candidate("cand-a", "shot a");
+    const shotBCandidate = candidate("cand-b", "shot b");
+    const shotCCandidate = candidate("cand-c", "shot c");
+    const draft: ProductionRun = {
+      schemaVersion: 1, runId: "op-inc", projectId: "project-1", revision: 2,
+      status: "draft", stageId: "generate", playbook: { name: "generation.single-shot", version: "1.0.0" },
+      origin: { host: "semantic-mcp" },
+      policy: { mode: "balanced", trustedHosts: [], allowedProviders: [], allowedModels: [], maxSpend: null, maxAttemptsPerJob: 2, minimizeUploads: true },
+      budget: { currency: "CNY", authorized: 0, reserved: 0, actual: 0, unsettled: 0 },
+      planVersion: 1, snapshotCursor: 2, stages: [], gates: [], jobs: [], artifacts: [],
+      generationPlan: {
+        operationId: "op-inc", state: "draft", candidate: shotACandidate,
+        shots: [
+          { shotId: "shot-a", candidate: shotACandidate, included: true, updatedAt: now },
+          { shotId: "shot-b", candidate: shotBCandidate, included: false, updatedAt: now },
+          { shotId: "shot-c", candidate: shotCCandidate, updatedAt: now },
+        ],
+        updatedAt: now,
+      },
+      createdAt: now, updatedAt: now,
+    };
+    const shotAContract = compileExecutionContract({ ...shotACandidate }, registry);
+    const shotCContract = compileExecutionContract({ ...shotCCandidate }, registry);
+    const sealShots: ProductionGenerationShot[] = [
+      { shotId: "shot-a", candidate: { ...shotACandidate, sealedContractHash: shotAContract.contractHash }, contract: shotAContract, included: true, updatedAt: now },
+      { shotId: "shot-b", candidate: shotBCandidate, included: false, updatedAt: now },
+      { shotId: "shot-c", candidate: { ...shotCCandidate, sealedContractHash: shotCContract.contractHash }, contract: shotCContract, updatedAt: now },
+    ];
+    const effect = applyProductionCommand(draft, {
+      commandId: "seal-inc", expectedRevision: 2, type: "generation.seal",
+      payload: { contract: shotAContract, shots: sealShots, planHash: "plan-hash-inc" }, issuedAt: now,
+    }, now);
+
+    const sealed = effect.run.generationPlan!;
+    expect(sealed.state).toBe("sealed");
+    const included = (sealed.shots ?? []).filter((shot) => shot.included !== false);
+    // Only included shots carry a sealed contract; excluded shots do not.
+    expect(included.map((shot) => shot.shotId).sort()).toEqual(["shot-a", "shot-c"]);
+    expect(sealed.shots?.find((s) => s.shotId === "shot-b")?.contract).toBeUndefined();
+    expect(sealed.shots?.find((s) => s.shotId === "shot-a")?.contract?.contractHash).toBe(shotAContract.contractHash);
+  });
+});

--- a/electron/productionRun/productionRunReducer.ts
+++ b/electron/productionRun/productionRunReducer.ts
@@ -7,12 +7,77 @@ import type {
   ProductionJob,
   ProductionJobStatus,
   ProductionGenerationPlan,
+  ProductionGenerationShot,
   ProductionRun,
   ProductionRunStatus,
   ProductionStage,
   RunCommand,
 } from "./productionRunTypes";
 import { validateProductionExecutionBinding } from "./productionExecutionBinding";
+
+/**
+ * P4 S1 shot 谱系 = 一个 job 归属哪一镜。多镜 job 把 shotId 写进 `metadata.shotId`（子合同派生时带上）；
+ * 单镜/legacy job 无此字段 → 归属默认镜（返回 undefined，等价于「不参与 shot 分组」）。
+ * attempt 单调性、new_attempt 连坐豁免都按这个谱系键分组，绝不跨镜比较。
+ */
+function jobShotLineage(job: Pick<ProductionJob, "metadata">): string | undefined {
+  const shotId = job.metadata?.shotId;
+  return typeof shotId === "string" && shotId.trim() ? shotId : undefined;
+}
+
+/** Update one shot inside a plan by id; throws if the plan has no such shot. */
+function replaceShot(
+  plan: ProductionGenerationPlan,
+  shotId: string,
+  update: (shot: ProductionGenerationShot) => ProductionGenerationShot,
+): ProductionGenerationShot[] {
+  const shots = plan.shots ?? [];
+  let found = false;
+  const next = shots.map((shot) => {
+    if (shot.shotId !== shotId) return shot;
+    found = true;
+    return update(shot);
+  });
+  if (!found) throw new Error(`Generation shot not found: ${shotId}`);
+  return next;
+}
+
+/** A shot is included in the sealed contract unless it was explicitly unchecked (试拍/分批). */
+function isShotIncluded(shot: Pick<ProductionGenerationShot, "included">): boolean {
+  return shot.included !== false;
+}
+
+/**
+ * P4 S1 seal helper: validate + freeze the shots[] payload. Returns undefined for a single-shot seal
+ * (no shots[] payload → today's byte-identical path). For a multi-shot seal, every INCLUDED shot must
+ * carry a matching sealed sub-contract; excluded shots must not; shot ids must be unique and non-empty.
+ */
+function sealGenerationShots(plan: ProductionGenerationPlan, raw: unknown): ProductionGenerationShot[] | undefined {
+  if (raw === undefined) return undefined;
+  if (!Array.isArray(raw) || raw.length === 0) throw new Error("Multi-shot generation seal requires a non-empty shots list");
+  const seen = new Set<string>();
+  const sealed = raw.map((value, index) => {
+    if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error(`Invalid generation shot ${index}`);
+    const shot = value as ProductionGenerationShot;
+    const shotId = typeof shot.shotId === "string" ? shot.shotId.trim() : "";
+    if (!shotId || seen.has(shotId)) throw new Error(`Invalid generation shot id at ${index}`);
+    seen.add(shotId);
+    const included = isShotIncluded(shot);
+    if (included) {
+      if (!shot.contract || typeof shot.contract.contractHash !== "string" || !shot.contract.contractHash.trim()) {
+        throw new Error(`Included generation shot ${shotId} needs a sealed sub-contract`);
+      }
+      if (shot.candidate?.sealedContractHash !== shot.contract.contractHash) {
+        throw new Error(`Generation shot ${shotId} sub-contract does not match its sealed candidate`);
+      }
+    } else if (shot.contract) {
+      throw new Error(`Excluded generation shot ${shotId} must not carry a sealed sub-contract`);
+    }
+    return shot;
+  });
+  void plan;
+  return sealed;
+}
 
 export type ProductionCommandEffect = {
   run: ProductionRun;
@@ -180,7 +245,31 @@ export function applyProductionCommand(
     case "generation.patch": {
       const currentPlan = current.generationPlan;
       if (!currentPlan || currentPlan.state !== "draft") throw new Error("new_draft_required: edit a new generation draft");
-      const patch = record(command.payload, "patch") as Partial<ProductionGenerationPlan["candidate"]>;
+      const patch = record(command.payload, "patch") as Partial<ProductionGenerationShot["candidate"]>;
+      // P4 S1 shot-addressing patch variant: edit one shot's candidate (model/mode/params/prompt/refs)
+      // and/or its included flag (试拍/分批). No shotId → patch the top-level candidate exactly as today.
+      const rawShotId = typeof command.payload.shotId === "string" ? command.payload.shotId.trim() : "";
+      const shotId = rawShotId || undefined;
+      if (shotId) {
+        const hasIncluded = typeof command.payload.included === "boolean";
+        const shots = replaceShot(currentPlan, shotId, (shot) => ({
+          ...shot,
+          candidate: {
+            ...shot.candidate,
+            ...patch,
+            revision: shot.candidate.revision + 1,
+            parameters: patch.parameters ? structuredClone(patch.parameters) : structuredClone(shot.candidate.parameters),
+            references: patch.references ? structuredClone(patch.references) : structuredClone(shot.candidate.references),
+          },
+          ...(hasIncluded ? { included: command.payload.included as boolean } : {}),
+          updatedAt: now,
+        }));
+        return {
+          run: { ...current, generationPlan: { ...currentPlan, shots, updatedAt: now }, updatedAt: now },
+          eventType: "generation.plan.updated",
+          message: currentPlan.operationId,
+        };
+      }
       const candidate = {
         ...currentPlan.candidate,
         ...patch,
@@ -202,8 +291,24 @@ export function applyProductionCommand(
       if (contract.candidateId !== currentPlan.candidate.candidateId || contract.candidateRevision !== currentPlan.candidate.revision) {
         throw new Error("Generation contract does not match the current draft");
       }
+      // P4 S1 multi-shot seal: freeze per-shot sub-contracts (included shots only) + the plan-level hash.
+      // Single-shot seal (no shots[] in payload) stays byte-identical to today.
+      const sealedShots = sealGenerationShots(currentPlan, command.payload.shots);
+      const rawPlanHash = typeof command.payload.planHash === "string" ? command.payload.planHash.trim() : "";
+      if (sealedShots && !rawPlanHash) throw new Error("A multi-shot generation seal requires a plan hash");
       return {
-        run: { ...current, generationPlan: { ...currentPlan, candidate: { ...currentPlan.candidate, sealedContractHash: contract.contractHash }, contract, state: "sealed", updatedAt: now }, updatedAt: now },
+        run: {
+          ...current,
+          generationPlan: {
+            ...currentPlan,
+            candidate: { ...currentPlan.candidate, sealedContractHash: contract.contractHash },
+            contract,
+            state: "sealed",
+            ...(sealedShots ? { shots: sealedShots, planHash: rawPlanHash } : {}),
+            updatedAt: now,
+          },
+          updatedAt: now,
+        },
         eventType: "generation.plan.sealed",
         message: currentPlan.operationId,
       };
@@ -235,13 +340,23 @@ export function applyProductionCommand(
       const receiptId = text(command.payload, "receiptId");
       const contractHash = text(command.payload, "contractHash");
       if (!currentPlan || currentPlan.state !== "sealed" || !currentPlan.contract) throw new Error("A sealed generation plan is required before approval");
-      if (currentPlan.contract.contractHash !== contractHash) throw new Error("Generation approval does not match the sealed contract");
+      // P4 S1: a multi-shot receipt is keyed on the plan-level hash (covers the whole operation);
+      // a single-shot receipt is keyed on the one sealed contract hash. Accept whichever this plan uses.
+      const expectedHash = currentPlan.shots ? currentPlan.planHash : currentPlan.contract.contractHash;
+      if (expectedHash !== contractHash) throw new Error("Generation approval does not match the sealed contract");
       const rawAttempt = command.payload.attempt;
       const approvedAttempt = rawAttempt === undefined ? undefined : Number(rawAttempt);
       if (approvedAttempt !== undefined && (!Number.isInteger(approvedAttempt) || approvedAttempt < 1)) throw new Error("Generation approval attempt is invalid");
       if (currentPlan.approvedReceiptId === receiptId && currentPlan.approvedAttempt === approvedAttempt) return { run: current, eventType: "generation.plan.approved", message: currentPlan.operationId };
+      // P4 S1: the plan-level receipt approves every INCLUDED shot (a per-operation receipt covers the
+      // whole batch — §1). Excluded shots stay unapproved. Single-shot plans (no shots[]) are unaffected.
+      const approvedShots = currentPlan.shots
+        ? currentPlan.shots.map((shot) => (isShotIncluded(shot)
+            ? { ...shot, approvedReceiptId: receiptId, ...(approvedAttempt === undefined ? {} : { approvedAttempt }), approvedAt: now, updatedAt: now }
+            : shot))
+        : undefined;
       return {
-        run: { ...current, generationPlan: { ...currentPlan, approvedReceiptId: receiptId, ...(approvedAttempt === undefined ? {} : { approvedAttempt }), approvedAt: now, updatedAt: now }, updatedAt: now },
+        run: { ...current, generationPlan: { ...currentPlan, approvedReceiptId: receiptId, ...(approvedAttempt === undefined ? {} : { approvedAttempt }), ...(approvedShots ? { shots: approvedShots } : {}), approvedAt: now, updatedAt: now }, updatedAt: now },
         eventType: "generation.plan.approved",
         message: currentPlan.operationId,
       };
@@ -251,17 +366,49 @@ export function applyProductionCommand(
       if (!currentPlan || !currentPlan.contract || (currentPlan.state !== "sealed" && currentPlan.state !== "submitted")) throw new Error("A submitted generation is required before a new attempt");
       const job = record(command.payload, "job") as ProductionJob;
       if (current.jobs.some((item) => item.jobId === job.jobId)) throw new Error(`Duplicate job: ${job.jobId}`);
-      if (!Number.isInteger(job.attempt) || job.attempt < 1 || current.jobs.some((item) => item.attempt >= job.attempt && item.provider === job.provider && item.model === job.model && item.stageId === job.stageId)) {
+      // P4 S1: a per-shot attempt addresses one shot lineage. Absent shotId = single-shot (today's chain).
+      const rawShotId = typeof command.payload.shotId === "string" ? command.payload.shotId.trim() : "";
+      const shotId = rawShotId || undefined;
+      if (shotId && !(currentPlan.shots ?? []).some((shot) => shot.shotId === shotId)) throw new Error(`Generation shot not found: ${shotId}`);
+      // Attempt monotonicity is scoped to the SAME shot lineage — a sibling shot's attempt N must not
+      // block this shot's attempt N. For single-shot plans the lineage is "the default shot" (undefined),
+      // which keeps the original provider/model/stage comparison across the whole plan's default jobs.
+      const jobLineage = shotId ?? jobShotLineage(job);
+      const lineageConflict = current.jobs.some((item) =>
+        item.attempt >= job.attempt
+        && item.provider === job.provider
+        && item.model === job.model
+        && item.stageId === job.stageId
+        && (jobShotLineage(item) ?? undefined) === (jobLineage ?? undefined));
+      if (!Number.isInteger(job.attempt) || job.attempt < 1 || lineageConflict) {
         throw new Error("Generation attempt must be newer than the previous attempt");
       }
       if (job.executionBinding) {
         const binding = validateProductionExecutionBinding(job.executionBinding);
         if (binding.runId !== current.runId || binding.providerNamespace !== job.provider || binding.providerIdempotencyKey !== job.idempotencyKey) throw new Error("Invalid execution binding for new generation attempt");
       }
+      // Multi-shot: keep the plan-level receipt, reset ONLY this shot's per-shot approval + bump its
+      // attemptCount — never clear plan-level approval, never touch sibling shots (§3.3).
+      // Single-shot: keep today's behavior (the plan-level receipt IS the shot's, so it must be cleared).
+      const nextPlan: ProductionGenerationPlan = shotId
+        ? {
+            ...currentPlan,
+            state: "sealed",
+            shots: replaceShot(currentPlan, shotId, (shot) => ({
+              ...shot,
+              approvedReceiptId: undefined,
+              approvedAt: undefined,
+              approvedAttempt: undefined,
+              attemptCount: job.attempt,
+              updatedAt: now,
+            })),
+            updatedAt: now,
+          }
+        : { ...currentPlan, state: "sealed", approvedReceiptId: undefined, approvedAt: undefined, approvedAttempt: undefined, updatedAt: now };
       return {
         run: {
           ...current,
-          generationPlan: { ...currentPlan, state: "sealed", approvedReceiptId: undefined, approvedAt: undefined, approvedAttempt: undefined, updatedAt: now },
+          generationPlan: nextPlan,
           jobs: [...current.jobs, job],
           updatedAt: now,
         },

--- a/electron/productionRun/productionRunTypes.ts
+++ b/electron/productionRun/productionRunTypes.ts
@@ -172,6 +172,34 @@ export type ProductionJob = {
   updatedAt: string;
 };
 
+/**
+ * P4 S1 一个镜头的可编辑草稿 + shot 粒度记账。
+ *
+ * 单镜链的旧形态（plan 顶层直接挂 candidate/contract/approvedReceiptId）保持不动 —— 一个 shots[]
+ * 为空的 plan 就是「一个默认镜」，读路径全部走顶层字段，老 Run 快照零迁移。多镜形态把每一镜的
+ * candidate/子合同/批准记账/attempt 谱系收进这里，plan 顶层只保留计划级的 hash 与状态。
+ *
+ * 记账降到 shot 粒度是硬要求（§3.3）：一镜 new_attempt 不得清计划级批准、不得连坐其他镜；
+ * attempt 单调性只在**同一镜谱系**内比较（`attemptCount` = 该镜已发起的提交尝试数）。
+ */
+export type ProductionGenerationShot = {
+  /** Stable per-shot identity; enters the sub-contract and every derived key (jobId/idempotency). */
+  shotId: string;
+  /** Checkbox for 试拍/分批: a sealed contract only covers included shots. Absent → included. */
+  included?: boolean;
+  candidate: PlanCandidate;
+  /** Sealed sub-contract for this shot; absent until the plan is sealed. */
+  contract?: ExecutionContractV1;
+  /** Shot-grained receipt approval — never cleared by a sibling shot's new attempt. */
+  approvedReceiptId?: string;
+  approvedAt?: string;
+  /** Which explicit submission attempt this shot's latest human receipt authorizes. */
+  approvedAttempt?: number;
+  /** Monotonic count of submission attempts issued for THIS shot's lineage (attempt-scoped to the shot). */
+  attemptCount?: number;
+  updatedAt: string;
+};
+
 export type ProductionGenerationPlan = {
   operationId: string;
   state: "draft" | "sealed" | "cancelled" | "submitted";
@@ -181,6 +209,13 @@ export type ProductionGenerationPlan = {
   approvedAt?: string;
   /** Which explicit submission attempt the latest human receipt authorizes. */
   approvedAttempt?: number;
+  /**
+   * P4 S1 多镜形态：每镜的草稿 + shot 粒度记账。空/缺省 = 单镜旧形态（走顶层 candidate/contract）。
+   * 顶层字段永不删除（老 Run 快照读路径依赖它）；多镜时顶层继续描述「默认镜」以维持向后兼容。
+   */
+  shots?: ProductionGenerationShot[];
+  /** Plan-level hash freezing the whole multi-shot operation (anchor + included shots) at seal time. */
+  planHash?: string;
   updatedAt: string;
 };
 


### PR DESCRIPTION
## 范围（P4 计划 S1 切片）

实现 `docs/superpowers/plans/2026-08-24-p4-multishot-continuity.md` §7 的 **S1：多镜 schema + 寻址**。这是 P4 多镜连续性的**地基切片**——只加多镜形态与 shot 粒度寻址，**P1–P3 单镜链行为零变化**（向后兼容是硬要求）。调度器/真实定价/确认卡/UI/画布落地/MCP 对外行为全部留给 S2–S7。

### 改了什么

**1. `generationPlan` 多镜形态**（`electron/productionRun/productionRunTypes.ts`）
- 新增 `ProductionGenerationShot`（`shotId`、`included` 勾选位、per-shot `candidate`/`contract`、shot 粒度 `approvedReceiptId`/`approvedAttempt`、`attemptCount` 谱系）。
- `ProductionGenerationPlan` 同容器加 `shots?[]` + 计划级 `planHash`。**老 Run 快照（无 `shots[]`）读路径不变**——顶层 `candidate`/`contract`/`approvedReceiptId` 就是默认镜。

**2. reducer shot 寻址变体**（`productionRunReducer.ts`：patch/seal/approve/new_attempt）
- `seal`：冻结 per-shot 子合同（**只覆盖勾选镜**）+ `planHash`。
- `approve`：给每个勾选镜盖 per-shot receipt；多镜 receipt 按 `planHash` 对账，单镜按唯一合同 hash（保持旧行为）。
- `new_attempt`：**降为 shot 粒度**——保留计划级 `approvedReceiptId`、只重置被寻址镜、不连坐其他镜；attempt 单调性**限定同一镜谱系**（`metadata.shotId`），镜 A attempt 2 不阻止镜 B attempt 2。
- `patch`：新增按 `shotId` 编辑某镜 candidate + `included` 勾选位的变体。

**3. submission 门面参数化**（`productionGenerationSubmission.ts`：五入口 start/poll/materialize/resume/createNewAttempt）
- 全部接可选 `shotId`；不带 = 默认镜，行为与今天完全一致。
- `jobIdFor` / `providerIdempotencyKey` / 执行绑定 `shotId` **显式含 shotId**——两条参数完全相同的镜不再撞键。

**4. commandId 撞车修复（#4）**
- `job.add` / `budget.authorize` / `explicit-retry` 的 suffix 照 outbox 样式编进 `jobId`，同 Run 第二个 Job 不再被 command dedupe 静默吞掉。

### 测试（TDD 先红后绿）
新增 `productionMultiShotSchema.test.ts`（7 例）：
- 两镜同参数 → jobId / providerIdempotencyKey / commandId 三者都不撞。
- 老 Run 快照（单镜旧形态）读回放兼容。
- 一镜 new_attempt：计划级 receipt 保留、姊妹镜不动、attemptCount 记账。
- attempt 单调性限同镜谱系（含「同镜内仍拒陈旧 attempt」反向断言）。
- seal 只把勾选镜封进子合同。
- shot 寻址 patch 只动目标镜。

### 验证
- `pnpm run gates` **全绿**（filesize/tokens/i18n/heavy-path/controls/walkthroughs/lint/typecheck/test/build）。
- `electron/productionRun`（192）+ `electron/capabilityCore`（622）全套绿，**单镜行为零变化**。
- 回归门：`node tests/ux/mcp-generation-single-shot-gui-fallback.e2e.mjs` → **14/14 断言，provider POST=1、GET=1、真实额度=0**。
- 单文件 ≤800 行（reducer 672 / submission 608 / types 371）。加新删旧：单 hash 寻址私有函数已被参数化取代，无并行版。

### 遗留 / 设计说明
- 多镜 receipt 键从「顶层合同 hash」改为 **plan-level `planHash`**（单镜仍按合同 hash）——受计划「一 receipt 批整个 operation」约束，是自然落点，非岔路。
- 默认镜的 `providerIdempotencyKey` 格式变长（含 `shotId`=jobId），但仅影响**新建**的默认镜 job；in-flight job 走 `ensureBinding` 复用既有绑定，不受影响。E2E 已端到端验证新格式。
- 无计划外设计岔路需要用户拍板。

计划文档：`docs/superpowers/plans/2026-08-24-p4-multishot-continuity.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)