### PR TITLE
fix: headless 参考投影把首帧塞进参考数组，两族互斥键同时发出

### DIFF
--- a/docs/research/model-radar/latest.json
+++ b/docs/research/model-radar/latest.json
@@ -3,29 +3,7 @@
     {
       "vendor": "kie",
       "total": 141,
-      "added": [
-        {
-          "vendor": "kie",
-          "category": "video",
-          "slug": "wan/3-0-video",
-          "title": "Wan 3.0 - Video",
-          "url": "https://docs.kie.ai/market/wan/3-0-video.md"
-        },
-        {
-          "vendor": "kie",
-          "category": "video",
-          "slug": "wan/3-0-video-prime",
-          "title": "Wan 3.0 - Video Prime",
-          "url": "https://docs.kie.ai/market/wan/3-0-video-prime.md"
-        },
-        {
-          "vendor": "kie",
-          "category": "audio",
-          "slug": "elevenlabs/text-to-speech-turbo-2-5",
-          "title": "elevenlabs/text-to-speech-turbo-2-5",
-          "url": "https://docs.kie.ai/market/elevenlabs/text-to-speech-turbo-2-5.md"
-        }
-      ],
+      "added": [],
       "removed": [],
       "uncovered": [
         {

--- a/electron/catalog/taskParams.test.ts
+++ b/electron/catalog/taskParams.test.ts
@@ -185,3 +185,120 @@ describe("projectReferencesOntoBodyKeys — headless 参考键形态投影（W1d
     expect(projectReferencesOntoBodyKeys(undefined, editBody)).toEqual({});
   });
 });
+
+describe("projectReferencesOntoBodyKeys — 帧意图优先（2026-08-27 真机 422 的回归）", () => {
+  // Wan 3.0（kie）真实 seed body：**同时**声明帧键与参考数组键，而官方规定两族硬互斥。
+  const wan30Body = {
+    model: "{{request.params.model}}",
+    input: {
+      prompt: "{{request.prompt}}",
+      first_frame_url: "{{request.params.first_frame_url}}",
+      last_frame_url: "{{request.params.last_frame_url}}",
+      reference_image_urls: "{{request.params.reference_image_urls}}",
+      reference_video_urls: "{{request.params.reference_video_urls}}",
+      reference_audio_urls: "{{request.params.reference_audio_urls}}",
+    },
+  };
+  const FIRST = "https://x/first.png";
+  const LAST = "https://x/last.png";
+
+  // 病史：扁平 firstFrameUrl 被「每族优先数组键」的启发式塞进 reference_image_urls，
+  // 而标准键 firstFrameUrl 又原样留着 → 渲染出的 body 两族键同时出现 → kie HTTP 422
+  // "first_frame_url / last_frame_url and reference_*_urls are mutually exclusive"。
+  // 只有渲染层（按选中模式构造 archetypeInput）躲过了，headless/MCP/agent 提交全中。
+  it("扁平 firstFrameUrl 只落帧键，**绝不**同时填参考数组键", () => {
+    const overlay = projectReferencesOntoBodyKeys({ firstFrameUrl: FIRST }, wan30Body);
+    expect(overlay).toEqual({ first_frame_url: FIRST });
+    // 负例对照：数组键一旦回来就红——这正是 422 的直接成因。
+    expect(overlay).not.toHaveProperty("reference_image_urls");
+    expect(Object.keys(overlay)).toHaveLength(1);
+  });
+
+  it("首尾帧各归各位，仍不碰参考数组", () => {
+    const overlay = projectReferencesOntoBodyKeys({ firstFrameUrl: FIRST, lastFrameUrl: LAST }, wan30Body);
+    expect(overlay).toEqual({ first_frame_url: FIRST, last_frame_url: LAST });
+    expect(overlay).not.toHaveProperty("reference_image_urls");
+  });
+
+  it("只给参考图列表时照旧走数组键（没把这条路修死）", () => {
+    const overlay = projectReferencesOntoBodyKeys({ referenceImageUrls: ["https://x/a.png", "https://x/b.png"] }, wan30Body);
+    expect(overlay).toEqual({ reference_image_urls: ["https://x/a.png", "https://x/b.png"] });
+  });
+
+  it("调用方**自己**同时给了首帧与参考图 → 各归各位（这个组合是他要的，不是我们造的）", () => {
+    // 我们只保证不**发明**互斥组合；调用方显式要的组合照发，由上游按自己的规则裁决。
+    const overlay = projectReferencesOntoBodyKeys({ firstFrameUrl: FIRST, referenceImageUrls: ["https://x/a.png"] }, wan30Body);
+    expect(overlay).toEqual({ first_frame_url: FIRST, reference_image_urls: ["https://x/a.png"] });
+  });
+
+  it("UI 路逐字节 no-op（archetypeInput 权威，短路投影）", () => {
+    const overlay = projectReferencesOntoBodyKeys(
+      { firstFrameUrl: FIRST, archetypeInput: { first_frame_url: FIRST } },
+      wan30Body,
+    );
+    expect(overlay).toEqual({});
+  });
+
+  it("body **没有**帧键时，首帧照旧落进数组键（Wan 2.7 / HappyHorse 用 image_urls 兼作首帧位）", () => {
+    // 这条守的是「别把修复做过头」：帧意图优先只在 body 真有帧键时生效。
+    const wan27Body = { model: "m", image_urls: "{{request.params.image_urls}}" };
+    expect(projectReferencesOntoBodyKeys({ firstFrameUrl: FIRST }, wan27Body)).toEqual({ image_urls: [FIRST] });
+  });
+
+  it("控制开关键不是帧载体：return_last_frame 不许接走首帧", () => {
+    // seedance 的 return_last_frame（返回尾帧图的布尔开关）名字里有 frame，但它是开关不是载体。
+    // 误判会让首帧落到一个布尔位上，真正的图一张都发不出去。
+    const body = { image_urls: "{{request.params.image_urls}}", return_last_frame: "{{request.params.return_last_frame}}" };
+    const overlay = projectReferencesOntoBodyKeys({ firstFrameUrl: FIRST }, body);
+    expect(overlay).toEqual({ image_urls: [FIRST] });
+    expect(overlay).not.toHaveProperty("return_last_frame");
+  });
+});
+
+describe("投影不变量：全体内置 mapping 都不许同时发出帧键与同族参考数组键（P2 类级门岗）", () => {
+  // 要求是「修在根上，让**任何**同时带帧槽与参考槽的档案都安全，而不只是 Wan 3.0」。
+  // 故这条不针对某个模型，而是遍历**全部**内置 mapping：只要一条 body 同时声明了真帧键与
+  // 图族数组键，就断言「只给首帧」时投影绝不会两个都填。新增档案落进这个形状会被自动覆盖。
+  it("遍历全部内置 mapping", async () => {
+    const [{ applyBuiltinSeeds }, { bodyReferencedParamKeys }, { classifyReferenceKeyDetailed }] = await Promise.all([
+      import("./seedBuiltins"),
+      import("./paramTranslate"),
+      import("./referenceReachability"),
+    ]);
+    const state = applyBuiltinSeeds(
+      { version: 4, vendors: [], models: [], mappings: [], apiKeysByVendor: {} },
+      "2026-01-01T00:00:00.000Z",
+    ).state;
+
+    const FRAME_URL = "https://x/frame.png";
+    const violations: string[] = [];
+    let covered = 0;
+
+    for (const mapping of state.mappings) {
+      const body = mapping.create?.body;
+      if (!body) continue;
+      const keys = bodyReferencedParamKeys(body);
+      // 真帧键：名字命中 first/last_frame **且**被分类器认作参考载体（排除 return_last_frame 这类开关）。
+      const frameKeys = keys.filter(
+        (k) => /first_frame|last_frame/i.test(k) && !/with_roles|_contents?\b/i.test(k) && classifyReferenceKeyDetailed(k),
+      );
+      const arrayKeys = keys.filter((k) => /^(reference_)?image_urls$|^input_urls$|^reference_images$/i.test(k));
+      if (frameKeys.length === 0 || arrayKeys.length === 0) continue;
+      covered += 1;
+
+      const overlay = projectReferencesOntoBodyKeys({ firstFrameUrl: FRAME_URL }, body);
+      const filledFrame = frameKeys.filter((k) => overlay[k] !== undefined);
+      const filledArray = arrayKeys.filter((k) => overlay[k] !== undefined);
+      if (filledFrame.length > 0 && filledArray.length > 0) {
+        violations.push(`${mapping.vendorKey}/${mapping.modelKey ?? mapping.id}: 同时填了 ${filledFrame} 与 ${filledArray}`);
+      }
+      if (filledArray.length > 0 && filledFrame.length === 0) {
+        violations.push(`${mapping.vendorKey}/${mapping.modelKey ?? mapping.id}: 首帧被投进数组键 ${filledArray}（帧键 ${frameKeys} 空着）`);
+      }
+    }
+
+    // 前提坐实：真有这个形状的 mapping 存在，否则这条测试等于没测（空跑绿）。
+    expect(covered).toBeGreaterThan(0);
+    expect(violations).toEqual([]);
+  });
+});

--- a/electron/catalog/taskParams.ts
+++ b/electron/catalog/taskParams.ts
@@ -187,6 +187,22 @@ const OBJECT_SHAPE_REF_KEY = /with_roles|_contents\b|_content\b/i;
 // classifyReferenceKeyDetailed 的 multiImage 只覆盖 image 族的多图信号，video/audio 复数键靠此补齐 → 塞数组不塞单串。
 const ARRAY_SHAPE_REF_KEY = /_urls$|urls$|_images$|images$|_paths$|paths$/i;
 
+/**
+ * 帧槽：**归一后的标准来源键** ↔ **body 侧帧键的判据**。
+ *
+ * 为什么需要它（2026-08-27 真机 422 的根因）：`referenceInputParams` 把调用方的 `firstFrameUrl`
+ * 归一成 `first_frame_url`，**帧意图是保留着的**；但 `carriedReferenceUrlsByFamily` 会把同族的
+ * URL 拍平成一个列表，意图在那一步丢了。于是下游「每族优先数组键」的启发式把首帧塞进了
+ * `reference_image_urls`——对 Wan 3.0 这种「首/尾帧与 reference_* 官方硬互斥」的模型，
+ * 结果是 body 里两族键同时出现，kie 直接 422。
+ *
+ * 注意 `first_frame` / `last_frame` 两条判据互不包含（不能只用 /frame/），否则尾帧会被首帧规则先吞。
+ */
+const FRAME_SLOTS: ReadonlyArray<{ sourceKey: string; bodyKeyRe: RegExp }> = [
+  { sourceKey: "first_frame_url", bodyKeyRe: /first_frame/i },
+  { sourceKey: "last_frame_url", bodyKeyRe: /last_frame/i },
+];
+
 /** 往这个 body 参考键投影时该塞数组还是单串：多图键（multiImage）或复数 URL 键 → 数组；否则单串（首帧/单图聚合位）。 */
 function refKeyWantsArray(key: string, multiImage: boolean): boolean {
   return multiImage || ARRAY_SHAPE_REF_KEY.test(key);
@@ -416,6 +432,8 @@ function archetypeReferenceUrlsByFamily(extras: JsonRecord): Record<ReferenceFam
  *  · **每族至多填一个键**——headless 的 references 是**扁平列表**（无「这张是首帧、那张是角色图」的槽区分），
  *    同族多个 body 键（如 image_urls + first_frame_image）全填会把同一批 URL 重复塞进互斥键。**优先多值键**
  *    （扁平列表的天然去处），无多值键才退单值键（首帧/单图聚合位）。渲染层靠边 mode 区分槽，headless 靠这条。
+ *    ⚠️ **例外：首/尾帧不是「扁平列表」**——调用方写 `firstFrameUrl` 就是明确表态「这张是首帧」，
+ *    这份意图必须一路送到 body 的 first_frame_url，见下面「帧意图优先」。
  *  · **跳过对象形态键**（image_with_roles / *_contents）——它们要的是 [{url, role}] 对象，plain URL 塞进去既错
  *    形状又与 image_urls 互斥（seedance SEEDANCE_I2V_BODY 正是此例）。这些键只有渲染层 archetypeInput 才构造得对，
  *    headless 走 plain 键即可，对象键留空由模板引擎自动丢（= 该模型的「plain 参考」模式）。
@@ -442,10 +460,46 @@ export function projectReferencesOntoBodyKeys(
     (Array.isArray(value) && value.length > 0) ||
     (value != null && typeof value === "object");
 
+  const archetypeInput = isJsonRecord(src.archetypeInput) ? src.archetypeInput : {};
+  const bodyKeys = bodyReferencedParamKeys(createBody);
+
+  // ── 帧意图优先 ────────────────────────────────────────────────────────────
+  // 调用方写 `firstFrameUrl` 是明确表态「这张是首帧」，不是"一张随便的参考图"。
+  // 若这条 body 有对应的帧键，就**直接投到帧键**，并把该 URL 从族池里**取走**——
+  // 取走是关键：族池空了，下面的数组候选就不会再把同一张图塞进 reference_image_urls，
+  // 于是「首帧 + 参考数组」这对互斥键不可能被我们**同时**发出去（Wan 3.0 的 422 根因）。
+  //
+  // body 没有帧键时（如 Wan 2.7 / HappyHorse 用 image_urls 兼作首帧位）不消费，
+  // 首帧照旧落进数组候选——老行为逐字节不变。
+  const frameOverlay: Record<string, unknown> = {};
+  const consumed = new Set<string>();
+  const normalized = referenceInputParams(src);
+  for (const { sourceKey, bodyKeyRe } of FRAME_SLOTS) {
+    const url = typeof normalized[sourceKey] === "string" ? (normalized[sourceKey] as string).trim() : "";
+    if (!url) continue;
+    const target = bodyKeys.find(
+      (key) =>
+        bodyKeyRe.test(key) &&
+        !OBJECT_SHAPE_REF_KEY.test(key) &&
+        classifyReferenceKeyDetailed(key) &&
+        !hasNonEmpty(src[key]) &&
+        !hasNonEmpty(archetypeInput[key]),
+    );
+    if (!target) continue;
+    frameOverlay[target] = url;
+    consumed.add(url);
+  }
+  if (consumed.size > 0) {
+    for (const family of Object.keys(byFamily) as ReferenceFamily[]) {
+      byFamily[family] = byFamily[family].filter((url) => !consumed.has(url));
+      flatByFamily[family] = flatByFamily[family].filter((url) => !consumed.has(url));
+    }
+  }
+
   // 先按族归拢 body 里可填的 plain 参考键（跳过对象形态键），每族选一个目标：优先数组键（扁平列表天然去处）。
   const candidateByFamily: Partial<Record<ReferenceFamily, { key: string; wantsArray: boolean }>> = {};
-  const archetypeInput = isJsonRecord(src.archetypeInput) ? src.archetypeInput : {};
-  for (const key of bodyReferencedParamKeys(createBody)) {
+  for (const key of bodyKeys) {
+    if (frameOverlay[key] !== undefined) continue; // 已被帧意图占用
     const detail = classifyReferenceKeyDetailed(key);
     if (!detail) continue; // 非参考载体键（size/duration/seed…）不碰。
     if (OBJECT_SHAPE_REF_KEY.test(key)) continue; // 对象形态键（image_with_roles/*_contents）headless 不填，留空由模板丢。
@@ -457,7 +511,7 @@ export function projectReferencesOntoBodyKeys(
     if (!current || (wantsArray && !current.wantsArray)) candidateByFamily[detail.family] = { key, wantsArray };
   }
 
-  const overlay: Record<string, unknown> = {};
+  const overlay: Record<string, unknown> = { ...frameOverlay };
   for (const family of Object.keys(candidateByFamily) as ReferenceFamily[]) {
     // Renderer-produced archetypeInput is authoritative. Only project a second key when a
     // distinct flat source exists; that deliberately preserves mixed-input detection.


### PR DESCRIPTION
> 接替 #192（我误删远端分支把它自动关掉了，内容不变，已 rebase 到最新 main 并重跑 gates）。

## 症状与现场

2026-08-27 Wan 3.0 付费验收首跑撞 HTTP 422：`first_frame_url / last_frame_url and reference_*_urls are mutually exclusive`。渲染出的 body 里两族键**同时**出现。

```
projectReferencesOntoBodyKeys({ firstFrameUrl: U }, wan30Body)
  => { reference_image_urls: [U] }        // 错：进了数组键
projectReferencesOntoBodyKeys({ firstFrameUrl: U, archetypeInput:{first_frame_url:U} }, wan30Body)
  => {}                                   // 对：archetypeInput 权威，短路
```

扁平那条又把标准键 `firstFrameUrl` 原样留着 → 最终 body 两族都有。

## 根因

`referenceInputParams` 把 `firstFrameUrl` 归一成 `first_frame_url`，**帧意图是保留着的**；但 `carriedReferenceUrlsByFamily` 把同族 URL 拍平成一个列表，**意图在那一步就丢了**。于是候选选择那行「每族优先数组键」的启发式（`wantsArray && !current.wantsArray`）把首帧投进了 `reference_image_urls`——它是**模式盲**的，看不出「这张是首帧」。

只有渲染层躲过了：它按选中模式构造 `archetypeInput`，短路整个投影。所以这是 **headless / MCP / agent 提交专属**的洞，UI 路不受影响。

## 修法（修在根上，不是给 Wan 3.0 打补丁）

新增 `FRAME_SLOTS`（归一来源键 ↔ body 帧键判据），在候选选择**之前**先做「帧意图优先」：若这条 body 有对应帧键 → 直接投到帧键，并把该 URL **从族池里取走**。

取走是关键：族池空了，数组候选就不会再把同一张图塞进 `reference_image_urls`，于是这对互斥键**在结构上不可能**被我们同时发出。

三条边界都守住了：

| 场景 | 行为 |
|---|---|
| body **没有**帧键（Wan 2.7 / HappyHorse 用 `image_urls` 兼作首帧位） | 不消费，首帧照旧落数组键 —— **老行为逐字节不变** |
| `return_last_frame` 这类**控制开关** | 不是帧载体（`CONTROL_KEY_PREFIX` 已排除），不许接走首帧 —— 否则图一张都发不出去 |
| 调用方**自己**同时给首帧和参考图 | 各归各位。我们只保证不**发明**互斥组合；他显式要的组合照发，由上游裁决 |

## ⚠️ 影响面比报告的大

类级门岗在「撤掉修复」的阳性对照下抓出 **9 条 mapping**，不只 Wan 3.0 —— **kie Seedance 2.0 与 2.5 同样中招**（body 也是帧键 + 参考数组同存），只是此前没人在 headless 路上给它们传过首帧，一直没炸。

## 测试

- **8 条针对性回归**，含负例对照：数组键一旦回来立刻红。
- **类级不变量**（对应「修在根上让任何同形档案都安全」这条要求）：遍历**全部**内置 mapping，凡 body 同时声明真帧键与图族数组键的，断言「只给首帧」时绝不两个都填、也绝不只填数组。新档案落进这个形状自动被覆盖。另断言 `covered > 0`，防这条测试哪天变成空跑绿。
- **过阳性对照**：撤掉消费逻辑 → 4 条红，类级门岗完整列出 9 条违规。

`pnpm run typecheck` 干净 · `pnpm run test` 6812 通过 · `pnpm run gates` 全过（已 rebase 到含 #184 的最新 main 后重跑）。

## 附带一条自查

第二个 commit 修正 `docs/research/model-radar/latest.json`：上一版雷达 PR 里它存的是我做**阳性对照**时的输出（人为把 3 条从快照拿掉以验证雷达真会报新增，结果那次的 `added` 被一起提交了）。后果不严重（下次真跑即覆盖）但它是**假的**——谁看都会以为那三条刚上新。已用一次干净运行重写。教训：阳性对照要在独立副本上做，别让验证用的污染态混进产物。

🤖 Generated with [Claude Code](https://claude.com/claude-code)