### PR TITLE
fix: 参考素材传输的三个洞——data: URI 直穿 vendor、base64 兜底图被静默丢、几 MB base64 写进 project.json

### DIFF
--- a/electron/catalog/assetLocalization.test.ts
+++ b/electron/catalog/assetLocalization.test.ts
@@ -19,14 +19,21 @@ import {
 import type { AssetIngestion } from "./types";
 
 const localUrl = (p: string) => `nomi-local://asset/proj/${p}`;
+// 内联素材（headless/MCP 直接给 data: URI，或落盘失败退回 base64 的兜底路径）。
+const PNG_BYTES = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52]);
+const MP4_BYTES = Buffer.concat([Buffer.from([0x00, 0x00, 0x00, 0x20]), Buffer.from("ftypisom"), Buffer.from("mdat")]);
+const inlineImageUrl = (salt = "") =>
+  `data:image/png;base64,${Buffer.concat([PNG_BYTES, Buffer.from(salt)]).toString("base64")}`;
+const inlineVideoUrl = () => `data:video/mp4;base64,${MP4_BYTES.toString("base64")}`;
 const fakeAsset = (name: string): LocalAsset => ({ bytes: Buffer.from("hello-" + name), contentType: "image/png", fileName: name });
 const read = (url: string): LocalAsset | null => fakeAsset(url.split("/").pop() || "x");
 // 默认 multipart mock：返回声明 urlPath 能读到的形状。各用例可覆盖。
 const noMultipart = vi.fn();
 
 describe("isLocalAssetUrl / collect / replace", () => {
-  it("detects nomi-local urls only", () => {
+  it("detects local assets: nomi-local + inline data uris, never public urls", () => {
     expect(isLocalAssetUrl(localUrl("a.png"))).toBe(true);
+    expect(isLocalAssetUrl(inlineImageUrl())).toBe(true);
     expect(isLocalAssetUrl("https://x/a.png")).toBe(false);
     expect(isLocalAssetUrl(42)).toBe(false);
   });
@@ -706,5 +713,164 @@ describe("comfyui-upload（本地 ComfyUI 首帧上传，S2）", () => {
     );
     expect((out.value as { firstFrameUrl: string }).firstFrameUrl).toBe("in/frame.png");
     expect(post).toHaveBeenCalledTimes(1);
+  });
+});
+
+/**
+ * data: URI 与 nomi-local 走**同一条**物化/上传链。
+ *
+ * 根因（2026-08-26 真实付费实测）：此前 isLocalAssetUrl 只认 nomi-local://，一个 data: URI 一路直穿到
+ * vendor body —— 火山方舟 Ark 收（HTTP 200），kie.ai 的 nano-banana-2 / seedream-5-lite / flux-2-pro
+ * 三个模型一律 HTTP 500 "File type not supported"。同一张参考图换个供应商就挂，而 L3 参考护栏还判「有参考」。
+ * 修在这里=每个 vendor 拿到的永远是公网 URL，整类「谁收 data: 谁不收」的差异当场消失。
+ */
+describe("localizeAssetsForVendor — data: URI 与 nomi-local 同链", () => {
+  const uploadUrlIngestion: AssetIngestion = { strategy: "upload-url", endpoint: "https://up/x", base64Field: "b", urlPath: "url" };
+  const neverRead = vi.fn(() => null); // 内联素材零 IO：不该碰读盘器
+
+  it("内联图片上传换公网 URL，body 里带的是解码后的真字节", async () => {
+    const post = vi.fn().mockResolvedValue({ url: "https://pub/inline.png" });
+    const out = await localizeAssetsForVendor(
+      { image_input: [inlineImageUrl()], prompt: "hi" },
+      () => [{ vendorKey: "kie", ingestion: uploadUrlIngestion, uploadApiKey: "k" }],
+      neverRead,
+      post,
+      noMultipart,
+    );
+    expect(out.uploaded).toBe(1);
+    expect((out.value as { image_input: string[] }).image_input).toEqual(["https://pub/inline.png"]);
+    expect(neverRead).not.toHaveBeenCalled();
+    const body = post.mock.calls[0][2] as Record<string, string>;
+    expect(body.b).toBe(`data:image/png;base64,${PNG_BYTES.toString("base64")}`);
+  });
+
+  it("公网 URL 原样穿过，一次上传都不发（零成本直通不被本次修改破坏）", async () => {
+    const post = vi.fn();
+    const extras = { image_urls: ["https://cdn/a.png"], input_urls: ["http://cdn/b.png"], prompt: "hi" };
+    const out = await localizeAssetsForVendor(extras, () => [{ vendorKey: "kie", ingestion: uploadUrlIngestion, uploadApiKey: "k" }], neverRead, post, noMultipart);
+    expect(out.uploaded).toBe(0);
+    expect(out.value).toBe(extras);
+    expect(post).not.toHaveBeenCalled();
+  });
+
+  it("内联素材与 nomi-local 混在一个请求里，各自换出可达 URL", async () => {
+    const post = vi.fn()
+      .mockResolvedValueOnce({ url: "https://pub/from-file.png" })
+      .mockResolvedValueOnce({ url: "https://pub/from-inline.png" });
+    const out = await localizeAssetsForVendor(
+      { referenceImages: [localUrl("a.png"), inlineImageUrl()] },
+      () => [{ vendorKey: "kie", ingestion: uploadUrlIngestion, uploadApiKey: "k" }],
+      read,
+      post,
+      noMultipart,
+    );
+    expect(out.uploaded).toBe(2);
+    expect((out.value as { referenceImages: string[] }).referenceImages).toEqual([
+      "https://pub/from-file.png",
+      "https://pub/from-inline.png",
+    ]);
+  });
+
+  it("同一份内联字节只上传一次；不同字节各传各的、文件名不重（重名=覆盖=两个参考塌成一张）", async () => {
+    const postMultipart = vi.fn().mockImplementation((_u, _h, _f, fileName: string) => Promise.resolve({ url: `https://pub/${fileName}` }));
+    const first = inlineImageUrl();
+    const second = inlineImageUrl("other");
+    const out = await localizeAssetsForVendor(
+      { referenceImages: [first, second, first] },
+      () => [{ vendorKey: "apimart", ingestion: { strategy: "upload-multipart", endpoint: "https://up/m", urlPath: "url" }, uploadApiKey: "k" }],
+      neverRead,
+      vi.fn(),
+      postMultipart,
+    );
+    expect(out.uploaded).toBe(2); // first 去重
+    const names = postMultipart.mock.calls.map((call) => call[3] as string);
+    expect(new Set(names).size).toBe(2);
+    expect(names.every((name) => name.endsWith(".png"))).toBe(true);
+    const values = (out.value as { referenceImages: string[] }).referenceImages;
+    expect(values[0]).toBe(values[2]);
+    expect(values[0]).not.toBe(values[1]);
+  });
+
+  it("内联视频按字节判成 video → 走视频通道（不被 mime 声明骗进图片 base64 通道被 413）", async () => {
+    const post = vi.fn();
+    const postMultipart = vi.fn().mockResolvedValue({ data: { downloadUrl: "https://pub/clip.mp4" } });
+    const videoIngestion: AssetIngestion = { strategy: "upload-stream", endpoint: "https://vid/up", urlPath: "data.downloadUrl", accepts: ["image", "video"] };
+    const out = await localizeAssetsForVendor(
+      { referenceVideoUrls: [inlineVideoUrl()] },
+      (kind) => (kind === "video" ? [{ vendorKey: "kie", ingestion: videoIngestion, uploadApiKey: "vk" }] : []),
+      neverRead,
+      post,
+      postMultipart,
+    );
+    expect(post).not.toHaveBeenCalled();
+    expect((out.value as { referenceVideoUrls: string[] }).referenceVideoUrls).toEqual(["https://pub/clip.mp4"]);
+    expect((postMultipart.mock.calls[0][5] as Record<string, string>).fileName.endsWith(".mp4")).toBe(true);
+  });
+
+  it("inline-base64 供应商（如魔搭）：内联素材归一后原样内联，不空跑一次上传", async () => {
+    const post = vi.fn();
+    const out = await localizeAssetsForVendor(
+      { image_url: inlineImageUrl() },
+      () => [{ vendorKey: "modelscope", ingestion: { strategy: "inline-base64" }, uploadApiKey: "" }],
+      neverRead,
+      post,
+      noMultipart,
+    );
+    expect((out.value as { image_url: string }).image_url).toBe(`data:image/png;base64,${PNG_BYTES.toString("base64")}`);
+    expect(post).not.toHaveBeenCalled();
+  });
+
+  it("认不出类型的内联素材付费前拒发，且不把几 MB base64 糊进消息", async () => {
+    // 既没声明媒体类型、字节也嗅不出 → 不能瞎猜是图还是视频（猜错=送错通道被 413）。
+    const unknown = `data:application/octet-stream;base64,${"A".repeat(4000)}`;
+    const resolver = () => [{ vendorKey: "kie", ingestion: uploadUrlIngestion, uploadApiKey: "k" }];
+    expect(() => assertLocalAssetTransportReady({ referenceImages: [unknown] }, resolver, neverRead))
+      .toThrow(/无法识别本地素材/);
+    try {
+      assertLocalAssetTransportReady({ referenceImages: [unknown] }, resolver, neverRead);
+    } catch (error) {
+      expect((error as Error).message.length).toBeLessThan(200);
+    }
+  });
+
+  it("minimizeUploads 剪枝不碰内联素材（当场带进来的字节不可能是过期残留）", async () => {
+    const post = vi.fn().mockResolvedValue({ url: "https://pub/inline.png" });
+    const out = await localizeAssetsForVendor(
+      { referenceImages: [inlineImageUrl(), localUrl("stale.png")] },
+      () => [{ vendorKey: "kie", ingestion: uploadUrlIngestion, uploadApiKey: "k" }],
+      read,
+      post,
+      noMultipart,
+      { minimizeUploads: true, activeAssetUrls: [] }, // 名单里一个都没有
+    );
+    expect((out.value as { referenceImages: string[] }).referenceImages).toEqual(["https://pub/inline.png"]);
+  });
+
+  it("assertLocalAssetTransportReady：内联素材没有可用通道 → 付费前拒发", () => {
+    expect(() => assertLocalAssetTransportReady({ referenceImages: [inlineImageUrl()] }, () => [], neverRead))
+      .toThrow(/没有可用的图片上传通道/);
+    expect(() => assertLocalAssetTransportReady(
+      { referenceImages: [inlineImageUrl()] },
+      () => [{ vendorKey: "kie", ingestion: uploadUrlIngestion, uploadApiKey: "k" }],
+      neverRead,
+    )).not.toThrow();
+  });
+});
+
+/** blob:/file: 谁都够不着：与其让 vendor 500（或更糟——静默无视参考照样扣费），不如付费前拒发。 */
+describe("出站前拦截够不着的素材值（blob: / file:）", () => {
+  const resolver = () => [{ vendorKey: "kie", ingestion: { strategy: "upload-url", endpoint: "https://up/x", base64Field: "b", urlPath: "url" } as AssetIngestion, uploadApiKey: "k" }];
+
+  it("assertLocalAssetTransportReady 与 localizeAssetsForVendor 两处都拦（付费守卫前后各一道）", async () => {
+    expect(() => assertLocalAssetTransportReady({ referenceImages: ["blob:file:///abc-123"] }, resolver, read))
+      .toThrow(/发不出去/);
+    await expect(localizeAssetsForVendor({ referenceImages: ["file:///Users/me/a.png"] }, resolver, read, vi.fn(), noMultipart))
+      .rejects.toThrow(/发不出去/);
+  });
+
+  it("提到 file:// 的普通文案不误杀（判定只认整串就是 blob:/file: 地址）", async () => {
+    const extras = { prompt: "别用 file:// 这种地址", notes: "/Users/me/a.png" };
+    const out = await localizeAssetsForVendor(extras, resolver, read, vi.fn(), noMultipart);
+    expect(out.value).toBe(extras);
   });
 });

--- a/electron/catalog/assetLocalization.ts
+++ b/electron/catalog/assetLocalization.ts
@@ -1,4 +1,6 @@
-// R1 通用解析器：把 request 里的本地素材(nomi-local://)在发送前变成 vendor 够得着的值。
+// R1 通用解析器：把 request 里的本地素材在发送前变成 vendor 够得着的值。
+// 「本地素材」= `nomi-local://`（项目内文件）**与** `data:`（内联字节）——形态判定住 assetValueScheme，
+// 两者共用同一条物化/上传链，于是每个 vendor 收到的永远是公网 URL，不再「这家收 data: 那家 500」。
 // **通用第一**：本模块与任何具体供应商无关——它只认「一份 AssetIngestion 声明」,按 strategy 分叉。
 // KIE 等具体供应商的端点/字段/响应路径只住在各自的声明里(单源),由 curatedAssetIngestion 提供。
 // 全部依赖注入(读本地字节 read / POST 上传 postJson),故可零网络零额度单测。
@@ -11,8 +13,13 @@ import {
   ingestionVisibility,
   type AnonymousAssetConsent,
 } from "./assetTransportPolicy";
-
-const NOMI_LOCAL_PREFIX = "nomi-local://";
+import {
+  classifyAssetValue,
+  describeAssetValue,
+  isLocalizableAssetValue,
+  parseInlineDataAsset,
+  unreachableAssetValueError,
+} from "./assetValueScheme";
 
 export type LocalAsset = {
   bytes: Buffer;
@@ -70,8 +77,12 @@ export type HttpPostMultipart = (
   fileField?: string,
 ) => Promise<unknown>;
 
+/**
+ * 「这个值发送前必须先本地化」——即 `nomi-local://`（读盘）**或** `data:` 内联字节（就地解码）。
+ * 形态判定住 assetValueScheme（单一真相源），本函数只是本模块的门面。
+ */
 export function isLocalAssetUrl(value: unknown): value is string {
-  return typeof value === "string" && value.startsWith(NOMI_LOCAL_PREFIX);
+  return isLocalizableAssetValue(value);
 }
 
 /** contentType → 媒体类型(image/video/audio)。未知一律按 image(今天的通道都面向图片)。 */
@@ -92,7 +103,7 @@ export function ingestionAccepts(ingestion: AssetIngestion, kind: AssetMediaKind
   return accepts.includes(kind);
 }
 
-/** 递归收集任意 JSON 结构里所有 nomi-local URL(去重)。标量/数组元素/对象值都认。 */
+/** 递归收集任意 JSON 结构里所有待本地化素材值(nomi-local:// / data:,去重)。标量/数组元素/对象值都认。 */
 export function collectLocalAssetUrls(value: unknown, out: Set<string> = new Set()): Set<string> {
   if (isLocalAssetUrl(value)) out.add(value);
   else if (Array.isArray(value)) for (const item of value) collectLocalAssetUrls(item, out);
@@ -100,7 +111,29 @@ export function collectLocalAssetUrls(value: unknown, out: Set<string> = new Set
   return out;
 }
 
-/** 递归把结构里的 nomi-local URL 按映射替换(返回新结构,不改原对象)。 */
+/** 递归收集所有「谁都够不着」的素材值(blob:/file:)——判定与理由见 assetValueScheme.classifyAssetValue。 */
+export function collectUnreachableAssetValues(value: unknown, out: Set<string> = new Set()): Set<string> {
+  if (classifyAssetValue(value) === "unreachable") out.add(value as string);
+  else if (Array.isArray(value)) for (const item of value) collectUnreachableAssetValues(item, out);
+  else if (value && typeof value === "object") for (const item of Object.values(value)) collectUnreachableAssetValues(item, out);
+  return out;
+}
+
+/** 出站前拦住 blob:/file:：它们进 body 必错(vendor 拉不到),而这一步在付费守卫之前,失败零花费。 */
+function assertNoUnreachableAssetValues(value: unknown): void {
+  for (const unreachable of collectUnreachableAssetValues(value)) throw unreachableAssetValueError(unreachable);
+}
+
+/**
+ * 素材值 → 字节。`data:` 就地解码（零 IO，与 vendor 无关），其余交给注入的读盘器。
+ * 这是「本地素材只有 nomi-local:// 一种」那个假设的收口点：新增一种本地形态只改这里。
+ */
+function readLocalizableAsset(url: string, read: LocalAssetReader): LocalAsset | null {
+  if (classifyAssetValue(url) === "inline-data") return parseInlineDataAsset(url);
+  return read(url);
+}
+
+/** 递归把结构里的待本地化素材值按映射替换(返回新结构,不改原对象)。 */
 export function replaceLocalAssetUrls<T>(value: T, urlMap: Map<string, string>): T {
   if (isLocalAssetUrl(value)) return (urlMap.get(value) ?? value) as unknown as T;
   if (Array.isArray(value)) return value.map((item) => replaceLocalAssetUrls(item, urlMap)) as unknown as T;
@@ -126,11 +159,12 @@ export function assertLocalAssetTransportReady(
   const effectiveValue = options.minimizeUploads && options.activeAssetUrls
     ? pruneInactiveLocalAssets(value, new Set(options.activeAssetUrls))
     : value;
+  assertNoUnreachableAssetValues(effectiveValue);
   for (const url of collectLocalAssetUrls(effectiveValue)) {
-    const asset = read(url);
-    if (!asset) throw new Error(`参考素材的本地文件读取失败（可能已被删除或随项目迁移）：${url}。请重新生成该节点或重新导入这张素材。`);
+    const asset = readLocalizableAsset(url, read);
+    if (!asset) throw new Error(`参考素材的本地文件读取失败（可能已被删除或随项目迁移）：${describeAssetValue(url)}。请重新生成该节点或重新导入这张素材。`);
     if (!asset.contentType || asset.contentType.toLowerCase().split(";")[0].trim() === "application/octet-stream") {
-      throw new Error(`无法识别本地素材「${asset.fileName || url}」的类型，不能安全判断它是图片、视频还是音频。请重新导入并保留正确的文件扩展名。`);
+      throw new Error(`无法识别本地素材「${asset.fileName || describeAssetValue(url)}」的类型，不能安全判断它是图片、视频还是音频。请重新导入并保留正确的文件扩展名。`);
     }
     if (trustedOriginalUrl(asset)) continue;
     const mediaKind = mediaKindFromContentType(asset.contentType);
@@ -207,8 +241,8 @@ export async function resolveLocalAsset(
     }
     throw new Error(`所有免配置上传 host 都失败：${errors.join("；") || "(链为空)"}`);
   }
-  const asset = read(localUrl);
-  if (!asset) throw new Error(`参考素材的本地文件读取失败（可能已被删除或随项目迁移）：${localUrl}。请重新生成该节点或重新导入这张素材。`);
+  const asset = readLocalizableAsset(localUrl, read);
+  if (!asset) throw new Error(`参考素材的本地文件读取失败（可能已被删除或随项目迁移）：${describeAssetValue(localUrl)}。请重新生成该节点或重新导入这张素材。`);
   // 本地 ComfyUI：LoadImage 只认上传回的 input 目录文件名（非公网 URL），故**跳过下面的 trustedOriginalUrl
   // 公网 URL 快路**，恒把本地字节 POST 到 /upload/image 换文件名（field 名 "image"、type=input、overwrite 避重名堆积）。
   if (ingestion.strategy === "comfyui-upload") {
@@ -322,6 +356,10 @@ export type LocalizeAssetsOptions = {
 };
 
 function pruneInactiveLocalAssets(value: unknown, active: ReadonlySet<string>): unknown {
+  // 内联字节永远算「活的」：它是本次请求**当场带进来**的，不可能是画布上早已过期的残留引用
+  // （剪枝要解决的是那个）。若按 activeAssetUrls 名单剪，调用方自己拼名单时漏了它 = 参考被
+  // 静默丢掉照样出图照样扣费——这是本次修复最不该复制的失败形状。
+  if (classifyAssetValue(value) === "inline-data") return value;
   if (isLocalAssetUrl(value)) return active.has(value) ? value : undefined;
   if (Array.isArray(value)) return value.map((item) => pruneInactiveLocalAssets(item, active)).filter((item) => item !== undefined);
   if (value && typeof value === "object") {
@@ -396,15 +434,16 @@ export async function localizeAssetsForVendor(
   const effectiveValue = options.minimizeUploads && options.activeAssetUrls
     ? pruneInactiveLocalAssets(value, new Set(options.activeAssetUrls))
     : value;
+  assertNoUnreachableAssetValues(effectiveValue);
   const urls = Array.from(collectLocalAssetUrls(effectiveValue));
   if (urls.length === 0) {
     return { value: effectiveValue === value ? value : stripTransportHints(effectiveValue), uploaded: 0 };
   }
   const urlMap = new Map<string, string>();
   for (const url of urls) {
-    const asset = read(url);
+    const asset = readLocalizableAsset(url, read);
     if (asset && (!asset.contentType || asset.contentType.toLowerCase().split(";")[0].trim() === "application/octet-stream")) {
-      throw new Error(`无法识别本地素材「${asset.fileName || url}」的类型，不能安全判断它是图片、视频还是音频。请重新导入并保留正确的文件扩展名。`);
+      throw new Error(`无法识别本地素材「${asset.fileName || describeAssetValue(url)}」的类型，不能安全判断它是图片、视频还是音频。请重新导入并保留正确的文件扩展名。`);
     }
     const mediaKind = mediaKindFromContentType(asset?.contentType);
     const candidates = resolveIngestion(mediaKind);

--- a/electron/catalog/assetLocalization.ts
+++ b/electron/catalog/assetLocalization.ts
@@ -16,6 +16,7 @@ import {
 import {
   classifyAssetValue,
   describeAssetValue,
+  humanSize,
   isLocalizableAssetValue,
   parseInlineDataAsset,
   unreachableAssetValueError,
@@ -385,13 +386,6 @@ function stripTransportHints(value: unknown): unknown {
     return out;
   }
   return value;
-}
-
-/** 人话文件大小（错误里要告诉用户「多大」，否则他没法判断该压到多少）。 */
-function humanSize(bytes: number): string {
-  if (bytes >= 1024 * 1024) return `${(bytes / 1024 / 1024).toFixed(1)}MB`;
-  if (bytes >= 1024) return `${Math.round(bytes / 1024)}KB`;
-  return `${bytes}B`;
 }
 
 const MEDIA_LABEL: Record<AssetMediaKind, string> = { image: "图片", video: "视频", audio: "音频" };

--- a/electron/catalog/assetValueScheme.test.ts
+++ b/electron/catalog/assetValueScheme.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from "vitest";
+import {
+  classifyAssetValue,
+  describeAssetValue,
+  isLocalizableAssetValue,
+  parseInlineDataAsset,
+  unreachableAssetValueError,
+} from "./assetValueScheme";
+
+// 真 PNG 头（≥12 字节，魔数嗅探要够长）。
+const PNG_BYTES = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52]);
+// ISO-BMFF：4 字节 box size + "ftyp" + brand。
+const MP4_BYTES = Buffer.concat([Buffer.from([0x00, 0x00, 0x00, 0x20]), Buffer.from("ftypisom"), Buffer.from("mdat")]);
+const dataUrl = (mime: string, bytes: Buffer) => `data:${mime};base64,${bytes.toString("base64")}`;
+
+describe("classifyAssetValue", () => {
+  it("认 nomi-local 与 data: 媒体内联为「要本地化」", () => {
+    expect(classifyAssetValue("nomi-local://asset/p/a.png")).toBe("nomi-local");
+    expect(classifyAssetValue(dataUrl("image/png", PNG_BYTES))).toBe("inline-data");
+    expect(classifyAssetValue(dataUrl("video/mp4", MP4_BYTES))).toBe("inline-data");
+    expect(classifyAssetValue("data:;base64,aGVsbG8=")).toBe("inline-data"); // 无声明 mime → 交给嗅探
+    expect(isLocalizableAssetValue(dataUrl("image/png", PNG_BYTES))).toBe(true);
+  });
+
+  it("公网 URL 与普通字符串一律不碰（原样发给 vendor）", () => {
+    expect(classifyAssetValue("https://cdn/a.png")).toBeNull();
+    expect(classifyAssetValue("http://cdn/a.png")).toBeNull();
+    expect(classifyAssetValue("images/nomi")).toBeNull();
+    expect(classifyAssetValue("一段普通提示词")).toBeNull();
+    expect(classifyAssetValue(42)).toBeNull();
+    expect(classifyAssetValue(null)).toBeNull();
+    expect(isLocalizableAssetValue("https://cdn/a.png")).toBe(false);
+  });
+
+  it("非媒体 data: 不当素材（别把一段 JSON/文案传去图床）", () => {
+    expect(classifyAssetValue("data:text/plain,hello")).toBeNull();
+    expect(classifyAssetValue("data:application/json;base64,e30=")).toBeNull();
+    expect(classifyAssetValue("data:image/png")).toBeNull(); // 没有逗号 = 不是 data URI
+  });
+
+  it("blob:/file: 判为 unreachable（发出去必错）", () => {
+    expect(classifyAssetValue("blob:file:///abc-123")).toBe("unreachable");
+    expect(classifyAssetValue("file:///Users/me/a.png")).toBe("unreachable");
+    expect(isLocalizableAssetValue("blob:file:///abc-123")).toBe(false);
+  });
+
+  it("裸文件系统路径与含空白的自由文本不判 unreachable（误杀比漏判更贵）", () => {
+    // 自由文本里提到 file:// —— 判死会让一条正常生成整个失败。
+    expect(classifyAssetValue("不支持 file:// 这种地址")).toBeNull();
+    expect(classifyAssetValue("/Users/me/a.png")).toBeNull();
+    expect(classifyAssetValue("C:\\Users\\me\\a.png")).toBeNull();
+  });
+});
+
+describe("parseInlineDataAsset", () => {
+  it("base64 载荷逐字节还原，contentType 走字节嗅探", () => {
+    const asset = parseInlineDataAsset(dataUrl("image/png", PNG_BYTES));
+    expect(asset?.bytes.equals(PNG_BYTES)).toBe(true);
+    expect(asset?.contentType).toBe("image/png");
+    expect(asset?.fileName.endsWith(".png")).toBe(true);
+  });
+
+  it("声明的 mime 说谎时以字节为准（视频被标成 image/png 不能进图片通道）", () => {
+    const asset = parseInlineDataAsset(dataUrl("image/png", MP4_BYTES));
+    expect(asset?.contentType).toBe("video/mp4");
+    expect(asset?.fileName.endsWith(".mp4")).toBe(true);
+  });
+
+  it("嗅探认不出时退回声明的 mime", () => {
+    const svg = "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%2F%3E";
+    const asset = parseInlineDataAsset(svg);
+    expect(asset?.contentType).toBe("image/svg+xml");
+    expect(asset?.bytes.toString("utf8")).toContain("<svg");
+  });
+
+  it("文件名随内容变（同一请求里两张内联图不许重名 → 上传端点覆盖 = 两个参考塌成一张）", () => {
+    const a = parseInlineDataAsset(dataUrl("image/png", PNG_BYTES));
+    const b = parseInlineDataAsset(dataUrl("image/png", Buffer.concat([PNG_BYTES, Buffer.from("different")])));
+    const again = parseInlineDataAsset(dataUrl("image/png", PNG_BYTES));
+    expect(a?.fileName).not.toBe(b?.fileName);
+    expect(a?.fileName).toBe(again?.fileName); // 同字节 → 同名（幂等）
+  });
+
+  it("坏载荷判死，不放一堆垃圾字节上路", () => {
+    expect(parseInlineDataAsset("data:image/png;base64,")).toBeNull(); // 空载荷
+    expect(parseInlineDataAsset("data:image/png;base64,!!!not base64!!!")).toBeNull();
+    expect(parseInlineDataAsset("https://cdn/a.png")).toBeNull();
+    expect(parseInlineDataAsset("data:text/plain,hi")).toBeNull(); // 非媒体
+  });
+});
+
+describe("describeAssetValue / unreachableAssetValueError", () => {
+  it("错误消息不把几 MB base64 糊到用户脸上", () => {
+    const huge = dataUrl("image/png", Buffer.concat(Array.from({ length: 2000 }, () => PNG_BYTES)));
+    const described = describeAssetValue(huge);
+    expect(described.length).toBeLessThan(80);
+    expect(described).toContain("data:image/png;base64,");
+    expect(described).toContain("KB 内联素材");
+    expect(describeAssetValue("https://cdn/a.png")).toBe("https://cdn/a.png");
+  });
+
+  it("unreachable 报错说清「为什么发不出去 + 怎么办」", () => {
+    const message = unreachableAssetValueError("blob:file:///abc").message;
+    expect(message).toContain("blob:");
+    expect(message).toContain("服务商拉不到");
+    expect(message).toContain("导入");
+  });
+});

--- a/electron/catalog/assetValueScheme.ts
+++ b/electron/catalog/assetValueScheme.ts
@@ -62,8 +62,10 @@ export function classifyAssetValue(value: unknown): AssetValueScheme | null {
   return null;
 }
 
-/** 素材值需要本地化（物化/上传）才发得出去。 */
-export function isLocalizableAssetValue(value: unknown): value is string {
+/** 素材值需要本地化（物化/上传）才发得出去。
+ *  刻意**不写成 `value is string` 类型守卫**：调用方常常已经拿着 string（如渲染层白名单），
+ *  守卫会把否定分支窄成 never，后面再判别的形态就编译不过。要守卫用 isLocalAssetUrl。 */
+export function isLocalizableAssetValue(value: unknown): boolean {
   const scheme = classifyAssetValue(value);
   return scheme === "nomi-local" || scheme === "inline-data";
 }
@@ -118,6 +120,26 @@ export function parseInlineDataAsset(value: string): { bytes: Buffer; contentTyp
   const contentType = contentTypeFromMagicBytes(bytes) ?? (header.mime || "application/octet-stream");
   const extension = extensionFromContentType(contentType) || "bin";
   return { bytes, contentType, fileName: `inline-${contentTag(bytes)}.${extension}` };
+}
+
+/** 人话文件大小（错误/记账面要告诉用户「多大」，否则他没法判断该压到多少）。 */
+export function humanSize(bytes: number): string {
+  if (bytes >= 1024 * 1024) return `${(bytes / 1024 / 1024).toFixed(1)}MB`;
+  if (bytes >= 1024) return `${Math.round(bytes / 1024)}KB`;
+  return `${bytes}B`;
+}
+
+/** data: URI 的**解码后**字节数（base64 载荷按 3/4 折算）。用于记账面报体积，不解码整串。 */
+export function inlineAssetByteLength(value: string): number {
+  const header = parseDataUrlHeader(value);
+  if (!header) return 0;
+  const payloadLength = value.length - header.payloadStart;
+  return header.base64 ? Math.floor((payloadLength * 3) / 4) : payloadLength;
+}
+
+/** data: URI 声明的 mime（没声明按 octet-stream）。记账面用，不碰字节。 */
+export function inlineAssetMime(value: string): string {
+  return parseDataUrlHeader(value)?.mime || "application/octet-stream";
 }
 
 /** 素材值的人话短标识：data: URI 动辄几 MB，原样拼进错误消息会给用户糊一屏 base64。 */

--- a/electron/catalog/assetValueScheme.ts
+++ b/electron/catalog/assetValueScheme.ts
@@ -1,0 +1,138 @@
+// 出站素材值的**形态判定**单一真相源。request.extras 里的一个字符串，发给供应商前只有三种命运：
+//   ① reachable   —— http(s) 公网 URL：所有 vendor 都够得着，原样发。
+//   ② localizable —— 只有 app 自己读得到的本地素材，**必须先物化/上传换公网 URL**：
+//                    `nomi-local://`（项目内文件，读盘）与 `data:`（内联字节，就地解码）。
+//   ③ unreachable —— `blob:` / `file:`：只在本机某个进程/页面里有意义，任何 vendor 都拉不到，
+//                    发出去必错 → **付费守卫前**就抛人话，别让用户花钱换一个必然的失败。
+//
+// 为什么 data: 必须归到 ②（2026-08-26 真实付费实测）：此前只认 `nomi-local://`，data: URI 一路直穿到
+// vendor body，于是**同一张参考图在不同 vendor 上一个成一个挂**——火山方舟 Ark 收 data:（HTTP 200），
+// kie.ai 三个模型（nano-banana-2 的 image_input / seedream 的 image_urls / flux-2 的 input_urls）
+// 全部 HTTP 500 "File type not supported"。L3 参考护栏也拦不住：参考「确实在 body 里」。
+// UI 主路径先把上传的图落成项目素材所以碰不到；headless/MCP 和落盘失败退回 base64 的兜底路径会碰到。
+//
+// 为什么单独成模块：assetLocalization 管「怎么上传」，本模块只做纯字符串/字节运算（可裸测），
+// 顺带让 assetLocalization 不撑破 800 行（R9）。
+//
+// ⚠️ 本模块被 renderer 间接 import（catalogTaskActions → assetLocalization.collectLocalAssetUrls），
+// 故**不许 import 任何 node: 内置模块**；Buffer 只在函数体内用（renderer 只走 classify，不解码）。
+
+import { contentTypeFromMagicBytes, extensionFromContentType } from "../assets/mediaTypes";
+
+export const NOMI_LOCAL_PREFIX = "nomi-local://";
+
+/** 素材值形态。null（见 classifyAssetValue）= 这根本不是一个需要处理的素材值。 */
+export type AssetValueScheme = "nomi-local" | "inline-data" | "unreachable";
+
+/** 内联 data: URI 只当**媒体**素材看：媒体 mime、octet-stream、或没声明 mime（靠嗅探）。
+ *  `data:text/...` / `data:application/json` 这类是普通参数值，原样放行（别把一段 JSON 传去图床）。 */
+function isMediaMime(mime: string): boolean {
+  if (!mime) return true; // data:;base64,… → 无声明，交给字节嗅探
+  return /^(image|video|audio|model)\//.test(mime) || mime === "application/octet-stream";
+}
+
+/** data: URI 的 header（"data:" 与 "," 之间）→ { mime, base64 }；不是合法 data: URI 返回 null。 */
+function parseDataUrlHeader(value: string): { mime: string; base64: boolean; payloadStart: number } | null {
+  if (!/^data:/i.test(value)) return null;
+  const commaIndex = value.indexOf(",");
+  if (commaIndex < 0) return null;
+  const header = value.slice("data:".length, commaIndex);
+  const parts = header.split(";");
+  const mime = (parts[0] || "").trim().toLowerCase();
+  const base64 = parts.slice(1).some((part) => part.trim().toLowerCase() === "base64");
+  return { mime, base64, payloadStart: commaIndex + 1 };
+}
+
+/**
+ * 一个值是不是「发送前需要处理的素材」，是哪一类。不是素材值（普通字符串/公网 URL/数字…）→ null。
+ *
+ * unreachable 判定**只认 blob:/file: 两个明确 scheme 且整串无空白**：extras 里混着自由文本
+ * （提示词片段、备注），拿「像路径」去猜会把正常文案判成坏素材，整条生成误杀。裸文件系统路径
+ * （`/Users/…`、`C:\…`）因此**不判**——它与普通参数值（如 uploadPath "images/nomi"）没法安全区分；
+ * 它进 body 一样发不出去，但那属于调用方给错了值，我们不去猜。
+ */
+export function classifyAssetValue(value: unknown): AssetValueScheme | null {
+  if (typeof value !== "string" || !value) return null;
+  if (value.startsWith(NOMI_LOCAL_PREFIX)) return "nomi-local";
+  if (/^data:/i.test(value)) {
+    const header = parseDataUrlHeader(value);
+    return header && isMediaMime(header.mime) ? "inline-data" : null;
+  }
+  if (/^(blob|file):/i.test(value) && !/\s/.test(value)) return "unreachable";
+  return null;
+}
+
+/** 素材值需要本地化（物化/上传）才发得出去。 */
+export function isLocalizableAssetValue(value: unknown): value is string {
+  const scheme = classifyAssetValue(value);
+  return scheme === "nomi-local" || scheme === "inline-data";
+}
+
+/** 内容派生的短标签，给内联素材当文件名后缀用（同一份字节永远同名，两份不同字节几乎不同名）。
+ *  只吃头尾各 8KB + 总长度：整段 FNV 对几十 MB 的视频要空转几千万次，而这里只为「别重名」。 */
+function contentTag(bytes: Uint8Array): string {
+  const SAMPLE = 8 * 1024;
+  let hash = 0x811c9dc5;
+  const mix = (byte: number) => {
+    hash ^= byte;
+    hash = Math.imul(hash, 0x01000193) >>> 0;
+  };
+  for (let i = 0; i < Math.min(SAMPLE, bytes.length); i += 1) mix(bytes[i]);
+  for (let i = Math.max(0, bytes.length - SAMPLE); i < bytes.length; i += 1) mix(bytes[i]);
+  mix(bytes.length & 0xff);
+  mix((bytes.length >>> 8) & 0xff);
+  mix((bytes.length >>> 16) & 0xff);
+  return hash.toString(36);
+}
+
+/**
+ * data: URI → 字节 + contentType + 文件名（`nomi-local://` 的 readNomiLocalAsset 在内联侧的对应物）。
+ * 不是 data: URI / 载荷坏掉 / 空载荷 → null（调用方按「素材读不出来」抛人话）。
+ *
+ * contentType **字节优先**：与 resolveContentType 同口径——mime 是生产者随手声明的，字节是事实
+ * （见 mediaTypes.contentTypeFromMagicBytes 的注释：认错类型会把视频送进图片通道被 413 顶回来）。
+ * 认不出则退回声明的 mime，再退 octet-stream（上游据此 fail-closed，不瞎猜是图还是视频）。
+ *
+ * 文件名带内容标签：同一次请求里两张不同的内联图不能重名——kie 这类「uploadPath + fileName」的
+ * 托管端点重名有覆盖风险，覆盖了就是两个参考塌成同一张图，而且**看起来一切正常**。
+ */
+export function parseInlineDataAsset(value: string): { bytes: Buffer; contentType: string; fileName: string } | null {
+  const header = parseDataUrlHeader(value);
+  if (!header || !isMediaMime(header.mime)) return null;
+  const payload = value.slice(header.payloadStart);
+  if (!payload) return null;
+  let bytes: Buffer;
+  try {
+    if (header.base64) {
+      // Buffer.from(…, "base64") 会**静默忽略**非法字符：不先校验，一段坏载荷会变成一堆垃圾字节
+      // 被当成合法素材传上去。宁可在这里判死。
+      if (!/^[A-Za-z0-9+/\-_=\s]+$/.test(payload)) return null;
+      bytes = Buffer.from(payload, "base64");
+    } else {
+      bytes = Buffer.from(decodeURIComponent(payload), "utf8");
+    }
+  } catch {
+    return null;
+  }
+  if (bytes.length === 0) return null;
+  const contentType = contentTypeFromMagicBytes(bytes) ?? (header.mime || "application/octet-stream");
+  const extension = extensionFromContentType(contentType) || "bin";
+  return { bytes, contentType, fileName: `inline-${contentTag(bytes)}.${extension}` };
+}
+
+/** 素材值的人话短标识：data: URI 动辄几 MB，原样拼进错误消息会给用户糊一屏 base64。 */
+export function describeAssetValue(value: string): string {
+  const header = parseDataUrlHeader(value);
+  if (!header) return value;
+  const size = Math.max(1, Math.round(value.length / 1024));
+  return `${value.slice(0, header.payloadStart)}…（${size}KB 内联素材）`;
+}
+
+/** blob:/file: 进了出站请求 —— 付费前拦下并告诉用户怎么办（这类值任何 vendor 都拉不到）。 */
+export function unreachableAssetValueError(value: string): Error {
+  const scheme = value.slice(0, value.indexOf(":") + 1).toLowerCase();
+  return new Error(
+    `参考素材「${describeAssetValue(value).slice(0, 120)}」发不出去：${scheme} 地址只在本机有效，服务商拉不到它。` +
+      `请先把这份素材导入项目（拖进画布 / 素材库导入 / MCP 用 nomi_import_asset），再作为参考连上。`,
+  );
+}

--- a/electron/runtime.provider-adapter.test.ts
+++ b/electron/runtime.provider-adapter.test.ts
@@ -88,4 +88,76 @@ describe("executeProfileOperation adapter verification seam", () => {
     const body = JSON.parse(String((fetchFn.mock.calls[0]?.[1] as RequestInit | undefined)?.body || "{}"));
     expect(body.image).toBe(`data:image/png;base64,${Buffer.from("png-fixture").toString("base64")}`);
   });
+
+  /**
+   * 出站 body 里**永远不该**出现 data: URI（除非该 vendor 的策略就是 inline-base64，见上一条）。
+   * 2026-08-26 真实付费实测：raw data: URI 直穿到 wire 时，Ark 收（200）、kie 三个模型全 500
+   * "File type not supported" —— 同一张图换个供应商就挂。这条把「wire 上是公网 URL」钉死在
+   * runtime 层（不只是 assetLocalization 单测）。
+   */
+  it("materialises a caller-supplied data: URI into a public url before it reaches the wire", async () => {
+    const fetchFn = vi.fn(async (input: unknown, _init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes("/uploads/images")) {
+        return new Response(JSON.stringify({ url: "https://cdn.example.com/uploaded.png" }), { status: 200 });
+      }
+      return new Response(JSON.stringify({ data: [{ url: "https://cdn.example.com/output.png" }] }), { status: 200 });
+    });
+    vi.stubGlobal("fetch", fetchFn);
+    const { executeProfileOperation } = await import("./runtime");
+    const now = "2026-08-26T00:00:00.000Z";
+    const pngBytes = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52]);
+    const vendor: Vendor = {
+      key: "upload-example",
+      name: "Upload Example",
+      enabled: false,
+      baseUrlHint: "https://api.example.com/v1",
+      authType: "bearer",
+      assetIngestion: { strategy: "upload-multipart", endpoint: "https://api.example.com/v1/uploads/images", urlPath: "url", accepts: ["image"] },
+      createdAt: now,
+      updatedAt: now,
+    };
+    const model: Model = {
+      vendorKey: vendor.key,
+      modelKey: "paint-v2",
+      labelZh: "Paint V2",
+      kind: "image",
+      enabled: false,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    await executeProfileOperation({
+      vendor,
+      model,
+      apiKey: "sk-test",
+      request: {
+        kind: "image_edit",
+        prompt: "keep the composition",
+        extras: {
+          modelKey: model.modelKey,
+          // headless/MCP 调用方直接给内联字节（UI 主路径会先落成项目素材，碰不到这条）。
+          referenceImages: [`data:image/png;base64,${pngBytes.toString("base64")}`],
+        },
+      },
+      operation: {
+        method: "POST",
+        path: "/images/edits",
+        body: {
+          model: "{{model.modelKey}}",
+          prompt: "{{request.prompt}}",
+          image: "{{request.params.image_url}}",
+        },
+      },
+      // 读盘器一次都不该被调用：内联字节零 IO。
+      localAssetReader: () => null,
+    });
+
+    const uploadCall = fetchFn.mock.calls.find((call) => String(call[0]).includes("/uploads/images"));
+    expect(uploadCall).toBeDefined();
+    const generateCall = fetchFn.mock.calls.find((call) => String(call[0]).includes("/images/edits"));
+    const body = JSON.parse(String((generateCall?.[1] as RequestInit | undefined)?.body || "{}"));
+    expect(body.image).toBe("https://cdn.example.com/uploaded.png");
+    expect(JSON.stringify(body)).not.toContain("data:");
+  });
 });

--- a/electron/vendor/provenance.test.ts
+++ b/electron/vendor/provenance.test.ts
@@ -50,3 +50,56 @@ describe("buildTaskProvenance(profile/fallback 两路径共用,修主路径漏�
     expect(typeof provenance.timestamp).toBe("number");
   });
 });
+
+/**
+ * 内联素材（data: URI）进记账面必须先摘要。
+ * 三处实伤（详见 provenance.inlineAssetDigest 注释）：溯源随 project.json 永久落盘、溯源面板
+ * 把 params 整段 JSON 铺进 <pre>、指纹要先把整个 extras stringify 再 sha256。
+ */
+describe("内联素材摘要（记账面只留身份，不留整串）", () => {
+  const pngBytes = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d]);
+  const inline = (salt = "") => `data:image/png;base64,${Buffer.concat([pngBytes, Buffer.from(salt)]).toString("base64")}`;
+  const requestWith = (url: string) => ({
+    kind: "image_edit",
+    prompt: "keep it",
+    extras: { referenceImages: [url], archetypeInput: { image_input: [url] }, aspectRatio: "16:9" },
+  });
+
+  it("recipe 与 provenance 都换成摘要：整串 base64 一个字节都不留", () => {
+    const url = inline();
+    const recipe = buildNormalizedRecipe({ vendor, model, request: requestWith(url) });
+    const provenance = buildTaskProvenance({ vendor, model, request: requestWith(url), vendorRequestId: "task-1" });
+    for (const serialized of [JSON.stringify(recipe), JSON.stringify(provenance)]) {
+      expect(serialized).not.toContain("base64,");
+      expect(serialized).toContain("nomi-inline-asset:sha256-");
+      expect(serialized).toContain("image/png");
+    }
+    // 嵌套结构（档案投影）里的那份也换掉，不只是顶层。
+    const nested = (recipe.params.archetypeInput as { image_input: string[] }).image_input[0];
+    expect(nested.startsWith("nomi-inline-asset:")).toBe(true);
+  });
+
+  it("摘要是内容身份：同字节恒同（指纹仍命中）、异字节恒异（不串图）", () => {
+    const same = JSON.stringify(buildNormalizedRecipe({ vendor, model, request: requestWith(inline()) }));
+    const sameAgain = JSON.stringify(buildNormalizedRecipe({ vendor, model, request: requestWith(inline()) }));
+    const other = JSON.stringify(buildNormalizedRecipe({ vendor, model, request: requestWith(inline("x")) }));
+    expect(same).toBe(sameAgain);
+    expect(same).not.toBe(other);
+  });
+
+  it("非内联值原样：公网 URL / nomi-local / 普通参数不被摘要碰", () => {
+    const recipe = buildNormalizedRecipe({
+      vendor,
+      model,
+      request: { kind: "k", prompt: "p", extras: { a: "https://cdn/a.png", b: "nomi-local://asset/p/a.png", c: 3 } },
+    });
+    expect(recipe.params).toMatchObject({ a: "https://cdn/a.png", b: "nomi-local://asset/p/a.png", c: 3 });
+  });
+
+  it("摘要体积恒定：几 MB 的内联素材也只留一行", () => {
+    const huge = `data:image/png;base64,${"A".repeat(4 * 1024 * 1024)}`;
+    const recipe = buildNormalizedRecipe({ vendor, model, request: requestWith(huge) });
+    expect(JSON.stringify(recipe).length).toBeLessThan(600);
+    expect(JSON.stringify(recipe)).toContain("3.0MB"); // 报的是解码后体积
+  });
+});

--- a/electron/vendor/provenance.ts
+++ b/electron/vendor/provenance.ts
@@ -1,7 +1,9 @@
 // 配方与溯源(harness S4-1):一份数据三用(总方案 §7.5)——
 // provenance 给人看(N20 复现)、NormalizedRecipe 给机器比(S8 指纹)、事件给审计(N21)。
-// 纯函数零依赖;P2 修根因:provenance 此前只有 fallback 路径写、profile 主路径漏写,
+// 纯函数;P2 修根因:provenance 此前只有 fallback 路径写、profile 主路径漏写,
 // 两条路径从此共用本模块(单一真相)。
+import crypto from "node:crypto";
+import { classifyAssetValue, humanSize, inlineAssetByteLength, inlineAssetMime } from "../catalog/assetValueScheme";
 import type { Model, Vendor } from "../catalog/types";
 
 /** 与 runtime.TaskResult["provenance"] 结构兼容(该类型为 runtime 私有,这里结构化对齐)。 */
@@ -43,6 +45,37 @@ export type NormalizedRecipe = {
 // forceRerun 是缓存控制旗标(S8 强制重跑),不影响生成产物——进指纹会假漂。
 const ROUTING_EXTRA_KEYS = new Set(["projectId", "nodeId", "forceRerun"]);
 
+/**
+ * 内联素材（`data:` URI）在**记账面**上的替身。
+ *
+ * 记账面 = 指纹(S8) / 溯源(E11) / 事件日志(S4-1) —— 它们要的是「这次用的是哪份素材」这个**身份**，
+ * 不是素材本身。而 extras 里的一个 data: URI 动辄几 MB，原样带进去有三处实伤：
+ *   ① 溯源随 node.result.provenance **写进 project.json**，每生成一次多躺一份 base64，永不回收；
+ *   ② 溯源面板是 `JSON.stringify(params, null, 2)` 直接铺进 <pre> —— 几 MB 就是一次界面级卡死；
+ *   ③ 指纹要把整个 extras 先 JSON.stringify 再 sha256，白扛一遍几 MB 的字符串搬运。
+ * （事件日志那侧已有结构保证：eventLogRepository 的 MAX_FIELD_BYTES 会把超限字段整条丢掉，
+ *   见那里 2026-08-20「九宫格卡半小时」的注释。这里换成摘要后，它记到的反而是有用的身份。）
+ *
+ * 摘要必须是**内容身份**（sha256 整串）：指纹缓存拿它当「同配方」判据，弱哈希碰撞 = 秒回一张
+ * 别人的图，还看不出来。同字节恒同摘要（缓存命中不丢）、异字节恒异摘要（不串图）。
+ */
+export function inlineAssetDigest(value: string): string {
+  const sha = crypto.createHash("sha256").update(value).digest("hex").slice(0, 16);
+  return `nomi-inline-asset:sha256-${sha};${inlineAssetMime(value)};${humanSize(inlineAssetByteLength(value))}`;
+}
+
+/** 递归把结构里的内联素材换成摘要(返回新结构,不改原对象)。非内联值一律原样。 */
+export function digestInlineAssets<T>(value: T): T {
+  if (classifyAssetValue(value) === "inline-data") return inlineAssetDigest(value as string) as unknown as T;
+  if (Array.isArray(value)) return value.map((item) => digestInlineAssets(item)) as unknown as T;
+  if (value && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [key, item] of Object.entries(value)) out[key] = digestInlineAssets(item);
+    return out as unknown as T;
+  }
+  return value;
+}
+
 function sortedParams(request: RecipeRequestFields): Record<string, unknown> {
   const raw: Record<string, unknown> = {
     ...(request.width != null ? { width: request.width } : {}),
@@ -51,7 +84,7 @@ function sortedParams(request: RecipeRequestFields): Record<string, unknown> {
     ...(request.cfgScale != null ? { cfgScale: request.cfgScale } : {}),
   };
   for (const [key, value] of Object.entries(request.extras || {})) {
-    if (!ROUTING_EXTRA_KEYS.has(key) && value != null) raw[key] = value;
+    if (!ROUTING_EXTRA_KEYS.has(key) && value != null) raw[key] = digestInlineAssets(value);
   }
   const out: Record<string, unknown> = {};
   for (const key of Object.keys(raw).sort()) out[key] = raw[key];
@@ -94,7 +127,8 @@ export function buildTaskProvenance(input: {
       ...(request.height != null ? { height: request.height } : {}),
       ...(request.steps != null ? { steps: request.steps } : {}),
       ...(request.cfgScale != null ? { cfgScale: request.cfgScale } : {}),
-      ...(request.extras ? { extras: request.extras } : {}),
+      // 内联素材换摘要：溯源要随 project.json 永久落盘、还要整段铺进溯源面板（见 inlineAssetDigest）。
+      ...(request.extras ? { extras: digestInlineAssets(request.extras) } : {}),
     },
     vendorRequestId: input.vendorRequestId,
     timestamp: Date.now(),

--- a/src/workbench/generationCanvas/runner/generationReferenceResolver.test.ts
+++ b/src/workbench/generationCanvas/runner/generationReferenceResolver.test.ts
@@ -158,3 +158,28 @@ describe('B4 — 连线视频/音频参考分流（不漏进 referenceImages / �
     expect(refs.referenceVideos).toEqual([])
   })
 })
+
+/**
+ * 落盘失败退回 base64 的兜底图（persistNodeImage：可持久化、不丢图）连线当参考。
+ * 修前：asUrl 判空 → 参考被静默丢掉 → L3 反过来说「你没连参考」（把原因说反了），
+ * 或按纯文生跑照样扣费。修后：内联字节照常成为参考，出站前由主进程物化上传。
+ */
+describe('resolveGenerationReferences — base64 兜底图也能当参考', () => {
+  const inlineImage = `data:image/png;base64,${Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d]).toString('base64')}`
+
+  it('reference 边的源只有内联 base64 → 进 referenceImages', () => {
+    const source = node('c1', 'image', inlineImage)
+    const target = node('g1', 'image')
+    const edges: GenerationCanvasEdge[] = [{ id: 'e1', source: 'c1', target: 'g1', mode: 'reference' }]
+    const refs = resolveGenerationReferences(target, { nodes: [source, target], edges })
+    expect(refs.referenceImages).toEqual([inlineImage])
+  })
+
+  it('first_frame 边的源只有内联 base64 → 进 firstFrameUrl', () => {
+    const source = node('c1', 'image', inlineImage)
+    const target = node('v1', 'video')
+    const edges: GenerationCanvasEdge[] = [{ id: 'e1', source: 'c1', target: 'v1', mode: 'first_frame' }]
+    const refs = resolveGenerationReferences(target, { nodes: [source, target], edges })
+    expect(refs.firstFrameUrl).toBe(inlineImage)
+  })
+})

--- a/src/workbench/generationCanvas/runner/referenceUrl.test.ts
+++ b/src/workbench/generationCanvas/runner/referenceUrl.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { resultUrl, findNodeResultUrl } from './referenceUrl'
+import { asUrl, resultUrl, findNodeResultUrl } from './referenceUrl'
 import type { GenerationCanvasNode, GenerationNodeResult } from '../model/generationCanvasTypes'
 
 // L2（2026-07-06）：URL 口径翻转为**本地持久文件优先**。providerUrl 是服务商临时直链（kie ~3 天 /
@@ -34,5 +34,36 @@ describe('findNodeResultUrl — 节点/历史引用同口径', () => {
   })
   it('nodeId:resultId → 历史条目（providerUrl-only 兜底仍可用）', () => {
     expect(findNodeResultUrl(byId, 'n1:r1')).toBe('https://cdn/r1.png')
+  })
+})
+
+// 白名单本身（2026-08-26）：形态判定与出站侧共用 assetValueScheme，别再各列一份。
+describe('asUrl — 放行「能发出去或主进程能物化」的形态', () => {
+  const inlineImage = `data:image/png;base64,${Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d]).toString('base64')}`
+
+  it('公网 URL 与 nomi-local 照旧放行（含首尾空白修剪）', () => {
+    expect(asUrl('https://cdn/a.png')).toBe('https://cdn/a.png')
+    expect(asUrl('  http://cdn/a.png  ')).toBe('http://cdn/a.png')
+    expect(asUrl('nomi-local://asset/p/a.png')).toBe('nomi-local://asset/p/a.png')
+  })
+
+  it('data: 内联字节放行 —— 修「落盘失败退回 base64 的图连线当参考被静默丢掉」', () => {
+    expect(asUrl(inlineImage)).toBe(inlineImage)
+    expect(resultUrl({ url: inlineImage } as GenerationNodeResult)).toBe(inlineImage)
+  })
+
+  it('blob: 仍放行（要喂参考 chip 的显示；到不了 vendor 由主进程付费前拒发）', () => {
+    expect(asUrl('blob:file:///abc-123')).toBe('blob:file:///abc-123')
+  })
+
+  it('裸 / 开头不再放行（既发不出去也只有开发态显示得出来，全仓无生产者）', () => {
+    expect(asUrl('/prompt-media/expressions/a.webp')).toBe('')
+  })
+
+  it('非媒体 data: 与非 URL 判空（节点引用另走 findNodeResultUrl）', () => {
+    expect(asUrl('data:text/plain,hello')).toBe('')
+    expect(asUrl('n1:r1')).toBe('')
+    expect(asUrl('')).toBe('')
+    expect(asUrl(42)).toBe('')
   })
 })

--- a/src/workbench/generationCanvas/runner/referenceUrl.ts
+++ b/src/workbench/generationCanvas/runner/referenceUrl.ts
@@ -1,15 +1,33 @@
 // 参考 URL 解析的**唯一**底层助手：从节点 result 取可用 URL、按白名单校验、按 `nodeId[:resultId]`
 // 引用定位。generationReferenceResolver（生成期）与 referenceSlots（能力驱动槽解析）共用这一份，
 // 不再各写一套（P1 单一真相源）。
+import { isLocalizableAssetValue } from '../../../../electron/catalog/assetValueScheme'
 import type { GenerationCanvasNode, GenerationNodeResult } from '../model/generationCanvasTypes'
 
-/** 只放行能直接喂给 vendor / 本地化的 URL 形态；其余（自定义 scheme、空串）一律视为无 URL。 */
+/**
+ * 参考 URL 白名单：放行「能喂给 vendor（http/https）」或「主进程能物化成公网 URL」的形态，
+ * 其余（自定义 scheme、空串）视为无 URL。
+ *
+ * **可本地化的那一档不在这里手列**，直接问 assetValueScheme（与出站侧同一个判定器，P1 单一真相）：
+ * 今天是 `nomi-local://`（抽帧 IPC 的返回值、导入落盘的素材）+ `data:` 内联字节；以后加一种形态，
+ * 出站能处理的当天这里就自动认，不会再出现「主进程收得下、渲染层先把它丢了」的裂缝。
+ *
+ * `data:` 从「被丢掉」改成放行，修的是一条静默丢参考（2026-08-26）：卡片上传/切图/导入在**落盘
+ * 失败**时会把 base64 留在 node.result.url（兜底：可持久化、不丢图，见 persistNodeImage）。这类
+ * 节点连线当参考时 URL 在此判空 → 参考被悄悄丢掉 → 要么 L3 报「你没连参考」（把原因说反了），
+ * 要么按纯文生跑照样扣费。主进程现在会把内联字节物化上传（assetLocalization），这里没有再拦的理由。
+ *
+ * `blob:` 继续放行是**有意的**：本函数同时喂参考 chip 的显示（referenceSlots 的 fill.url），
+ * 而 blob: 正是「还没落盘的即时预览」那一档，拦了它 chip 就空着。它到不了 vendor 也不会静默上路——
+ * 主进程在付费守卫前拒发并说清原因（assetValueScheme 判 unreachable）。
+ * 裸 `/` 开头曾一并放行，此处删掉：它既不是可达 URL（发给 vendor 必错），也只有开发态的 Vite
+ * 根路径下才显示得出来（打包后渲染层不从 http 根提供服务），全仓扫不到任何生产者。
+ */
 export function asUrl(value: unknown): string {
   if (typeof value !== 'string') return ''
   const trimmed = value.trim()
-  // nomi-local:// 是项目内素材协议（抽帧 IPC 的返回值就是它）——必须放行，
-  // 否则尾帧接力抽出的帧 URL 进解析即被丢弃。
-  return /^https?:\/\//i.test(trimmed) || trimmed.startsWith('/') || trimmed.startsWith('blob:') || trimmed.startsWith('nomi-local://') ? trimmed : ''
+  if (/^https?:\/\//i.test(trimmed) || isLocalizableAssetValue(trimmed)) return trimmed
+  return trimmed.startsWith('blob:') ? trimmed : ''
 }
 
 /** 从一条 result 取可用 URL：**优先本地持久文件**（nomi-local://）——chip 预览永不腐烂；发送前由

--- a/tests/ux/reference-url-scheme-boot.walk.mjs
+++ b/tests/ux/reference-url-scheme-boot.walk.mjs
@@ -1,0 +1,105 @@
+// R13 走查：参考 URL 白名单改判定器之后，**生产构建的渲染层**照常起得来、画布照常画。
+//
+// 为什么非走查不可（单测证不了这条）：referenceUrl.asUrl 从「手列 scheme」改成了 import
+// electron/catalog/assetValueScheme。那个模块的函数体里用了 Buffer —— 单测跑在 node 里，Buffer
+// 天然存在，永远绿；渲染层没有 Buffer，一旦 Vite 把它提到模块初始化期（或解析出别的 node 依赖），
+// 整个画布 chunk 会在**用户点进生成画布的那一刻**炸掉，而 build 门岗照样是绿的。
+// 所以这里只验一件事，但必须在真产物上验：**打包后的那份 renderer**（dist，不是 Vite dev server，
+// 两者的模块解析不是一回事）里，加载画布 + 渲染一个节点（会跑 useNodeDisplayPrompt →
+// resolveReferenceSlots → asUrl）不产生任何渲染层错误。
+//
+// 用法：pnpm run build && node tests/ux/reference-url-scheme-boot.walk.mjs
+import { launchNomiApp } from './_launchApp.mjs'
+import { mkdirSync, mkdtempSync, rmSync } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { expectVisible, screenshotSettled } from './_assert.mjs'
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
+const shotsDir = path.join(repoRoot, 'tests/ux/shots/reference-url-scheme-boot')
+const tempRoot = mkdtempSync(path.join(os.tmpdir(), 'nomi-reference-url-scheme-'))
+const userDataDir = path.join(tempRoot, 'user-data')
+const projectsDir = path.join(tempRoot, 'projects')
+rmSync(shotsDir, { recursive: true, force: true })
+for (const dir of [projectsDir, shotsDir]) mkdirSync(dir, { recursive: true })
+
+const { app, win: initialWin } = await launchNomiApp({
+  name: 'reference-url-scheme-boot',
+  userDataDir,
+  settingsDir: userDataDir,
+  projectsDir,
+  args: ['--no-proxy-server'],
+  settleMs: 0,
+})
+
+let win = initialWin
+const getWin = () => {
+  const live = app.windows().filter((candidate) => !candidate.isClosed())
+  win = live.find((candidate) => /projectId=/.test(candidate.url())) || live[live.length - 1] || win
+  return win
+}
+
+// 渲染层错误全程收集：未捕获异常 + console.error。模块级炸裂两者必中其一。
+const rendererErrors = []
+const watchWindow = (target) => {
+  target.on('pageerror', (error) => rendererErrors.push(`pageerror: ${error.message}`))
+  target.on('console', (message) => {
+    if (message.type() === 'error') rendererErrors.push(`console.error: ${message.text().slice(0, 200)}`)
+  })
+}
+watchWindow(initialWin)
+app.on('window', watchWindow)
+
+const failures = []
+const check = (ok, label, detail = '') => {
+  console.log(`  ${ok ? '✓' : '✗'} ${label}${detail ? ` — ${detail}` : ''}`)
+  if (!ok) failures.push(`${label}${detail ? ` — ${detail}` : ''}`)
+}
+
+try {
+  // 首启引导让路（点不到就算了，下面的断言才是判据）。
+  for (let index = 0; index < 6; index += 1) {
+    const action = getWin().locator('button, [role="button"], a', { hasText: /跳过|完成|知道了|开始创作|稍后/ }).first()
+    if (await action.isVisible().catch(() => false)) await action.click({ timeout: 900 }).catch(() => {})
+    await getWin().keyboard.press('Escape').catch(() => {})
+    await getWin().waitForTimeout(180)
+  }
+  const blankProject = getWin().locator('button, [role="button"]', { hasText: '新建空白项目' }).first()
+  if (await blankProject.isVisible().catch(() => false)) await blankProject.click()
+  await getWin().waitForTimeout(1200)
+
+  const generation = getWin().getByRole('button', { name: '生成', exact: true }).first()
+  await generation.waitFor({ timeout: 15_000 })
+  await generation.click()
+  const toolbar = getWin().locator('.generation-canvas-v2-toolbar').first()
+  await expectVisible(toolbar, '生成画布工具栏渲染出来了（画布 chunk 加载成功）')
+  check(true, '生成画布工具栏可见')
+
+  // 建一个图片节点：节点渲染会跑 useNodeDisplayPrompt → resolveReferenceSlots → asUrl，
+  // 即本次改动的那条真实调用链。它炸的话节点画不出来 / 抛 pageerror。
+  await toolbar.locator('[data-node-kind="image"]').click()
+  const node = getWin().locator('[data-kind="image"][data-node-id]').last()
+  await expectVisible(node, '图片节点渲染完成（参考槽解析链跑通）')
+  const nodeId = await node.getAttribute('data-node-id')
+  check(Boolean(nodeId), '节点带 data-node-id', String(nodeId))
+
+  const shot = path.join(shotsDir, 'canvas-with-image-node.png')
+  await screenshotSettled(getWin(), { path: shot })
+  console.log(`  · 截图 ${shot}`)
+
+  const schemeErrors = rendererErrors.filter((line) => /Buffer|require is not defined|Cannot read|Failed to fetch dynamically/i.test(line))
+  check(schemeErrors.length === 0, '渲染层无模块级错误（Buffer/require/动态 import）', schemeErrors.join(' | ') || '零条')
+  check(rendererErrors.length === 0, '渲染层零错误', rendererErrors.slice(0, 3).join(' | ') || '零条')
+} catch (error) {
+  failures.push(`异常：${error instanceof Error ? error.message : String(error)}`)
+} finally {
+  await app.close().catch(() => {})
+  rmSync(tempRoot, { recursive: true, force: true })
+}
+
+if (failures.length) {
+  console.error(`\nWALK FAIL（${failures.length}）：\n- ${failures.join('\n- ')}`)
+  process.exit(1)
+}
+console.log('\n✅ 走查通过：生产构建的渲染层带着新判定器正常渲染画布与节点。')


### PR DESCRIPTION
## 一句话

**同一张参考图，换个服务商就挂**——根因是「什么算本地素材」这个判定只认 `nomi-local://`，一个 `data:` URI 就能一路直穿到出站请求体。顺着这条线把同族的另外两个洞一起堵了。

## 三处改动

### 1. `data:` URI 与 `nomi-local://` 走同一条上传链（ed3039ee）

2026-08-26 真实付费实测：raw `data:` URI 上 wire 时，火山方舟 Ark 收（HTTP 200），kie.ai 三个模型全 HTTP 500 `"File type not supported"`（nano-banana-2 的 `image_input` / seedream-5-lite 的 `image_urls` / flux-2-pro 的 `input_urls`）。L3 参考护栏拦不住——参考**确实在 body 里**，只是不是所有 vendor 都够得着。

把「本地素材」从「只有 nomi-local://」扩成显式形态判定（新模块 `catalog/assetValueScheme`，纯字符串/字节运算可裸测）：

| 形态 | 处理 |
|---|---|
| `nomi-local://` | 读盘 → 上传链（不变） |
| `data:`（媒体） | 就地解码 → **同一条**上传链 → 每个 vendor 收到公网 URL |
| `blob:` / `file:` | 谁都够不着，**付费守卫之前**拒发并说人话 |
| `http(s)://` / 普通字符串 | 一律不碰，零开销直通 |

非媒体 `data:`（text/json）与裸文件系统路径**不判为素材**：前者是普通参数值，后者与正常字符串没法安全区分，猜错等于误杀整条生成。

同族的三个坑一并堵：contentType 字节优先（mime 说谎时不把视频送进图片 base64 通道撞 413）、内联素材文件名带内容标签（重名→上传端点覆盖→两个参考塌成一张，且看起来一切正常）、错误消息截断（几 MB base64 不再糊进用户看到的报错）。

### 2. base64 兜底图能当参考了 + 记账面只留摘要（9a8f68e8）

卡片上传/切图/拖入导入在**落盘失败**时会把 base64 留在 `node.result.url`（兜底：可持久化、不丢图）。这类节点连线当参考时被渲染层白名单 `asUrl` 判空 → 参考**被静默丢掉** → 要么 L3 反过来报「你没连参考」，要么按纯文生跑照样扣费。

放开白名单前先堵住连带风险——extras 会被三处记账面带走，逐个查了实况：

| 记账面 | 落盘吗 | 已有防护 | 判决 |
|---|---|---|---|
| 溯源 provenance | ✅ 随 `node.result.provenance` 进 project.json | ❌ 无 | **必修**（每生成一次多躺一份 base64，永不回收；溯源面板还把 params 整段铺进 `<pre>`） |
| 指纹 recipe（S8） | ❌ 纯内存 | — | 顺手修（整个 extras 先 stringify 再 sha256） |
| 事件日志 | ✅ | ✅ `MAX_FIELD_BYTES=256KB` | 无需改 |

修法：`digestInlineAssets` 把 `data:` 换成 `nomi-inline-asset:sha256-…;image/png;1.2MB`。摘要必须是**内容身份**（sha256 整串）——指纹缓存拿它当「同配方」判据，弱哈希碰撞＝秒回一张别人的图还看不出来。

白名单本身不再手列形态，改成问 `assetValueScheme`（与出站侧同一判定器，P1 单一真相）：以后出站能处理哪种形态，渲染层当天自动认。顺带删掉裸 `/` 开头那档（`git log -S` 追到是抽公共函数时从旧副本搬来的，全仓无生产者，发出去必错、也只有开发态显示得出来）；`blob:` 保留并写清理由（同一函数还喂参考 chip 的显示）。

### 3. 走查：生产构建的渲染层带着新判定器照常画画布（a71c4e56）

单测在这条上结构性失明：`asUrl` 现在 import 的模块函数体里用了 `Buffer`，单测跑在 node 里永远绿，渲染层没有 Buffer，一旦被提到模块初始化期，画布会在用户点进「生成」的那一刻炸，而 build 门岗照样绿。故在 **dist 打包产物**（非 Vite dev server）上验：加载画布 + 建图片节点（跑真实的 `useNodeDisplayPrompt → resolveReferenceSlots → asUrl` 链）零渲染层错误，截图人眼确认。

## 验证

- **反向验证过会红**：还原修复前的判定 → 8 条测试当场失败；还原渲染层白名单 → 3 条当场失败。不是自证式绿灯。
- runtime 层端到端断言：caller 递 `data:` URI 进 extras → **wire 上必须是公网 URL 且整个 body 不含 `data:`**。
- 走查截图已人眼看过（dist 产物，mac；本次改动无平台分支）。
- `pnpm run gates` 全过（6710 tests）。

## 已知遗留（未做，故意）

`asUrl` 仍是**一个白名单服务两个问题**（「能显示吗」vs「能发出去吗」），`blob:` 那条注释就是这个张力的产物。收干净要拆成两个函数并改 `referenceSlots` / `generationReferenceResolver` 的取用——跨文件重构，不混进本次。

🤖 Generated with [Claude Code](https://claude.com/claude-code)