### PR TITLE
fix(apimart): harden MiniMax H3 contract and polling

### DIFF
--- a/docs/plan/2026-08-25-apimart-h3-contract-hardening.md
+++ b/docs/plan/2026-08-25-apimart-h3-contract-hardening.md
@@ -1,0 +1,65 @@
+# APIMart MiniMax H3 契约加固实施计划
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use test-driven-development to execute each task in order.
+
+**Goal:** 让 MiniMax H3 的最终请求体在发送前严格满足 APIMart 的首尾帧/多模态参考互斥契约，并把 headless 视频轮询默认值对齐到官方建议。
+
+**Architecture:** 保留 APIMart 单一异步端点和当前模式投影；在模板渲染完成后的请求变换层增加 H3 专属、可审计的契约护栏，发现混发或音频单独输入时在扣费前失败。轮询预算抽成纯函数，UI 行为不变，MCP/headless 视频默认等待 15 分钟并继续允许 `NOMI_POLL_TIMEOUT_MS` 覆盖。
+
+**Tech Stack:** Electron + TypeScript + Vitest + APIMart curated catalog.
+
+---
+
+### Task 1: H3 最终请求体互斥护栏
+
+**Files:**
+- Modify: `electron/catalog/apimartVideos.ts`
+- Modify: `electron/tasks/requestTransforms.ts` (only if registration needs a shared import boundary)
+- Create: `electron/catalog/apimartMinimaxH3.ts` if the transform is kept beside the APIMart recipe
+- Test: `electron/catalog/apimartSeedance25H3.test.ts`
+
+- [x] **Step 1: Write failing tests**
+
+  Render the H3 `image_to_video` mapping with both frame and reference fields populated. Assert that the named request transform rejects the body before transport. Render an audio-only R2V body and assert the same transform rejects it. Assert a valid frame body removes the ignored `aspect_ratio` and empty `webhook` fields.
+
+- [x] **Step 2: Run the focused test and verify the expected failure**
+
+  Run `pnpm vitest run electron/catalog/apimartSeedance25H3.test.ts --reporter=verbose`.
+
+- [x] **Step 3: Implement the smallest request transform**
+
+  Register `apimart-minimax-h3` and attach it only to the H3 `image_to_video` mapping. The transform must inspect the rendered body, throw a user-facing deterministic error for frame/reference mixing or audio-only reference input, and delete `aspect_ratio` for frame requests plus empty optional `webhook` values.
+
+- [x] **Step 4: Run the focused test and verify it passes**
+
+  Run the same Vitest command and confirm all H3 tests pass.
+
+### Task 2: Headless polling budget
+
+**Files:**
+- Modify: `electron/capabilityCore/core.ts`
+- Test: `electron/capabilityCore/core.test.ts`
+
+- [x] **Step 1: Write a failing pure-function test**
+
+  Export a resolver for the effective poll timeout and assert video kinds default to `900000`, non-video kinds remain `240000`, and a positive `NOMI_POLL_TIMEOUT_MS` value still wins.
+
+- [x] **Step 2: Run the focused test and verify the expected failure**
+
+  Run `pnpm vitest run electron/capabilityCore/core.test.ts --reporter=verbose`.
+
+- [x] **Step 3: Implement the resolver and use it in the existing loop**
+
+  Replace the inline `300000` video default with the resolver; preserve the existing timeout error and no-resubmit behavior.
+
+- [x] **Step 4: Run focused tests**
+
+  Run the H3 test and core test together.
+
+### Task 3: Verification and delivery
+
+**Files:**
+- No additional source files.
+
+- [x] Run focused tests, then `pnpm run check:filesize`, `pnpm run check:tokens`, `pnpm run check:i18n`, `pnpm run lint:ci`, `pnpm run typecheck`, `pnpm run test`, and `pnpm run build`.
+- [ ] Inspect the diff, commit only scoped files, push `codex/apimart-h3-contract-fix-20260825`, and open a pull request against `main`.

--- a/electron/capabilityCore/core.test.ts
+++ b/electron/capabilityCore/core.test.ts
@@ -12,6 +12,7 @@ import {
   listAllProjects,
   readProjectCanvas,
   referencesFromEdges,
+  resolveCapabilityPollTimeoutMs,
   setProjectNodePrompt,
 } from './core'
 import { createDiskGateway, type PlanConfirmInfo, type ProjectGateway } from './gateway'
@@ -39,6 +40,15 @@ describe('referencesFromEdges（连参考边=喂参考图，headless 兜底）',
   it('非参考类边（first_frame 等）不计入此兜底', () => {
     const s = { ...(snap as object), edges: [{ id: 'e', source: 'a', target: 'b', mode: 'first_frame', order: 0 }] } as never
     expect(referencesFromEdges(s, 'b')).toEqual([])
+  })
+})
+
+describe('headless 轮询预算', () => {
+  it('视频默认等待 15 分钟，非视频维持 4 分钟，显式环境变量优先', () => {
+    expect(resolveCapabilityPollTimeoutMs('text_to_video', undefined)).toBe(900_000)
+    expect(resolveCapabilityPollTimeoutMs('image_to_video', undefined)).toBe(900_000)
+    expect(resolveCapabilityPollTimeoutMs('text_to_image', undefined)).toBe(240_000)
+    expect(resolveCapabilityPollTimeoutMs('image_to_video', '1234')).toBe(1234)
   })
 })
 

--- a/electron/capabilityCore/core.ts
+++ b/electron/capabilityCore/core.ts
@@ -87,6 +87,13 @@ export type FetchTaskResultFn = (payload: { taskId: string; vendor: string; task
 
 const TERMINAL_STATUSES = new Set(['succeeded', 'failed'])
 
+/** Headless/MCP 轮询上限：视频 API 官方建议客户端最多等待 15 分钟，允许环境变量覆盖。 */
+export function resolveCapabilityPollTimeoutMs(kind: string, envValue: string | undefined = process.env.NOMI_POLL_TIMEOUT_MS): number {
+  const override = Number(envValue)
+  if (Number.isFinite(override) && override > 0) return override
+  return kind === 'text_to_video' || kind === 'image_to_video' ? 900_000 : 240_000
+}
+
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms))
 }
@@ -589,10 +596,9 @@ export async function generateOnProject(
 
     // 异步 vendor 首调返 queued/processing → 本进程内轮询到终态（视频给更长超时）。无 fetch 注入则不轮询。
     if (fetchTaskResultFn && result.status && !TERMINAL_STATUSES.has(result.status)) {
-      // 慢 vendor（如 runninghub/ComfyUI 队列可达数分钟）可经 NOMI_POLL_TIMEOUT_MS 调大本进程轮询上限，
-      // 否则 240s/300s 到点 break → 结果未取回（headless 返 queued）。缺省维持原值。
-      const envPoll = Number(process.env.NOMI_POLL_TIMEOUT_MS)
-      const timeoutMs = Number.isFinite(envPoll) && envPoll > 0 ? envPoll : (kind === 'text_to_video' || kind === 'image_to_video' ? 300000 : 240000)
+      // 慢 vendor（如 APIMart H3 官方资源有限）可经 NOMI_POLL_TIMEOUT_MS 覆盖本进程轮询上限；
+      // 视频默认 15 分钟与供应商建议一致，避免 5 分钟时任务仍在上游排队却被本地判失败。
+      const timeoutMs = resolveCapabilityPollTimeoutMs(kind)
       // 轮询间隔与渲染层同策：视频 3s、其余 1.5s（厂商文档要求查询间隔 ≥3-5s，见
       // docs/plan/2026-07-31-seedance-api-contract-reconciliation.md §三）。跨进程边界拿不到
       // 渲染层的 resolvePollIntervalMs，故此处是**配对常量，改一处必改另一处**（同 vendorErrorIpc

--- a/electron/catalog/apimartMinimaxH3.ts
+++ b/electron/catalog/apimartMinimaxH3.ts
@@ -1,0 +1,44 @@
+// MiniMax-H3 的 APIMart 发送前契约护栏。
+//
+// APIMart 用字段自动路由：首/尾帧与多模态参考是两组互斥输入。模板层会按模式丢掉
+// undefined，但存量节点/旧 mapping 仍可能把两组值都带到渲染后的 body；这里在扣费与
+// HTTP 发送之间做最后一道、模型专属且可审计的校验。
+import { registerRequestTransform } from "../tasks/requestTransforms";
+
+type JsonRecord = Record<string, unknown>;
+
+function isRecord(value: unknown): value is JsonRecord {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function hasWireValue(value: unknown): boolean {
+  if (typeof value === "string") return value.trim().length > 0;
+  if (Array.isArray(value)) return value.length > 0;
+  return value != null;
+}
+
+export function normalizeMinimaxH3Body(body: unknown): unknown {
+  if (!isRecord(body)) return body;
+
+  const hasFrame = hasWireValue(body.first_frame_image) || hasWireValue(body.last_frame_image);
+  const hasImageReference = hasWireValue(body.image_urls);
+  const hasVideoReference = hasWireValue(body.video_urls);
+  const hasAudioReference = hasWireValue(body.audio_urls);
+  const hasReference = hasImageReference || hasVideoReference || hasAudioReference;
+
+  if (hasFrame && hasReference) {
+    throw new Error("MiniMax H3 请求参数冲突：首尾帧与参考素材不能同时使用，请只保留一组输入。");
+  }
+  if (!hasFrame && hasAudioReference && !hasImageReference && !hasVideoReference) {
+    throw new Error("MiniMax H3 多模态参考中音频不能单独输入，请至少提供参考图或参考视频。");
+  }
+
+  const normalized = { ...body };
+  // APIMart 文档规定 I2V 比例由输入图片决定，显式 aspect_ratio 会被忽略；不把旧模式残值发出去。
+  if (hasFrame) delete normalized.aspect_ratio;
+  // 可选 webhook 的空字符串不是有效地址，省略它而不是把空字段交给上游校验。
+  if (typeof normalized.webhook === "string" && normalized.webhook.trim() === "") delete normalized.webhook;
+  return normalized;
+}
+
+registerRequestTransform("apimart-minimax-h3", normalizeMinimaxH3Body);

--- a/electron/catalog/apimartSeedance25H3.test.ts
+++ b/electron/catalog/apimartSeedance25H3.test.ts
@@ -1,9 +1,35 @@
 import { describe, expect, it } from "vitest";
+import { buildHttpRequest, buildTemplateContext } from "../ai/requestPipeline";
+import { applyRequestTransform } from "../tasks/requestTransforms";
 import { buildArchetypeInputParams } from "../../src/workbench/generationCanvas/nodes/controls/archetypeMeta";
 import { getArchetypeById } from "../../src/config/modelArchetypes";
 import { applyBuiltinSeeds } from "./seedBuiltins";
+import { APIMART_VIDEO_MODELS } from "./apimartVideos";
+import { applyParamMap } from "./paramTranslate";
+import { taskTemplateParams } from "./taskParams";
 
 const emptyCatalog = () => ({ version: 4, vendors: [], models: [], mappings: [], apiKeysByVendor: {} });
+
+function renderH3I2vBody(extras: Record<string, unknown>) {
+  const mapping = APIMART_VIDEO_MODELS.find((model) => model.modelKey === "MiniMax-H3")?.mappings.find((item) => item.taskKind === "image_to_video");
+  if (!mapping) throw new Error("MiniMax-H3 image_to_video mapping is missing");
+  const request = { kind: "image_to_video", prompt: "镜头缓慢推近", extras };
+  const context = buildTemplateContext({
+    request,
+    params: applyParamMap(mapping.create.paramMap, taskTemplateParams(request)),
+    model: { modelKey: "MiniMax-H3" },
+    modelKey: "MiniMax-H3",
+    apiKey: "TEST_SECRET",
+  });
+  const built = buildHttpRequest({
+    baseUrl: "https://api.apimart.ai",
+    authType: "bearer",
+    apiKey: "TEST_SECRET",
+    context,
+    operation: mapping.create,
+  });
+  return { mapping, body: built.body as Record<string, unknown> };
+}
 
 describe("APIMart Seedance 2.5 / MiniMax-H3 curated 接入", () => {
   it("fresh seed 包含四个官方入口，且 mapping 桶按模型精确绑定", () => {
@@ -65,5 +91,34 @@ describe("APIMart Seedance 2.5 / MiniMax-H3 curated 接入", () => {
     const params = buildArchetypeInputParams(meta, archetype!, { firstFrameUrl: "https://x/first.png" });
     expect(params.first_frame_image).toBe("https://x/first.png");
     expect(params.first_frame_url).toBeUndefined();
+  });
+
+  it("H3 最终请求体拒绝首尾帧与多模态参考混发", async () => {
+    const { mapping, body } = renderH3I2vBody({
+      first_frame_image: "https://x/first.png",
+      image_urls: ["https://x/reference.png"],
+    });
+
+    await expect(
+      applyRequestTransform(mapping.create.request_transform, body, { baseUrl: "https://api.apimart.ai" }),
+    ).rejects.toThrow(/首尾帧.*参考素材/);
+  });
+
+  it("H3 多模态参考拒绝音频单独输入，并清理首尾帧模式忽略的字段", async () => {
+    const ref = renderH3I2vBody({
+      audio_urls: ["https://x/reference.mp3"],
+    });
+    await expect(
+      applyRequestTransform(ref.mapping.create.request_transform, ref.body, { baseUrl: "https://api.apimart.ai" }),
+    ).rejects.toThrow(/音频不能单独/);
+
+    const frame = renderH3I2vBody({
+      first_frame_image: "https://x/first.png",
+      aspect_ratio: "16:9",
+      webhook: "",
+    });
+    const transformed = await applyRequestTransform(frame.mapping.create.request_transform, frame.body, { baseUrl: "https://api.apimart.ai" });
+    expect(transformed).not.toHaveProperty("aspect_ratio");
+    expect(transformed).not.toHaveProperty("webhook");
   });
 });

--- a/electron/catalog/apimartVideos.ts
+++ b/electron/catalog/apimartVideos.ts
@@ -17,6 +17,7 @@
 import type { HttpOperation, ProfileKind } from "./types";
 import type { ParamMap } from "./paramTranslate";
 import { APIMART_CREATE_TASK_ID_PATH, APIMART_STATUS_MAPPING, APIMART_VIDEO_QUERY_OP } from "./apimartVendor";
+import "./apimartMinimaxH3";
 
 const CREATE_HEADERS = { Authorization: "Bearer {{user_api_key}}", "Content-Type": "application/json" };
 
@@ -91,6 +92,8 @@ function videoModel(p: {
   idKey?: string;
   /** body 的 model 字段引用。缺省 {{model.modelKey}}；变体合并模型传 VARIANT_MODEL_REF。 */
   modelRef?: string;
+  /** 模板渲染后、HTTP 发送前的具名请求护栏。 */
+  requestTransform?: string;
   /** 省略 = 该模型无纯文生模式（Vidu Q3 参考生：image_urls 必填，只有 i2v mapping）。 */
   t2vBody?: Record<string, unknown>;
   i2vBody?: Record<string, unknown>;
@@ -100,10 +103,14 @@ function videoModel(p: {
   const idKey = p.idKey ?? p.archetypeId;
   const mappings: ApimartVideoModel["mappings"] = [];
   if (p.t2vBody) {
-    mappings.push({ id: `seed-apimart-${idKey}-text_to_video`, taskKind: "text_to_video", name: `${p.labelZh} · 文生视频`, create: videoCreateOp(p.t2vBody, p.modelRef) });
+    const create = videoCreateOp(p.t2vBody, p.modelRef);
+    if (p.requestTransform) create.request_transform = p.requestTransform;
+    mappings.push({ id: `seed-apimart-${idKey}-text_to_video`, taskKind: "text_to_video", name: `${p.labelZh} · 文生视频`, create });
   }
   if (p.i2vBody) {
-    mappings.push({ id: `seed-apimart-${idKey}-image_to_video`, taskKind: "image_to_video", name: `${p.labelZh} · 图生视频`, create: videoCreateOp(p.i2vBody, p.modelRef, p.i2vDrops?.length ? dropParamMap(p.i2vDrops) : undefined) });
+    const create = videoCreateOp(p.i2vBody, p.modelRef, p.i2vDrops?.length ? dropParamMap(p.i2vDrops) : undefined);
+    if (p.requestTransform) create.request_transform = p.requestTransform;
+    mappings.push({ id: `seed-apimart-${idKey}-image_to_video`, taskKind: "image_to_video", name: `${p.labelZh} · 图生视频`, create });
   }
   return { modelKey: p.modelKey, labelZh: p.labelZh, archetypeId: p.archetypeId, mappings };
 }
@@ -177,6 +184,7 @@ export const APIMART_VIDEO_MODELS: ApimartVideoModel[] = [
   }),
   videoModel({
     modelKey: "MiniMax-H3", labelZh: "MiniMax H3", archetypeId: "minimax-h3-apimart",
+    requestTransform: "apimart-minimax-h3",
     t2vBody: { duration: DURATION, resolution: RESOLUTION, aspect_ratio: ASPECT, watermark: "{{request.params.watermark}}", webhook: "{{request.params.webhook}}" },
     i2vBody: { duration: DURATION, resolution: RESOLUTION, aspect_ratio: ASPECT, watermark: "{{request.params.watermark}}", webhook: "{{request.params.webhook}}", first_frame_image: "{{request.params.first_frame_image}}", last_frame_image: "{{request.params.last_frame_image}}", image_urls: IMAGE_URLS, video_urls: VIDEO_URLS, audio_urls: AUDIO_URLS },
   }),


### PR DESCRIPTION
## Why

APIMart's MiniMax-H3 endpoint routes by request fields. `first_frame_image` / `last_frame_image` (I2V) are mutually exclusive with `image_urls` / `video_urls` / `audio_urls` (R2V), and audio cannot be sent alone. The screenshot's 400 is therefore a request-contract violation, not an authentication failure.

## What changed

- Add a named MiniMax-H3 request transform after template rendering and before HTTP transport.
  - Reject frame + reference mixing with a deterministic Chinese error.
  - Reject audio-only R2V.
  - Drop I2V `aspect_ratio` (APIMart ignores it when frames are present) and empty `webhook`.
- Attach the transform to both curated H3 create mappings.
- Raise headless/MCP video polling default from 5 minutes to 15 minutes, matching APIMart's client timeout recommendation; preserve `NOMI_POLL_TIMEOUT_MS` override.
- Add red/green regression tests for the final rendered body and the polling resolver.

## Verification

- `pnpm vitest run electron/catalog/apimartSeedance25H3.test.ts electron/catalog/apimartVideoSharedContracts.test.ts electron/catalog/paramConsistency.test.ts electron/tasks/requestTransforms.test.ts electron/catalog/taskParams.test.ts electron/capabilityCore/core.test.ts --reporter=dot` — 71 passed
- `pnpm run check:filesize` — passed
- `pnpm run check:tokens` — passed
- `pnpm run check:i18n` — passed
- `pnpm run lint:ci` — 0 errors, 96 existing warnings (under max 98)
- `pnpm run typecheck` — passed
- `pnpm run test` — 732 files passed, 1 skipped; 6451 tests passed, 1 skipped
- `pnpm run build` — passed

Official contract references:
- https://docs.apimart.ai/cn/api-reference/videos/minimax-h3/generation
- https://docs.apimart.ai/cn/api-reference/tasks/status
