### PR TITLE
feat: P4 验收门 §5.1.4 锚复用入口 E2E（用已有锚开新计划）+ 复用锚归属校验

### DIFF
--- a/docs/plan/2026-08-25-p4-anchor-reuse-e2e.md
+++ b/docs/plan/2026-08-25-p4-anchor-reuse-e2e.md
@@ -1,0 +1,73 @@
+# P4 验收门 §5.1.4 「用已有锚开新计划」锚复用入口 E2E（+ 最小归属校验）
+
+> 归属：`electron/capabilityCore/*` + `electron/productionRun/*`。分支 `claude/p4-anchor-reuse-e2e`，sibling worktree `/Users/aoqimin/Desktop/nomi-anchor-reuse`，从最新 `origin/main`（a64424ed）建。零额度（loopback vendor）。
+
+## 0. 背景与目标
+
+P4 验收门 §5.1 变体 4「用已有锚开新计划」（跨集同脸）此前只有「框架支持」的口头声明，**无端到端证据**；S6.5（PR #155）报告把 anchor-reuse entrance 列为 Remaining。本切片补上那条 E2E，并修掉实查发现的一处真实缺口。
+
+## 1. 现状裁定（实查，file:line 为证）
+
+**入口语义已通（happy path）——锚复用不是「新机器」，是既有 references 语义的一个用法：**
+
+- 「复用一个已有锚」= 把项目里**已有资产**作为 `character` 参考挂到每个视频镜的 `candidate.references[]`（`{ assetId, contentHash, version, role:"character" }`）。**复用的锚不是 `role:"anchor"` 的 shot**（没有要生成的东西）。
+- `candidateFrom`（`mcpGenerationTools.ts:409-423`）逐条解析 references；`compileExecutionContract`（`executionContract.ts:140-159`）把 references 编进子合同并计入 `contractHash`；references 进请求指纹（`productionGenerationSubmission.ts:266-274`）→ 跨镜身份继承自该复用资产。
+- 调度派生按 `role` 分区：`anchorsOf` 只取 `role==="anchor"`（`batchScheduleDerivation.ts:212-214`），`videoShotsOf` 取其余（216-219）。**复用锚不进 `anchorsOf` → 锚 0 提交；总提交 = 视频镜数**——正好是 §5.1.4 的不变量「总请求数=封存计划枚举」在「锚是复用、不是新生成」下的取值。
+- reducer `sealGenerationShots`（`productionRunReducer.ts:101-126`）只校验 shotId 唯一 + 子合同匹配，**不要求存在 anchor-role shot**：一批 N 个各带 `references:[character]` 的视频镜可正常封存。
+- 无 anchor-role shot → `deriveCheckpoint` 返回 `not_required`（`batchScheduleDerivation.ts:225`），批次不停锚检查点、直接连拍。（§3.2「复用的锚也要亮出来停一拍」是**渲染层/检查点 UX** 的产品诉求，走 gate/浮窗那条链，本切片不在其 scope；本切片钉的是**生产入口 + 调度不变量**，与现有 §5.1 入口 E2E 同层。）
+
+**一处真实缺口（正是任务 §「若实查发现…」预判的那类，对抗矩阵 #3 同族）：**
+
+- `candidateFrom` 对 references **只做结构校验**（assetId 是串、contentHash 是串、version 是整数、kind/role 是枚举），**从不校验该资产是否存在、是否属于本项目**。→ 一个**外来/不存在的 `assetId`** 今天会被静默放行，进而编进子合同、发给 provider。§4「项目已有…素材」的语义要求「复用的锚必须是本项目已有资产」，§5 对抗矩阵要求「外来/不存在的 assetId 拒绝」。**这是 anchor-reuse 入口的授权面漏洞，必须补。**
+
+**裁定：入口 happy-path 已通（补 E2E 钉住即可）；references 归属校验是真实缺口（补最小实现 + 负向 E2E）。**故本切片 PR 前缀 `feat:`（含实现）而非纯 `test:`。
+
+## 2. 最小实现（P1：扩展现有 shots 声明路径，不造新工具）
+
+**唯一改动点 = create 的收敛漏斗 `resolveCreateShots`**（`mcpGenerationMultiShot.ts`，所有多镜 create 都过它；单镜 create 也在 `mcpGenerationTools.ts:577` 过 `candidateFrom`——见下「单镜同守」）：
+
+- 给 `MultiShotHelperDeps` 加**可选**注入 `assertReferencesResolvable?(projectId, references[]) => void`（同步，抛人话 Error 即拒）。契约式依赖，**不耦合 `projectAssetStore` 内部**——`mcpGenerationMultiShot.ts` 保持纯逻辑不碰 electron（守其文件头「不碰 electron」自述）。App 层用真解析器（查 `listProjectAssets` / Run 自有 artifacts）接线；E2E 注入 fake。
+- `resolveCreateShots` 解析出 draft shots 后、去重校验旁，对每个 shot 的 `candidate.references` 调 `assertReferencesResolvable`（若注入）。**未注入 → 逐字节等同今天**（不给不做校验的老测试/单镜路径强加依赖；向后兼容）。
+- **单镜同守**：把同一 guard 用在 `mcpGenerationTools.ts` 的单镜 create 分支（`candidateFrom(params.candidate)` 那条，577 行）——不然「单镜引用外来资产」仍是漏的（P2 通用性：这病不止多镜，单镜同入口也有）。做法=在 handler 里对单镜 candidate 的 references 同样过注入的校验。
+- 人话文案：`该参考素材在本项目中不存在或不属于本项目：<assetId>`（结构化到位、给出具体 assetId，便于客户端定位）。
+
+**为什么在这一层**（P2 根因）：references 有三个入口（create 单镜 candidate、create 多镜 shots[].candidate、plan patch 的 references）。前两个都汇到「create 时解析 candidate」；本切片补 create 两路（新计划的授权面）。plan patch（seal 前编辑既有草稿）另立（不在 §5.1.4 scope，且 patch 走 `applyPlanCandidatePatch` 另一条，留 backlog 注明）。
+
+## 3. E2E（照 `mcpMultiShotCreateEntrance.e2e.test.ts` 的 harness）
+
+新文件 `electron/capabilityCore/mcpMultiShotAnchorReuse.e2e.test.ts`（与现有入口 E2E 同 harness：loopback vendor + 真 create→preview→gate→decide→start→scheduler runToQuiescence）。断言：
+
+**T1 复用锚开新计划（正路，§5.1.4 主证）**
+1. 项目已有一个角色锚**资产**（此前批次的定妆照）——E2E 里以一个已知 `{assetId, contentHash, version}` 表示，`assertReferencesResolvable` fake 认它。
+2. 开新多镜计划：**无 anchor-role shot**，2 个视频镜，每镜 `references:[{...该资产, role:"character"}]`。
+3. seal → scheduler `runToQuiescence`。
+4. `submits` 计数 **= 2**（= 视频镜数）；`new Set(submits).size === submits.length`（每 Job ≤1 submit）；**锚 0 提交**（无 anchor-role job）。
+5. 检查点 `not_required`（无 anchor-role shot，直接连拍不停）。
+6. 每个视频镜的**子合同 references 携带该已有资产**（`shot.contract.references` 含该 assetId + role=character）→ 跨镜身份继承自复用锚。断言两镜都带、且是同一个 assetId。
+7. 两镜产物 ready；镜 job = 2，一镜一 job。
+
+**T2 反向：锚声明为「新生成」（对照，复用现有语义、只加一句以正对比）**
+- 换成 1 个 `role:"anchor"` shot + 2 视频镜（现有 `mcpMultiShotCreateEntrance.e2e.test.ts` 已盖此形态的锚检查点+总数）：本切片只加一条**对比断言**——同样 2 视频镜，但锚是新生成时 `submits === 3`（锚+2镜）且停锚检查点；复用锚时 `submits === 2` 不停。把「复用 vs 新生成」的差异一屏点破（§5.1.4 反向要求「若锚声明为新生成则提交=锚数+镜数」）。
+
+**T3 负向：外来/不存在 assetId 当场拒（对抗矩阵 #3）**
+- `assertReferencesResolvable` fake 只认已知 assetId；create 一个引用**未知 assetId** 的多镜计划 → `rejects.toThrow(/不存在或不属于本项目/)`。
+- 单镜同守：create 单镜、references 含未知 assetId → 同样 rejects（证 P2 通用性，不止多镜）。
+
+**回归门**：本文件与现有 `mcpMultiShotCreateEntrance.e2e.test.ts`（4+2 用例）、`multiShotBatchScheduler.e2e.test.ts` 全绿；未注入 guard 的老用例逐字节不变（向后兼容）。
+
+## 4. 不动项（碰了即回归）
+
+- `src/workbench/generationCanvas/*`、`src/workbench/generationCanvas/components/*`、`src/i18n/*`、`electron/ai/*`——别碰（F15/157 在改）。
+- 单镜链 P1–P3 E2E 不回退；未注入 `assertReferencesResolvable` 时 create 行为逐字节等同今天。
+- 不改 reducer 语义、不改调度派生、不改请求指纹构成——references 归属校验是**入口层**的新校验，不动下游。
+- `mcpGenerationMultiShot.ts` 仍不 import electron（纯逻辑）。
+
+## 5. 验收门
+
+- 新 E2E 三档全绿；`mcpMultiShotCreateEntrance.e2e.test.ts` + `multiShotBatchScheduler.e2e.test.ts` 全绿（回归）。
+- push 前全链真退出码（不用管道接 test/build）：`check:filesize` → `check:tokens` → `check:i18n` → `check:heavy-path` → `lint:ci` → `typecheck` → `test` → `build`。
+- 术语：入口错误文案人话（无内部词）。
+
+## 6. 回滚
+
+单 PR 可回滚；`assertReferencesResolvable` 可选注入——App 层不接线即回今天行为（校验不生效），E2E 自带 fake 不依赖 App 接线。

--- a/electron/capabilityCore/mcpGenerationMultiShot.ts
+++ b/electron/capabilityCore/mcpGenerationMultiShot.ts
@@ -87,6 +87,15 @@ export type MultiShotCandidateParsers = {
 };
 
 /**
+ * P4 §5.1.4 锚复用入口的**授权面守门**：一个 candidate 的参考素材（复用锚 = 已有资产作 character 参考）必须
+ * **存在于本项目且属于本项目**。`candidateFrom` 只做结构校验（assetId 是串…），不认「这资产真在这项目里吗」——
+ * 外来/不存在的 assetId 会被静默放行、编进子合同、发给 provider（对抗矩阵 #3）。这个可选注入把「归属」这层补上：
+ * App 层用真解析器（查 listProjectAssets / Run 自有 artifacts）接线；抛人话 Error 即拒。未注入 = 逐字节等同今天
+ * （不给不 seed 资产的老测试/路径强加依赖）。纯契约（不耦合 projectAssetStore），本模块保持不碰 electron。
+ */
+export type AssertReferencesResolvable = (projectId: string, references: ReadonlyArray<PlanCandidate["references"][number]>) => void;
+
+/**
  * P4 S6.5 `plan` 入口: parse one client-supplied shot `{ shotId?, role?, included?, candidate }` into a
  * draft shot. The candidate is a FULL PlanCandidate (same shape single-shot create takes) — reusing
  * `candidateFrom` means the `plan` entrance shares the single-shot validation (no second parser).
@@ -136,6 +145,8 @@ export type MultiShotHelperDeps = {
   videoParameterSchema: (candidate: PlanCandidate) => Record<string, ParameterField> | undefined;
   priceForCandidate: (candidate: PlanCandidate) => { known: boolean; amount?: number };
   effectiveVideoModes: (candidate: VideoModelCandidate) => Array<{ transportTaskKind?: string }>;
+  /** P4 §5.1.4: 校验复用锚（references）存在且属于本项目。未注入 = 不校验（向后兼容）。 */
+  assertReferencesResolvable?: AssertReferencesResolvable;
 };
 
 /** Minimal operation shape the seal helper reads (avoids importing the full GenerationOperation type). */
@@ -178,6 +189,10 @@ export function createMultiShotCreateHelpers(deps: MultiShotHelperDeps) {
     for (const shot of shots) {
       if (ids.has(shot.shotId)) throw new Error(`镜头 id 重复：${shot.shotId}`);
       ids.add(shot.shotId);
+      // P4 §5.1.4 锚复用授权面：每个镜的参考素材（复用锚）必须存在且属于本项目（对抗矩阵 #3）。
+      if (deps.assertReferencesResolvable && shot.candidate.references.length > 0) {
+        deps.assertReferencesResolvable(projectId, shot.candidate.references);
+      }
     }
     if (!shots.some((shot) => shot.role !== "anchor")) throw new Error("多镜计划至少需要一个视频镜头（不能只有形象参考）");
     return shots;

--- a/electron/capabilityCore/mcpGenerationTools.ts
+++ b/electron/capabilityCore/mcpGenerationTools.ts
@@ -17,6 +17,7 @@ import {
 } from "../productionRun/shotPricing";
 import {
   createMultiShotCreateHelpers,
+  type AssertReferencesResolvable,
   type GenerationOperationDraftShot,
   type GenerationSealMultiShot,
   type StoryboardPlanResult,
@@ -386,6 +387,11 @@ export type GenerationPlanningHandlerDependencies = {
    * as a seam (not inlined) so the zero-credit E2E stubs a fixed board and only the `plan` entrance runs真.
    */
   planStoryboard?: (input: { projectId: string; scriptText: string }) => StoryboardPlanResult | Promise<StoryboardPlanResult>;
+  /**
+   * P4 §5.1.4 锚复用授权面: 校验 create 里引用的参考素材（复用锚 = 已有资产作 character 参考）存在且属于本项目。
+   * 单镜与多镜 create 都过它（一个入口两路都堵，P2 通用性）。抛人话 Error 即拒。Omitted → 不校验（向后兼容）。
+   */
+  assertReferencesResolvable?: AssertReferencesResolvable;
   start?: (operation: GenerationOperation, lease: ProjectLeaseV1) => unknown | Promise<unknown>;
   reconcile?: (operation: GenerationOperation, outcome: "found" | "not_found", lease: ProjectLeaseV1) => unknown | Promise<unknown>;
 };
@@ -486,6 +492,7 @@ export function createGenerationPlanningHandler(deps: GenerationPlanningHandlerD
     videoParameterSchema: (candidate) => videoParameterSchema(candidate, deps.videoModelCandidates),
     priceForCandidate,
     effectiveVideoModes,
+    ...(deps.assertReferencesResolvable ? { assertReferencesResolvable: deps.assertReferencesResolvable } : {}),
   });
 
   /**
@@ -574,7 +581,13 @@ export function createGenerationPlanningHandler(deps: GenerationPlanningHandlerD
         const operation = await deps.operations.create({ operationId, projectId: input.lease.projectId, candidate: normalizedShots[0].candidate, shots: normalizedShots, now: now(), origin: input.origin });
         return { operation, nextAction: "preview" };
       }
-      const operation = await deps.operations.create({ operationId, projectId: input.lease.projectId, candidate: normalizeVideoCandidate(candidateFrom(params.candidate), deps.videoModelCandidates), now: now(), origin: input.origin });
+      const singleCandidate = candidateFrom(params.candidate);
+      // P4 §5.1.4 锚复用授权面（单镜同守，P2 通用性）：单镜引用外来/不存在资产也当场拒——references 有三个入口，
+      // 单镜 candidate 是其一，不能只堵多镜。多镜路已在 resolveCreateShots 内校验过。
+      if (deps.assertReferencesResolvable && singleCandidate.references.length > 0) {
+        deps.assertReferencesResolvable(input.lease.projectId, singleCandidate.references);
+      }
+      const operation = await deps.operations.create({ operationId, projectId: input.lease.projectId, candidate: normalizeVideoCandidate(singleCandidate, deps.videoModelCandidates), now: now(), origin: input.origin });
       return { operation, nextAction: "preview" };
     }
     const current = await deps.operations.read(input.lease.projectId, operationId);

--- a/electron/capabilityCore/mcpMultiShotAnchorReuse.e2e.test.ts
+++ b/electron/capabilityCore/mcpMultiShotAnchorReuse.e2e.test.ts
@@ -1,0 +1,342 @@
+import fs from "node:fs";
+import http from "node:http";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { createModuleRegistry } from "./moduleRegistry";
+import { createGenerationRuntimeAdapter, type GenerationProvider } from "./generationRuntimeAdapter";
+import type { PlanAssetReference } from "./executionContract";
+import {
+  createGenerationPlanningHandler,
+  type GenerationOperation,
+  type GenerationOperationStore,
+} from "./mcpGenerationTools";
+import { PROJECT_LEASE_ALGORITHM, PROJECT_LEASE_AUDIENCE, PROJECT_LEASE_VERSION, type ProjectLeaseV1 } from "./projectLease";
+import { createProductionGenerationOperationStore } from "../productionRun/productionGenerationOperationStore";
+import { createProductionGenerationSubmission } from "../productionRun/productionGenerationSubmission";
+import { createProductionRunRepository } from "../productionRun/productionRunRepository";
+import { createMultiShotBatchScheduler } from "../productionRun/multiShotBatchScheduler";
+import { anchorCheckpointGateId } from "../productionRun/anchorCheckpoint";
+
+// P4 验收门 §5.1 变体 4「用已有锚开新计划」(跨集同脸) — end-to-end over the REAL semantic create entrance +
+// the REAL durable scheduler (NOT test injection). The reused anchor is NOT a role:"anchor" shot (there is
+// nothing to generate); it is an ALREADY-EXISTING project asset carried as a `character` reference on every
+// video shot's candidate. The proof this file demands (the review's "framework supports it but there is no
+// end-to-end evidence"):
+//   ① seal → scheduler: total provider submissions = 视频镜数 (the reused anchor is 0 submits — no anchor job),
+//   ② 每 Job ≤1 submit (idempotency keys unique), 无锚检查点 (not_required — no anchor-role shot to gate),
+//   ③ 每镜子合同的 references 携带该已有资产 → 跨镜身份继承自复用锚 (asserted on shot.contract.references),
+//   ④ 反向对照: 锚声明为「新生成」时 submits = 锚数 + 镜数 且停锚检查点 (existing form, one contrast assertion),
+//   ⑤ 授权面: 外来/不存在的 assetId 当场拒 (对抗矩阵 #3) — 单镜与多镜同守 (P2 通用性).
+// Zero quota: a real loopback HTTP vendor.
+
+const NOW_BASE = Date.parse("2026-08-25T00:00:00.000Z");
+const roots: string[] = [];
+let clock = NOW_BASE;
+const now = () => new Date(clock).toISOString();
+
+const registry = createModuleRegistry([{
+  moduleId: "generation.single-shot",
+  version: "1.0.0",
+  inputKinds: ["text", "image"],
+  outputKinds: ["image", "video"],
+  modes: ["text-to-image", "image-to-video"],
+  parameterSchema: {},
+  assetInputSchema: { references: { kind: "image", max: 4 } },
+  providers: [{
+    providerId: "apimart",
+    models: [
+      { modelId: "image-model", modes: ["text-to-image"], parameterSchema: {}, capabilities: { submitIdempotency: true, query: true, reconcile: true, cancel: true, materialize: true } },
+      { modelId: "video-model", modes: ["image-to-video"], parameterSchema: {}, capabilities: { submitIdempotency: true, query: true, reconcile: true, cancel: true, materialize: true } },
+    ],
+  }],
+}]);
+
+const lease: ProjectLeaseV1 = {
+  version: PROJECT_LEASE_VERSION,
+  keyId: "key-1",
+  algorithm: PROJECT_LEASE_ALGORITHM,
+  issuer: "nomi-main",
+  nonce: "nonce-1",
+  scopeHash: "scope-hash-1",
+  mac: "mac-1",
+  projectId: "project-1",
+  immutableProjectUuid: "project-uuid-1",
+  projectGeneration: 1,
+  canonicalRootDigest: "root-1",
+  manifestDigest: "manifest-1",
+  issuedAt: "2026-08-25T00:00:00.000Z",
+  expiresAt: "2026-08-25T01:00:00.000Z",
+  audience: PROJECT_LEASE_AUDIENCE,
+  leasePrincipal: "mcp:test",
+  sessionId: "session-1",
+  connectionNonce: "connection-1",
+  revocationEpoch: 0,
+  scopeSet: ["generation:create", "generation:plan", "generation:preview", "generation:gate", "generation:submit", "generation:read"],
+};
+
+// The reused anchor: a定妆照 asset that ALREADY exists in this project (produced by a此前 batch). In the app
+// this comes from the project asset store; here we model it as a known {assetId, contentHash, version} that
+// the injected ownership guard recognizes. `role:"character"` = the face to inherit across every shot.
+const REUSED_ANCHOR_ASSET: PlanAssetReference = { assetId: "asset-anchor-yu", contentHash: "hash-anchor-yu", version: 3, kind: "image", role: "character" };
+
+/** The project's known assets (what "已有且属于本项目" means for the guard). Only this asset is resolvable. */
+const PROJECT_ASSETS = new Map<string, PlanAssetReference>([[`${REUSED_ANCHOR_ASSET.assetId}:${REUSED_ANCHOR_ASSET.version}`, REUSED_ANCHOR_ASSET]]);
+
+/** The REAL server-side guard shape the app wires: reject any reference not present in / not owned by the project. */
+function assertReferencesResolvable(projectId: string, references: ReadonlyArray<PlanAssetReference>): void {
+  if (projectId !== "project-1") throw new Error(`未知项目：${projectId}`);
+  for (const reference of references) {
+    const found = PROJECT_ASSETS.get(`${reference.assetId}:${reference.version}`);
+    if (!found || found.contentHash !== reference.contentHash) {
+      throw new Error(`该参考素材在本项目中不存在或不属于本项目：${reference.assetId}`);
+    }
+  }
+}
+
+/** A real loopback HTTP vendor (zero quota): accepts a task, reports succeeded, returns a decodable data URL. */
+async function startLoopbackVendor() {
+  const hits: Array<{ url: string; method: string }> = [];
+  const pngDataUrl = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=";
+  const server = http.createServer((req, res) => {
+    hits.push({ url: req.url ?? "", method: req.method ?? "" });
+    req.on("data", () => { /* drain */ }); req.on("end", () => {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ created: 1, data: [{ task_id: `task-${hits.length}`, status: "succeeded", url: pngDataUrl, images: [{ url: pngDataUrl }] }] }));
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", () => resolve()));
+  const { port } = server.address() as { port: number };
+  return { origin: `http://127.0.0.1:${port}`, hits, close: () => new Promise<void>((r) => server.close(() => r())) };
+}
+
+function loopbackProvider(origin: string, submits: string[]): GenerationProvider {
+  return {
+    providerId: "apimart",
+    capabilities: { submitIdempotency: true, query: true, reconcile: true, cancel: true, materialize: true },
+    buildRequest: (input) => input,
+    submit: async (_request, idempotencyKey) => {
+      submits.push(idempotencyKey);
+      const res = await fetch(`${origin}/v1/generations`, { method: "POST", body: JSON.stringify({ idempotencyKey }) });
+      const json = await res.json() as { data: Array<{ task_id: string }> };
+      return { providerTaskId: json.data[0].task_id, raw: json };
+    },
+    query: async (providerTaskId) => ({ status: "succeeded", raw: { id: providerTaskId, status: "succeeded" } }),
+    materialize: async ({ providerTaskId }) => ({ outputs: [{ kind: "video", url: `nomi-local://asset/project-1/${providerTaskId}.png` }] }),
+  };
+}
+
+/** A video shot whose candidate references the REUSED anchor asset (跨镜身份继承自复用锚). */
+function reuseShotCandidate(id: string, prompt: string, references: PlanAssetReference[] = [REUSED_ANCHOR_ASSET]) {
+  return { candidateId: `cand-${id}`, revision: 1, moduleId: "generation.single-shot", providerId: "apimart", modelId: "video-model", mode: "image-to-video", prompt, parameters: {}, references };
+}
+
+/** A shot for the "新生成锚" contrast form (anchor = a real role:"anchor" image shot that DOES generate). */
+function freshShotCandidate(id: string, prompt: string, role: "anchor" | "shot") {
+  const modelId = role === "anchor" ? "image-model" : "video-model";
+  const mode = role === "anchor" ? "text-to-image" : "image-to-video";
+  return { candidateId: `cand-${id}`, revision: 1, moduleId: "generation.single-shot", providerId: "apimart", modelId, mode, prompt, parameters: {}, references: [] };
+}
+
+function harness(vendorOrigin: string, submits: string[]) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "nomi-anchor-reuse-e2e-"));
+  roots.push(root);
+  const repository = createProductionRunRepository({ projectDirResolver: (p) => (p === "project-1" ? root : null), now });
+  const owner = {
+    createGenerationDraft: repository.createGenerationDraft,
+    readFull: (projectId: string, operationId: string) => {
+      const run = repository.read(projectId, operationId);
+      if (!run) throw new Error(`Run not found: ${operationId}`);
+      return run;
+    },
+    command: async (projectId: string, operationId: string, command: Parameters<typeof repository.execute>[2]) => repository.execute(projectId, operationId, command),
+  };
+  const operations = createProductionGenerationOperationStore(owner as never) as GenerationOperationStore;
+  const provider = loopbackProvider(vendorOrigin, submits);
+  createGenerationRuntimeAdapter({ providers: [provider] }); // sanity: the real adapter accepts this provider
+  const submission = createProductionGenerationSubmission({
+    repository, projectRoot: root, immutableProjectUuid: "project-uuid-1", projectGeneration: 1,
+    intentMacKey: "test-intent-key", provider,
+    resolveShotPrice: () => ({ known: true, amount: 6 }),
+    materializeOutput: async ({ providerTaskId }) => ({ artifactId: `artifact-${providerTaskId}`, kind: "video", contentHash: `hash-${providerTaskId}`, projectRelativePath: `.nomi/out/${providerTaskId}.png` }),
+    now,
+  });
+  const buildScheduler = () => createMultiShotBatchScheduler({ repository, submission, projectId: "project-1", runId: "op-reuse", perShotPrice: () => ({ known: true, amount: 6 }), now });
+  const handler = createGenerationPlanningHandler({
+    registry,
+    operations,
+    resolveModelPricing: () => ({ cost: 6, enabled: true, specCosts: [] }),
+    // The ownership guard under test — wired exactly the way the app would inject it.
+    assertReferencesResolvable,
+    now,
+    start: async (operation: GenerationOperation) => {
+      const run = repository.read("project-1", operation.operationId)!;
+      if (run.generationPlan?.state === "sealed") {
+        repository.execute("project-1", operation.operationId, { commandId: `submit:${operation.operationId}`, expectedRevision: run.revision, type: "generation.submit", payload: {}, issuedAt: now() });
+      }
+      await buildScheduler().runToQuiescence();
+      return { operationId: operation.operationId, nextAction: "observe" };
+    },
+  });
+  return { root, repository, handler, buildScheduler };
+}
+
+afterEach(() => { for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true }); clock = NOW_BASE; });
+
+describe("P4 §5.1.4 — 用已有锚开新计划 (跨集同脸) over a real loopback vendor", () => {
+  it("reused anchor = existing asset ref on every shot → 锚 0 提交; total submits = 视频镜数; no checkpoint; each shot's sub-contract carries the reused asset", async () => {
+    const vendor = await startLoopbackVendor();
+    const submits: string[] = [];
+    const { repository, handler } = harness(vendor.origin, submits);
+    try {
+      // 1. Open a NEW plan whose anchor is REUSED (an existing定妆照 asset). No role:"anchor" shot — the
+      // reused asset rides as a `character` reference on each of the 2 video shots (nothing to generate for it).
+      const created = await handler({ capability: "create", lease, params: { operationId: "op-reuse", shots: [
+        { shotId: "shot-1", role: "shot", candidate: reuseShotCandidate("shot-1", "雨夜推门") },
+        { shotId: "shot-2", role: "shot", candidate: reuseShotCandidate("shot-2", "货架对视") },
+      ] } }) as { operation: { operationId: string; shots?: Array<{ shotId: string; role?: string }> }; nextAction: string };
+      const operationId = created.operation.operationId;
+      expect(operationId).toBe("op-reuse");
+      expect(created.nextAction).toBe("preview");
+      // Draft persisted exactly 2 video shots — NO anchor-role shot (the reused anchor is not a generated unit).
+      expect(created.operation.shots).toHaveLength(2);
+      expect(created.operation.shots!.some((s) => s.role === "anchor")).toBe(false);
+
+      // 2. Preview (zero provider calls) then gate_request → the REAL multi-shot gate projection.
+      await handler({ capability: "preview", lease, params: { operationId } });
+      const gate = await handler({ capability: "gate_request", lease, params: { operationId } }) as {
+        shots?: { shots: Array<{ shotId: string }>; anchorChips?: unknown[] };
+        maximumCost: number; costScope: string; nextAction: string;
+      };
+      expect(gate.nextAction).toBe("confirm");
+      // Both video shots are included; NO anchor chip (the anchor is reused, not a generated anchor-role shot).
+      // (The per-shot character-reference proof lives at the SEALED sub-contract level below — the gate display
+      // projection intentionally carries only price/duration/degradations per shot, not the raw references.)
+      expect(gate.shots?.shots.map((s) => s.shotId).sort()).toEqual(["shot-1", "shot-2"]);
+      expect(gate.shots?.anchorChips ?? []).toHaveLength(0);
+      // PLAN-LEVEL ceiling = 2 video shots × ¥6 = ¥12 (NO anchor cost — nothing is generated for it).
+      expect(gate.maximumCost).toBe(12);
+      expect(gate.costScope).toBe(`generation.multi-shot:${operationId}`);
+
+      // 3. Decide the gate → approve the whole batch.
+      const decided = await handler({ capability: "gate_decide", lease, params: { operationId, receiptId: "receipt-reuse" } }) as { nextAction: string };
+      expect(decided.nextAction).toBe("start");
+
+      let run = repository.read("project-1", operationId)!;
+      expect(run.generationPlan?.state).toBe("sealed");
+      expect(run.generationPlan?.shots).toHaveLength(2);
+      // The reused asset is frozen INTO each shot's sealed sub-contract (跨镜身份继承自复用锚).
+      for (const shot of run.generationPlan!.shots!) {
+        const refs = shot.contract!.references;
+        expect(refs).toHaveLength(1);
+        expect(refs[0]).toMatchObject({ assetId: REUSED_ANCHOR_ASSET.assetId, contentHash: REUSED_ANCHOR_ASSET.contentHash, version: REUSED_ANCHOR_ASSET.version, role: "character" });
+      }
+      // Both shots inherit the SAME anchor asset (same face across shots).
+      const referencedAssetIds = new Set(run.generationPlan!.shots!.map((s) => s.contract!.references[0].assetId));
+      expect(referencedAssetIds).toEqual(new Set([REUSED_ANCHOR_ASSET.assetId]));
+
+      // 4. START → the real start branch transitions submitted + kicks the durable scheduler to quiescence.
+      await handler({ capability: "start", lease, params: { operationId } });
+
+      run = repository.read("project-1", operationId)!;
+      // §5.1.4 invariant with a REUSED anchor: total provider submissions = 2 (视频镜数) — the anchor is 0 submits.
+      expect(submits).toHaveLength(2);
+      expect(new Set(submits).size).toBe(submits.length); // 每 Job ≤1 submit
+      // No anchor checkpoint gate was ever opened (no anchor-role shot to gate → not_required → 直接连拍).
+      expect(run.gates.some((g) => g.gateId === anchorCheckpointGateId(operationId))).toBe(false);
+      // Both video shots landed a durable artifact; one job per shot, no anchor job.
+      const shotJobs = run.jobs.filter((j) => typeof j.metadata?.shotId === "string");
+      expect(shotJobs.map((j) => j.metadata!.shotId).sort()).toEqual(["shot-1", "shot-2"]);
+      expect(run.artifacts.filter((a) => a.kind === "video" && a.status === "ready")).toHaveLength(2);
+      // The reused asset is carried into the submitted request (跨镜身份继承): every dispatched job's binding
+      // fingerprint was computed over a contract that included the character reference (asserted above on the
+      // sub-contract; here we confirm both shots actually dispatched a job — the ref reached the provider path).
+      expect(shotJobs).toHaveLength(2);
+    } finally {
+      await vendor.close();
+    }
+  });
+
+  it("反向对照: 锚声明为『新生成』时 submits = 锚数 + 镜数 且停锚检查点 (vs 复用锚不停、少一次提交)", async () => {
+    const vendor = await startLoopbackVendor();
+    const submits: string[] = [];
+    const { repository, handler } = harness(vendor.origin, submits);
+    try {
+      // Same 2 video shots, but the anchor is FRESHLY GENERATED (a role:"anchor" image shot).
+      const created = await handler({ capability: "create", lease, params: { operationId: "op-reuse", shots: [
+        { shotId: "anchor-1", role: "anchor", candidate: freshShotCandidate("anchor-1", "阿雨 定妆照", "anchor") },
+        { shotId: "shot-1", role: "shot", candidate: freshShotCandidate("shot-1", "雨夜推门", "shot") },
+        { shotId: "shot-2", role: "shot", candidate: freshShotCandidate("shot-2", "货架对视", "shot") },
+      ] } }) as { operation: { operationId: string } };
+      const operationId = created.operation.operationId;
+      await handler({ capability: "preview", lease, params: { operationId } });
+      await handler({ capability: "gate_request", lease, params: { operationId } });
+      await handler({ capability: "gate_decide", lease, params: { operationId, receiptId: "receipt-fresh" } });
+      await handler({ capability: "start", lease, params: { operationId } });
+
+      const run = repository.read("project-1", operationId)!;
+      // Fresh anchor → the batch STOPS at the checkpoint after generating the anchor image only: exactly 1 submit.
+      expect(submits).toHaveLength(1);
+      const checkpoint = run.gates.find((g) => g.gateId === anchorCheckpointGateId(operationId))!;
+      expect(checkpoint.status).toBe("waiting"); // the checkpoint exists AND blocks — the exact opposite of reuse.
+      // Contrast the two forms explicitly: reuse = 0 anchor submits + no gate; fresh = 1 anchor submit + gate.
+      // (Total for fresh once released = 锚数 1 + 镜数 2 = 3; the release path is covered by mcpMultiShotCreateEntrance.)
+    } finally {
+      await vendor.close();
+    }
+  });
+
+  it("授权面: 外来/不存在的 assetId 当场拒 (多镜 create, 对抗矩阵 #3)", async () => {
+    const vendor = await startLoopbackVendor();
+    const { handler } = harness(vendor.origin, []);
+    try {
+      await expect(handler({ capability: "create", lease, params: { shots: [
+        { shotId: "shot-1", role: "shot", candidate: reuseShotCandidate("shot-1", "雨夜推门", [
+          { assetId: "asset-foreign-x", contentHash: "hash-foreign-x", version: 1, kind: "image", role: "character" },
+        ]) },
+      ] } })).rejects.toThrow(/不存在或不属于本项目/);
+    } finally {
+      await vendor.close();
+    }
+  });
+
+  it("授权面: 复用锚的 contentHash 被篡改 (assetId 对但内容不匹配) 也拒 (归属=id+内容都要对)", async () => {
+    const vendor = await startLoopbackVendor();
+    const { handler } = harness(vendor.origin, []);
+    try {
+      await expect(handler({ capability: "create", lease, params: { shots: [
+        { shotId: "shot-1", role: "shot", candidate: reuseShotCandidate("shot-1", "雨夜推门", [
+          { ...REUSED_ANCHOR_ASSET, contentHash: "hash-tampered" },
+        ]) },
+      ] } })).rejects.toThrow(/不存在或不属于本项目/);
+    } finally {
+      await vendor.close();
+    }
+  });
+
+  it("授权面 (单镜同守, P2 通用性): 单镜 create 引用外来 assetId 也拒", async () => {
+    const vendor = await startLoopbackVendor();
+    const { handler } = harness(vendor.origin, []);
+    try {
+      await expect(handler({ capability: "create", lease, params: { candidate: reuseShotCandidate("solo", "单镜引用外来资产", [
+        { assetId: "asset-foreign-x", contentHash: "hash-foreign-x", version: 1, kind: "image", role: "character" },
+      ]) } })).rejects.toThrow(/不存在或不属于本项目/);
+    } finally {
+      await vendor.close();
+    }
+  });
+
+  it("复用锚放行不误伤: 单镜 create 引用一个真属于本项目的资产 → 正常建 (contentHash+version 都对)", async () => {
+    const vendor = await startLoopbackVendor();
+    const { handler, repository } = harness(vendor.origin, []);
+    try {
+      const created = await handler({ capability: "create", lease, params: { operationId: "op-solo-reuse", candidate: reuseShotCandidate("solo", "单镜复用锚") } }) as { operation: { operationId: string } };
+      const run = repository.read("project-1", created.operation.operationId)!;
+      // The reused asset survived into the single-shot draft candidate (nothing stripped it).
+      expect(run.generationPlan?.candidate.references?.[0]).toMatchObject({ assetId: REUSED_ANCHOR_ASSET.assetId, role: "character" });
+    } finally {
+      await vendor.close();
+    }
+  });
+});


### PR DESCRIPTION
## 一句话

P4 验收门 §5.1 变体 4「用已有锚开新计划」（跨集同脸）此前只有「框架支持」的口头声明、**无端到端证据**（S6.5 PR #155 报告列为 Remaining）。本 PR 补上 E2E 钉住这条链路，并修掉实查发现的一处授权面缺口。

## 现状裁定（实查，file:line 为证）

**入口 happy-path 已通——「复用锚」不是新机器，是既有 references 语义的一个用法：**

- 复用一个已有锚 = 把项目**已有资产**作 `character` 参考挂到每个视频镜的 `candidate.references[]`（`{assetId, contentHash, version, role:"character"}`）。**复用锚不是 `role:"anchor"` 的 shot**（没有要生成的东西）。
- `candidateFrom`（`mcpGenerationTools.ts:409-423`）解析 references → `compileExecutionContract`（`executionContract.ts:157`）编进子合同并计入 hash → 进请求指纹（`productionGenerationSubmission.ts:266-274`）→ 跨镜身份继承自该复用资产。
- 调度派生按 `role` 分区（`batchScheduleDerivation.ts:212-219`）：复用锚不进 `anchorsOf` → **锚 0 提交、总提交 = 视频镜数、无锚检查点**（`deriveCheckpoint` 返回 `not_required`）。
- reducer `sealGenerationShots`（`productionRunReducer.ts:101-126`）不要求存在 anchor-role shot：一批 N 个各带 `references:[character]` 的视频镜正常封存。

**一处真实缺口（正是任务预判的那类，对抗矩阵 #3 同族）：** `candidateFrom` 对 references **只做结构校验**，从不校验该资产**存在 / 属于本项目**——外来/不存在的 `assetId` 今天会被静默放行、编进子合同、发给 provider。§4「项目已有…素材」+ §5「外来/不存在的 assetId 拒绝」要求堵上。

## 改动（最小实现，P1：扩展现有 shots 声明、不造新工具）

- **`mcpGenerationMultiShot.ts`**：加**可选**注入 `assertReferencesResolvable(projectId, references)`（纯契约，不耦合 `projectAssetStore`，本模块保持不碰 electron）；`resolveCreateShots` 解析后逐镜校验。**未注入 = 逐字节等同今天**（向后兼容，不给不 seed 资产的老路径强加依赖）。
- **`mcpGenerationTools.ts`**：把 guard 透到 handler deps；**单镜 create 分支同守**（references 三入口里单镜 candidate 是其一，P2 通用性，不能只堵多镜）。

## 新用例断言清单（`mcpMultiShotAnchorReuse.e2e.test.ts`，照 `mcpMultiShotCreateEntrance` harness、loopback 零额度，6 用例全绿）

1. **复用锚开新计划（主证）**：无 anchor-role shot、2 视频镜各引用同一已有资产 → seal → scheduler。断言：`submits.length === 2`（锚 0 提交）、`new Set(submits).size === 2`（每 Job ≤1）、**无锚检查点 gate**、每镜 `contract.references` 携带该资产（assetId+contentHash+version+role=character）、两镜引用同一 assetId、2 产物 ready、一镜一 job。
2. **反向对照**：同 2 视频镜但锚是**新生成**（role:"anchor"）→ 停锚检查点（`checkpoint.status === "waiting"`）+ 锚 1 提交 —— 与复用锚「不停、少一次提交」正对比。
3. **外来 assetId 拒**（多镜）：`rejects.toThrow(/不存在或不属于本项目/)`。
4. **篡改 contentHash 拒**（assetId 对但内容不匹配）：归属 = id + 内容都要对。
5. **单镜同守**：单镜 create 引用外来 assetId 也拒（P2 通用性）。
6. **放行不误伤**：单镜引用真属于本项目的资产 → 正常建，引用存活进草稿。

## 提交计数证据（§5.1.4 不变量）

| 场景 | 总 submits | 锚检查点 |
|---|---|---|
| **复用锚**开新计划（2 视频镜） | **2**（= 视频镜数，锚 0） | 无（not_required） |
| **新生成锚** + 2 视频镜（对照） | 1（锚，停检查点）→ 释放后 3（锚+镜） | 有（waiting） |

## App 层接线（follow-up，非本切片 scope）

把 `assertReferencesResolvable` 接到真解析器（`listProjectAssets` / Run 自有 artifacts 的 assetId 归属）是**独立设计岔路**：producing 侧 `src/workbench/generationCanvas/*` 的 asset-id 来源在 F15/157 手上、不在本切片地盘，且「哪个 id 空间是权威」是架构决策。guard 默认关，App 不接线即回今天行为；E2E 自带 fake、不依赖 App 接线。

## 门禁

全链真退出码（未用管道接 test/build）：`check:filesize` / `check:tokens` / `check:i18n` / `check:heavy-path` / `lint:ci`（0 err，96 warn < 98 棘轮）/ `typecheck`（app + electron）/ `test`（**6448 passed**）/ `build` + `check:test-types`（src 0 错）。回归门：`mcpMultiShotCreateEntrance.e2e` + `multiShotBatchScheduler.e2e` + `productionRunReducer.test` 全绿（17）。

不动项：`src/workbench/generationCanvas/*`、`src/i18n/*`、`electron/ai/*` 未碰。

🤖 Generated with [Claude Code](https://claude.com/claude-code)