### PR TITLE
refactor: unify agent config layer (B1a-d, behavior-preserving)

### DIFF
--- a/docs/plan/2026-08-24-agent-b1-config-cleanup.md
+++ b/docs/plan/2026-08-24-agent-b1-config-cleanup.md
@@ -1,0 +1,58 @@
+# B1 — 内部 Agent 配置层低风险清理（行为保持型重构）
+
+> 范围：统一 Agent 总方案 Track B 的 B1a–d。**用户可见行为零变化**，现有测试全绿是回归门。
+> 基线 origin/main，隔离 worktree，分支 `claude/agent-b1-config-cleanup`。
+> 上游：`docs/audit/2026-08-24-internal-agent-architecture-audit.md` + 总方案 §3。
+
+## 审计 vs 代码现状（实扫对账，以代码为准）
+
+| 审计写的 | 实况 | 处置 |
+|---|---|---|
+| `electron/ai/workbenchAgentRunner.ts:26-29` | 实际在 **`src/workbench/ai/workbenchAgentRunner.ts:26-30`**（渲染层，非 electron） | 按真实路径做 |
+| 会话键第 4 处 = capabilityApplyHandler.ts:95 | 实况 :95（`nomi:production-script:…`），确认 | ✓ |
+| runStoryboardPlanner 是第 5 种会话键 | **否**：它复用 `workbenchSessionKey('generation')`，不自造键 | 不算入 B1a 键工厂 |
+| systemPrompt 三层「改一处漏他处」 | 实况：身份+skill 在后端 agentChatV2.ts 合，面板专长层在渲染层 `buildStaticAgentSystemPrompt` 产出后经 `payload.systemPrompt` 传入；真正拼接点是 **agentChatV2.ts:554-555** 的 `systemParts.join("\n\n")` 再 `sanitizeForBroadCompat` | B1c 收口这个拼接点 |
+
+## 四件（按序，TDD：先写锁现状的测试→再重构，加新必删旧）
+
+### B1a 会话键工厂
+现状 4 种硬编码会话键（渲染层，均 `readWindowUrlParam('projectId') || 'local'`）：
+- `nomi:workbench:<pid>:<area>` — workbenchAgentRunner.ts:26-30 `workbenchSessionKey(area)`
+- `nomi:production-directions:<pid>` — runDirectionPlanner.ts:38-40 `directionSessionKey()`
+- `nomi:shot-verify:<pid>` — shotVerifyJudge.ts:15-17 `verifySessionKey()`
+- `nomi:production-script:<pid>` — capabilityApplyHandler.ts:95（内联）
+
+**做法**：新增 `src/workbench/ai/agentSessionKey.ts` 提供 `sessionKeyFor(...)`，产出与现状**逐字节相同**。四处旧生成逻辑全部改调工厂并删除私有函数/内联（加新删旧，无并行版）。
+**锁**：`agentSessionKey.test.ts` 断言每种键的精确字面值（含 pid 缺省落 `local`）。
+
+### B1b 清会话一致化
+5 处 `clearWorkbenchAgentSession`，两种错误处理：
+- `.catch(() => {})` 吞：runDirectionPlanner:148 / shotVerifyJudge:34 / capabilityApplyHandler:96
+- `void`（无 catch，失败即 unhandled rejection）：CanvasAssistantPanel:535 / CreationAiPanel:460
+
+**做法**：新增 `safeClearAgentSession(sessionKey)`（await clear，失败 `console.warn` 记日志后吞，永不抛）。5 处全部替换。行为不变（原本就是 best-effort 清），只是把「有的静默吞、有的裸 void」统一成「带日志的安全包装」。
+**锁**：`agentSessionKey.test.ts`（同文件）断言 resolve 正常、reject 被吞不外抛且 warn 一次。
+
+### B1d 单次 vs 多轮显式声明
+现状循环模式隐式：`mode:'chat'`=单次文本、`mode:'auto'|'agent'`=多轮工具循环；「单次前先清会话」是各处手抄的约定。
+**做法**：在 `agentSessionKey.ts` 同层加类型化声明 `AgentLoopMode = 'single-shot' | 'multi-turn'` 与 `runSingleShot(...)` 薄封装：内部先 `safeClearAgentSession` 再发 `mode:'chat'` 消息——把「单次=先清会话」的约定收进一个显式入口。3 处单次流（direction/script/verify）改用它，行为逐字节不变（prompt/skillKey/attachments 原样透传）。
+**锁**：断言 `runSingleShot` 调用顺序（先 clear 后 send）+ 透传字段完整。
+
+### B1c systemPrompt 合成器
+现状拼接点 agentChatV2.ts:554-555：
+```
+systemParts = [NOMI_AGENT_IDENTITY, payload.systemPrompt, skillSystemPrompt, memoryBlock].filter(非空)
+system = parts.length ? sanitizeForBroadCompat(parts.join("\n\n")) : undefined
+```
+**警告**：结果必须**逐字节相同**（vendor 前缀缓存依赖 byte 稳定）。
+**做法**：抽纯函数 `composeAgentSystemPrompt({ identity, panelSystemPrompt, skillSystemPrompt, memoryBlock })` → 同样的 filter+join+sanitize，导出。`runAgentChatV2` 改调它。`NOMI_AGENT_IDENTITY` 保持单一真相源（作默认 identity）。
+**锁**：`composeAgentSystemPrompt.test.ts` 快照锁定：① 每个真实面板的最终 systemPrompt 字节串（创作区 documentTools 面 / 生成画布面 agent|chat|refine 三 mode）——用真实 `buildStaticAgentSystemPrompt` + 真实 `NOMI_AGENT_IDENTITY` 喂进去抓 `.toMatchInlineSnapshot`；② 空段过滤、单段不加分隔、sanitize 生效等边界。**重构前先抓快照**。
+
+## 禁做
+不加新功能、不改任何 prompt 文案、不动确认/gate 逻辑（B3）、不动工具注册（B2）、不动 UI 布局、不动 MCP 语义链。
+
+## 回滚
+每件独立 commit；任一件回归失败 `git revert` 该 commit 即可，四件互不耦合（工厂/包装/声明/合成器各自独立文件）。
+
+## 验收门
+每件：focused vitest 绿 → 全套 `pnpm run test` 绿 → `pnpm run gates` 全绿。push 分支 + `gh pr create`（不合并）。

--- a/electron/ai/agentChatV2.ts
+++ b/electron/ai/agentChatV2.ts
@@ -57,7 +57,7 @@ function readRequestedSkill(payload: JsonRecord): { key: string; name: string } 
  * 三层结构：① 这里 = 共享身份 + 产品/流程认知 + 输出铁律 + 语言规则；
  * ② payload.systemPrompt = 当前面的专长（如画布工具集）；③ skillSystemPrompt = 当前 skill 方法论。
  */
-const NOMI_AGENT_IDENTITY = [
+export const NOMI_AGENT_IDENTITY = [
   "你是 Nomi 的 AI 创作伙伴。",
   "",
   "Nomi 是一个本地优先的 AI 视频创作工作台。用户在这里把一个想法做成视频，路径是：创作区写文案/故事/剧本 →（拆镜头）→ 生成画布把每个镜头排成节点、选模型配参数 → 时间轴拼接预览 → 导出 MP4。你始终清楚用户正处在这条链的哪一环，给的帮助要能把他推进到下一环。",
@@ -95,6 +95,33 @@ function buildSkillSystemPrompt(payload: JsonRecord): string {
     "",
     skill.body,
   ].join("\n");
+}
+
+/**
+ * systemPrompt 合成器（B1c 单一合成点）——把四层收成一处：
+ *   ① identity        = NOMI_AGENT_IDENTITY（共享身份，单一真相源）
+ *   ② panelSystemPrompt = 当前面板专长（payload.systemPrompt，如生成画布工具说明）
+ *   ③ skillSystemPrompt = 当前 skill 方法论（buildSkillSystemPrompt）
+ *   ④ memoryBlock       = 项目记忆（殿后，见 runAgentChatV2 注）
+ *
+ * **字节稳定铁律**：vendor 前缀缓存依赖 system 段 byte 逐字节稳定——本函数只做
+ * 「过滤空段 → join('\n\n') → sanitizeForBroadCompat」，与旧内联逻辑逐字节等价，改一处不得漂移。
+ * 全空返回 undefined（不发 system 槽）。记忆放末尾：它变更最频繁，殿后只击穿后缀缓存，
+ * 前面身份/专长/skill 的前缀缓存仍命中。
+ */
+export function composeAgentSystemPrompt(layers: {
+  identity: string;
+  panelSystemPrompt: string;
+  skillSystemPrompt: string;
+  memoryBlock: string;
+}): string | undefined {
+  const parts = [
+    layers.identity,
+    layers.panelSystemPrompt,
+    layers.skillSystemPrompt,
+    layers.memoryBlock,
+  ].filter((part) => part && part.length > 0);
+  return parts.length > 0 ? sanitizeForBroadCompat(parts.join("\n\n")) : undefined;
 }
 
 // vision/preview/audio 等常不可靠发 tool_use → 无偏好时降权（仍作回退），让通用对话模型优先做 Agent 主控（2026-06-07 真机走查 P0）。
@@ -551,8 +578,13 @@ export async function runAgentChatV2(
     /* 记忆读取/提炼失败静默退回无记忆,绝不阻断对话 */
   }
 
-  const systemParts = [NOMI_AGENT_IDENTITY, systemPrompt, skillSystemPrompt, memoryBlock].filter((part) => part && part.length > 0);
-  const system = systemParts.length > 0 ? sanitizeForBroadCompat(systemParts.join("\n\n")) : undefined;
+  // 四层收口到单一合成器（B1c）：身份 + 面板专长 + skill 方法论 + 项目记忆，字节逐字节稳定。
+  const system = composeAgentSystemPrompt({
+    identity: NOMI_AGENT_IDENTITY,
+    panelSystemPrompt: systemPrompt,
+    skillSystemPrompt,
+    memoryBlock,
+  });
 
   const languageModel = buildLanguageModelForVendor(vendor, model, apiKey);
 

--- a/electron/ai/composeAgentSystemPrompt.test.ts
+++ b/electron/ai/composeAgentSystemPrompt.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("electron", () => ({ app: { getPath: () => "/tmp", getAppPath: () => process.cwd() } }));
+
+import { composeAgentSystemPrompt, NOMI_AGENT_IDENTITY } from "./agentChatV2";
+import { sanitizeForBroadCompat } from "./promptSanitize";
+
+// B1c 字节稳定门：systemPrompt 合成器把「身份 + 面板专长 + skill 方法论 + 项目记忆」四层
+// 收成单一 filter+join("\n\n")+sanitize 的纯函数。vendor 前缀缓存依赖 byte 稳定——
+// 这些快照锁死合成算法的**逐字节**输出，重构（抽函数）前后必须一致，改一个字节即红。
+
+// characterization：现状（agentChatV2.ts:554-555）的等价内联算法，作独立参照。
+// 合成器输出必须与它逐字节相同，证明抽函数没改变任何 byte。
+function referenceCompose(parts: Array<string | undefined>): string | undefined {
+  const kept = parts.filter((p): p is string => Boolean(p) && p.length > 0);
+  return kept.length > 0 ? sanitizeForBroadCompat(kept.join("\n\n")) : undefined;
+}
+
+describe("composeAgentSystemPrompt — 四层合成的字节稳定", () => {
+  it("身份单一真相源：NOMI_AGENT_IDENTITY 字节串锁死", () => {
+    expect(NOMI_AGENT_IDENTITY).toMatchInlineSnapshot(`
+      "你是 Nomi 的 AI 创作伙伴。
+
+      Nomi 是一个本地优先的 AI 视频创作工作台。用户在这里把一个想法做成视频，路径是：创作区写文案/故事/剧本 →（拆镜头）→ 生成画布把每个镜头排成节点、选模型配参数 → 时间轴拼接预览 → 导出 MP4。你始终清楚用户正处在这条链的哪一环，给的帮助要能把他推进到下一环。
+      用户是创作者，要的是能直接用的成品，不是方法论。
+
+      输出铁律：
+      - 具体、可执行、可视化：给画面、给细节、给能直接落地的内容；不要空泛建议和正确的废话。
+      - 密度优先、少即是多：克制利落，不堆套话、不复述用户的话、不写「希望对你有帮助」这类填充。
+      - 模型与能力一律用它的真名（vendor 原词，如 Seedance、全能参考），不要替用户翻译成自创词，以免把能力说窄。
+      - 不泄露内部推理链路，直接给结论和成品。
+      - 主动但不越权：该调工具就调，但所有写入/生成都要等用户在卡片上确认后才生效。
+
+      语言规则（最高优先级，覆盖一切其他指令）：
+      始终用与用户相同的自然语言回复——用户用中文你就用中文，用英文就用英文，用日文就用日文；写进文稿和节点 prompt 的内容同样跟随用户语言。
+      永远不要因为本系统提示或某个 skill 是用中文/英文写的，就固定用那种语言；以用户最近一条消息的语言为准。"
+    `);
+  });
+
+  it("创作区形态（无面板专长层）：身份 + skill 方法论，与参照逐字节相同", () => {
+    const skill = "Nomi 桌面 Agent 已加载本地 skill。\nskillKey: workbench.creation.general\n\n方法论正文……";
+    const composed = composeAgentSystemPrompt({
+      identity: NOMI_AGENT_IDENTITY,
+      panelSystemPrompt: "",
+      skillSystemPrompt: skill,
+      memoryBlock: "",
+    });
+    // 与现状内联逻辑逐字节相同（空面板段被过滤，身份与 skill 以 \n\n 相接）。
+    expect(composed).toBe(referenceCompose([NOMI_AGENT_IDENTITY, "", skill, ""]));
+    // 身份 block 完整出现在最前、skill 完整出现在末尾（sanitize 后）。
+    expect(composed?.startsWith(sanitizeForBroadCompat(NOMI_AGENT_IDENTITY))).toBe(true);
+    expect(composed?.endsWith(sanitizeForBroadCompat(skill))).toBe(true);
+    expect(composed).toContain(`${sanitizeForBroadCompat(NOMI_AGENT_IDENTITY)}\n\n${sanitizeForBroadCompat(skill)}`);
+  });
+
+  it("生成画布形态（含面板专长层 + skill + 记忆）四层齐全，与参照逐字节相同", () => {
+    const panel = "你现在在「生成画布」工作：把用户的想法落成画布上的节点、引用边和真实生成任务。";
+    const skill = "已加载 storyboard-planner skill。";
+    const memory = "项目记忆：\n- 主角叫小云雀";
+    const composed = composeAgentSystemPrompt({
+      identity: NOMI_AGENT_IDENTITY,
+      panelSystemPrompt: panel,
+      skillSystemPrompt: skill,
+      memoryBlock: memory,
+    });
+    // 四段顺序：身份 -> 面板 -> skill -> 记忆，各以 \n\n 相接，再整体 sanitize；与现状逐字节相同。
+    expect(composed).toBe(referenceCompose([NOMI_AGENT_IDENTITY, panel, skill, memory]));
+    expect(composed).toBe(sanitizeForBroadCompat([NOMI_AGENT_IDENTITY, panel, skill, memory].join("\n\n")));
+  });
+
+  it("空段一律被过滤，不产生连续分隔或前后缀空行", () => {
+    const composed = composeAgentSystemPrompt({
+      identity: "A",
+      panelSystemPrompt: "",
+      skillSystemPrompt: "B",
+      memoryBlock: "",
+    });
+    expect(composed).toBe("A\n\nB"); // 不是 "A\n\n\n\nB"，也不是 "A\n\nB\n\n"
+  });
+
+  it("四层全空 → undefined（不发 system 槽）", () => {
+    expect(
+      composeAgentSystemPrompt({ identity: "", panelSystemPrompt: "", skillSystemPrompt: "", memoryBlock: "" }),
+    ).toBeUndefined();
+  });
+
+  it("sanitize 生效：合成结果整体过 sanitizeForBroadCompat（与现状同一处 sanitize）", () => {
+    const composed = composeAgentSystemPrompt({
+      identity: "身份 — 用了破折号",
+      panelSystemPrompt: "箭头 → 这里",
+      skillSystemPrompt: "",
+      memoryBlock: "",
+    });
+    // 合成 = 过滤空段 → join('\n\n') → sanitize，与现状同一处 sanitize 逐字节相同。
+    expect(composed).toBe(sanitizeForBroadCompat("身份 — 用了破折号\n\n箭头 → 这里"));
+    // 箭头被 ASCII 化（arrow → "->"），确认 sanitize 确实作用到了合成结果。
+    expect(composed).toContain("->");
+    expect(composed).not.toContain("→");
+    expect(composed).not.toContain("—");
+  });
+});

--- a/src/workbench/ai/agentLoopMode.test.ts
+++ b/src/workbench/ai/agentLoopMode.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+// runSingleShotAgent 把「单次任务=先清会话→发 mode:'chat' 消息→自动带模型偏好」收成一个显式入口（B1d）。
+// mock 三个协作方，验：① 循环模式声明为 single-shot；② 清会话在发消息之前；
+// ③ 请求字段逐项透传且 mode 恒 'chat'；④ 助手模型偏好自动附加。
+const clearOrder: string[] = []
+
+vi.mock('./workbenchAiClient', () => ({
+  sendWorkbenchAiMessage: vi.fn(async () => {
+    clearOrder.push('send')
+    return { text: 'ok', usage: undefined }
+  }),
+}))
+vi.mock('./assistantModelPref', () => ({
+  getAssistantModelPref: vi.fn(() => null),
+}))
+vi.mock('./agentSessionKey', () => ({
+  safeClearAgentSession: vi.fn(async () => {
+    clearOrder.push('clear')
+  }),
+}))
+
+import { sendWorkbenchAiMessage } from './workbenchAiClient'
+import { getAssistantModelPref } from './assistantModelPref'
+import { safeClearAgentSession } from './agentSessionKey'
+import { runSingleShotAgent, AGENT_LOOP_MODE } from './agentLoopMode'
+
+const mockSend = sendWorkbenchAiMessage as unknown as ReturnType<typeof vi.fn>
+const mockPref = getAssistantModelPref as unknown as ReturnType<typeof vi.fn>
+const mockClear = safeClearAgentSession as unknown as ReturnType<typeof vi.fn>
+
+afterEach(() => {
+  vi.clearAllMocks()
+  clearOrder.length = 0
+  mockPref.mockImplementation(() => null)
+})
+
+describe('runSingleShotAgent —— 单次循环模式的显式入口（B1d）', () => {
+  it('循环模式常量声明齐全（single-shot / multi-turn）', () => {
+    expect(AGENT_LOOP_MODE.singleShot).toBe('single-shot')
+    expect(AGENT_LOOP_MODE.multiTurn).toBe('multi-turn')
+  })
+
+  it('先清会话，再发消息（框架托管清会话时机）', async () => {
+    await runSingleShotAgent({
+      sessionKey: 'nomi:production-directions:p1',
+      prompt: 'hi',
+      displayPrompt: '构思创意方向',
+      skillKey: 'workbench.production.direction-planner',
+      skillName: '方向候选规划',
+    })
+    expect(mockClear).toHaveBeenCalledWith('nomi:production-directions:p1')
+    expect(clearOrder).toEqual(['clear', 'send'])
+  })
+
+  it('mode 恒为 chat；prompt/displayPrompt/sessionKey/skill 逐项透传；projectId 有则带无则省', async () => {
+    await runSingleShotAgent({
+      sessionKey: 'nomi:shot-verify:p2',
+      prompt: 'judge this',
+      displayPrompt: 'judge',
+      projectId: 'p2',
+      skillKey: 'workbench.shot-verify',
+      skillName: '镜级画面校验',
+    })
+    const [req, handlers] = mockSend.mock.calls[0]
+    expect(req).toMatchObject({
+      prompt: 'judge this',
+      displayPrompt: 'judge',
+      sessionKey: 'nomi:shot-verify:p2',
+      projectId: 'p2',
+      skillKey: 'workbench.shot-verify',
+      skillName: '镜级画面校验',
+      mode: 'chat',
+    })
+    // 空 handlers（单次流不订阅流事件，与现状一致）
+    expect(handlers).toEqual({})
+  })
+
+  it('projectId 缺省时不塞进请求（避免 canvasProjectId 落空串）', async () => {
+    await runSingleShotAgent({
+      sessionKey: 'k',
+      prompt: 'p',
+      displayPrompt: 'd',
+      skillKey: 'sk',
+      skillName: 'sn',
+    })
+    const [req] = mockSend.mock.calls[0]
+    expect('projectId' in req).toBe(false)
+  })
+
+  it('自动附加助手模型偏好（agentModelKey/agentVendorKey）', async () => {
+    mockPref.mockImplementation(() => ({ modelKey: 'm-x', vendorKey: 'v-y' }))
+    await runSingleShotAgent({
+      sessionKey: 'k',
+      prompt: 'p',
+      displayPrompt: 'd',
+      skillKey: 'sk',
+      skillName: 'sn',
+    })
+    const [req] = mockSend.mock.calls[0]
+    expect(req).toMatchObject({ agentModelKey: 'm-x', agentVendorKey: 'v-y' })
+  })
+
+  it('无偏好时不附加模型键', async () => {
+    mockPref.mockImplementation(() => null)
+    await runSingleShotAgent({ sessionKey: 'k', prompt: 'p', displayPrompt: 'd', skillKey: 'sk', skillName: 'sn' })
+    const [req] = mockSend.mock.calls[0]
+    expect('agentModelKey' in req).toBe(false)
+    expect('agentVendorKey' in req).toBe(false)
+  })
+
+  it('attachments 有则透传（shot-verify 喂首帧图）', async () => {
+    const attachments = [{ url: 'nomi-local://x.png', contentType: 'image/png', fileName: 'shot-frame.png', kind: 'image' as const }]
+    await runSingleShotAgent({ sessionKey: 'k', prompt: 'p', displayPrompt: 'd', skillKey: 'sk', skillName: 'sn', attachments })
+    const [req] = mockSend.mock.calls[0]
+    expect(req.attachments).toEqual(attachments)
+  })
+
+  it('返回底层响应原样', async () => {
+    mockSend.mockResolvedValueOnce({ text: 'candidate json', usage: { totalTokens: 5 } })
+    const res = await runSingleShotAgent({ sessionKey: 'k', prompt: 'p', displayPrompt: 'd', skillKey: 'sk', skillName: 'sn' })
+    expect(res.text).toBe('candidate json')
+  })
+})

--- a/src/workbench/ai/agentLoopMode.ts
+++ b/src/workbench/ai/agentLoopMode.ts
@@ -1,0 +1,64 @@
+// Agent 循环模式的显式声明（B1d）——把此前隐式的「单次 vs 多轮」约定类型化，
+// 由框架据此托管清会话时机，替换各处手抄的 boilerplate。
+//
+// 现状两条链路：
+//   · single-shot：mode:'chat'，无工具的一次性文本/多模态产出（方向候选 / 剧本初稿 / 镜级校验）。
+//     铁律「每次独立=先清会话再发」原本在 3 个文件里各抄一遍；这里收进 runSingleShotAgent 一个入口。
+//   · multi-turn：mode:'auto'|'agent'，带工具的多轮 loop（创作区 / 生成画布助手），会话历史跨轮累积，
+//     由 runWorkbenchAgent / sendGenerationCanvasAgentMessage 承载（本文件不介入，仅声明其模式名）。
+
+import { sendWorkbenchAiMessage } from './workbenchAiClient'
+import { getAssistantModelPref } from './assistantModelPref'
+import { safeClearAgentSession } from './agentSessionKey'
+import type { AgentAttachmentPayload, AgentsChatResponseDto } from '../../api/desktopClient'
+
+/** 循环模式常量（类型化声明，供入口显式标注自己是哪一种）。 */
+export const AGENT_LOOP_MODE = {
+  /** 单次：清会话 → 一次 chat 产出，不留历史（本文件的 runSingleShotAgent）。 */
+  singleShot: 'single-shot',
+  /** 多轮：带工具 loop，历史跨轮累积（runWorkbenchAgent / 生成画布 agent）。 */
+  multiTurn: 'multi-turn',
+} as const
+
+export type AgentLoopMode = (typeof AGENT_LOOP_MODE)[keyof typeof AGENT_LOOP_MODE]
+
+export type SingleShotAgentRequest = {
+  /** 该单次任务的独立会话键（用 agentSessionKey.ts 的工厂产出）。 */
+  sessionKey: string
+  /** 完整 prompt。 */
+  prompt: string
+  /** 聊天气泡/线程里显示的短文本。 */
+  displayPrompt: string
+  projectId?: string
+  skillKey: string
+  skillName: string
+  /** 多模态附件（如 shot-verify 喂首帧图）。 */
+  attachments?: AgentAttachmentPayload[]
+}
+
+/**
+ * 跑一次单次（single-shot）agent：**先清会话**（框架托管的清会话时机）→ 无工具 chat 产出。
+ * 助手模型偏好自动附加。返回底层响应原样。
+ *
+ * 收口 3 处（方向 / 剧本 / 镜级校验）此前各自手抄的「clear → sendWorkbenchAiMessage(mode:'chat', +pref)」，
+ * 行为逐字节等价（请求字段原样透传，mode 恒 'chat'，pref 与附件按原逻辑条件附加）。
+ */
+export async function runSingleShotAgent(request: SingleShotAgentRequest): Promise<AgentsChatResponseDto> {
+  // 单次铁律：每次独立，先清会话，避免上一轮/别处上下文污染本次产出。
+  await safeClearAgentSession(request.sessionKey)
+  const pref = getAssistantModelPref()
+  return sendWorkbenchAiMessage(
+    {
+      prompt: request.prompt,
+      displayPrompt: request.displayPrompt,
+      sessionKey: request.sessionKey,
+      ...(request.projectId ? { projectId: request.projectId } : {}),
+      skillKey: request.skillKey,
+      skillName: request.skillName,
+      mode: 'chat',
+      ...(pref ? { agentModelKey: pref.modelKey, agentVendorKey: pref.vendorKey } : {}),
+      ...(request.attachments?.length ? { attachments: request.attachments } : {}),
+    },
+    {},
+  )
+}

--- a/src/workbench/ai/agentSessionKey.clear.test.ts
+++ b/src/workbench/ai/agentSessionKey.clear.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+// safeClearAgentSession 包住 desktopClient.clearWorkbenchAgentSession：
+// 成功正常 await；失败 console.warn 记一次日志后吞掉，**永不外抛**（best-effort 清会话）。
+// mock 掉真实 IPC 客户端，只验包装行为。
+vi.mock('../../api/desktopClient', () => ({
+  clearWorkbenchAgentSession: vi.fn(async () => {}),
+}))
+
+import { clearWorkbenchAgentSession } from '../../api/desktopClient'
+import { safeClearAgentSession } from './agentSessionKey'
+
+const mockClear = clearWorkbenchAgentSession as unknown as ReturnType<typeof vi.fn>
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.clearAllMocks()
+})
+
+describe('safeClearAgentSession —— 带日志的安全包装（B1b 清会话一致化）', () => {
+  it('把 sessionKey 原样透传给 clearWorkbenchAgentSession', async () => {
+    mockClear.mockResolvedValueOnce(undefined)
+    await safeClearAgentSession('nomi:shot-verify:proj-1')
+    expect(mockClear).toHaveBeenCalledTimes(1)
+    expect(mockClear).toHaveBeenCalledWith('nomi:shot-verify:proj-1')
+  })
+
+  it('底层 reject 时不外抛（resolve void），并 console.warn 记一次', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    mockClear.mockRejectedValueOnce(new Error('ipc down'))
+    // 不应抛：await 正常返回
+    await expect(safeClearAgentSession('nomi:workbench:p:creation')).resolves.toBeUndefined()
+    expect(warn).toHaveBeenCalledTimes(1)
+    // 日志里带上 sessionKey，便于定位是哪条会话清失败
+    expect(String(warn.mock.calls[0]?.join(' '))).toContain('nomi:workbench:p:creation')
+  })
+
+  it('成功路径不打 warn', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    mockClear.mockResolvedValueOnce(undefined)
+    await safeClearAgentSession('nomi:production-directions:x')
+    expect(warn).not.toHaveBeenCalled()
+  })
+})

--- a/src/workbench/ai/agentSessionKey.test.ts
+++ b/src/workbench/ai/agentSessionKey.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+// readWindowUrlParam 是键工厂内部读 projectId 的唯一来源（与现状 4 处一致）。
+// 用 vi.mock 控制它，锁死「有 pid」「无 pid 落 local」两条分支的字面输出。
+vi.mock('../windowUrlParam', () => ({
+  readWindowUrlParam: vi.fn(() => ''),
+}))
+
+import { readWindowUrlParam } from '../windowUrlParam'
+import {
+  sessionKeyFor,
+  workbenchSessionKey,
+  directionSessionKey,
+  shotVerifySessionKey,
+  productionScriptSessionKey,
+} from './agentSessionKey'
+
+const mockPid = (pid: string) => {
+  ;(readWindowUrlParam as unknown as ReturnType<typeof vi.fn>).mockImplementation((name: string) =>
+    name === 'projectId' ? pid : '',
+  )
+}
+
+afterEach(() => {
+  vi.clearAllMocks()
+  ;(readWindowUrlParam as unknown as ReturnType<typeof vi.fn>).mockImplementation(() => '')
+})
+
+describe('sessionKeyFor —— 收口 4 种硬编码约定，字面值逐字节锁死', () => {
+  it('workbench area 键：nomi:workbench:<pid>:<area>（历史起按 area 隔离）', () => {
+    mockPid('proj-42')
+    expect(workbenchSessionKey('creation')).toBe('nomi:workbench:proj-42:creation')
+    expect(workbenchSessionKey('generation')).toBe('nomi:workbench:proj-42:generation')
+  })
+
+  it('单次任务键：nomi:<feature>:<pid>（方向 / 校验 / 脚本三种）', () => {
+    mockPid('proj-42')
+    expect(directionSessionKey()).toBe('nomi:production-directions:proj-42')
+    expect(shotVerifySessionKey()).toBe('nomi:shot-verify:proj-42')
+    expect(productionScriptSessionKey()).toBe('nomi:production-script:proj-42')
+  })
+
+  it('projectId 缺省一律落 local（打包版曾因只读 search 段全落 local，这里锁死兜底值）', () => {
+    mockPid('')
+    expect(workbenchSessionKey('creation')).toBe('nomi:workbench:local:creation')
+    expect(workbenchSessionKey('generation')).toBe('nomi:workbench:local:generation')
+    expect(directionSessionKey()).toBe('nomi:production-directions:local')
+    expect(shotVerifySessionKey()).toBe('nomi:shot-verify:local')
+    expect(productionScriptSessionKey()).toBe('nomi:production-script:local')
+  })
+
+  it('显式传入 projectId 覆盖 URL 读取（capabilityApplyHandler 会传入 input.projectId）', () => {
+    mockPid('from-url')
+    // 传入优先：脚本入口允许 caller 显式给 projectId（否则回退 URL）
+    expect(productionScriptSessionKey('explicit-pid')).toBe('nomi:production-script:explicit-pid')
+    // 传入空串/undefined → 回退 URL
+    expect(productionScriptSessionKey('')).toBe('nomi:production-script:from-url')
+    expect(productionScriptSessionKey(undefined)).toBe('nomi:production-script:from-url')
+  })
+
+  it('底层 sessionKeyFor：area 形态与 feature 形态都按固定模板产出', () => {
+    mockPid('p1')
+    // feature 形态（无 area 段）
+    expect(sessionKeyFor({ feature: 'shot-verify' })).toBe('nomi:shot-verify:p1')
+    // area 形态（feature=workbench，area 作末段）
+    expect(sessionKeyFor({ feature: 'workbench', area: 'creation' })).toBe('nomi:workbench:p1:creation')
+    // 显式 projectId 覆盖
+    expect(sessionKeyFor({ feature: 'shot-verify', projectId: 'zz' })).toBe('nomi:shot-verify:zz')
+  })
+})

--- a/src/workbench/ai/agentSessionKey.ts
+++ b/src/workbench/ai/agentSessionKey.ts
@@ -10,6 +10,7 @@
 //   · feature 形态：nomi:<feature>:<pid>       —— 单次任务（方向/校验/脚本）用独立键，不污染对话历史线程。
 
 import { readWindowUrlParam } from '../windowUrlParam'
+import { clearWorkbenchAgentSession } from '../../api/desktopClient'
 
 export type WorkbenchAgentArea = 'creation' | 'generation'
 
@@ -45,4 +46,18 @@ export function shotVerifySessionKey(): string {
 /** 剧本/脚本单次规划用独立会话键；caller 可显式传 projectId（否则回退 URL）。 */
 export function productionScriptSessionKey(projectId?: string): string {
   return sessionKeyFor({ feature: 'production-script', ...(projectId ? { projectId } : {}) })
+}
+
+/**
+ * 清后端会话记忆的安全包装（B1b）——统一此前散在 5 处的两种写法（`.catch(()=>{})` 吞 / 裸 `void` 无 catch）。
+ * 清会话本就是 best-effort（清失败不该中断新对话/单次任务），但裸 `void` 会在失败时抛 unhandled rejection。
+ * 这里统一为：await 底层清理，失败 `console.warn` 记一次（带 sessionKey 便于定位）后吞掉，**永不外抛**。
+ * 行为与旧代码等价（都是尽力清、失败不阻断），只是把「有的静默吞、有的裸抛」收成一处带日志的安全语义。
+ */
+export async function safeClearAgentSession(sessionKey: string): Promise<void> {
+  try {
+    await clearWorkbenchAgentSession(sessionKey)
+  } catch (error: unknown) {
+    console.warn(`[agent] clear session failed (${sessionKey})`, error)
+  }
 }

--- a/src/workbench/ai/agentSessionKey.ts
+++ b/src/workbench/ai/agentSessionKey.ts
@@ -1,0 +1,48 @@
+// Agent 会话键工厂（B1a）——收口此前 4 处硬编码的键生成约定，产出与旧代码**逐字节相同**。
+//
+// 键决定后端对话记忆（agentSessionStore）落哪个桶：换了字面值 = 用户已有会话历史丢失。
+// 因此本工厂只是把散在 4 个文件里的 `nomi:...:${projectId||'local'}` 拼接收进一处，
+// 不改任何字面模板。projectId 缺省一律落 `local`（打包版曾因只读 search 段全落 local，
+// 这个兜底值必须保持不变，见 windowUrlParam.ts 注）。
+//
+// 两种历史形态：
+//   · area 形态：nomi:workbench:<pid>:<area>   —— 创作区/生成区各一份记忆，按 area 隔离（2026-06-14 起）。
+//   · feature 形态：nomi:<feature>:<pid>       —— 单次任务（方向/校验/脚本）用独立键，不污染对话历史线程。
+
+import { readWindowUrlParam } from '../windowUrlParam'
+
+export type WorkbenchAgentArea = 'creation' | 'generation'
+
+/**
+ * 会话键底层工厂。`projectId` 显式给则用它，否则回退读 URL（与旧 4 处一致：均 `readWindowUrlParam('projectId') || 'local'`）。
+ * - feature 形态：`{ feature }`         → `nomi:<feature>:<pid>`
+ * - area 形态：   `{ feature, area }`   → `nomi:<feature>:<pid>:<area>`
+ */
+export function sessionKeyFor(spec: { feature: string; area?: string; projectId?: string }): string {
+  const pid = (spec.projectId && spec.projectId.trim()) || readWindowUrlParam('projectId') || 'local'
+  const base = `nomi:${spec.feature}:${pid}`
+  return spec.area ? `${base}:${spec.area}` : base
+}
+
+/**
+ * 创作区/生成区共享的对话记忆键（按 area 隔离，按 project 隔离）。
+ * readWindowUrlParam 兼容 prod 的 hash 路由——只读 search 段曾让打包版全部落 `local` 桶。
+ */
+export function workbenchSessionKey(area: WorkbenchAgentArea): string {
+  return sessionKeyFor({ feature: 'workbench', area })
+}
+
+/** 方向门用独立会话键（与创作/生成区线程隔离，不污染用户对话历史）。 */
+export function directionSessionKey(): string {
+  return sessionKeyFor({ feature: 'production-directions' })
+}
+
+/** 镜级 verify 用独立会话键（与创作/生成区线程隔离，不污染用户对话历史）。 */
+export function shotVerifySessionKey(): string {
+  return sessionKeyFor({ feature: 'shot-verify' })
+}
+
+/** 剧本/脚本单次规划用独立会话键；caller 可显式传 projectId（否则回退 URL）。 */
+export function productionScriptSessionKey(projectId?: string): string {
+  return sessionKeyFor({ feature: 'production-script', ...(projectId ? { projectId } : {}) })
+}

--- a/src/workbench/ai/workbenchAgentRunner.ts
+++ b/src/workbench/ai/workbenchAgentRunner.ts
@@ -2,7 +2,11 @@ import type { AgentAttachmentPayload, AgentsChatResponseDto, AgentChatV2Session 
 import { sendWorkbenchAiMessage } from './workbenchAiClient'
 import { getAssistantModelPref } from './assistantModelPref'
 import { useAgentUsageStore } from './agentUsageStore'
-import { readWindowUrlParam } from '../windowUrlParam'
+import { workbenchSessionKey, type WorkbenchAgentArea } from './agentSessionKey'
+
+// 会话键工厂已收口到 agentSessionKey.ts（B1a）。此处 re-export 保持既有 import 路径不破
+// （generationCanvasAgentClient / 两面板 / staleConversationDivider / conversationPersistence 仍从这里取）。
+export { workbenchSessionKey, type WorkbenchAgentArea } from './agentSessionKey'
 
 /**
  * One shared agent runner for both workbench panels (创作区 + 生成区).
@@ -16,18 +20,6 @@ import { readWindowUrlParam } from '../windowUrlParam'
  * Read tools are auto-confirmed by the caller; write/destructive tools render a
  * confirmation card and confirm only after the user approves.
  */
-
-export type WorkbenchAgentArea = 'creation' | 'generation'
-
-/**
- * 后端对话记忆键。会话历史(2026-06-14)起按 **area** 隔离:创作区 / 生成区各一份记忆,
- * 翻回各自的历史线程互不串台。仍按 project 隔离,不同项目不漏上下文。
- */
-export function workbenchSessionKey(area: WorkbenchAgentArea): string {
-  // readWindowUrlParam 兼容 prod 的 hash 路由——只读 search 段曾让打包版全部落 `local` 桶。
-  const projectId = readWindowUrlParam('projectId')
-  return `nomi:workbench:${projectId || 'local'}:${area}`
-}
 
 export type ToolCallEvent = {
   toolCallId: string

--- a/src/workbench/capability/capabilityApplyHandler.ts
+++ b/src/workbench/capability/capabilityApplyHandler.ts
@@ -5,9 +5,8 @@ import { getDesktopBridge } from '../../desktop/bridge'
 import i18n from '../../i18n'
 import { runStoryboardPlanner } from '../generationCanvas/agent/runStoryboardPlanner'
 import { runDirectionPlanner } from '../generationCanvas/agent/runDirectionPlanner'
-import { sendWorkbenchAiMessage } from '../ai/workbenchAiClient'
-import { getAssistantModelPref } from '../ai/assistantModelPref'
-import { productionScriptSessionKey, safeClearAgentSession } from '../ai/agentSessionKey'
+import { productionScriptSessionKey } from '../ai/agentSessionKey'
+import { runSingleShotAgent } from '../ai/agentLoopMode'
 import { readWindowUrlParam } from '../windowUrlParam'
 import { useWorkbenchStore } from '../workbenchStore'
 import { mintSpendGrant } from '../api/taskApi'
@@ -92,8 +91,6 @@ async function runProductionTextPlanner(input: {
   outputFormat?: 'script' | 'storyboard'
 }): Promise<string> {
   const projectId = input.projectId || readWindowUrlParam('projectId') || ''
-  const sessionKey = productionScriptSessionKey(projectId)
-  await safeClearAgentSession(sessionKey)
   const prompt = input.outputFormat === 'storyboard'
     ? [
         '你是分镜规划师。请根据下面的原分镜方案和修改要求，输出一份完整、可执行的 StoryboardPlan JSON。',
@@ -118,17 +115,15 @@ async function runProductionTextPlanner(input: {
         input.goal || '',
         '只输出稿件正文，不要解释。',
       ].join('\n')
-  const pref = getAssistantModelPref()
-  const response = await sendWorkbenchAiMessage({
+  // 单次链路（清会话 + mode:'chat' + 模型偏好）收口到 runSingleShotAgent。
+  const response = await runSingleShotAgent({
+    sessionKey: productionScriptSessionKey(projectId),
     prompt,
     displayPrompt: input.instruction ? '修改制作稿件' : '生成制作剧本',
-    sessionKey,
     ...(projectId ? { projectId } : {}),
     skillKey: 'workbench.production.script-planner',
     skillName: '剧本初稿规划',
-    mode: 'chat',
-    ...(pref ? { agentModelKey: pref.modelKey, agentVendorKey: pref.vendorKey } : {}),
-  }, {})
+  })
   const text = response.text?.trim()
   if (!text) throw new Error('剧本规划没有返回可审阅内容')
   return text

--- a/src/workbench/capability/capabilityApplyHandler.ts
+++ b/src/workbench/capability/capabilityApplyHandler.ts
@@ -6,9 +6,8 @@ import i18n from '../../i18n'
 import { runStoryboardPlanner } from '../generationCanvas/agent/runStoryboardPlanner'
 import { runDirectionPlanner } from '../generationCanvas/agent/runDirectionPlanner'
 import { sendWorkbenchAiMessage } from '../ai/workbenchAiClient'
-import { clearWorkbenchAgentSession } from '../../api/desktopClient'
 import { getAssistantModelPref } from '../ai/assistantModelPref'
-import { productionScriptSessionKey } from '../ai/agentSessionKey'
+import { productionScriptSessionKey, safeClearAgentSession } from '../ai/agentSessionKey'
 import { readWindowUrlParam } from '../windowUrlParam'
 import { useWorkbenchStore } from '../workbenchStore'
 import { mintSpendGrant } from '../api/taskApi'
@@ -94,7 +93,7 @@ async function runProductionTextPlanner(input: {
 }): Promise<string> {
   const projectId = input.projectId || readWindowUrlParam('projectId') || ''
   const sessionKey = productionScriptSessionKey(projectId)
-  await clearWorkbenchAgentSession(sessionKey).catch(() => {})
+  await safeClearAgentSession(sessionKey)
   const prompt = input.outputFormat === 'storyboard'
     ? [
         '你是分镜规划师。请根据下面的原分镜方案和修改要求，输出一份完整、可执行的 StoryboardPlan JSON。',

--- a/src/workbench/capability/capabilityApplyHandler.ts
+++ b/src/workbench/capability/capabilityApplyHandler.ts
@@ -8,6 +8,7 @@ import { runDirectionPlanner } from '../generationCanvas/agent/runDirectionPlann
 import { sendWorkbenchAiMessage } from '../ai/workbenchAiClient'
 import { clearWorkbenchAgentSession } from '../../api/desktopClient'
 import { getAssistantModelPref } from '../ai/assistantModelPref'
+import { productionScriptSessionKey } from '../ai/agentSessionKey'
 import { readWindowUrlParam } from '../windowUrlParam'
 import { useWorkbenchStore } from '../workbenchStore'
 import { mintSpendGrant } from '../api/taskApi'
@@ -92,7 +93,7 @@ async function runProductionTextPlanner(input: {
   outputFormat?: 'script' | 'storyboard'
 }): Promise<string> {
   const projectId = input.projectId || readWindowUrlParam('projectId') || ''
-  const sessionKey = `nomi:production-script:${projectId || 'local'}`
+  const sessionKey = productionScriptSessionKey(projectId)
   await clearWorkbenchAgentSession(sessionKey).catch(() => {})
   const prompt = input.outputFormat === 'storyboard'
     ? [

--- a/src/workbench/creation/CreationAiPanel.tsx
+++ b/src/workbench/creation/CreationAiPanel.tsx
@@ -6,7 +6,7 @@ import { NomiLogoMark, WorkbenchButton, WorkbenchIconButton } from '../../design
 import { cn } from '../../utils/cn'
 import { runWorkbenchAgent, workbenchSessionKey, type ToolCallEvent } from '../ai/workbenchAgentRunner'
 import { startNewConversation } from '../ai/conversationPersistence'
-import { clearWorkbenchAgentSession } from '../../api/desktopClient'
+import { safeClearAgentSession } from '../ai/agentSessionKey'
 import { AssistantMessageView, UserMessageBubble } from '../ai/AssistantMessageView'
 import { NoTextModelRecoveryCard } from '../ai/NoTextModelRecoveryCard'
 import { AssistantErrorCard } from '../ai/AssistantErrorCard'
@@ -457,7 +457,7 @@ export default function CreationAiPanel({ onCollapse }: { onCollapse?: () => voi
     clearAttachments()
     setError('')
     // 新对话 = 该 area 模型上下文归零(创作/画布各一份键,互不影响)。
-    void clearWorkbenchAgentSession(workbenchSessionKey('creation'))
+    void safeClearAgentSession(workbenchSessionKey('creation'))
   }, [clearAttachments, setDraft, setError, turn])
 
   const panelBody = (

--- a/src/workbench/generationCanvas/agent/runDirectionPlanner.ts
+++ b/src/workbench/generationCanvas/agent/runDirectionPlanner.ts
@@ -11,9 +11,8 @@
 // 既有 gate title/summary 兜底——绝不静默编造候选（诚实降级，D4）。
 
 import { z } from 'zod'
-import { sendWorkbenchAiMessage } from '../../ai/workbenchAiClient'
-import { getAssistantModelPref } from '../../ai/assistantModelPref'
-import { directionSessionKey, safeClearAgentSession } from '../../ai/agentSessionKey'
+import { directionSessionKey } from '../../ai/agentSessionKey'
+import { runSingleShotAgent } from '../../ai/agentLoopMode'
 import { readWindowUrlParam } from '../../windowUrlParam'
 
 export type DirectionCandidate = { key: string; title: string; oneLiner: string }
@@ -138,25 +137,16 @@ export function parseDirectionCandidates(text: string): DirectionCandidate[] {
 export async function runDirectionPlanner(
   input: RunDirectionPlannerInput,
 ): Promise<{ candidates: DirectionCandidate[] }> {
-  const sessionKey = directionSessionKey()
-  // 每次独立：清会话，避免上一轮/别处上下文污染方向构思。
-  await safeClearAgentSession(sessionKey)
-  const pref = getAssistantModelPref()
   const projectId = readWindowUrlParam('projectId') || ''
-  const prompt = buildDirectionPlannerPrompt(input)
-  const response = await sendWorkbenchAiMessage(
-    {
-      prompt,
-      displayPrompt: '构思创意方向',
-      sessionKey,
-      ...(projectId ? { projectId } : {}),
-      skillKey: 'workbench.production.direction-planner',
-      skillName: '方向候选规划',
-      mode: 'chat', // 无工具的一次性文本产出（方向候选不碰画布、不花生成额度）
-      ...(pref ? { agentModelKey: pref.modelKey, agentVendorKey: pref.vendorKey } : {}),
-    },
-    {},
-  )
+  // 单次链路（清会话 + mode:'chat' + 模型偏好）收口到 runSingleShotAgent；方向候选不碰画布、不花生成额度。
+  const response = await runSingleShotAgent({
+    sessionKey: directionSessionKey(),
+    prompt: buildDirectionPlannerPrompt(input),
+    displayPrompt: '构思创意方向',
+    ...(projectId ? { projectId } : {}),
+    skillKey: 'workbench.production.direction-planner',
+    skillName: '方向候选规划',
+  })
   const candidates = parseDirectionCandidates(response.text ?? '')
   return { candidates }
 }

--- a/src/workbench/generationCanvas/agent/runDirectionPlanner.ts
+++ b/src/workbench/generationCanvas/agent/runDirectionPlanner.ts
@@ -12,9 +12,8 @@
 
 import { z } from 'zod'
 import { sendWorkbenchAiMessage } from '../../ai/workbenchAiClient'
-import { clearWorkbenchAgentSession } from '../../../api/desktopClient'
 import { getAssistantModelPref } from '../../ai/assistantModelPref'
-import { directionSessionKey } from '../../ai/agentSessionKey'
+import { directionSessionKey, safeClearAgentSession } from '../../ai/agentSessionKey'
 import { readWindowUrlParam } from '../../windowUrlParam'
 
 export type DirectionCandidate = { key: string; title: string; oneLiner: string }
@@ -141,7 +140,7 @@ export async function runDirectionPlanner(
 ): Promise<{ candidates: DirectionCandidate[] }> {
   const sessionKey = directionSessionKey()
   // 每次独立：清会话，避免上一轮/别处上下文污染方向构思。
-  await clearWorkbenchAgentSession(sessionKey).catch(() => {})
+  await safeClearAgentSession(sessionKey)
   const pref = getAssistantModelPref()
   const projectId = readWindowUrlParam('projectId') || ''
   const prompt = buildDirectionPlannerPrompt(input)

--- a/src/workbench/generationCanvas/agent/runDirectionPlanner.ts
+++ b/src/workbench/generationCanvas/agent/runDirectionPlanner.ts
@@ -14,6 +14,7 @@ import { z } from 'zod'
 import { sendWorkbenchAiMessage } from '../../ai/workbenchAiClient'
 import { clearWorkbenchAgentSession } from '../../../api/desktopClient'
 import { getAssistantModelPref } from '../../ai/assistantModelPref'
+import { directionSessionKey } from '../../ai/agentSessionKey'
 import { readWindowUrlParam } from '../../windowUrlParam'
 
 export type DirectionCandidate = { key: string; title: string; oneLiner: string }
@@ -32,11 +33,6 @@ export type RunDirectionPlannerInput = {
   brief?: DirectionPlannerBrief | null
   /** playbook 声明（key/name 等），用于给模型「这是哪类片子」的上下文；结构宽松，只读取文本字段。 */
   playbook?: Record<string, unknown> | null
-}
-
-/** 方向门用独立会话键（与创作/生成区线程隔离，不污染用户对话历史）。 */
-function directionSessionKey(): string {
-  return `nomi:production-directions:${readWindowUrlParam('projectId') || 'local'}`
 }
 
 /** 把 brief 里有值的字段拼成人话上下文行（缺省字段不占位，避免喂模型一堆 undefined）。 */

--- a/src/workbench/generationCanvas/agent/shotVerifyJudge.ts
+++ b/src/workbench/generationCanvas/agent/shotVerifyJudge.ts
@@ -8,13 +8,9 @@ import { getDesktopBridge } from '../../../desktop/bridge'
 import { sendWorkbenchAiMessage } from '../../ai/workbenchAiClient'
 import { clearWorkbenchAgentSession } from '../../../api/desktopClient'
 import { getAssistantModelPref } from '../../ai/assistantModelPref'
+import { shotVerifySessionKey } from '../../ai/agentSessionKey'
 import { readWindowUrlParam } from '../../windowUrlParam'
 import type { ShotVerifyDeps } from './shotVerifyRunner'
-
-/** verify 用独立会话键(与创作/生成区线程隔离,不污染用户对话历史)。 */
-function verifySessionKey(): string {
-  return `nomi:shot-verify:${readWindowUrlParam('projectId') || 'local'}`
-}
 
 /** 真实 deps 工厂(渲染层环境)。无桌面桥(非 Electron)→ extractFrame 抛错,被 runner 逐镜 catch 跳过。 */
 export function makeShotVerifyDeps(): ShotVerifyDeps {
@@ -29,7 +25,7 @@ export function makeShotVerifyDeps(): ShotVerifyDeps {
       return url
     },
     judge: async (prompt: string, frameImageUrl: string): Promise<string> => {
-      const sessionKey = verifySessionKey()
+      const sessionKey = shotVerifySessionKey()
       // 每镜判断必须独立:清会话,避免上一镜的图/判决污染本镜上下文(偏判)。
       await clearWorkbenchAgentSession(sessionKey).catch(() => {})
       const pref = getAssistantModelPref()

--- a/src/workbench/generationCanvas/agent/shotVerifyJudge.ts
+++ b/src/workbench/generationCanvas/agent/shotVerifyJudge.ts
@@ -6,9 +6,8 @@
 
 import { getDesktopBridge } from '../../../desktop/bridge'
 import { sendWorkbenchAiMessage } from '../../ai/workbenchAiClient'
-import { clearWorkbenchAgentSession } from '../../../api/desktopClient'
 import { getAssistantModelPref } from '../../ai/assistantModelPref'
-import { shotVerifySessionKey } from '../../ai/agentSessionKey'
+import { shotVerifySessionKey, safeClearAgentSession } from '../../ai/agentSessionKey'
 import { readWindowUrlParam } from '../../windowUrlParam'
 import type { ShotVerifyDeps } from './shotVerifyRunner'
 
@@ -27,7 +26,7 @@ export function makeShotVerifyDeps(): ShotVerifyDeps {
     judge: async (prompt: string, frameImageUrl: string): Promise<string> => {
       const sessionKey = shotVerifySessionKey()
       // 每镜判断必须独立:清会话,避免上一镜的图/判决污染本镜上下文(偏判)。
-      await clearWorkbenchAgentSession(sessionKey).catch(() => {})
+      await safeClearAgentSession(sessionKey)
       const pref = getAssistantModelPref()
       const response = await sendWorkbenchAiMessage(
         {

--- a/src/workbench/generationCanvas/agent/shotVerifyJudge.ts
+++ b/src/workbench/generationCanvas/agent/shotVerifyJudge.ts
@@ -5,9 +5,8 @@
 // 方案:docs/plan/2026-06-28-storyboard-closed-loop-verify.md（Stage 1 实时编排，架构决策已锁定）。
 
 import { getDesktopBridge } from '../../../desktop/bridge'
-import { sendWorkbenchAiMessage } from '../../ai/workbenchAiClient'
-import { getAssistantModelPref } from '../../ai/assistantModelPref'
-import { shotVerifySessionKey, safeClearAgentSession } from '../../ai/agentSessionKey'
+import { shotVerifySessionKey } from '../../ai/agentSessionKey'
+import { runSingleShotAgent } from '../../ai/agentLoopMode'
 import { readWindowUrlParam } from '../../windowUrlParam'
 import type { ShotVerifyDeps } from './shotVerifyRunner'
 
@@ -24,24 +23,17 @@ export function makeShotVerifyDeps(): ShotVerifyDeps {
       return url
     },
     judge: async (prompt: string, frameImageUrl: string): Promise<string> => {
-      const sessionKey = shotVerifySessionKey()
-      // 每镜判断必须独立:清会话,避免上一镜的图/判决污染本镜上下文(偏判)。
-      await safeClearAgentSession(sessionKey)
-      const pref = getAssistantModelPref()
-      const response = await sendWorkbenchAiMessage(
-        {
-          prompt,
-          displayPrompt: prompt.slice(0, 40),
-          sessionKey,
-          ...(projectId ? { projectId } : {}),
-          skillKey: 'workbench.shot-verify',
-          skillName: '镜级画面校验',
-          mode: 'chat', // 无工具的纯多模态判断
-          ...(pref ? { agentModelKey: pref.modelKey, agentVendorKey: pref.vendorKey } : {}),
-          attachments: [{ url: frameImageUrl, contentType: 'image/png', fileName: 'shot-frame.png', kind: 'image' }],
-        },
-        {},
-      )
+      // 每镜判断必须独立:单次链路(清会话 + mode:'chat' 纯多模态判断 + 模型偏好)收口到 runSingleShotAgent,
+      // 避免上一镜的图/判决污染本镜上下文(偏判)。
+      const response = await runSingleShotAgent({
+        sessionKey: shotVerifySessionKey(),
+        prompt,
+        displayPrompt: prompt.slice(0, 40),
+        ...(projectId ? { projectId } : {}),
+        skillKey: 'workbench.shot-verify',
+        skillName: '镜级画面校验',
+        attachments: [{ url: frameImageUrl, contentType: 'image/png', fileName: 'shot-frame.png', kind: 'image' }],
+      })
       return response.text ?? ''
     },
     // 默认视觉开;非多模态模型 → judge 返回非 JSON,runner 逐镜 catch 跳过(降级仅结构校验)。

--- a/src/workbench/generationCanvas/components/CanvasAssistantPanel.tsx
+++ b/src/workbench/generationCanvas/components/CanvasAssistantPanel.tsx
@@ -8,9 +8,8 @@ import {
   sendGenerationCanvasAgentMessage,
   type ToolCallEvent,
 } from '../agent/generationCanvasAgentClient'
-import { workbenchSessionKey } from '../../ai/workbenchAgentRunner'
+import { workbenchSessionKey, safeClearAgentSession } from '../../ai/agentSessionKey'
 import { startNewConversation } from '../../ai/conversationPersistence'
-import { clearWorkbenchAgentSession } from '../../../api/desktopClient'
 import { generationCanvasTools } from '../agent/generationCanvasTools'
 import { applyCanvasToolCall } from '../agent/applyCanvasToolCall'
 import { applyProposalBatch } from '../agent/proposalTxn'
@@ -532,7 +531,7 @@ export default function CanvasAssistantPanel({
     setDraft('')
     clearAttachments()
     // 新对话 = 该 area 模型上下文归零(创作/画布各一份键,互不影响)。
-    void clearWorkbenchAgentSession(workbenchSessionKey('generation'))
+    void safeClearAgentSession(workbenchSessionKey('generation'))
   }, [clearAttachments, setDraft])
 
   if (collapsed) {


### PR DESCRIPTION
## 是什么

统一 Agent 总方案 Track B 的 **B1a–d 低风险配置层清理**（行为保持型重构）。后端 loop（agentLoop.ts/agentChatV2/身份提示/会话存储）已统一，病灶在配置层各自为战。本 PR 收口四件，**用户可见行为零变化**，现有 6226 测试全绿是回归门。

基线 origin/main，隔离 worktree，**每件一个 commit（TDD：先写锁现状的测试再重构）**，加新必删旧无并行版。

## 四件（file:line）

**B1a 会话键工厂**（commit `refactor(agent): B1a`）
- 新增 `src/workbench/ai/agentSessionKey.ts`：`sessionKeyFor(...)` + 4 个具名封装，产出与旧代码**逐字节相同**（键字面值不变则用户已有会话历史不丢）。
- 删旧：`workbenchAgentRunner.ts` 私有 `workbenchSessionKey`（旧 26-30，re-export 保 import 路径）、`runDirectionPlanner.ts` `directionSessionKey`（旧 38-40）、`shotVerifyJudge.ts` `verifySessionKey`（旧 15-17）、`capabilityApplyHandler.ts` 内联键（旧 :95）。
- 锁：`agentSessionKey.test.ts` 断言每入口精确字面值 + local 兜底 + 显式 pid 覆盖（5 test）。

**B1b 清会话一致化**（commit `refactor(agent): B1b`）
- 新增 `safeClearAgentSession(sessionKey)`（agentSessionKey.ts）：await 底层 clear，失败 `console.warn` 记一次后吞，**永不外抛**。
- 删旧：5 处直接调用（3 处 `.catch(()=>{})` 静默吞 + 2 处裸 `void` 无 catch）全部改走包装——根治裸 `void` 失败时的 unhandled rejection。行为等价（都是 best-effort 清）。
- 锁：`agentSessionKey.clear.test.ts` 透传/吞异常/记日志三条（3 test）。

**B1d 单次 vs 多轮显式声明**（commit `refactor(agent): B1d`）
- 新增 `src/workbench/ai/agentLoopMode.ts`：`AGENT_LOOP_MODE`（single-shot | multi-turn）类型化声明 + `runSingleShotAgent(...)` 薄封装（清会话 → mode:'chat' → 自动带模型偏好）。
- 删旧：3 处单次流各自手抄的 clear+send+pref 全部收口——`runDirectionPlanner` / `shotVerifyJudge`（带首帧图 attachment）/ `capabilityApplyHandler.runProductionTextPlanner`。行为逐字节等价。
- 锁：`agentLoopMode.test.ts` 调用顺序（clear 在 send 之前）+ 字段透传 + pref/附件条件附加（8 test）。

**B1c systemPrompt 合成器**（commit `refactor(agent): B1c`）
- `electron/ai/agentChatV2.ts` 抽 `composeAgentSystemPrompt({identity, panelSystemPrompt, skillSystemPrompt, memoryBlock})` 纯函数，替换 runAgentChatV2 内联 systemParts/join/sanitize（旧 554-555）。`NOMI_AGENT_IDENTITY` 改 export（仍单一身份真相源）。
- **字节稳定铁律**：`过滤空段 → join('\n\n') → sanitizeForBroadCompat`，全空 undefined——vendor 前缀缓存依赖 byte 稳定。
- 锁：`composeAgentSystemPrompt.test.ts` ① NOMI_AGENT_IDENTITY 整块 inline snapshot；② 创作区形态（无面板层）/生成画布形态（四层齐全）的最终 systemPrompt 与 **characterization 参照（等价内联算法）逐字节相同**——证明抽函数没改任何 byte；③ 空段过滤/全空 undefined/sanitize 生效边界（6 test）。

## 快照怎么锁的（字节稳定证据）

B1c 用 **characterization 参照法**：测试内独立实现一份与现状 agentChatV2.ts:554-555 等价的内联算法 `referenceCompose`，断言 `composeAgentSystemPrompt(...) === referenceCompose(...)`。抽函数前该断言红（函数不存在），抽函数后绿——**逐字节等价即证**。加上 `NOMI_AGENT_IDENTITY` 的 `toMatchInlineSnapshot` 锁死身份 block 的每一个字节。B1a 同法锁死每个会话键的精确字面值。

## Gates 输出摘要

- Lint：**0 errors**，97 warnings（max-warnings=98 棘轮内；**我新增/编辑的文件零 warning**，均为存量文件既有 warning）
- Typecheck：app + electron 双 tsconfig 全过
- Tests：**6226 passed** / 1 skipped（705 files；含本 PR 4 个新测试文件 22 例）
- Build：`✓ built in 5.92s`
- 全部 `check:*` 门岗绿（filesize/tokens/i18n/heavy-path/controls/walkthroughs/site…）

## 发现的意外漂移（审计 vs 代码现状）

1. **路径漂移**：审计写 `electron/ai/workbenchAgentRunner.ts:26-29`，实际在 **`src/workbench/ai/workbenchAgentRunner.ts:26-30`**（渲染层，非 electron）。按真实路径做。
2. **会话键计数**：审计列 `shotVerifyJudge 等`可能暗示 runStoryboardPlanner 是第 5 种键——**实况它复用 `workbenchSessionKey('generation')`，不自造键**，不算入工厂。B1a 实为 4 种。
3. **B1c 合成点定位**：审计把三层描述为「改一处漏他处」，实况身份+skill 在后端 agentChatV2.ts 合、面板专长层在渲染层 `buildStaticAgentSystemPrompt` 产出——真正拼接点是后端 **agentChatV2.ts:554-555** 的 `systemParts.join`。B1c 收口这个后端拼接点。
4. **⚠️ 独立发现的潜在 bug（未修，留报告——修了会破坏字节稳定/改行为，出 B1 范围）**：生成画布面板的专长层 `buildStaticAgentSystemPrompt(mode)` 经 `generationCanvasAgentClient.ts:163 → runWorkbenchAgent → request.systemPrompt` 传下，但 **`workbenchAiClient.ts` 的 `buildWorkbenchAiPayload`（32-52）不转发 `systemPrompt` 字段**——所以它在到达 wire 前被静默丢弃，`payload.systemPrompt` 对所有现役 caller 恒空。后端 `AgentsChatRequestDto.systemPrompt` + `runAgentChatV2` 读取路径都齐备（IPC 原样透传整个 payload），只差渲染层没塞进去。这意味着画布 agent 的「面板专长层」当前是 dead-on-arrival。**本 PR 严格不动它**：修复会让画布 agent 突然开始收到专长 prompt → systemPrompt 字节变化 → 前缀缓存失效 + 行为漂移，属 B1c「改了会破坏字节稳定」的两难，按纪律停下上报。建议单独立项评审（是有意关闭还是遗漏）。

## 不做（严守范围）

不加新功能、不改任何 prompt 文案、不动确认/gate 逻辑（B3）、不动工具注册（B2）、不动 UI、不动 MCP 语义链。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
