### PR TITLE
feat: P4 S2 per-shot real pricing and seal precheck

### DIFF
--- a/electron/capabilityCore/appIntegration.ts
+++ b/electron/capabilityCore/appIntegration.ts
@@ -34,6 +34,7 @@ import { requestRenderer, rendererTargetIdentity } from './rendererBridge'
 import { createGenerationPlanningHandler } from './mcpGenerationTools'
 import { createProductionGenerationOperationStore } from '../productionRun/productionGenerationOperationStore'
 import { createProductionGenerationSubmission } from '../productionRun/productionGenerationSubmission'
+import { createCatalogModelPricingResolver, createCatalogShotPriceResolver } from '../productionRun/catalogPricingResolver'
 import type { ModuleRegistry } from './moduleRegistry'
 import { createCatalogModuleRegistry } from './moduleCatalogBootstrap'
 import { createGenerationProviderBootstrap } from './generationProviderBootstrap'
@@ -203,12 +204,16 @@ export async function startCapabilityCore(
         })),
       })))
     const generationService = getProductionRunService()
+    // P4 S2: real per-shot pricing from the live catalog (resolve lazily so pricing edits apply).
+    const resolveModelPricing = (providerId: string, modelId: string) => createCatalogModelPricingResolver(readCatalog().models)(providerId, modelId)
+    const resolveShotPrice = (contract: Parameters<ReturnType<typeof createCatalogShotPriceResolver>>[0]) => createCatalogShotPriceResolver(readCatalog().models)(contract)
     const generationPlanning = authorities.generationPlanning
       ?? createGenerationPlanningHandler({
         registry: generationRegistry,
         operations: createProductionGenerationOperationStore(generationService),
         videoModelCandidates,
         recommendVideoGeneration,
+        resolveModelPricing,
         providerReadiness: ({ providerId }) => providerBootstrap.readinessByProvider[providerId] ?? { providerReady: false, missingForSubmit: ['configured_provider'] },
         start: async (operation, lease) => {
           const provider = providerBootstrap.providers.find((candidate) => candidate.providerId === operation.contract?.providerId)
@@ -221,6 +226,7 @@ export async function startCapabilityCore(
             projectGeneration: lease.projectGeneration,
             intentMacKey: ensureCapabilitySigningKey('generation-intent'),
             provider,
+            resolveShotPrice,
             materializeOutput: ({ projectId, providerTaskId, output }) => outputMaterializer.materialize({ projectId, providerTaskId, output }),
           }).start({ projectId: lease.projectId, operationId: operation.operationId })
         },
@@ -237,6 +243,7 @@ export async function startCapabilityCore(
             projectGeneration: lease.projectGeneration,
             intentMacKey: ensureCapabilitySigningKey('generation-intent'),
             provider,
+            resolveShotPrice,
             materializeOutput: ({ projectId, providerTaskId, output }) => outputMaterializer.materialize({ projectId, providerTaskId, output }),
           })
           try {

--- a/electron/capabilityCore/mcpGenerationTools.test.ts
+++ b/electron/capabilityCore/mcpGenerationTools.test.ts
@@ -275,4 +275,58 @@ describe("semantic MCP generation tools", () => {
     await expect(handler({ capability: "gate_request", params: { operationId }, lease })).resolves.toMatchObject({ nextAction: "confirm", providerCapabilityProfile: "submit_only", recoveryNotice: expect.stringContaining("核对") });
     expect((await operations.read("project-1", operationId))?.state).toBe("sealed");
   });
+
+  // P4 S2: preview surfaces a per-shot pricing projection and gate_request carries the derived
+  // maximumCost — both derived from the injected catalog pricing, never a hard-coded number.
+  describe("P4 S2 pricing on preview + gate_request", () => {
+    const resolveModelPricing = (providerId: string, modelId: string) =>
+      providerId === "fixture-provider" && modelId === "fixture-model"
+        ? { cost: 10, enabled: true, specCosts: [{ specKey: "aspectRatio:1:1", cost: 4, enabled: true }] }
+        : undefined;
+
+    it("projects a known per-shot price + total on preview without any provider call", async () => {
+      const operations = createInMemoryGenerationOperationStore();
+      const handler = createGenerationPlanningHandler({ registry, operations, resolveModelPricing, now: () => "2026-08-23T00:00:00.000Z" });
+      const created = await handler({ capability: "create", params: { candidate: candidate() }, lease });
+      const operationId = (created as { operation: { operationId: string } }).operation.operationId;
+      const preview = await handler({ capability: "preview", params: { operationId }, lease }) as {
+        pricing: { shots: Array<{ price: unknown; durationEstimate: unknown; degradations: unknown[] }>; total: unknown };
+      };
+      // base 10 + matched specCost 4 (aspectRatio:1:1) = 14.
+      expect(preview.pricing.shots[0].price).toEqual({ known: true, amount: 14 });
+      expect(preview.pricing.shots[0].durationEstimate).toEqual({ known: false });
+      expect(preview.pricing.shots[0].degradations).toEqual([]);
+      expect(preview.pricing.total).toEqual({ knownSubtotal: 14, unknownShotCount: 0, currency: "CNY" });
+    });
+
+    it("reports the price as unknown on preview when no pricing resolver is wired", async () => {
+      const operations = createInMemoryGenerationOperationStore();
+      const handler = createGenerationPlanningHandler({ registry, operations, now: () => "2026-08-23T00:00:00.000Z" });
+      const created = await handler({ capability: "create", params: { candidate: candidate() }, lease });
+      const operationId = (created as { operation: { operationId: string } }).operation.operationId;
+      const preview = await handler({ capability: "preview", params: { operationId }, lease }) as {
+        pricing: { shots: Array<{ price: unknown }>; total: unknown };
+      };
+      expect(preview.pricing.shots[0].price).toEqual({ known: false });
+      expect(preview.pricing.total).toEqual({ knownSubtotal: 0, unknownShotCount: 1, currency: "CNY" });
+    });
+
+    it("puts the derived price into the receipt's maximumCost (no longer ¥0) with costKnown=true", async () => {
+      const operations = createInMemoryGenerationOperationStore();
+      const handler = createGenerationPlanningHandler({ registry, operations, resolveModelPricing, now: () => "2026-08-23T00:00:00.000Z" });
+      const created = await handler({ capability: "create", params: { candidate: candidate() }, lease });
+      const operationId = (created as { operation: { operationId: string } }).operation.operationId;
+      await expect(handler({ capability: "gate_request", params: { operationId }, lease }))
+        .resolves.toMatchObject({ maximumCost: 14, costKnown: true, currency: "CNY", nextAction: "confirm" });
+    });
+
+    it("keeps maximumCost 0 + costKnown=false for an unpriced model (unbounded, like today)", async () => {
+      const operations = createInMemoryGenerationOperationStore();
+      const handler = createGenerationPlanningHandler({ registry, operations, now: () => "2026-08-23T00:00:00.000Z" });
+      const created = await handler({ capability: "create", params: { candidate: candidate() }, lease });
+      const operationId = (created as { operation: { operationId: string } }).operation.operationId;
+      await expect(handler({ capability: "gate_request", params: { operationId }, lease }))
+        .resolves.toMatchObject({ maximumCost: 0, costKnown: false, nextAction: "confirm" });
+    });
+  });
 });

--- a/electron/capabilityCore/mcpGenerationTools.ts
+++ b/electron/capabilityCore/mcpGenerationTools.ts
@@ -6,6 +6,13 @@ import {
   type ExecutionContractV1,
   type PlanCandidate,
 } from "./executionContract";
+import {
+  deriveShotPrice,
+  projectMultiShotPreview,
+  type ModelPricing,
+  type MultiShotPreviewProjection,
+  type ShotPrice,
+} from "../productionRun/shotPricing";
 import type { ModuleRegistry } from "./moduleRegistry";
 import type { ParameterField } from "./moduleManifest";
 import type { ProjectLeaseV1 } from "./projectLease";
@@ -275,6 +282,13 @@ export type GenerationPlanningHandlerDependencies = {
     input: VideoGenerationRecommendationInput,
     candidates: readonly VideoModelCandidate[],
   ) => VideoGenerationRecommendationResult;
+  /**
+   * P4 S2: resolve the catalog pricing row for a provider/model identity (candidate.providerId maps
+   * to the catalog vendorKey). preview derives per-shot single prices from it; gate_request feeds the
+   * derived amount into the receipt's maximumCost (replacing the ¥0 placeholder). Omitted → preview
+   * reports the price as unknown and gate_request keeps maximumCost 0 (unpriced, unbounded like today).
+   */
+  resolveModelPricing?: (providerId: string, modelId: string) => ModelPricing | undefined;
   start?: (operation: GenerationOperation, lease: ProjectLeaseV1) => unknown | Promise<unknown>;
   reconcile?: (operation: GenerationOperation, outcome: "found" | "not_found", lease: ProjectLeaseV1) => unknown | Promise<unknown>;
 };
@@ -318,6 +332,37 @@ function videoRecommendationInput(candidate: PlanCandidate): VideoGenerationReco
 }
 
 const normalizedModelIdentity = (value: string): string => value.trim().toLowerCase();
+
+/**
+ * P4 S2: a shot's duration estimate in seconds from its selected parameters, or undefined when it
+ * cannot be honestly estimated (plan §9: "估不出的诚实标未知"). Reads the same duration keys the
+ * recommendation input reads (duration / durationSeconds), so the estimate matches the sealed request.
+ */
+function shotDurationSeconds(candidate: Pick<PlanCandidate, "parameters">): number | undefined {
+  const parameters = candidate.parameters ?? {};
+  if (typeof parameters.duration === "number" && Number.isFinite(parameters.duration) && parameters.duration >= 0) return parameters.duration;
+  if (typeof parameters.durationSeconds === "number" && Number.isFinite(parameters.durationSeconds) && parameters.durationSeconds >= 0) return parameters.durationSeconds;
+  return undefined;
+}
+
+/**
+ * P4 S2: whether the selected video model exposes a reference-image channel (a mode slot that accepts
+ * image references). Used to flag the "该模型认不了脸" degradation for character shots on models with
+ * no image-reference slot. When the model is not a known video candidate we cannot prove absence, so we
+ * assume support (no false degradation warning).
+ */
+const IMAGE_REFERENCE_SLOT_KINDS = new Set(["image_ref", "first_frame", "last_frame"]);
+
+function modelSupportsReferenceImage(candidate: PlanCandidate, candidates: readonly VideoModelCandidate[] | undefined): boolean {
+  const selected = candidates ? videoCandidateForPlan(candidate, candidates) : null;
+  if (!selected) return true;
+  return effectiveVideoModes(selected.videoCandidate).some((mode) => mode.slots.some((slot) => IMAGE_REFERENCE_SLOT_KINDS.has(slot.kind)));
+}
+
+/** P4 S2: whether the candidate carries a character reference (role=character), i.e. a face to preserve. */
+function candidateHasCharacterReference(candidate: PlanCandidate): boolean {
+  return candidate.references.some((reference) => reference.role === "character");
+}
 
 /**
  * Keep recommendations anchored to the model the user currently selected in
@@ -478,6 +523,10 @@ function resolveProviderReadiness(
 
 export function createGenerationPlanningHandler(deps: GenerationPlanningHandlerDependencies) {
   const now = deps.now ?? (() => new Date().toISOString());
+  // P4 S2: derive a candidate's real per-shot price from the catalog pricing. Unknown (never a
+  // fabricated 0) when there is no resolver, no pricing row, disabled pricing, or no base cost.
+  const priceForCandidate = (candidate: PlanCandidate): ShotPrice =>
+    deriveShotPrice({ candidate, resolvePricing: (providerId, modelId) => deps.resolveModelPricing?.(providerId, modelId) });
   return async (input: { capability: string; params: Record<string, unknown>; lease?: ProjectLeaseV1; origin?: { host: string; actorId?: string } }): Promise<unknown> => {
     if (!input.lease) throw new Error("A verified project lease is required");
     const params = input.params;
@@ -562,11 +611,27 @@ export function createGenerationPlanningHandler(deps: GenerationPlanningHandlerD
       const recommendation = recommendationInput && deps.recommendVideoGeneration && deps.videoModelCandidates
         ? deps.recommendVideoGeneration(recommendationInput, candidatesForCurrentVideoModel(candidate, deps.videoModelCandidates))
         : undefined;
+      // P4 S2: per-shot pricing/duration/degradation projection. The mcp operation is single-candidate
+      // today, so this is a 1-shot projection; it uses the shared multi-shot projector so the same
+      // (single source of truth) function scales once shots[] is threaded through the operation.
+      // Still zero provider calls — pure derive over the catalog pricing (preview invariant).
+      const projection: MultiShotPreviewProjection = projectMultiShotPreview({
+        shots: [{
+          shotId: candidate.candidateId,
+          candidate,
+          hasCharacter: candidateHasCharacterReference(candidate),
+          supportsReferenceImage: modelSupportsReferenceImage(candidate, deps.videoModelCandidates),
+        }],
+        resolvePricing: (providerId, modelId) => deps.resolveModelPricing?.(providerId, modelId),
+        durationSeconds: (shotCandidate) => shotDurationSeconds(shotCandidate),
+        currency: "CNY",
+      });
       return {
         operationId,
         candidateRevision: current.candidate.revision,
         contract,
         ...(recommendation ? { recommendation } : {}),
+        pricing: projection,
         providerReady: readiness.providerReady,
         providerCapabilityProfile: readiness.providerCapabilityProfile,
         recoveryNotice: readiness.recoveryNotice,
@@ -582,6 +647,9 @@ export function createGenerationPlanningHandler(deps: GenerationPlanningHandlerD
       const sealed = current.state === "draft"
         ? await deps.operations.seal(input.lease.projectId, operationId, contract, now())
         : current;
+      // P4 S2: the receipt's cost ceiling is this shot's derived price. Unknown (no resolver / no
+      // catalog pricing) → 0, meaning unbounded exactly as before (an unpriced model still confirms).
+      const price = priceForCandidate(candidate);
       return {
         operation: sealed,
         operationId,
@@ -590,7 +658,8 @@ export function createGenerationPlanningHandler(deps: GenerationPlanningHandlerD
         model: `${contract.providerId}/${contract.modelId}`,
         referenceCount: contract.references.length,
         costScope: `generation.single-shot:${operationId}`,
-        maximumCost: 0,
+        maximumCost: price.known ? price.amount : 0,
+        costKnown: price.known,
         currency: "CNY",
         expiresAt: new Date(Date.parse(now()) + 10 * 60 * 1000).toISOString(),
         shotSummary: contract.prompt.slice(0, 120),

--- a/electron/capabilityCore/mcpStdioServer.ts
+++ b/electron/capabilityCore/mcpStdioServer.ts
@@ -35,6 +35,7 @@ import type { DispatchContext } from './dispatcher'
 import { createGenerationPlanningHandler } from './mcpGenerationTools'
 import { createProductionGenerationOperationStore } from '../productionRun/productionGenerationOperationStore'
 import { createProductionGenerationSubmission } from '../productionRun/productionGenerationSubmission'
+import { createCatalogModelPricingResolver, createCatalogShotPriceResolver } from '../productionRun/catalogPricingResolver'
 import type { ModuleRegistry } from './moduleRegistry'
 import { createCatalogModuleRegistry } from './moduleCatalogBootstrap'
 import { createGenerationProviderBootstrap } from './generationProviderBootstrap'
@@ -211,12 +212,18 @@ export async function startMcpStdioServer(authorities: McpStdioServerOptions = {
         ...(field.default === undefined ? {} : { defaultValue: field.default }),
       })),
     })))
+  // P4 S2: derive real per-shot prices from the live catalog pricing (readCatalog reflects user edits;
+  // resolve lazily so a mid-session pricing change is picked up). Preview/gate use the model-pricing
+  // resolver; the submission seam uses the contract→ShotPrice resolver for its ledger amounts.
+  const resolveModelPricing = (providerId: string, modelId: string) => createCatalogModelPricingResolver(readCatalog().models)(providerId, modelId)
+  const resolveShotPrice = (contract: Parameters<ReturnType<typeof createCatalogShotPriceResolver>>[0]) => createCatalogShotPriceResolver(readCatalog().models)(contract)
   const generationPlanning = authorities.generationPlanning
     ?? createGenerationPlanningHandler({
       registry: generationRegistry,
       operations: createProductionGenerationOperationStore(productionRuns),
       videoModelCandidates,
       recommendVideoGeneration,
+      resolveModelPricing,
       providerReadiness: ({ providerId }) => providerBootstrap.readinessByProvider[providerId] ?? { providerReady: false, missingForSubmit: ['configured_provider'] },
       start: async (operation, lease) => {
         const provider = providerBootstrap.providers.find((candidate) => candidate.providerId === operation.contract?.providerId)
@@ -229,6 +236,7 @@ export async function startMcpStdioServer(authorities: McpStdioServerOptions = {
           projectGeneration: lease.projectGeneration,
           intentMacKey: ensureCapabilitySigningKey('generation-intent'),
           provider,
+          resolveShotPrice,
           materializeOutput: ({ projectId, providerTaskId, output }) => outputMaterializer.materialize({ projectId, providerTaskId, output }),
         }).start({ projectId: lease.projectId, operationId: operation.operationId })
       },
@@ -245,6 +253,7 @@ export async function startMcpStdioServer(authorities: McpStdioServerOptions = {
           projectGeneration: lease.projectGeneration,
           intentMacKey: ensureCapabilitySigningKey('generation-intent'),
           provider,
+          resolveShotPrice,
           materializeOutput: ({ projectId, providerTaskId, output }) => outputMaterializer.materialize({ projectId, providerTaskId, output }),
         })
         try {

--- a/electron/productionRun/catalogPricingResolver.test.ts
+++ b/electron/productionRun/catalogPricingResolver.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+
+import type { Model } from "../catalog/types";
+import type { ExecutionContractV1 } from "../capabilityCore/executionContract";
+import { createCatalogModelPricingResolver, createCatalogShotPriceResolver } from "./catalogPricingResolver";
+
+// P4 S2: the runtime bridge from catalog rows to the pure derive. Resolves by vendorKey + modelKey/alias
+// (candidate.providerId = vendorKey, candidate.modelId = modelKey), adapts Model.pricing, never fabricates.
+
+function model(overrides: Partial<Model> = {}): Model {
+  return {
+    modelKey: "seedance-2.5",
+    vendorKey: "apimart",
+    modelAlias: null,
+    labelZh: "Seedance",
+    kind: "video",
+    enabled: true,
+    pricing: { cost: 12, enabled: true, specCosts: [{ specKey: "720p", cost: 3, enabled: true }] },
+    createdAt: "t",
+    updatedAt: "t",
+    ...overrides,
+  };
+}
+
+function contract(overrides: Partial<ExecutionContractV1> = {}): ExecutionContractV1 {
+  return {
+    schemaVersion: 1,
+    candidateId: "c1",
+    candidateRevision: 1,
+    moduleId: "generation.single-shot",
+    moduleVersion: "1.0.0",
+    providerId: "apimart",
+    modelId: "seedance-2.5",
+    mode: "text-to-video",
+    prompt: "a boat",
+    parameters: { resolution: "720p" },
+    references: [],
+    contractHash: "hash",
+    warnings: [],
+    droppedFields: [],
+    ...overrides,
+  };
+}
+
+describe("createCatalogModelPricingResolver", () => {
+  it("resolves pricing by vendorKey + modelKey (case-insensitive)", () => {
+    const resolve = createCatalogModelPricingResolver([model()]);
+    expect(resolve("APIMART", "Seedance-2.5")).toEqual({ cost: 12, enabled: true, specCosts: [{ specKey: "720p", cost: 3, enabled: true }] });
+  });
+
+  it("resolves pricing by modelAlias when modelKey does not match", () => {
+    const resolve = createCatalogModelPricingResolver([model({ modelKey: "internal-key", modelAlias: "seedance-2.5" })]);
+    expect(resolve("apimart", "seedance-2.5")?.cost).toBe(12);
+  });
+
+  it("returns undefined when no row matches (→ pure derive reports unknown)", () => {
+    const resolve = createCatalogModelPricingResolver([model()]);
+    expect(resolve("apimart", "no-such-model")).toBeUndefined();
+  });
+
+  it("returns undefined when the matched row has no pricing", () => {
+    const resolve = createCatalogModelPricingResolver([model({ pricing: undefined })]);
+    expect(resolve("apimart", "seedance-2.5")).toBeUndefined();
+  });
+});
+
+describe("createCatalogShotPriceResolver", () => {
+  it("derives a known per-shot price from a sealed contract + catalog pricing", () => {
+    const resolve = createCatalogShotPriceResolver([model()]);
+    // base 12 + matched specCost 3 (bare "720p" matches parameters.resolution) = 15.
+    expect(resolve(contract())).toEqual({ known: true, amount: 15 });
+  });
+
+  it("is unknown when the contract's model has no catalog pricing", () => {
+    const resolve = createCatalogShotPriceResolver([model({ pricing: undefined })]);
+    expect(resolve(contract())).toEqual({ known: false });
+  });
+});

--- a/electron/productionRun/catalogPricingResolver.ts
+++ b/electron/productionRun/catalogPricingResolver.ts
@@ -1,0 +1,57 @@
+import type { Model } from "../catalog/types";
+import type { ExecutionContractV1 } from "../capabilityCore/executionContract";
+import { deriveShotPrice, type ModelPricing, type ShotPrice } from "./shotPricing";
+
+/**
+ * P4 S2 — the runtime bridge from the catalog to the pure pricing derive.
+ *
+ * The catalog model row (`Model.pricing`, electron/catalog/types.ts:207-213) is the single pricing
+ * truth. A candidate/contract identifies its model by `providerId` (= catalog `vendorKey`) and
+ * `modelId` (= catalog `modelKey`) — see the E2E fixture where providerId "apimart" / modelId
+ * "gpt-image-2" matches vendorKey "apimart" / modelKey "gpt-image-2". This module resolves that row
+ * and adapts it into the `ModelPricing` shape the pure `shotPricing` functions consume. It reads a
+ * snapshot of `models` supplied by the caller (the wiring reads `readCatalog().models`); it never
+ * calls a provider and never fabricates a price.
+ */
+
+const normalized = (value: string): string => value.trim().toLowerCase();
+
+function toModelPricing(pricing: Model["pricing"]): ModelPricing | undefined {
+  if (!pricing || typeof pricing !== "object") return undefined;
+  const specCosts = Array.isArray(pricing.specCosts)
+    ? pricing.specCosts
+        .filter((spec): spec is NonNullable<typeof spec> => Boolean(spec) && typeof spec.specKey === "string")
+        .map((spec) => ({ specKey: spec.specKey, cost: spec.cost, enabled: spec.enabled }))
+    : [];
+  return { cost: pricing.cost, enabled: pricing.enabled, specCosts };
+}
+
+/**
+ * Build a `resolveModelPricing(providerId, modelId)` over a catalog models snapshot. Matches on
+ * vendorKey + (modelKey OR modelAlias), case-insensitively, mirroring how the rest of the semantic
+ * chain resolves model identity. Returns undefined when the model or its pricing is absent →
+ * the pure derive then reports the price as honestly unknown.
+ */
+export function createCatalogModelPricingResolver(models: readonly Model[]): (providerId: string, modelId: string) => ModelPricing | undefined {
+  return (providerId, modelId) => {
+    const vendor = normalized(providerId);
+    const model = normalized(modelId);
+    const row = models.find((item) =>
+      normalized(item.vendorKey) === vendor
+      && (normalized(item.modelKey) === model || (typeof item.modelAlias === "string" && normalized(item.modelAlias) === model)));
+    return row ? toModelPricing(row.pricing) : undefined;
+  };
+}
+
+/**
+ * Build a `resolveShotPrice(contract)` for the submission seam: derive the sealed sub-contract's real
+ * per-shot price from the same catalog snapshot. Unknown → the submission keeps its backward-compatible
+ * 0 ledger amount (an unpriced model still submits).
+ */
+export function createCatalogShotPriceResolver(models: readonly Model[]): (contract: ExecutionContractV1) => ShotPrice {
+  const resolvePricing = createCatalogModelPricingResolver(models);
+  return (contract) => deriveShotPrice({
+    candidate: { providerId: contract.providerId, modelId: contract.modelId, parameters: contract.parameters },
+    resolvePricing,
+  });
+}

--- a/electron/productionRun/productionGenerationSubmission.ts
+++ b/electron/productionRun/productionGenerationSubmission.ts
@@ -24,6 +24,7 @@ import {
 import { classifyGenerationResume, type GenerationResumeDecision } from "./productionRunResume";
 import { createProductionExecutionBinding, type ProductionExecutionBinding } from "./productionExecutionBinding";
 import type { ProductionArtifact, ProductionJob, ProductionRun } from "./productionRunTypes";
+import type { ShotPrice } from "./shotPricing";
 
 export { SubmissionReceiptUnknownError, SubmissionReconciliationRequiredError };
 
@@ -119,6 +120,14 @@ export type ProductionGenerationSubmissionDependencies = {
   intentMacKey: string | NodeJS.TypedArray;
   provider: GenerationProvider;
   now?: () => string;
+  /**
+   * P4 S2: derive the real per-shot price for a sealed sub-contract from the catalog pricing.
+   * Replaces the ¥0 placeholders on approval.maxSpend / budget authorize / reserve costCeiling.
+   * Omitted (or an unknown result) → the shot has no priced liability and the seam keeps its
+   * backward-compatible 0 ledger amount (an unpriced model, e.g. one with no catalog `pricing`,
+   * must still be submittable — see submissionOutbox line "costCeiling === null" hard-fail).
+   */
+  resolveShotPrice?: (contract: ExecutionContractV1) => ShotPrice;
   runtimeTaskId?: (input: { runId: string; contractHash: string; attempt?: number }) => string;
   afterProviderAcceptance?: (input: { providerTaskId: string; run: ProductionRun }) => void | Promise<void>;
   beforeDispatch?: (input: { run: ProductionRun; job: ProductionJob }) => void | Promise<void>;
@@ -256,6 +265,16 @@ export function createProductionGenerationSubmission(deps: ProductionGenerationS
   const now = deps.now ?? (() => new Date().toISOString());
   const adapter = createGenerationRuntimeAdapter({ providers: [deps.provider] });
 
+  /**
+   * P4 S2: the real ledger amount for one shot's sub-contract. A known price flows straight into
+   * approval.maxSpend / authorize / reserve; an unknown or unresolved price keeps the legacy 0
+   * (no priced liability — the shot still submits, matching pre-S2 behavior for unpriced models).
+   */
+  function ledgerAmountFor(contract: ExecutionContractV1): number {
+    const price = deps.resolveShotPrice?.(contract);
+    return price?.known ? price.amount : 0;
+  }
+
   function intentLog(runId: string) {
     return createProductionRunIntentLog({
       filePath: productionRunPaths(deps.projectRoot, runId).intents,
@@ -284,6 +303,8 @@ export function createProductionGenerationSubmission(deps: ProductionGenerationS
 
   function prepare(run: ProductionRun, contract: ExecutionContractV1, binding: ProductionExecutionBinding, jobId: string, attempt: number, shotId?: string): { run: ProductionRun; envelope: ReturnType<typeof createProductionRunRuntimeEnvelope> } {
     let current = run;
+    // P4 S2: this shot's real ledger amount (0 when the price is unknown — keeps unpriced models submittable).
+    const shotAmount = ledgerAmountFor(contract);
     const existingJob = current.jobs.find((job) => job.jobId === jobId);
     const addedJob = !existingJob;
     if (addedJob) {
@@ -326,7 +347,8 @@ export function createProductionGenerationSubmission(deps: ProductionGenerationS
             allowedProviders: [contract.providerId],
             allowedModels: [contract.modelId],
             currency: current.budget.currency,
-            maxSpend: 0,
+            // P4 S2: this shot's derived price is its authorized ceiling (0 = unknown/unpriced, unbounded like today).
+            maxSpend: shotAmount,
             maxAttemptsPerJob: current.policy.maxAttemptsPerJob,
             decidedAt: now(),
             expiresAt: new Date(Date.parse(now()) + 24 * 60 * 60 * 1000).toISOString(),
@@ -340,8 +362,11 @@ export function createProductionGenerationSubmission(deps: ProductionGenerationS
       if (current.budget.authorized === 0 && current.budget.reserved === 0 && current.budget.actual === 0 && current.budget.unsettled === 0) {
         // #4 commandId: without jobId, a second shot's authorize reuses the first's commandId and is
         // deduped into a stale-revision result. The billingEntryId already embeds jobId (via approvalId).
+        // P4 S2: authorize the ledger to this shot's derived price. For the single-shot chain that IS the
+        // plan cap; the plan-level cap that sums included shots up front is the scheduler's job (S4 §3.3),
+        // so this guard (first entry only) intentionally leaves multi-shot cap accumulation to S4.
         current = command(current, "budget.entry", {
-          entry: { billingEntryId: `${approvalId}:authorize`, kind: "authorize", amount: 0, occurredAt: now() },
+          entry: { billingEntryId: `${approvalId}:authorize`, kind: "authorize", amount: shotAmount, occurredAt: now() },
         }, `budget-authorize:${jobId}`);
       }
     }
@@ -426,7 +451,9 @@ export function createProductionGenerationSubmission(deps: ProductionGenerationS
         jobId,
         approvalId,
         planHash: lockedContract.contractHash,
-        costCeiling: 0,
+        // P4 S2: reserve this shot's derived price (the outbox also feeds it to authorizeSubmission as
+        // estimatedCost). 0 = unknown/unpriced → no priced reservation, keeping the pre-S2 submit path.
+        costCeiling: ledgerAmountFor(lockedContract),
         currency: run.budget.currency,
         allowRetryAfterAbort: input.definitelyNotSubmitted === true,
       });

--- a/electron/productionRun/productionRunReducer.ts
+++ b/electron/productionRun/productionRunReducer.ts
@@ -14,6 +14,51 @@ import type {
   RunCommand,
 } from "./productionRunTypes";
 import { validateProductionExecutionBinding } from "./productionExecutionBinding";
+import { checkSealAffordability, type ShotPrice } from "./shotPricing";
+
+/**
+ * P4 S2: raised when a seal is requested with a hard spend ceiling that cannot cover the known-price
+ * subtotal of the included shots. Carries the structured "最多只能完成前 N 镜" signal (plan §3.1/§4) so
+ * the caller can tell the user to change the checkbox selection or raise the cap and re-seal.
+ */
+export class SealBudgetExceededError extends Error {
+  readonly code = "seal_budget_exceeded" as const;
+
+  constructor(
+    readonly maxAffordableShots: number,
+    readonly knownSubtotal: number,
+    readonly maxSpend: number,
+  ) {
+    super(`seal_budget_exceeded: hard spend ceiling ${maxSpend} covers only the first ${maxAffordableShots} shot(s)`);
+    this.name = "SealBudgetExceededError";
+  }
+}
+
+/**
+ * P4 S2: parse the optional per-shot prices a caller derived from the catalog for the seal precheck.
+ * Prices are keyed by shotId (order is taken from the included shots, i.e. checkbox order). A missing
+ * entry for an included shot → that shot is unknown-priced (contributes 0 to the cap, flags certainty).
+ */
+function shotPricesFrom(raw: unknown): Map<string, ShotPrice> | undefined {
+  if (raw === undefined) return undefined;
+  if (!Array.isArray(raw)) throw new Error("Generation seal shotPrices must be an array");
+  const prices = new Map<string, ShotPrice>();
+  for (const [index, value] of raw.entries()) {
+    if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error(`Invalid seal shot price at ${index}`);
+    const entry = value as { shotId?: unknown; price?: unknown };
+    const shotId = typeof entry.shotId === "string" ? entry.shotId.trim() : "";
+    if (!shotId) throw new Error(`Invalid seal shot price id at ${index}`);
+    const price = entry.price as ShotPrice | undefined;
+    if (!price || typeof price !== "object" || typeof (price as { known?: unknown }).known !== "boolean") {
+      throw new Error(`Invalid seal shot price value at ${index}`);
+    }
+    if (price.known && !(Number.isFinite(price.amount) && price.amount >= 0)) {
+      throw new Error(`Invalid seal shot price amount at ${index}`);
+    }
+    prices.set(shotId, price.known ? { known: true, amount: price.amount } : { known: false });
+  }
+  return prices;
+}
 
 /**
  * P4 S1 shot 谱系 = 一个 job 归属哪一镜。多镜 job 把 shotId 写进 `metadata.shotId`（子合同派生时带上）；
@@ -296,6 +341,21 @@ export function applyProductionCommand(
       const sealedShots = sealGenerationShots(currentPlan, command.payload.shots);
       const rawPlanHash = typeof command.payload.planHash === "string" ? command.payload.planHash.trim() : "";
       if (sealedShots && !rawPlanHash) throw new Error("A multi-shot generation seal requires a plan hash");
+      // P4 S2 seal precheck: when the caller supplies per-shot prices (derived from the catalog), the
+      // reducer enforces the hard spend ceiling at the single source of truth. Absent shotPrices →
+      // byte-identical to today (no precheck, no costCertainty) so the single-shot chain is untouched.
+      const shotPrices = shotPricesFrom(command.payload.shotPrices);
+      let costCertainty: ProductionGenerationPlan["costCertainty"];
+      if (shotPrices) {
+        // Precheck order = included shots in their declared order (checkbox order), single default shot
+        // when there is no shots[] payload. maxAffordableShots is counted in exactly this order.
+        const orderedShots = sealedShots
+          ? sealedShots.filter(isShotIncluded).map((shot) => ({ shotId: shot.shotId, price: shotPrices.get(shot.shotId) ?? { known: false as const } }))
+          : [{ shotId: currentPlan.candidate.candidateId, price: shotPrices.get(currentPlan.candidate.candidateId) ?? { known: false as const } }];
+        const affordability = checkSealAffordability({ shots: orderedShots, maxSpend: current.policy.maxSpend });
+        if (!affordability.ok) throw new SealBudgetExceededError(affordability.maxAffordableShots, affordability.knownSubtotal, affordability.maxSpend);
+        costCertainty = affordability.hasUnknownPrice ? "partial" : "known";
+      }
       return {
         run: {
           ...current,
@@ -305,6 +365,7 @@ export function applyProductionCommand(
             contract,
             state: "sealed",
             ...(sealedShots ? { shots: sealedShots, planHash: rawPlanHash } : {}),
+            ...(costCertainty ? { costCertainty } : {}),
             updatedAt: now,
           },
           updatedAt: now,

--- a/electron/productionRun/productionRunTypes.ts
+++ b/electron/productionRun/productionRunTypes.ts
@@ -216,6 +216,12 @@ export type ProductionGenerationPlan = {
   shots?: ProductionGenerationShot[];
   /** Plan-level hash freezing the whole multi-shot operation (anchor + included shots) at seal time. */
   planHash?: string;
+  /**
+   * P4 S2 seal-time cost certainty. "known" = every included shot had a derived price at seal.
+   * "partial" = the plan sealed with at least one unpriced shot (honest "we could not price all of
+   * these"; the seal is still allowed when the hard cap is satisfied or unset — plan §3.1/§9).
+   */
+  costCertainty?: "known" | "partial";
   updatedAt: string;
 };
 

--- a/electron/productionRun/shotPricing.test.ts
+++ b/electron/productionRun/shotPricing.test.ts
@@ -1,0 +1,288 @@
+import { describe, expect, it } from "vitest";
+
+import type { PlanCandidate } from "../capabilityCore/executionContract";
+import {
+  checkSealAffordability,
+  deriveShotPrice,
+  projectMultiShotPreview,
+  type ModelPricingRow,
+  type ShotPriceInput,
+} from "./shotPricing";
+
+// P4 S2: per-shot pricing derive + preview projection + seal precheck.
+//
+// TDD (red→green). The pricing *matching* rule has no prior consumer in the repo — the catalog
+// `pricing`/`specCosts` shape (electron/catalog/types.ts:207-213) was authored but never joined
+// (documented as "数据已有全未用", docs/plan/2026-06-11-nomi-harness-master-plan.md:244). These tests
+// pin the rule S2 adopts: an enabled base `cost`, plus enabled `specCosts` whose `specKey` matches a
+// parameter selection on the shot (bare value OR `paramKey:paramValue`). No pricing / disabled / no
+// match → honest `{ known: false }`, never a fabricated 0.
+
+function candidate(overrides: Partial<PlanCandidate> = {}): PlanCandidate {
+  return {
+    candidateId: "cand-1",
+    revision: 1,
+    moduleId: "generation.single-shot",
+    providerId: "apimart",
+    modelId: "seedance-2.5",
+    mode: "text-to-video",
+    prompt: "a paper boat",
+    parameters: { resolution: "720p", duration: 5 },
+    references: [],
+    ...overrides,
+  };
+}
+
+function pricingRow(overrides: Partial<ModelPricingRow> = {}): ModelPricingRow {
+  return {
+    providerId: "apimart",
+    modelId: "seedance-2.5",
+    pricing: { cost: 10, enabled: true, specCosts: [] },
+    ...overrides,
+  };
+}
+
+function input(overrides: Partial<ShotPriceInput> = {}): ShotPriceInput {
+  return {
+    candidate: candidate(),
+    resolvePricing: (providerId, modelId) =>
+      providerId === "apimart" && modelId === "seedance-2.5" ? pricingRow().pricing : undefined,
+    ...overrides,
+  };
+}
+
+describe("deriveShotPrice", () => {
+  it("returns the base cost when the model has enabled pricing and no specCosts", () => {
+    expect(deriveShotPrice(input())).toEqual({ known: true, amount: 10 });
+  });
+
+  it("adds an enabled specCost when its bare-value specKey matches a selected parameter", () => {
+    const result = deriveShotPrice(
+      input({
+        resolvePricing: () => ({
+          cost: 10,
+          enabled: true,
+          specCosts: [{ specKey: "720p", cost: 4, enabled: true }],
+        }),
+      }),
+    );
+    expect(result).toEqual({ known: true, amount: 14 });
+  });
+
+  it("adds an enabled specCost when its paramKey:paramValue specKey matches a selection", () => {
+    const result = deriveShotPrice(
+      input({
+        resolvePricing: () => ({
+          cost: 10,
+          enabled: true,
+          specCosts: [{ specKey: "resolution:720p", cost: 6, enabled: true }],
+        }),
+      }),
+    );
+    expect(result).toEqual({ known: true, amount: 16 });
+  });
+
+  it("matches a numeric parameter selection (duration) by stringified value", () => {
+    const result = deriveShotPrice(
+      input({
+        resolvePricing: () => ({
+          cost: 10,
+          enabled: true,
+          specCosts: [{ specKey: "duration:5", cost: 3, enabled: true }],
+        }),
+      }),
+    );
+    expect(result).toEqual({ known: true, amount: 13 });
+  });
+
+  it("sums multiple matching specCosts on top of the base cost", () => {
+    const result = deriveShotPrice(
+      input({
+        resolvePricing: () => ({
+          cost: 10,
+          enabled: true,
+          specCosts: [
+            { specKey: "resolution:720p", cost: 4, enabled: true },
+            { specKey: "duration:5", cost: 3, enabled: true },
+          ],
+        }),
+      }),
+    );
+    expect(result).toEqual({ known: true, amount: 17 });
+  });
+
+  it("ignores a specCost whose specKey does not match any selection", () => {
+    const result = deriveShotPrice(
+      input({
+        resolvePricing: () => ({
+          cost: 10,
+          enabled: true,
+          specCosts: [{ specKey: "1080p", cost: 9, enabled: true }],
+        }),
+      }),
+    );
+    expect(result).toEqual({ known: true, amount: 10 });
+  });
+
+  it("ignores a disabled specCost even when its specKey matches", () => {
+    const result = deriveShotPrice(
+      input({
+        resolvePricing: () => ({
+          cost: 10,
+          enabled: true,
+          specCosts: [{ specKey: "720p", cost: 5, enabled: false }],
+        }),
+      }),
+    );
+    expect(result).toEqual({ known: true, amount: 10 });
+  });
+
+  it("is unknown (not 0) when the model has no pricing row at all", () => {
+    expect(deriveShotPrice(input({ resolvePricing: () => undefined }))).toEqual({ known: false });
+  });
+
+  it("is unknown when pricing exists but is disabled (enabled=false)", () => {
+    expect(
+      deriveShotPrice(input({ resolvePricing: () => ({ cost: 10, enabled: false, specCosts: [] }) })),
+    ).toEqual({ known: false });
+  });
+
+  it("is unknown when the base cost is not a finite non-negative number", () => {
+    expect(
+      deriveShotPrice(input({ resolvePricing: () => ({ cost: Number.NaN, enabled: true, specCosts: [] }) })),
+    ).toEqual({ known: false });
+  });
+});
+
+describe("projectMultiShotPreview", () => {
+  const resolvePricing = (_providerId: string, modelId: string) =>
+    modelId === "seedance-2.5"
+      ? { cost: 10, enabled: true, specCosts: [{ specKey: "720p", cost: 4, enabled: true }] }
+      : undefined;
+
+  it("returns per-shot price + a known-subtotal and an unknown-shot count", () => {
+    const projection = projectMultiShotPreview({
+      shots: [
+        { shotId: "shot-a", candidate: candidate({ candidateId: "a", parameters: { resolution: "720p" } }) },
+        { shotId: "shot-b", candidate: candidate({ candidateId: "b", modelId: "no-price-model", parameters: {} }) },
+      ],
+      resolvePricing,
+      durationSeconds: (c) => (typeof c.parameters.duration === "number" ? c.parameters.duration : undefined),
+    });
+    expect(projection.shots.map((shot) => shot.shotId)).toEqual(["shot-a", "shot-b"]);
+    expect(projection.shots[0].price).toEqual({ known: true, amount: 14 });
+    expect(projection.shots[1].price).toEqual({ known: false });
+    expect(projection.total).toEqual({ knownSubtotal: 14, unknownShotCount: 1, currency: "CNY" });
+  });
+
+  it("marks durationEstimate unknown when it cannot be estimated", () => {
+    const projection = projectMultiShotPreview({
+      shots: [{ shotId: "shot-a", candidate: candidate({ parameters: {} }) }],
+      resolvePricing,
+      durationSeconds: () => undefined,
+    });
+    expect(projection.shots[0].durationEstimate).toEqual({ known: false });
+  });
+
+  it("reports a known durationEstimate when the shot carries a duration", () => {
+    const projection = projectMultiShotPreview({
+      shots: [{ shotId: "shot-a", candidate: candidate({ parameters: { resolution: "720p", duration: 8 } }) }],
+      resolvePricing,
+      durationSeconds: (c) => (typeof c.parameters.duration === "number" ? c.parameters.duration : undefined),
+    });
+    expect(projection.shots[0].durationEstimate).toEqual({ known: true, seconds: 8 });
+  });
+
+  it("emits a structured degradation code (no vendor string) when a character shot lacks a reference-image channel", () => {
+    const projection = projectMultiShotPreview({
+      shots: [
+        {
+          shotId: "shot-a",
+          candidate: candidate({ references: [] }),
+          hasCharacter: true,
+          supportsReferenceImage: false,
+        },
+      ],
+      resolvePricing,
+      durationSeconds: () => 5,
+    });
+    expect(projection.shots[0].degradations).toEqual([
+      { code: "model_cannot_take_character_reference", params: { modelId: "seedance-2.5" } },
+    ]);
+  });
+
+  it("emits no degradation when the model supports the reference-image channel", () => {
+    const projection = projectMultiShotPreview({
+      shots: [
+        {
+          shotId: "shot-a",
+          candidate: candidate(),
+          hasCharacter: true,
+          supportsReferenceImage: true,
+        },
+      ],
+      resolvePricing,
+      durationSeconds: () => 5,
+    });
+    expect(projection.shots[0].degradations).toEqual([]);
+  });
+});
+
+describe("checkSealAffordability", () => {
+  const price = (amount: number) => ({ known: true as const, amount });
+
+  it("passes when no hard maxSpend is set (unbounded)", () => {
+    const result = checkSealAffordability({
+      shots: [{ shotId: "a", price: price(10) }, { shotId: "b", price: price(10) }],
+      maxSpend: null,
+    });
+    expect(result).toEqual({ ok: true, hasUnknownPrice: false });
+  });
+
+  it("passes when the hard maxSpend covers the whole known subtotal", () => {
+    const result = checkSealAffordability({
+      shots: [{ shotId: "a", price: price(10) }, { shotId: "b", price: price(10) }],
+      maxSpend: 25,
+    });
+    expect(result).toEqual({ ok: true, hasUnknownPrice: false });
+  });
+
+  it("rejects with maxAffordableShots counted in checkbox order when maxSpend < known subtotal", () => {
+    const result = checkSealAffordability({
+      shots: [
+        { shotId: "a", price: price(10) },
+        { shotId: "b", price: price(10) },
+        { shotId: "c", price: price(10) },
+      ],
+      maxSpend: 25,
+    });
+    // 10 + 10 = 20 ≤ 25, adding the third (30) exceeds → only the first two fit.
+    expect(result).toEqual({ ok: false, maxAffordableShots: 2, knownSubtotal: 30, maxSpend: 25 });
+  });
+
+  it("counts an unknown-price shot as affordable (0 cost toward the cap) but flags certainty", () => {
+    const result = checkSealAffordability({
+      shots: [
+        { shotId: "a", price: price(10) },
+        { shotId: "b", price: { known: false } },
+        { shotId: "c", price: price(10) },
+      ],
+      maxSpend: 25,
+    });
+    // Known subtotal is 20 ≤ 25 → passes, but an unknown-price shot exists → certainty flagged.
+    expect(result).toEqual({ ok: true, hasUnknownPrice: true });
+  });
+
+  it("rejects at the shot whose running known subtotal first breaches the cap, skipping unknown-price shots in the tally", () => {
+    const result = checkSealAffordability({
+      shots: [
+        { shotId: "a", price: price(20) },
+        { shotId: "b", price: { known: false } },
+        { shotId: "c", price: price(20) },
+      ],
+      maxSpend: 25,
+    });
+    // a=20 ≤ 25 fits; b unknown (0 toward cap) still fits; c pushes to 40 > 25 → 2 shots affordable.
+    expect(result).toEqual({ ok: false, maxAffordableShots: 2, knownSubtotal: 40, maxSpend: 25 });
+  });
+});

--- a/electron/productionRun/shotPricing.ts
+++ b/electron/productionRun/shotPricing.ts
@@ -1,0 +1,235 @@
+import type { PlanCandidate } from "../capabilityCore/executionContract";
+
+/**
+ * P4 S2 — per-shot pricing derive + preview projection + seal precheck (pure, provider-free).
+ *
+ * ## Why this module exists and where the numbers come from
+ *
+ * The only pricing truth source is the catalog model row's optional `pricing` field
+ * (electron/catalog/types.ts:207-213): `{ cost, enabled, specCosts: [{ specKey, cost, enabled }] }`.
+ * It is user-configurable. Everything here derives from it — never a hard-coded price.
+ *
+ * ## The specKey matching rule (no prior code precedent — see the plan §9 honesty boundary)
+ *
+ * The catalog `specCosts` shape has existed since C1 (commit ee7b0a47) but **no consumer ever joined
+ * it to a parameter selection** — the intended `estimateGenerationCost` (archetype params × specCosts)
+ * was documented as "数据已有全未用" (docs/plan/2026-06-11-nomi-harness-master-plan.md:244) and never
+ * built; there is no `specKey` example anywhere in the tree. S2 therefore has to *define* the rule.
+ * The conservative rule adopted here mirrors the documented additive join and stays honest:
+ *
+ *   price(shot) = pricing.cost  +  Σ specCost.cost   for every ENABLED specCost whose specKey matches
+ *                                                    a parameter the shot actually selected.
+ *
+ * A specKey "matches a selection" when it equals either:
+ *   - a bare selected value  (specKey "720p"           matches parameters.resolution === "720p"), or
+ *   - a paramKey:value pair  (specKey "resolution:720p" matches the same selection).
+ * Values are compared as trimmed strings (numeric selections stringify: duration 5 → "5").
+ *
+ * If there is no pricing row, pricing is disabled, or the base cost is not a finite non-negative
+ * number → the price is honestly `{ known: false }`. We NEVER substitute 0 for an unknown price:
+ * an unpriced model must surface as "未知" in preview, not as "¥0" (plan §3.1/§9). (The separate
+ * *ledger* wiring may still reserve 0 for an unpriced shot — that is "no priced liability to reserve",
+ * not a fabricated display price; the two concerns are deliberately kept apart.)
+ */
+
+export type ModelPricingSpec = {
+  specKey: string;
+  cost: number;
+  enabled: boolean;
+};
+
+export type ModelPricing = {
+  cost: number;
+  enabled: boolean;
+  specCosts: ReadonlyArray<ModelPricingSpec>;
+};
+
+/** A catalog model row reduced to its identity + pricing (the only fields this module reads). */
+export type ModelPricingRow = {
+  providerId: string;
+  modelId: string;
+  pricing?: ModelPricing;
+};
+
+/** Resolve the pricing config for a provider/model identity (candidate.providerId maps to vendorKey). */
+export type PricingResolver = (providerId: string, modelId: string) => ModelPricing | undefined;
+
+/** A derived per-shot price: an honest known amount, or explicitly unknown. Never a fabricated 0. */
+export type ShotPrice = { known: true; amount: number } | { known: false };
+
+export type ShotPriceInput = {
+  candidate: Pick<PlanCandidate, "providerId" | "modelId" | "parameters">;
+  resolvePricing: PricingResolver;
+};
+
+const normalizedIdentity = (value: string): string => value.trim().toLowerCase();
+
+function isFiniteNonNegative(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0;
+}
+
+/**
+ * The set of specKeys a shot's parameter selection can match: for each parameter, both the bare
+ * stringified value and the `paramKey:value` composite. Non-scalar values are ignored (a specCost
+ * cannot meaningfully key on an object/array selection).
+ */
+function selectedSpecKeys(parameters: Record<string, unknown>): Set<string> {
+  const keys = new Set<string>();
+  for (const [paramKey, raw] of Object.entries(parameters)) {
+    if (raw === undefined || raw === null) continue;
+    const scalar = typeof raw === "string" || typeof raw === "number" || typeof raw === "boolean";
+    if (!scalar) continue;
+    const value = String(raw).trim();
+    if (!value) continue;
+    keys.add(value);
+    keys.add(`${paramKey}:${value}`);
+  }
+  return keys;
+}
+
+/**
+ * Derive a single shot's price from its selected model + parameters and the catalog pricing.
+ * Pure. Returns `{ known: false }` (never 0) when the price cannot be honestly established.
+ */
+export function deriveShotPrice(input: ShotPriceInput): ShotPrice {
+  const pricing = input.resolvePricing(input.candidate.providerId, input.candidate.modelId);
+  if (!pricing || pricing.enabled !== true || !isFiniteNonNegative(pricing.cost)) return { known: false };
+
+  const selected = selectedSpecKeys(input.candidate.parameters ?? {});
+  let amount = pricing.cost;
+  for (const spec of pricing.specCosts ?? []) {
+    if (spec.enabled !== true) continue;
+    if (!isFiniteNonNegative(spec.cost)) continue;
+    const specKey = typeof spec.specKey === "string" ? spec.specKey.trim() : "";
+    if (!specKey) continue;
+    if (selected.has(specKey)) amount += spec.cost;
+  }
+  return { known: true, amount };
+}
+
+// ---------------------------------------------------------------------------------------------------
+// Preview projection
+// ---------------------------------------------------------------------------------------------------
+
+/** A structured, i18n-safe degradation reason. The renderer maps `code` (+`params`) via t(); never a string. */
+export type ShotDegradation = {
+  code: "model_cannot_take_character_reference";
+  params: { modelId: string };
+};
+
+/** An honest per-shot duration estimate: a known seconds value, or explicitly unknown. */
+export type DurationEstimate = { known: true; seconds: number } | { known: false };
+
+export type PreviewShotInput = {
+  shotId: string;
+  candidate: Pick<PlanCandidate, "providerId" | "modelId" | "parameters" | "references">;
+  /** Whether this shot references a character (for the "model can't take a face" degradation). */
+  hasCharacter?: boolean;
+  /** Whether the selected model exposes a reference-image channel. */
+  supportsReferenceImage?: boolean;
+};
+
+export type PreviewShotProjection = {
+  shotId: string;
+  price: ShotPrice;
+  durationEstimate: DurationEstimate;
+  degradations: ShotDegradation[];
+};
+
+export type MultiShotPreviewTotal = {
+  /** Sum of the KNOWN per-shot prices only. Unknown-price shots are excluded (not counted as 0). */
+  knownSubtotal: number;
+  /** How many shots have an unknown price — the honest "we could not price N of these" signal. */
+  unknownShotCount: number;
+  currency: string;
+};
+
+export type MultiShotPreviewProjection = {
+  shots: PreviewShotProjection[];
+  total: MultiShotPreviewTotal;
+};
+
+export type ProjectMultiShotPreviewInput = {
+  shots: ReadonlyArray<PreviewShotInput>;
+  resolvePricing: PricingResolver;
+  /** Estimate a shot's duration in seconds, or return undefined when it cannot be estimated. */
+  durationSeconds: (candidate: PreviewShotInput["candidate"]) => number | undefined;
+  currency?: string;
+};
+
+function shotDegradations(shot: PreviewShotInput): ShotDegradation[] {
+  const degradations: ShotDegradation[] = [];
+  if (shot.hasCharacter === true && shot.supportsReferenceImage === false) {
+    degradations.push({ code: "model_cannot_take_character_reference", params: { modelId: shot.candidate.modelId } });
+  }
+  return degradations;
+}
+
+/**
+ * Project a multi-shot plan into per-shot preview rows + an honest total. Pure — no provider call
+ * (preview must stay zero-request, an S2 invariant). Unknown prices/durations surface as unknown.
+ */
+export function projectMultiShotPreview(input: ProjectMultiShotPreviewInput): MultiShotPreviewProjection {
+  const currency = input.currency?.trim() || "CNY";
+  const shots = input.shots.map((shot): PreviewShotProjection => {
+    const price = deriveShotPrice({ candidate: shot.candidate, resolvePricing: input.resolvePricing });
+    const seconds = input.durationSeconds(shot.candidate);
+    const durationEstimate: DurationEstimate = isFiniteNonNegative(seconds)
+      ? { known: true, seconds }
+      : { known: false };
+    return { shotId: shot.shotId, price, durationEstimate, degradations: shotDegradations(shot) };
+  });
+  const knownSubtotal = shots.reduce((sum, shot) => (shot.price.known ? sum + shot.price.amount : sum), 0);
+  const unknownShotCount = shots.reduce((count, shot) => (shot.price.known ? count : count + 1), 0);
+  return { shots, total: { knownSubtotal, unknownShotCount, currency } };
+}
+
+// ---------------------------------------------------------------------------------------------------
+// Seal precheck
+// ---------------------------------------------------------------------------------------------------
+
+export type SealAffordabilityShot = {
+  shotId: string;
+  price: ShotPrice;
+};
+
+export type CheckSealAffordabilityInput = {
+  /** Shots in checkbox (selection) order — the order maxAffordableShots is counted in. */
+  shots: ReadonlyArray<SealAffordabilityShot>;
+  /** The hard spend ceiling (policy.maxSpend). null = unbounded. */
+  maxSpend: number | null;
+};
+
+export type SealAffordabilityResult =
+  | { ok: true; hasUnknownPrice: boolean }
+  | { ok: false; maxAffordableShots: number; knownSubtotal: number; maxSpend: number };
+
+/**
+ * Precheck whether a plan can be sealed under the hard spend ceiling.
+ * - maxSpend null → always ok (unbounded); still reports whether any shot price is unknown.
+ * - maxSpend set → walk shots in checkbox order accumulating KNOWN prices. Unknown-price shots
+ *   contribute 0 toward the cap (we cannot count what we cannot price) but still occupy a slot.
+ *   If the running known subtotal exceeds the cap, reject with maxAffordableShots = the count of
+ *   shots that fit before the breach (the "最多只能完成前 N 镜" signal, plan §3.1/§4).
+ *   When it fits, ok — but flag hasUnknownPrice so the caller can mark cost certainty (plan S2 §3).
+ */
+export function checkSealAffordability(input: CheckSealAffordabilityInput): SealAffordabilityResult {
+  const hasUnknownPrice = input.shots.some((shot) => !shot.price.known);
+  const knownSubtotal = input.shots.reduce((sum, shot) => (shot.price.known ? sum + shot.price.amount : sum), 0);
+
+  if (input.maxSpend === null) return { ok: true, hasUnknownPrice };
+
+  const maxSpend = input.maxSpend;
+  let running = 0;
+  let affordable = 0;
+  for (const shot of input.shots) {
+    const next = running + (shot.price.known ? shot.price.amount : 0);
+    if (next > maxSpend) break;
+    running = next;
+    affordable += 1;
+  }
+  if (affordable < input.shots.length) {
+    return { ok: false, maxAffordableShots: affordable, knownSubtotal, maxSpend };
+  }
+  return { ok: true, hasUnknownPrice };
+}

--- a/electron/productionRun/shotPricingWiring.test.ts
+++ b/electron/productionRun/shotPricingWiring.test.ts
@@ -1,0 +1,222 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { compileExecutionContract, type PlanCandidate } from "../capabilityCore/executionContract";
+import { createModuleRegistry } from "../capabilityCore/moduleRegistry";
+import { applyProductionCommand, SealBudgetExceededError } from "./productionRunReducer";
+import { createProductionGenerationSubmission } from "./productionGenerationSubmission";
+import { createProductionRunRepository } from "./productionRunRepository";
+import type { ProductionGenerationShot, ProductionRun } from "./productionRunTypes";
+
+// P4 S2 wiring: the seal precheck (reducer, hard-cap enforced at the single source of truth) and the
+// real-number ledger on the submission seam (approval.maxSpend / budget authorize / reserve = derived
+// price, not ¥0). These are the "接线" half of S2 — the pure derive is covered in shotPricing.test.ts.
+
+const now = "2026-08-24T00:00:00.000Z";
+const roots: string[] = [];
+
+const registry = createModuleRegistry([{
+  moduleId: "generation.single-shot",
+  version: "1.0.0",
+  inputKinds: ["text"],
+  outputKinds: ["image"],
+  modes: ["text-to-image"],
+  parameterSchema: { aspectRatio: { type: "string" } },
+  assetInputSchema: { references: { kind: "image", max: 4 } },
+  providers: [{
+    providerId: "fixture-provider",
+    models: [{
+      modelId: "fixture-model",
+      modes: ["text-to-image"],
+      parameterSchema: {},
+      capabilities: { submitIdempotency: true, query: true, reconcile: true, cancel: true },
+    }],
+  }],
+}]);
+
+function candidate(candidateId: string, prompt: string): PlanCandidate {
+  return {
+    candidateId,
+    revision: 1,
+    moduleId: "generation.single-shot",
+    providerId: "fixture-provider",
+    modelId: "fixture-model",
+    mode: "text-to-image",
+    prompt,
+    parameters: { aspectRatio: "16:9" },
+    references: [],
+  };
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
+});
+
+// -----------------------------------------------------------------------------------------------
+// Seal precheck (reducer)
+// -----------------------------------------------------------------------------------------------
+
+function threeShotDraft(maxSpend: number | null): ProductionRun {
+  const a = candidate("cand-a", "shot a");
+  const b = candidate("cand-b", "shot b");
+  const c = candidate("cand-c", "shot c");
+  return {
+    schemaVersion: 1, runId: "op-seal", projectId: "project-1", revision: 2,
+    status: "draft", stageId: "generate", playbook: { name: "generation.single-shot", version: "1.0.0" },
+    origin: { host: "semantic-mcp" },
+    policy: { mode: "balanced", trustedHosts: [], allowedProviders: [], allowedModels: [], maxSpend, maxAttemptsPerJob: 2, minimizeUploads: true },
+    budget: { currency: "CNY", authorized: 0, reserved: 0, actual: 0, unsettled: 0 },
+    planVersion: 1, snapshotCursor: 2, stages: [], gates: [], jobs: [], artifacts: [],
+    generationPlan: {
+      operationId: "op-seal", state: "draft", candidate: a,
+      shots: [
+        { shotId: "shot-a", candidate: a, updatedAt: now },
+        { shotId: "shot-b", candidate: b, updatedAt: now },
+        { shotId: "shot-c", candidate: c, updatedAt: now },
+      ],
+      updatedAt: now,
+    },
+    createdAt: now, updatedAt: now,
+  };
+}
+
+function sealCommand(draft: ProductionRun, shotPrices: Array<{ shotId: string; price: unknown }> | undefined) {
+  const a = draft.generationPlan!.shots![0].candidate;
+  const b = draft.generationPlan!.shots![1].candidate;
+  const c = draft.generationPlan!.shots![2].candidate;
+  const aContract = compileExecutionContract(a, registry);
+  const bContract = compileExecutionContract(b, registry);
+  const cContract = compileExecutionContract(c, registry);
+  const shots: ProductionGenerationShot[] = [
+    { shotId: "shot-a", candidate: { ...a, sealedContractHash: aContract.contractHash }, contract: aContract, updatedAt: now },
+    { shotId: "shot-b", candidate: { ...b, sealedContractHash: bContract.contractHash }, contract: bContract, updatedAt: now },
+    { shotId: "shot-c", candidate: { ...c, sealedContractHash: cContract.contractHash }, contract: cContract, updatedAt: now },
+  ];
+  return {
+    commandId: "seal-op", expectedRevision: 2, type: "generation.seal" as const,
+    payload: { contract: aContract, shots, planHash: "plan-hash-seal", ...(shotPrices ? { shotPrices } : {}) },
+    issuedAt: now,
+  };
+}
+
+describe("P4 S2 seal precheck", () => {
+  it("rejects the seal with maxAffordableShots when the hard cap cannot cover the known subtotal", () => {
+    const draft = threeShotDraft(25);
+    const command = sealCommand(draft, [
+      { shotId: "shot-a", price: { known: true, amount: 10 } },
+      { shotId: "shot-b", price: { known: true, amount: 10 } },
+      { shotId: "shot-c", price: { known: true, amount: 10 } },
+    ]);
+    try {
+      applyProductionCommand(draft, command, now);
+      throw new Error("expected SealBudgetExceededError");
+    } catch (error) {
+      expect(error).toBeInstanceOf(SealBudgetExceededError);
+      const typed = error as SealBudgetExceededError;
+      expect(typed.code).toBe("seal_budget_exceeded");
+      expect(typed.maxAffordableShots).toBe(2); // 10 + 10 fit under 25; the third breaches.
+      expect(typed.maxSpend).toBe(25);
+      expect(typed.knownSubtotal).toBe(30);
+    }
+  });
+
+  it("seals and marks costCertainty=known when the cap covers every priced shot", () => {
+    const draft = threeShotDraft(40);
+    const effect = applyProductionCommand(draft, sealCommand(draft, [
+      { shotId: "shot-a", price: { known: true, amount: 10 } },
+      { shotId: "shot-b", price: { known: true, amount: 10 } },
+      { shotId: "shot-c", price: { known: true, amount: 10 } },
+    ]), now);
+    expect(effect.run.generationPlan?.state).toBe("sealed");
+    expect(effect.run.generationPlan?.costCertainty).toBe("known");
+  });
+
+  it("seals and marks costCertainty=partial when a shot price is unknown (cap satisfied by known ones)", () => {
+    const draft = threeShotDraft(25);
+    const effect = applyProductionCommand(draft, sealCommand(draft, [
+      { shotId: "shot-a", price: { known: true, amount: 10 } },
+      { shotId: "shot-b", price: { known: false } },
+      { shotId: "shot-c", price: { known: true, amount: 10 } },
+    ]), now);
+    // Known subtotal 20 ≤ 25 → seals; unknown shot flags partial certainty.
+    expect(effect.run.generationPlan?.state).toBe("sealed");
+    expect(effect.run.generationPlan?.costCertainty).toBe("partial");
+  });
+
+  it("seals unbounded (no maxSpend) and still records certainty", () => {
+    const draft = threeShotDraft(null);
+    const effect = applyProductionCommand(draft, sealCommand(draft, [
+      { shotId: "shot-a", price: { known: true, amount: 100 } },
+      { shotId: "shot-b", price: { known: true, amount: 100 } },
+      { shotId: "shot-c", price: { known: true, amount: 100 } },
+    ]), now);
+    expect(effect.run.generationPlan?.state).toBe("sealed");
+    expect(effect.run.generationPlan?.costCertainty).toBe("known");
+  });
+
+  it("stays byte-identical (no precheck, no costCertainty) when the caller supplies no shotPrices", () => {
+    const draft = threeShotDraft(25); // a cap that WOULD reject if a precheck ran
+    const effect = applyProductionCommand(draft, sealCommand(draft, undefined), now);
+    expect(effect.run.generationPlan?.state).toBe("sealed");
+    expect(effect.run.generationPlan?.costCertainty).toBeUndefined();
+  });
+});
+
+// -----------------------------------------------------------------------------------------------
+// Real-number ledger on the submission seam
+// -----------------------------------------------------------------------------------------------
+
+function sealedApprovedSingleShot(priceAmount: number | null) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "nomi-s2-ledger-"));
+  roots.push(root);
+  const repository = createProductionRunRepository({
+    projectDirResolver: (projectId) => (projectId === "project-1" ? root : null),
+    now: () => now,
+    randomId: (() => { let n = 0; return () => `id-${++n}`; })(),
+  });
+  const planCandidate = candidate("candidate-1", "a paper boat");
+  const contract = compileExecutionContract(planCandidate, registry);
+  repository.createGenerationDraft({
+    operationId: "op-1", projectId: "project-1", origin: { host: "semantic-mcp" }, candidate: planCandidate,
+    policy: { trustedHosts: ["semantic-mcp"], allowedProviders: ["fixture-provider"], allowedModels: ["fixture-model"], maxSpend: null, maxAttemptsPerJob: 2 },
+  });
+  repository.execute("project-1", "op-1", { commandId: "generation.seal:op-1", expectedRevision: 0, type: "generation.seal", payload: { contract }, issuedAt: now });
+  repository.execute("project-1", "op-1", { commandId: "generation.approve:op-1:receipt-1", expectedRevision: 1, type: "generation.approve", payload: { receiptId: "receipt-1", contractHash: contract.contractHash }, issuedAt: now });
+  const submit = vi.fn(async () => ({ providerTaskId: "provider-task-1", raw: { accepted: true } }));
+  const runner = createProductionGenerationSubmission({
+    repository, projectRoot: root, immutableProjectUuid: "project-uuid-1", projectGeneration: 1, intentMacKey: "test-intent-key",
+    provider: { providerId: "fixture-provider", capabilities: { submitIdempotency: true, query: true, reconcile: true, cancel: true }, buildRequest: (input) => input, submit },
+    resolveShotPrice: () => (priceAmount === null ? { known: false } : { known: true, amount: priceAmount }),
+    now: () => now,
+  });
+  return { repository, runner, submit };
+}
+
+describe("P4 S2 real-number ledger on submission", () => {
+  it("authorizes + reserves the derived price and records it as the approval's maxSpend", async () => {
+    const { repository, runner } = sealedApprovedSingleShot(12);
+    await runner.start({ projectId: "project-1", operationId: "op-1" });
+
+    const run = repository.read("project-1", "op-1")!;
+    // Ledger authorized to the derived price, and the shot's price reserved (no longer ¥0).
+    expect(run.budget.authorized).toBe(12);
+    expect(run.budget.reserved).toBe(12);
+
+    const approval = repository.readApprovals("project-1", "op-1").find((a) => a.jobIds.includes(run.jobs[0].jobId));
+    expect(approval?.maxSpend).toBe(12);
+  });
+
+  it("keeps the ledger at 0 for an unknown-priced model (unpriced models still submit, pre-S2 behavior)", async () => {
+    const { repository, runner, submit } = sealedApprovedSingleShot(null);
+    await expect(runner.start({ projectId: "project-1", operationId: "op-1" })).resolves.toMatchObject({ nextAction: "observe" });
+    expect(submit).toHaveBeenCalledTimes(1);
+
+    const run = repository.read("project-1", "op-1")!;
+    expect(run.budget.authorized).toBe(0);
+    expect(run.budget.reserved).toBe(0);
+    const approval = repository.readApprovals("project-1", "op-1").find((a) => a.jobIds.includes(run.jobs[0].jobId));
+    expect(approval?.maxSpend).toBe(0);
+  });
+});


### PR DESCRIPTION
## What

P4 S2 slice: derive **real per-shot prices from the catalog** and replace the ¥0 placeholders on the semantic generation chain; add a **preview per-shot projection** and a **seal-time affordability precheck**. The P1–P3 single-shot chain stays byte-identical (it is the 1-shot special case). Plan: `docs/superpowers/plans/2026-08-24-p4-multishot-continuity.md` §7 S2 (with §2 "新机器" 2, §3.1, §3.3, §4, §9).

## Scope (file:line)

**Pure core — `electron/productionRun/shotPricing.ts` (new, fully tested):**
- `deriveShotPrice` — base `pricing.cost` + enabled `specCosts` whose `specKey` matches a parameter selection (bare value **or** `paramKey:value`). No pricing / disabled / no finite base cost → honest `{ known: false }`, **never a fabricated 0**.
- `projectMultiShotPreview` — per-shot `{ price, durationEstimate, degradations[] }` + total `{ knownSubtotal, unknownShotCount }`. Duration honestly-unknown when unestimable; the "model can't take a character reference" degradation is a **structured `code`+`params`** (no vendor string → renderer `t()`s it). Pure, zero provider calls.
- `checkSealAffordability` — walks included shots in checkbox order accumulating **known** prices (unknown-price shots contribute 0 but occupy a slot); over the cap → `{ maxAffordableShots }` ("最多完成前 N 镜"); within cap → ok + `hasUnknownPrice`.

**Real-number wiring (¥0 removed for priced models):**
- `mcpGenerationTools.ts` — `gate_request.maximumCost` = derived price + `costKnown` flag; `preview` now carries the `pricing` projection. Both zero-request. `resolveModelPricing` dep added.
- `productionGenerationSubmission.ts` — `approval.maxSpend` / budget `authorize` / reserve `costCeiling` = derived per-shot price via injected `resolveShotPrice`. Unknown/unpriced → **0 ledger amount** (no priced liability; unpriced models still submit — the outbox hard-fails only on a `null` costCeiling, not 0).
- `productionRunReducer.ts` — seal precheck enforced at the reducer (single source of truth) when the caller supplies catalog-derived `shotPrices`; throws typed `SealBudgetExceededError` and stamps `generationPlan.costCertainty` (`known` | `partial`). Absent `shotPrices` → byte-identical seal. `costCertainty` field added to `productionRunTypes.ts`.
- `catalogPricingResolver.ts` (new) — bridges `readCatalog().models` → the pure derive (vendorKey + modelKey/alias); wired into `mcpStdioServer.ts` + `appIntegration.ts`, resolved **lazily** so live pricing edits apply.

**Deferred to later slices (as the plan dictates):** lock-internal cumulative halt (S4 §3.3); the plan-level `authorize` that sums included shots up front (S4 scheduler); confirm-card UI (S3); canvas (S5).

## Fork the plan did not cover (flagged per instructions)

The plan said to derive the `specKey` matching rule from "existing GUI-side `specCosts` consumers". **There is no such consumer** — the catalog `specCosts` shape has existed since C1 (`ee7b0a47`) but the join was documented as "数据已有全未用" (`docs/plan/2026-06-11-nomi-harness-master-plan.md:244`, the never-built `estimateGenerationCost`); there is no `specKey` example anywhere in the tree. S2 therefore **defines** the rule, mirroring that documented additive "params × specCosts" join, and documents it prominently in `shotPricing.ts`. Reviewer sign-off on the rule welcome.

## Verification

- **Tests (TDD red→green):** `shotPricing.test.ts` (20), `shotPricingWiring.test.ts` (7: reducer precheck + submission ledger), `catalogPricingResolver.test.ts` (6), `mcpGenerationTools.test.ts` (+4 pricing on preview/gate). Full electron suite **3047/3047 passing** (`vitest run electron --no-file-parallelism`, deterministic).
- **Gates green:** `check:filesize` / `tokens` / `dangling-tokens` / `archetype-*` / `secrets` / `symlinks` / `i18n` / `heavy-path` / `controls` / `e2e-launch` / `walkthroughs` / `site` / `lint:ci` (0 errors) / `typecheck` / `build`.
- **Regression E2E:** `node tests/ux/mcp-generation-single-shot-gui-fallback.e2e.mjs` → **14/14, provider POST=1 GET=1, real quota=0**. Confirms the single-shot chain works with the pricing wiring and preview stays zero-request (the fixture model has no `pricing` → derives unknown → `maximumCost` stays 0, gate confirms, submit once).

## Known pre-existing issue (not from this slice)

The legacy `ProductionRunService` driver/gate tests (`productionRunDriver`, `productionSampleGate`, `productionShotGate`, `productionQaVerify`, `productionTrustLevel`, `productionGateIdempotency`) are **flaky under parallel `vitest run`** — they poll a file-lock loop on a 5s wall-clock deadline. Proven pre-existing: a clean `origin/main` flaked in **4 of 5** parallel runs; both `origin/main` and this branch pass **3047/3047 single-threaded**. This slice's code is outside their execution path (they use `provider: 'local'` and never touch `shotPricing`/`resolveShotPrice`/`readCatalog`). Flagged as a separate hardening task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)