### PR TITLE
ci+fix: 补 Windows 走查门岗，判定 Electron 43 在 win32 零回归

### DIFF
--- a/.github/workflows/win-gate.yml
+++ b/.github/workflows/win-gate.yml
@@ -21,11 +21,8 @@ on:
         description: Branch, tag, or commit to verify
         required: true
         default: main
-  # ⚠️ 临时：workflow_dispatch 要能被调用，本文件得先在默认分支上。为了在合入前就拿到
-  # 「Electron 43 在 win32 到底行不行」的答案，先挂一条只认这个验证分支的 push 触发。
-  # 拿到结论后删掉这一段，只留 workflow_dispatch。
-  push:
-    branches: [claude/win-gate-*]
+  # 合入 main 后即可在 Actions UI 里按 ref 手动跑（workflow_dispatch 要求本文件在默认分支上）。
+  # 验证期曾临时挂过 push: [claude/win-gate-*] 以便合入前拿结论，结论已出（计划书 §9.8），故移除。
 
 permissions:
   contents: read

--- a/.github/workflows/win-gate.yml
+++ b/.github/workflows/win-gate.yml
@@ -25,7 +25,7 @@ on:
   # 「Electron 43 在 win32 到底行不行」的答案，先挂一条只认这个验证分支的 push 触发。
   # 拿到结论后删掉这一段，只留 workflow_dispatch。
   push:
-    branches: [claude/win-gate-verify]
+    branches: [claude/win-gate-*]
 
 permissions:
   contents: read

--- a/.github/workflows/win-gate.yml
+++ b/.github/workflows/win-gate.yml
@@ -1,0 +1,115 @@
+# Windows 侧的走查门岗——补 `docs/plan/2026-08-24-electron-31-to-43-upgrade.md` §6 验收门第 4 条。
+#
+# 为什么要有这个 workflow：
+#   Electron 31 → 43 那轮升级（PR #135）在 mac 上验得很足，但 win32 一格没打勾，
+#   PR 正文自己写着「本机无 Windows，mac 结果顶不了 win32」。而 v0.20.1 的真实下载数据是
+#   Windows 234 / mac 53——**82% 的用户跑在一个从没验过的 Electron 大版本上**。
+#
+#   根因不是「那轮忘了验」，是 `quality-gate.yml` 里压根没有 Windows job：
+#   只有 ubuntu-latest（跑走查）和 macos-latest（只打包、不走查）。开发机是 macOS，
+#   于是 win32 是个结构性盲区——不补 CI，下次任何平台敏感的改动会原样再漏一遍。
+#
+# 为什么是 workflow_dispatch 而不是挂 push：
+#   main 上 4 天进了 107 个 PR，Windows runner 计费 2x、单跑约 20 分钟，挂 push 成本不成比例。
+#   先按需跑；是否转成常驻门（或改 schedule 每日一跑）待定，见对话记录。
+name: Win Gate
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Branch, tag, or commit to verify
+        required: true
+        default: main
+  # ⚠️ 临时：workflow_dispatch 要能被调用，本文件得先在默认分支上。为了在合入前就拿到
+  # 「Electron 43 在 win32 到底行不行」的答案，先挂一条只认这个验证分支的 push 触发。
+  # 拿到结论后删掉这一段，只留 workflow_dispatch。
+  push:
+    branches: [claude/win-gate-verify]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: win-gate-${{ inputs.ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  win-walkthrough:
+    name: Windows Walkthrough
+    runs-on: windows-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.8.1
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # 现场自证：先把真正跑起来的 Electron 版本打出来，别让「验过了」建立在没核对的前提上。
+      # 装机版和 package.json 声明的版本对不上过（本地 pnpm install 只做 link、没跑 postinstall，
+      # dist/ 压根不存在），那种情况下走查是拿旧二进制跑的，全绿也证明不了 43。
+      - name: Report actual Electron version
+        shell: bash
+        run: |
+          echo "package.json declares: $(node -p "require('./package.json').devDependencies.electron")"
+          echo "node_modules/electron/dist/version: $(cat node_modules/electron/dist/version)"
+
+      - name: Build
+        run: pnpm run build
+
+      # 与 quality-gate.yml 的 ubuntu job 同两步，去掉 xvfb（Windows runner 自带桌面会话）。
+      - name: Electron smoke journeys
+        run: pnpm run test:e2e
+
+      - name: Real user journey suite
+        run: pnpm run test:journeys
+
+      # 走查截图是人眼判断用的证据（R13），失败时尤其要能拿回来看。
+      - name: Upload walkthrough screenshots
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: win-walkthrough-screenshots
+          path: |
+            evals/runs/**/screenshots/**
+            evals/runs/**/output.jsonl
+          if-no-files-found: warn
+          retention-days: 7
+
+  win-package:
+    name: Windows NSIS Package
+    runs-on: windows-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.8.1
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Build
+        run: pnpm run build
+      - name: Package NSIS x64
+        run: pnpm exec electron-builder --win nsis --x64 --publish never
+      - uses: actions/upload-artifact@v4
+        with:
+          name: nomi-win-x64-nsis
+          path: release/*.exe
+          if-no-files-found: error
+          retention-days: 7

--- a/docs/plan/2026-08-24-electron-31-to-43-upgrade.md
+++ b/docs/plan/2026-08-24-electron-31-to-43-upgrade.md
@@ -180,6 +180,7 @@ on(event: 'console-message', listener: (
 2. `pnpm run test:e2e` + `pnpm run test:packaging` 绿。
 3. **mac**：`pnpm run dist:mac:dir` 出包 → 打开 → 走查（起动、建项目、画布放视频、导出）+ **通知实弹**。
 4. **win**：NSIS x64 出包 → 真机安装 → 同一套走查（改哪面验哪面，win32 不能拿 mac 结果顶）。
+   → **2026-08-26 已补，见 §9.8。结论：Electron 43 在 win32 零回归。**「真机安装」那一格仍是空的（CI 顶不了）。
 5. **§2.2 专项**：渲染层故意 `console.error` 一条，确认主进程日志里级别**仍判为 error**（防静默降级）。
 6. **§2.4 专项**：干净克隆 → `pnpm install` → 直接 `pnpm dev`，确认不因缺二进制而失败。
 7. 走查截图必须**自己 Read 过**才算数（R13 眼见链）。
@@ -386,3 +387,51 @@ getBitmap(options?: BitmapOptions): void;
 若无遥测，可从 GitHub release 的下载数据或群反馈粗估。
 
 **Windows 侧无此问题**：32→44 无最低版本变化，且本仓 `win.target` 只有 x64。
+
+**§9.7 补数据（2026-08-26）**：v0.20.1 的 GitHub release 真实下载数拿到了——
+mac arm64 **41** / mac Intel **12** / win **234**。即 77% 的 mac 用户是 Apple Silicon（M1 起出厂即
+Big Sur，全都能升 12+），风险只可能落在 12 个 Intel 下载里；且 mac 仅占总量 53/287 ≈ 18%。
+另：macOS 10.15 / 11 本身已 EOL，2026-02 那次更新只续了 iMessage/FaceTime 证书，
+Apple 安全索引里无任何 CVE 条目。
+
+### 9.8 ✅ 验收门第 4 条（win32）已补——Electron 43 零回归
+
+2026-08-24 那轮 win32 一格没打勾（本机无 Windows）。**根因不是「那轮忘了验」**：
+`quality-gate.yml` 只有 ubuntu-latest（跑走查）和 macos-latest（只打包、不走查），
+**Windows 一个 job 都没有**——开发机是 macOS，win32 是结构性盲区。
+已补 `.github/workflows/win-gate.yml`：把 ubuntu job 的两步原样镜像到 windows-latest，
+另加 NSIS x64 出包，走查证据传 artifact。
+
+**单变量对照**（两组共用同一套走查工装，diff 只有 package.json 一行 + lockfile）：
+
+| | 实验组 Electron **43.4.1** | 对照组 Electron **31.7.7** |
+|---|---|---|
+| NSIS x64 出包 | ✅ success | ✅ success |
+| `test:e2e` smoke | ✅ success | ✅ success |
+| j3-first-success | ✅ 8/8 | ✅ 8/8 |
+| j5 `真实 MP4 已导出且非空` | ✅ | ✅ |
+| j5 `ffprobe 识别到视频流` | ✅ | ✅ |
+| j5 `提示词与重新生成控件同时可操作` | ❌ | ❌ **同错，数字逐位相同** |
+
+失败项两组的几何数据**完全一致**（含浮点尾数）：
+`promptVisibleHeight:0`，`composer{top:636.300048828125, bottom:662.2999877929688,
+left:290.34375, right:869.65625}`，`stage{top:88, bottom:719, left:60, right:1100}`。
+
+→ **判定：Electron 43 在 win32 上零回归。** 那条红是既有 Windows-only 问题
+（断言 2026-08-17 随 v0.20.0 发布准备加入，在 Linux 上一直绿；Windows 上大概率从那天起就红，
+只是 CI 里没有 Windows、没人看得见）。**不构成本次升级的阻塞项，另开任务修。**
+
+**注意 §2.1 类陷阱又出现了一次**：首跑报
+`infra error: ENOENT ... nomi-export-*.partial.mp4`，看起来像「Electron 43 把 Windows 导出搞坏了」。
+截图直接推翻——绿色 toast 明写「已导出到项目 exports 文件夹」，**产品导出成功了**。
+根因在走查工装 `evals/journeys/j5-edit-export.mjs` 的 `latestExport()`：
+`exportPaths.ts:69` 把 ffmpeg 在写的临时文件命名成 `<final>.partial.mp4`，它同样
+`endsWith(".mp4")` 会被当成品捞进来；而 `.filter()` 与 `.sort()` 各 `stat` 一次，
+ffmpeg 在两次之间把它改名成最终名，第二次 `stat` 直接 ENOENT 抛穿。
+**全平台潜伏 bug，Windows 只是导出慢、正好把竞态窗口撞开。** 已修并 A/B 证实
+（修复后两个导出断言均转绿）。教训与 §9.3 同族：**工装自己的 bug 会被 catch 洗成产品结论。**
+
+**仍未闭合**：「真机安装」那一格 CI 顶不了——走查跑的是 dev 构建，不是装完的 NSIS 产物，
+两者在 asar 打包、路径、`ensureExecutable` 的 ffmpeg 落地位置上有真实差异。
+补法：NSIS 静默安装后用 `launchNomiApp({ executablePath })` 指向装好的二进制再跑一遍
+（`_launchApp.mjs:115` 本就支持，`mcp-client-activation` 走查即此用法）。

--- a/evals/journeys/j5-edit-export.mjs
+++ b/evals/journeys/j5-edit-export.mjs
@@ -90,10 +90,23 @@ function latestExport(projectDir, startedAt) {
   const exportDir = path.join(projectDir, "exports");
   if (!fs.existsSync(exportDir)) return null;
   return fs.readdirSync(exportDir)
-    .filter((name) => name.endsWith(".mp4"))
+    // ffmpeg 的在写临时文件也叫 .mp4：exportPaths.ts:69 把它命名成 <final>.partial.mp4，
+    // 于是 endsWith(".mp4") 必然把半成品当成品捞进来。
+    .filter((name) => name.endsWith(".mp4") && !name.endsWith(".partial.mp4"))
     .map((name) => path.join(exportDir, name))
-    .filter((file) => fs.statSync(file).mtimeMs >= startedAt && fs.statSync(file).size > 0)
-    .sort((a, b) => fs.statSync(b).mtimeMs - fs.statSync(a).mtimeMs)[0] || null;
+    // stat 只做一次、结果随条目带走。原来 filter 和 sort 各 stat 一次，ffmpeg 在这两次之间
+    // 把 .partial.mp4 改名成最终名，第二次 stat 就 ENOENT 抛穿，报成「导出失败」——
+    // 而产品其实导出成功了。Windows 导出慢，正好把这个竞态窗口撞开；Linux/mac 只是没撞上，不是没有。
+    .flatMap((file) => {
+      try {
+        const stat = fs.statSync(file);
+        return [{ file, mtimeMs: stat.mtimeMs, size: stat.size }];
+      } catch {
+        return []; // 竞态中被改名/删除的文件跳过即可，不是错误
+      }
+    })
+    .filter((entry) => entry.mtimeMs >= startedAt && entry.size > 0)
+    .sort((a, b) => b.mtimeMs - a.mtimeMs)[0]?.file || null;
 }
 
 export default {


### PR DESCRIPTION
## 为什么做这个

PR #135（Electron 31→43）的验收门第 4 条「win NSIS 出包 → 真机安装 → 同一套走查」**一格没打勾**，PR 正文自己写着「本机无 Windows，mac 结果顶不了 win32」。

而 v0.20.1 的真实下载数是 **Windows 234 / mac 53**——82% 的用户跑在一个从没验过的 Electron 大版本上。

**根因不是「那轮忘了验」**：`quality-gate.yml` 里只有 `ubuntu-latest`（跑走查）和 `macos-latest`（**只打包、不走查**），**Windows 一个 job 都没有**。开发机是 macOS，于是 win32 是结构性盲区——不补 CI，下次任何平台敏感的改动会原样再漏一遍。mac 走查覆盖不到的 win32 分支现有 **31 处 / 19 个文件**，含导出 MP4 整条链（`ffmpegRunner` / `mediaProbe` / `ensureExecutable`）、浏览器容器 overlay、MCP 实例广播。

## 结论：Electron 43 在 win32 零回归

单变量对照，两组共用同一套走查工装，diff 只有 `package.json` 一行 + lockfile：

| | 实验组 **43.4.1** | 对照组 **31.7.7** |
|---|---|---|
| NSIS x64 出包 | ✅ | ✅ |
| `test:e2e` smoke | ✅ | ✅ |
| j3-first-success | ✅ 8/8 | ✅ 8/8 |
| j5 `真实 MP4 已导出且非空` | ✅ | ✅ |
| j5 `ffprobe 识别到视频流` | ✅ | ✅ |
| j5 `提示词与重新生成控件同时可操作` | ❌ | ❌ **同错** |

唯一那条红，两组几何数据**逐位相同**（含浮点尾数）：`promptVisibleHeight:0`、`composer{top:636.300048828125, bottom:662.2999877929688}`、`stage{top:88, bottom:719}`。

→ **不是 43 的回归。** 那是既有的 Windows-only 布局问题（断言 2026-08-17 随 v0.20.0 加入，Linux 上一直绿；Windows 上大概率从那天起就红，只是当时 CI 里没有 Windows job、没人看得见）。已另开任务，不阻塞升级。

**为什么不用「合并前的 main」当对照**：那之后隔着 135 commit / 106 个 UI 文件 / +5800 行，是脏对照，跑出什么都归因不到 Electron 头上。所以自己造了单变量对照（已确认可行：Electron 31.7.7 的 `electron.d.ts:9055` 里 `toBitmap()` 就存在，PR #135 那个修复向后兼容）。

## 顺带修掉一个真 bug（全平台潜伏）

首跑报 `infra error: ENOENT ... nomi-export-*.partial.mp4`，读起来就是「Electron 43 把 Windows 导出搞坏了」。**截图直接推翻**——绿色 toast 明写「已导出到项目 exports 文件夹」，产品导出成功了。

根因在 `evals/journeys/j5-edit-export.mjs` 的 `latestExport()`，两个 bug 叠着：

1. `exportPaths.ts:69` 把 ffmpeg 在写的临时文件命名成 `<final>.partial.mp4`——**它同样 `endsWith(".mp4")`**，必然被当成品捞进来。
2. `.filter()` 与 `.sort()` **各 `stat` 一次**，ffmpeg 在这两次之间把它改名成最终名，第二次 `stat` 直接 ENOENT 抛穿。

**全平台潜伏，Windows 只是导出慢、正好把竞态窗口撞开**——Linux/mac 不是没有，是没撞上。已修并 A/B 证实（修复后两个导出断言均转绿）。属于「harness 自己的 bug 被 catch 洗成产品结论」那一族。

## 仍未闭合（已写进计划书，没藏）

- **「真机安装」那格 CI 顶不了**：走查跑的是 dev 构建，不是装完的 NSIS 产物，两者在 asar 打包、路径、`ensureExecutable` 的 ffmpeg 落地位置上有真实差异。补法：NSIS 静默安装后用 `launchNomiApp({ executablePath })` 指向装好的二进制再跑一遍。
- **CI 的 Windows ≠ 用户的 Windows**（Azure VM、无 GPU、核数少、磁盘特性差很多）。这轮的绿证明「43 没引入回归」，不证明「Windows 上一切都好」。

## 成本说明

`win-gate.yml` 只挂 `workflow_dispatch`，**不挂 push**：main 上 4 天进了 107 个 PR，Windows runner 计费 2x、单跑约 20 分钟，挂 push 成本不成比例。是否转成常驻门（或改 schedule 每日一跑）另议。

## 验证

`pnpm run gates` 三次全过（每个 commit 一次）。证据全部回填进 `docs/plan/2026-08-24-electron-31-to-43-upgrade.md` §9.8，不让它只活在 7 天过期的 artifact 里。一次性对照分支已删。

🤖 Generated with [Claude Code](https://claude.com/claude-code)