### PR TITLE
feat: replace generation canvas renderer with React Flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,6 +125,7 @@
     "@tiptap/react": "^3.22.5",
     "@tiptap/starter-kit": "^3.22.5",
     "@tiptap/suggestion": "3.23.5",
+    "@xyflow/react": "12.11.5",
     "ai": "^4.3.19",
     "clsx": "^2.1.1",
     "electron-updater": "^6.8.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,6 +86,9 @@ importers:
       '@tiptap/suggestion':
         specifier: 3.23.5
         version: 3.23.5(@tiptap/core@3.23.5(@tiptap/pm@3.23.5))(@tiptap/pm@3.23.5)
+      '@xyflow/react':
+        specifier: 12.11.5
+        version: 12.11.5(@types/react-dom@18.3.7(@types/react@18.3.29))(@types/react@18.3.29)(immer@11.1.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       ai:
         specifier: ^4.3.19
         version: 4.3.19(react@18.3.1)(zod@3.25.76)
@@ -2094,6 +2097,24 @@ packages:
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-drag@3.0.7':
+    resolution: {integrity: sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-selection@3.0.11':
+    resolution: {integrity: sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==}
+
+  '@types/d3-transition@3.0.9':
+    resolution: {integrity: sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==}
+
+  '@types/d3-zoom@3.0.8':
+    resolution: {integrity: sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==}
+
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
 
@@ -2313,6 +2334,22 @@ packages:
     resolution: {integrity: sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==}
     engines: {node: '>=14.6'}
     deprecated: this version has critical issues, please update to the latest version
+
+  '@xyflow/react@12.11.5':
+    resolution: {integrity: sha512-QqoryGkqEhWBuQN9bZWRKhwr3Uoj9lCGj/tg0NnIWHHEOXV+5c8cYsc7Q9TST63V92lHqcNV9P5cjvJ9ZAmblQ==}
+    peerDependencies:
+      '@types/react': '>=17'
+      '@types/react-dom': '>=17'
+      react: '>=17'
+      react-dom: '>=17'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@xyflow/system@0.0.81':
+    resolution: {integrity: sha512-hfbafW4i7uLq7ILok8QWFFm4KMFw22lbZNJHKfHOMSOOoCk5e5m8yfr84UV9NaJajmogWaLVnp2XFU9JQejlqg==}
 
   abbrev@1.1.1:
     resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
@@ -2689,6 +2726,9 @@ packages:
     resolution: {integrity: sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==}
     engines: {node: '>=8'}
 
+  classcat@5.0.5:
+    resolution: {integrity: sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==}
+
   clean-stack@2.2.0:
     resolution: {integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==}
     engines: {node: '>=6'}
@@ -2826,6 +2866,44 @@ packages:
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-dispatch@3.0.1:
+    resolution: {integrity: sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==}
+    engines: {node: '>=12'}
+
+  d3-drag@3.0.0:
+    resolution: {integrity: sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==}
+    engines: {node: '>=12'}
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-selection@3.0.0:
+    resolution: {integrity: sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
+  d3-transition@3.0.1:
+    resolution: {integrity: sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      d3-selection: 2 - 3
+
+  d3-zoom@3.0.0:
+    resolution: {integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==}
+    engines: {node: '>=12'}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -7545,6 +7623,27 @@ snapshots:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-drag@3.0.7':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-selection@3.0.11': {}
+
+  '@types/d3-transition@3.0.9':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-zoom@3.0.8':
+    dependencies:
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-selection': 3.0.11
+
   '@types/debug@4.1.13':
     dependencies:
       '@types/ms': 2.1.0
@@ -7811,6 +7910,31 @@ snapshots:
   '@xmldom/xmldom@0.8.13': {}
 
   '@xmldom/xmldom@0.9.10': {}
+
+  '@xyflow/react@12.11.5(@types/react-dom@18.3.7(@types/react@18.3.29))(@types/react@18.3.29)(immer@11.1.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@xyflow/system': 0.0.81
+      classcat: 5.0.5
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      zustand: 4.5.7(@types/react@18.3.29)(immer@11.1.8)(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.29
+      '@types/react-dom': 18.3.7(@types/react@18.3.29)
+    transitivePeerDependencies:
+      - immer
+
+  '@xyflow/system@0.0.81':
+    dependencies:
+      '@types/d3-drag': 3.0.7
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-selection': 3.0.11
+      '@types/d3-transition': 3.0.9
+      '@types/d3-zoom': 3.0.8
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-zoom: 3.0.0
 
   abbrev@1.1.1: {}
 
@@ -8331,6 +8455,8 @@ snapshots:
 
   ci-info@4.4.0: {}
 
+  classcat@5.0.5: {}
+
   clean-stack@2.2.0: {}
 
   cli-cursor@3.1.0:
@@ -8434,6 +8560,42 @@ snapshots:
   cssesc@3.0.0: {}
 
   csstype@3.2.3: {}
+
+  d3-color@3.1.0: {}
+
+  d3-dispatch@3.0.1: {}
+
+  d3-drag@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-selection: 3.0.0
+
+  d3-ease@3.0.1: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-selection@3.0.0: {}
+
+  d3-timer@3.0.1: {}
+
+  d3-transition@3.0.1(d3-selection@3.0.0):
+    dependencies:
+      d3-color: 3.1.0
+      d3-dispatch: 3.0.1
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-timer: 3.0.1
+
+  d3-zoom@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
 
   debug@4.4.3:
     dependencies:

--- a/src/workbench/generationCanvas/components/GenerationCanvas.tsx
+++ b/src/workbench/generationCanvas/components/GenerationCanvas.tsx
@@ -19,10 +19,8 @@ import {
   type BrowserAssetCanvasImportItem,
 } from '../../../ui/browser/overlay/globalAssetPopoverEvents'
 import { getDesktopBridge } from '../../../desktop/bridge'
-import type { GenerationNodeKind } from '../model/generationCanvasTypes'
 import { isImageLikeGenerationNodeKind } from '../model/generationNodeKinds'
 import { getGenerationNodeComponent } from '../nodes/renderRegistry'
-import { completeNodeConnection } from '../nodes/completeNodeConnection'
 // 事件名单一真相源：派发方（深链）与监听方（这里）必须读同一个常量，否则改名字会静默断链。
 import { FOCUS_GENERATION_NODE_EVENT } from '../nodes/nodeSizing'
 import { useGenerationCanvasStore } from '../store/generationCanvasStore'
@@ -63,6 +61,7 @@ import { useCanvasBatchDockVisibility } from './useCanvasBatchDockVisibility'
 import { useCanvasScreenshotCapture } from './useCanvasScreenshotCapture'
 import { useComposerVisibilityPan } from './useComposerVisibilityPan'
 import { useCanvasFitSignal } from './useCanvasFitSignal'
+import { isReactFlowCanvasEnabled } from '../reactFlow/generationCanvasEngineFlag'
 import '../styles/generationCanvas.css'
 
 const StagingCaptureHost = lazyWithChunkBoundary('3D 站位捕获', () =>
@@ -74,6 +73,9 @@ const CameraMoveCaptureHost = lazyWithChunkBoundary('3D 运镜捕获', () =>
 const BatchPlanOverlay = lazyWithChunkBoundary('批量生成面板', () =>
   import('./BatchPlanOverlay').then((module) => ({ default: module.BatchPlanOverlay })),
 )
+const GenerationCanvasReactFlow = lazyWithChunkBoundary('React Flow 画布实验引擎', () =>
+  import('../reactFlow/GenerationCanvasReactFlow'),
+)
 
 const MULTI_SELECTION_BOUNDS_PADDING = 16
 const MULTI_SELECTION_TOOLBAR_OFFSET = 58
@@ -82,7 +84,7 @@ type GenerationCanvasProps = {
   readOnly?: boolean
 }
 
-export default function GenerationCanvas({ readOnly = false }: GenerationCanvasProps): JSX.Element {
+function LegacyGenerationCanvas({ readOnly = false }: GenerationCanvasProps): JSX.Element {
   const { t } = useTranslation()
   const isReady = useGenerationCanvasStore((state) => state.isReady)
   const allNodes = useGenerationCanvasStore((state) => state.nodes)
@@ -433,7 +435,7 @@ export default function GenerationCanvas({ readOnly = false }: GenerationCanvasP
         'success',
       )
     },
-    [activeCategoryId, getToolbarInsertionPosition, readOnly],
+    [activeCategoryId, getToolbarInsertionPosition, readOnly, t],
   )
 
   React.useEffect(
@@ -795,5 +797,19 @@ export default function GenerationCanvas({ readOnly = false }: GenerationCanvasP
         <SelectionPromptSaveController nodes={allNodes} disabled={readOnly} />
       </div>
     </section>
+  )
+}
+
+/**
+ * React Flow is the default renderer. The flag is evaluated at the component
+ * boundary so neither implementation conditionally changes its hook order;
+ * setting it to `legacy` provides an emergency rollback without a rebuild.
+ */
+export default function GenerationCanvas(props: GenerationCanvasProps): JSX.Element {
+  if (!isReactFlowCanvasEnabled()) return <LegacyGenerationCanvas {...props} />
+  return (
+    <React.Suspense fallback={null}>
+      <GenerationCanvasReactFlow {...props} />
+    </React.Suspense>
   )
 }

--- a/src/workbench/generationCanvas/components/useCanvasShortcuts.ts
+++ b/src/workbench/generationCanvas/components/useCanvasShortcuts.ts
@@ -59,6 +59,7 @@ export function useCanvasShortcuts(opts: {
   activeCategoryId: string
   /** 只用于清空（Escape）；签名收窄到 null 以兼容任意 ActiveEdge setState。 */
   setActiveEdge: (edge: null) => void
+  deleteActiveEdge?: () => void
   cancelConnection: () => void
   deleteSelectedNodes: () => void
   groupSelectedNodes: () => void
@@ -78,6 +79,7 @@ export function useCanvasShortcuts(opts: {
     selectedGroupCount,
     activeCategoryId,
     setActiveEdge,
+    deleteActiveEdge,
     cancelConnection,
     deleteSelectedNodes,
     groupSelectedNodes,
@@ -118,7 +120,13 @@ export function useCanvasShortcuts(opts: {
         return
       }
       if (event.key === 'Backspace' || event.key === 'Delete') {
-        if (!selectedNodeCount) return
+        if (!selectedNodeCount) {
+          if (deleteActiveEdge) {
+            event.preventDefault()
+            deleteActiveEdge()
+          }
+          return
+        }
         event.preventDefault()
         const removedCount = selectedNodeCount
         deleteSelectedNodes()
@@ -230,6 +238,7 @@ export function useCanvasShortcuts(opts: {
     copySelectedNodes,
     cutSelectedNodes,
     deleteSelectedNodes,
+    deleteActiveEdge,
     getPastePosition,
     groupSelectedNodes,
     pasteNodes,

--- a/src/workbench/generationCanvas/nodes/useNodeDragResize.ts
+++ b/src/workbench/generationCanvas/nodes/useNodeDragResize.ts
@@ -16,6 +16,7 @@ import { toast } from '../../../ui/toast'
 import { emitCanvasGesture } from '../events/canvasEventEmitter'
 import { setCanvasDragging } from '../components/canvasDraggingFlag'
 import i18n from '../../../i18n'
+import { useGenerationFlowNodeManagedDrag } from '../reactFlow/generationFlowNodeContext'
 import {
   clampNumber,
   findTimelineDropTarget,
@@ -62,6 +63,7 @@ export function useNodeDragResize({
   updateNode,
   commitPersistedChange,
 }: UseNodeDragResizeArgs) {
+  const flowManagedDrag = useGenerationFlowNodeManagedDrag()
   const dragStartRef = React.useRef<{
     pointerX: number
     pointerY: number
@@ -161,6 +163,10 @@ export function useNodeDragResize({
   )
 
   const handlePointerDown = (event: React.PointerEvent<HTMLDivElement>) => {
+    // In the React Flow PoC the outer node wrapper owns drag/selection. Leave
+    // the event bubbling so React Flow can process it; the default canvas path
+    // keeps the existing custom gesture implementation.
+    if (flowManagedDrag) return
     const target = event.target as HTMLElement
     // C5 安全坑：放行 contenteditable / ProseMirror，否则点正文会被当成拖拽、吞掉光标。
     if (target.closest('button, input, textarea, select, [contenteditable="true"], .ProseMirror')) return
@@ -193,6 +199,7 @@ export function useNodeDragResize({
   }
 
   const handlePointerMove = (event: React.PointerEvent<HTMLDivElement>) => {
+    if (flowManagedDrag) return
     const resizeStart = resizeStartRef.current
     if (resizeStart) {
       const effectiveZoom = useGenerationCanvasStore.getState().canvasZoom || 1
@@ -313,6 +320,7 @@ export function useNodeDragResize({
   }
 
   const handlePointerUp = (event: React.PointerEvent<HTMLDivElement>) => {
+    if (flowManagedDrag) return
     flushScheduledMove()
     const dragStart = dragStartRef.current
     const hadResize = Boolean(resizeStartRef.current)
@@ -363,6 +371,7 @@ export function useNodeDragResize({
   }
 
   const handleResizePointerDown = (direction: ResizeDirection) => (event: React.PointerEvent<HTMLButtonElement>) => {
+    if (flowManagedDrag) return
     event.preventDefault()
     event.stopPropagation()
     if (readOnly) return

--- a/src/workbench/generationCanvas/reactFlow/GenerationCanvasReactFlow.tsx
+++ b/src/workbench/generationCanvas/reactFlow/GenerationCanvasReactFlow.tsx
@@ -1,0 +1,839 @@
+import React from 'react'
+import {
+  BaseEdge,
+  EdgeLabelRenderer,
+  Handle,
+  NodeResizer,
+  Position,
+  ReactFlow,
+  ReactFlowProvider,
+  ViewportPortal,
+  getBezierPath,
+  useReactFlow,
+  type EdgeProps,
+  type OnNodeDrag,
+  type OnEdgesDelete,
+  type OnConnectStart,
+  type OnConnectEnd,
+  type OnNodesChange,
+  type NodeProps,
+} from '@xyflow/react'
+import '@xyflow/react/dist/style.css'
+import './generationCanvasReactFlow.css'
+import { useTranslation } from 'react-i18next'
+import { toast } from '../../../ui/toast'
+import { lazyWithChunkBoundary } from '../../../ui/chunkBoundary'
+import { cn } from '../../../utils/cn'
+import { getDesktopBridge } from '../../../desktop/bridge'
+import {
+  subscribeBrowserAssetsImportToCanvas,
+  type BrowserAssetCanvasImportItem,
+} from '../../../ui/browser/overlay/globalAssetPopoverEvents'
+import { WORKSPACE_FILE_DRAG_MIME } from '../../explorer/workspaceFileDrag'
+import { ASSET_LIBRARY_DRAG_MIME } from '../../assets/assetLibraryDrag'
+import { useWorkbenchStore } from '../../workbenchStore'
+import { useGenerationCanvasStore } from '../store/generationCanvasStore'
+import type { GenerationCanvasNode } from '../model/generationCanvasTypes'
+import { getGenerationNodeComponent } from '../nodes/renderRegistry'
+import { getNodeSizeBounds, resolveNodeVisualSize } from '../nodes/nodeSizing'
+import { emitCanvasGesture } from '../events/canvasEventEmitter'
+import { getCanvasGroupBoxes } from '../components/generationCanvasGeometry'
+import { GroupFrameList } from '../components/GroupFrame'
+import { useCanvasSelectionDrag } from '../components/useCanvasSelectionDrag'
+import { useCanvasGroupActions } from '../components/useCanvasGroupActions'
+import { useCanvasShortcuts } from '../components/useCanvasShortcuts'
+import { useCanvasScreenshotCapture } from '../components/useCanvasScreenshotCapture'
+import { useCanvasProductionActions } from '../components/useCanvasProductionActions'
+import { useCanvasBatchDockVisibility } from '../components/useCanvasBatchDockVisibility'
+import { useCanvasFitSignal } from '../components/useCanvasFitSignal'
+import { useTidyCanvas } from '../components/useTidyCanvas'
+import { useAutoFitOnLoad } from '../components/useAutoFitOnLoad'
+import { CanvasNavigationStack } from '../components/CanvasNavigationStack'
+import { CanvasSelectionToolbar } from '../components/CanvasSelectionToolbar'
+import { CanvasBatchGenerateDock } from '../components/CanvasBatchGenerateDock'
+import { SelectionPromptSaveController } from '../components/SelectionPromptSaveController'
+import { useBatchPlanPreviewStore } from '../components/batchPlanPreview'
+import NodeContextMenu from '../components/NodeContextMenu'
+import { NodeAddMenu } from '../components/CanvasToolbar'
+import { buildCanvasMenuActions } from '../components/useCanvasMenuActions'
+import { hasClipboardContent } from '../store/canvasClipboard'
+import { getSelectedBounds } from '../components/generationCanvasGeometry'
+import { FOCUS_GENERATION_NODE_EVENT } from '../nodes/nodeSizing'
+import { availableEdgeModes } from '../components/edgeModeMenu'
+import { hasPendingScene3DCameraMoveCapture, hasPendingScene3DStagingCapture } from '../components/scene3dCaptureHostActivation'
+import { isImageLikeGenerationNodeKind } from '../model/generationNodeKinds'
+import { CanvasEmptyState } from '../components/CanvasEmptyState'
+import CanvasToolbar from '../components/CanvasToolbar'
+import {
+  BROWSER_ASSET_DRAG_MIME,
+  LEGACY_BROWSER_ASSET_DRAG_MIME,
+  handleCanvasStageDrop,
+  importBrowserAssetsToGenerationCanvas,
+} from '../components/canvasStageDrop'
+import {
+  canvasViewportFromFlow,
+  collectFlowPositionChanges,
+  flowViewportFromCanvas,
+  toGenerationFlowEdges,
+  toGenerationFlowNodes,
+  type GenerationFlowEdge,
+  type GenerationFlowNode,
+} from './generationCanvasReactFlowAdapter'
+import { GenerationFlowNodeScope } from './generationFlowNodeContext'
+
+const StagingCaptureHost = lazyWithChunkBoundary('3D 站位捕获', () =>
+  import('../nodes/scene3d/StagingCaptureHost').then((module) => ({ default: module.StagingCaptureHost })),
+)
+const CameraMoveCaptureHost = lazyWithChunkBoundary('3D 运镜捕获', () =>
+  import('../nodes/scene3d/CameraMoveCaptureHost').then((module) => ({ default: module.CameraMoveCaptureHost })),
+)
+const BatchPlanOverlay = lazyWithChunkBoundary('批量生成面板', () =>
+  import('../components/BatchPlanOverlay').then((module) => ({ default: module.BatchPlanOverlay })),
+)
+
+type GenerationCanvasReactFlowProps = { readOnly?: boolean }
+
+function GenerationFlowNodeView({ data, selected }: NodeProps<GenerationFlowNode>): JSX.Element {
+  const node = data.generationNode
+  const NodeComponent = getGenerationNodeComponent(node.kind)
+  const size = resolveNodeVisualSize(node)
+  const bounds = getNodeSizeBounds(node.kind)
+  const updateNode = useGenerationCanvasStore((state) => state.updateNode)
+  const captureHistory = useGenerationCanvasStore((state) => state.captureHistory)
+  const commitPersistedChange = useGenerationCanvasStore((state) => state.commitPersistedChange)
+  return (
+    <div className="generation-canvas-react-flow__node-shell" style={{ width: size.width, height: size.height }}>
+      <NodeResizer
+        isVisible={selected && !data.readOnly}
+        minWidth={bounds.minWidth}
+        minHeight={bounds.minHeight}
+        maxWidth={bounds.maxWidth}
+        maxHeight={bounds.maxHeight}
+        color="var(--nomi-accent)"
+        onResizeStart={() => captureHistory()}
+        onResize={(_event, params) => {
+          updateNode(node.id, {
+            position: { x: params.x, y: params.y },
+            size: { width: params.width, height: params.height },
+            meta: { ...(node.meta || {}), userResized: true, previewHeight: params.height },
+          }, { persist: false, emit: false, history: false })
+        }}
+        onResizeEnd={() => {
+          const latest = useGenerationCanvasStore.getState().nodes.find((candidate) => candidate.id === node.id)
+          if (latest) {
+            emitCanvasGesture([{
+              type: 'canvas.node.updated',
+              payload: {
+                nodeId: node.id,
+                patch: { position: latest.position, size: latest.size, meta: latest.meta },
+              },
+            }])
+          }
+          commitPersistedChange()
+        }}
+      />
+      <Handle id="target-left" type="target" position={Position.Left} className="generation-canvas-react-flow__handle" />
+      <Handle id="target-right" type="target" position={Position.Right} className="generation-canvas-react-flow__handle" />
+      <GenerationFlowNodeScope>
+        <NodeComponent node={node} selected={selected} readOnly={data.readOnly} />
+      </GenerationFlowNodeScope>
+      <Handle id="source-left" type="source" position={Position.Left} className="generation-canvas-react-flow__handle" />
+      <Handle id="source-right" type="source" position={Position.Right} className="generation-canvas-react-flow__handle" />
+    </div>
+  )
+}
+
+function GenerationFlowEdgeView({ id, sourceX, sourceY, targetX, targetY, sourcePosition, targetPosition, data, selected }: EdgeProps<GenerationFlowEdge>): JSX.Element {
+  const { t } = useTranslation()
+  const [path, labelX, labelY] = getBezierPath({ sourceX, sourceY, targetX, targetY, sourcePosition, targetPosition })
+  const edge = data?.generationEdge
+  const [menuOpen, setMenuOpen] = React.useState(false)
+  const updateEdgeMode = useGenerationCanvasStore((state) => state.updateEdgeMode)
+  const disconnectEdge = useGenerationCanvasStore((state) => state.disconnectEdge)
+  const nodes = useGenerationCanvasStore((state) => state.nodes)
+  const source = edge ? nodes.find((node) => node.id === edge.source) : undefined
+  const target = edge ? nodes.find((node) => node.id === edge.target) : undefined
+  const modes = source && target ? availableEdgeModes(source, target) : []
+  return (
+    <>
+      <BaseEdge
+        id={id}
+        path={path}
+        interactionWidth={30}
+        className={cn(selected ? 'generation-canvas-react-flow__edge--selected' : undefined)}
+      />
+      {edge?.mode && edge.mode !== 'reference' ? (
+        <EdgeLabelRenderer>
+          <div
+            className="generation-canvas-react-flow__edge-label"
+            style={{ transform: `translate(-50%, -50%) translate(${labelX}px, ${labelY}px)` }}
+          >
+            <button
+              type="button"
+              className="generation-canvas-react-flow__edge-label-button"
+              aria-haspopup="menu"
+              aria-expanded={selected && menuOpen}
+              onPointerDown={(event) => event.stopPropagation()}
+              onClick={(event) => {
+                event.stopPropagation()
+                if (selected) setMenuOpen((open) => !open)
+              }}
+            >
+              {t(`generationCommon.canvas.edge.modes.${edge.mode}`)}
+            </button>
+            {selected && menuOpen ? (
+              <div className="generation-canvas-react-flow__edge-menu" role="menu">
+                {modes.map((mode) => (
+                  <button
+                    key={mode}
+                    type="button"
+                    role="menuitemradio"
+                    aria-checked={mode === edge.mode}
+                    onClick={(event) => {
+                      event.stopPropagation()
+                      updateEdgeMode(edge.id, mode)
+                      setMenuOpen(false)
+                    }}
+                  >
+                    {t(`generationCommon.canvas.edge.modes.${mode}`)}
+                  </button>
+                ))}
+                <button
+                  type="button"
+                  className="generation-canvas-react-flow__edge-menu-delete"
+                  onClick={(event) => {
+                    event.stopPropagation()
+                    disconnectEdge(edge.id)
+                    setMenuOpen(false)
+                  }}
+                >
+                  {t('generationCommon.canvas.edge.disconnectAction')}
+                </button>
+              </div>
+            ) : null}
+          </div>
+        </EdgeLabelRenderer>
+      ) : null}
+    </>
+  )
+}
+
+const nodeTypes = { generation: GenerationFlowNodeView }
+const edgeTypes = { generation: GenerationFlowEdgeView }
+
+function GenerationCanvasReactFlowInner({ readOnly = false }: GenerationCanvasReactFlowProps): JSX.Element {
+  const { t } = useTranslation()
+  const flow = useReactFlow<GenerationFlowNode, GenerationFlowEdge>()
+  const hostRef = React.useRef<HTMLDivElement>(null)
+  const didMountSelectionRef = React.useRef(false)
+  const draggingRef = React.useRef(false)
+  const connectionStartRef = React.useRef<{ nodeId: string; side: 'left' | 'right' } | null>(null)
+  const pendingFocusNodeRef = React.useRef<string | null>(null)
+  const [selectedEdgeId, setSelectedEdgeId] = React.useState<string | null>(null)
+  const [stageSize, setStageSize] = React.useState({ width: 0, height: 0 })
+  const [minimapVisible, setMinimapVisible] = React.useState(true)
+  const [contextNodeMenu, setContextNodeMenu] = React.useState<{
+    stageX: number
+    stageY: number
+    canvasX: number
+    canvasY: number
+    nodeId: string | null
+  } | null>(null)
+  const [connectionCreateMenu, setConnectionCreateMenu] = React.useState<{
+    sourceNodeId: string
+    sourceSide: 'left' | 'right'
+    stageX: number
+    stageY: number
+    canvasX: number
+    canvasY: number
+  } | null>(null)
+  const activeCategoryId = useWorkbenchStore((state) => state.activeCategoryId)
+  const setActiveCategoryId = useWorkbenchStore((state) => state.setActiveCategoryId)
+  const categoryViewports = useWorkbenchStore((state) => state.categoryViewports)
+  const rememberCategoryViewport = useWorkbenchStore((state) => state.rememberCategoryViewport)
+  const timelineCollapsed = useWorkbenchStore((state) => state.timelinePanelCollapsed)
+  const allNodes = useGenerationCanvasStore((state) => state.nodes)
+  const allEdges = useGenerationCanvasStore((state) => state.edges)
+  const groups = useGenerationCanvasStore((state) => state.groups)
+  const hasPendingStagingCapture = useGenerationCanvasStore((state) => hasPendingScene3DStagingCapture(state.nodes))
+  const hasPendingCameraMoveCapture = useGenerationCanvasStore((state) => hasPendingScene3DCameraMoveCapture(state.nodes))
+  const hasBatchPlanPreview = useBatchPlanPreviewStore((state) => Boolean(state.plan))
+  const selectedNodeIds = useGenerationCanvasStore((state) => state.selectedNodeIds)
+  const isReady = useGenerationCanvasStore((state) => state.isReady)
+  const markReady = useGenerationCanvasStore((state) => state.markReady)
+  const selectNodes = useGenerationCanvasStore((state) => state.selectNodes)
+  const selectNode = useGenerationCanvasStore((state) => state.selectNode)
+  const addNode = useGenerationCanvasStore((state) => state.addNode)
+  const clearSelection = useGenerationCanvasStore((state) => state.clearSelection)
+  const moveNode = useGenerationCanvasStore((state) => state.moveNode)
+  const captureHistory = useGenerationCanvasStore((state) => state.captureHistory)
+  const commitPersistedChange = useGenerationCanvasStore((state) => state.commitPersistedChange)
+  const startConnection = useGenerationCanvasStore((state) => state.startConnection)
+  const connectToNode = useGenerationCanvasStore((state) => state.connectToNode)
+  const pendingConnectionSourceId = useGenerationCanvasStore((state) => state.pendingConnectionSourceId)
+  const pendingConnectionSourceSide = useGenerationCanvasStore((state) => state.pendingConnectionSourceSide)
+  const moveGroupNodes = useGenerationCanvasStore((state) => state.moveGroupNodes)
+  const moveSelectedNodes = useGenerationCanvasStore((state) => state.moveSelectedNodes)
+  const cancelConnection = useGenerationCanvasStore((state) => state.cancelConnection)
+  const deleteSelectedNodes = useGenerationCanvasStore((state) => state.deleteSelectedNodes)
+  const disconnectEdge = useGenerationCanvasStore((state) => state.disconnectEdge)
+  const copySelectedNodes = useGenerationCanvasStore((state) => state.copySelectedNodes)
+  const cutSelectedNodes = useGenerationCanvasStore((state) => state.cutSelectedNodes)
+  const pasteNodes = useGenerationCanvasStore((state) => state.pasteNodes)
+  const undo = useGenerationCanvasStore((state) => state.undo)
+  const redo = useGenerationCanvasStore((state) => state.redo)
+
+  const nodes = React.useMemo(
+    () => allNodes.filter((node) => (node.categoryId || 'shots') === activeCategoryId),
+    [activeCategoryId, allNodes],
+  )
+  const visibleNodeIds = React.useMemo(() => new Set(nodes.map((node) => node.id)), [nodes])
+  const edges = React.useMemo(
+    () => allEdges.filter((edge) => visibleNodeIds.has(edge.source) && visibleNodeIds.has(edge.target)),
+    [allEdges, visibleNodeIds],
+  )
+  const visibleGroups = React.useMemo(
+    () => groups.filter((group) => group.categoryId === activeCategoryId),
+    [activeCategoryId, groups],
+  )
+  const selectedSet = React.useMemo(() => new Set(selectedNodeIds), [selectedNodeIds])
+  const nodeById = React.useMemo(() => new Map(nodes.map((node) => [node.id, node])), [nodes])
+  const flowNodes = React.useMemo(
+    () => toGenerationFlowNodes(nodes, selectedSet, readOnly),
+    [nodes, readOnly, selectedSet],
+  )
+  const flowEdges = React.useMemo(
+    () => toGenerationFlowEdges(edges, nodeById).map((edge) => ({ ...edge, selected: edge.id === selectedEdgeId })),
+    [edges, nodeById, selectedEdgeId],
+  )
+  const groupBoxes = React.useMemo(() => getCanvasGroupBoxes(visibleGroups, nodes), [nodes, visibleGroups])
+  const selectedGroupIds = React.useMemo(() => {
+    return visibleGroups
+      .filter((group) => {
+        const memberIds = group.nodeIds.filter((nodeId) => nodeById.has(nodeId))
+        return memberIds.length > 0 && memberIds.every((nodeId) => selectedSet.has(nodeId))
+      })
+      .map((group) => group.id)
+  }, [nodeById, selectedSet, visibleGroups])
+  const selectedBounds = React.useMemo(() => getSelectedBounds(nodes, selectedNodeIds), [nodes, selectedNodeIds])
+  const viewport = React.useMemo(
+    () => flowViewportFromCanvas(categoryViewports[activeCategoryId] || { zoom: 1, offset: { x: 0, y: 0 } }),
+    [activeCategoryId, categoryViewports],
+  )
+  const zoomRef = React.useRef(viewport.zoom)
+  const offsetRef = React.useRef({ x: viewport.x, y: viewport.y })
+  zoomRef.current = viewport.zoom
+  offsetRef.current = { x: viewport.x, y: viewport.y }
+
+  React.useEffect(() => {
+    const handleFocusNode = (event: Event) => {
+      const nodeId = (event as CustomEvent<{ nodeId?: unknown }>).detail?.nodeId
+      if (typeof nodeId !== 'string' || !nodeId) return
+      const target = allNodes.find((node) => node.id === nodeId)
+      if (!target) {
+        toast(t('generationCommon.node.sourceNoLongerExists'), 'warning')
+        return
+      }
+      pendingFocusNodeRef.current = nodeId
+      setActiveCategoryId(target.categoryId || 'shots')
+      selectNode(nodeId)
+    }
+    window.addEventListener(FOCUS_GENERATION_NODE_EVENT, handleFocusNode)
+    return () => window.removeEventListener(FOCUS_GENERATION_NODE_EVENT, handleFocusNode)
+  }, [allNodes, selectNode, setActiveCategoryId, t])
+
+  React.useEffect(() => {
+    const nodeId = pendingFocusNodeRef.current
+    if (!nodeId) return
+    const target = nodes.find((node) => node.id === nodeId)
+    if (!target) return
+    const size = resolveNodeVisualSize(target)
+    pendingFocusNodeRef.current = null
+    void flow.setCenter(target.position.x + size.width / 2, target.position.y + size.height / 2, {
+      zoom: zoomRef.current,
+      duration: 220,
+    })
+  }, [activeCategoryId, flow, nodes, zoomRef])
+
+  React.useEffect(() => {
+    const host = hostRef.current
+    if (!host) return undefined
+    const updateSize = () => {
+      const rect = host.getBoundingClientRect()
+      setStageSize({ width: rect.width, height: rect.height })
+    }
+    updateSize()
+    const observer = typeof ResizeObserver === 'undefined' ? null : new ResizeObserver(updateSize)
+    observer?.observe(host)
+    return () => observer?.disconnect()
+  }, [])
+
+  React.useEffect(() => {
+    markReady()
+  }, [markReady])
+
+  const { handleGroupFramePointerDown } = useCanvasSelectionDrag({
+    readOnly,
+    selectedNodeCount: selectedNodeIds.length,
+    zoomRef,
+    captureHistory,
+    commitPersistedChange,
+    moveGroupNodes,
+    moveSelectedNodes,
+    selectNodes,
+  })
+  const {
+    handleGroupSelectedNodes,
+    handleUngroupSelectedNodes,
+    handleConnectToGroup,
+    contactSheetCount,
+    handleBuildContactSheet,
+  } = useCanvasGroupActions({
+    activeCategoryId,
+    selectedGroupIds,
+    selectedNodeIds,
+  })
+
+  const getInsertionPosition = React.useCallback(() => {
+    const rect = hostRef.current?.getBoundingClientRect()
+    if (!rect) return { x: 240, y: 240 }
+    return flow.screenToFlowPosition({ x: rect.left + rect.width * 0.4, y: rect.top + rect.height * 0.3 })
+  }, [flow])
+  const fitView = React.useCallback((animate = false) => {
+    if (!nodes.length) return
+    void flow.fitView({ padding: 0.12, duration: animate ? 200 : 0, minZoom: 0.2, maxZoom: 3 })
+  }, [flow, nodes.length])
+  const zoomTo = React.useCallback((nextZoom: number) => {
+    void flow.zoomTo(Math.min(3, Math.max(0.2, nextZoom)), { duration: 120 })
+  }, [flow])
+  const handleMinimapJump = React.useCallback((point: { x: number; y: number }) => {
+    void flow.setCenter(point.x, point.y, { zoom: zoomRef.current, duration: 0 })
+  }, [flow, zoomRef])
+  const getCanvasPointFromClientPoint = React.useCallback((clientX: number, clientY: number) => {
+    return flow.screenToFlowPosition({ x: clientX, y: clientY })
+  }, [flow])
+
+  useAutoFitOnLoad({
+    nodes,
+    selectedNodeIds,
+    activeCategoryId,
+    categoryViewports,
+    fitView,
+    stageRef: hostRef,
+    zoomRef,
+    offsetRef,
+  })
+  useCanvasFitSignal(fitView)
+  const { isTidying, tidy } = useTidyCanvas(activeCategoryId)
+  const production = useCanvasProductionActions({ activeCategoryId, selectedNodeIds })
+  const batchDock = useCanvasBatchDockVisibility({
+    readOnly,
+    selectedCount: selectedNodeIds.length,
+    eligibleIds: production.eligibleIds,
+  })
+  const { screenshotOverlay } = useCanvasScreenshotCapture({
+    readOnly,
+    getInsertPosition: getInsertionPosition,
+    categoryId: activeCategoryId,
+  })
+  const handleBrowserAssetsImportToCanvas = React.useCallback((assets: readonly BrowserAssetCanvasImportItem[]) => {
+    if (readOnly) return
+    const result = importBrowserAssetsToGenerationCanvas(assets, {
+      basePosition: getInsertionPosition(),
+      categoryId: activeCategoryId,
+    })
+    if (result.createdCount === 0) {
+      toast(t('generationCommon.canvas.noImportableAssets'), 'info')
+      return
+    }
+    toast(
+      result.createdCount === 1
+        ? t('generationCommon.canvas.importedOne')
+        : t('generationCommon.canvas.importedMany', { count: result.createdCount }),
+      'success',
+    )
+  }, [activeCategoryId, getInsertionPosition, readOnly, t])
+
+  React.useEffect(
+    () => subscribeBrowserAssetsImportToCanvas((assets) => handleBrowserAssetsImportToCanvas(assets)),
+    [handleBrowserAssetsImportToCanvas],
+  )
+
+  React.useEffect(() => {
+    const bridge = getDesktopBridge()?.browser?.assetOverlay
+    if (!bridge?.onImportToCanvas) return undefined
+    return bridge.onImportToCanvas((payload) => {
+      const assets = Array.isArray(payload?.assets) ? payload.assets as BrowserAssetCanvasImportItem[] : []
+      handleBrowserAssetsImportToCanvas(assets)
+    })
+  }, [handleBrowserAssetsImportToCanvas])
+
+  const handleZoomByStep = React.useCallback((direction: -1 | 1) => {
+    const current = flow.getViewport().zoom
+    zoomTo(current * (direction > 0 ? 1.1 : 1 / 1.1))
+  }, [flow, zoomTo])
+
+  const createContextMenu = React.useCallback((event: MouseEvent | React.MouseEvent, nodeId: string | null) => {
+    if (readOnly) return
+    event.preventDefault()
+    event.stopPropagation()
+    const rect = hostRef.current?.getBoundingClientRect()
+    if (!rect) return
+    const stageX = event.clientX - rect.left
+    const stageY = event.clientY - rect.top
+    const point = getCanvasPointFromClientPoint(event.clientX, event.clientY)
+    setContextNodeMenu({
+      nodeId,
+      stageX: Math.max(8, Math.min(rect.width - 156, stageX)),
+      stageY: Math.max(8, Math.min(rect.height - (nodeId ? 210 : 340), stageY)),
+      canvasX: Math.round(point.x),
+      canvasY: Math.round(point.y),
+    })
+  }, [getCanvasPointFromClientPoint, readOnly])
+
+  const handleNodeContextMenu = React.useCallback((event: React.MouseEvent, node: GenerationFlowNode) => {
+    if (readOnly) return
+    if (!selectedSet.has(node.id)) selectNode(node.id)
+    createContextMenu(event, node.id)
+  }, [createContextMenu, readOnly, selectNode, selectedSet])
+
+  const handlePaneContextMenu = React.useCallback((event: MouseEvent | React.MouseEvent) => {
+    if (readOnly) return
+    clearSelection()
+    createContextMenu(event, null)
+  }, [clearSelection, createContextMenu, readOnly])
+
+  React.useEffect(() => {
+    if (!contextNodeMenu && !connectionCreateMenu) return undefined
+    const closeMenus = () => {
+      setContextNodeMenu(null)
+      setConnectionCreateMenu(null)
+      cancelConnection()
+    }
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') closeMenus()
+    }
+    window.addEventListener('pointerdown', closeMenus)
+    window.addEventListener('keydown', handleKeyDown)
+    return () => {
+      window.removeEventListener('pointerdown', closeMenus)
+      window.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [cancelConnection, connectionCreateMenu, contextNodeMenu])
+
+  const { handleAddContextNode, handleNodeContextAction, handleAddConnectedNode } = buildCanvasMenuActions({
+    activeCategoryId,
+    contextNodeMenu,
+    setContextNodeMenu,
+    connectionCreateMenu,
+    setConnectionCreateMenu,
+    addNode,
+    startConnection,
+    copySelectedNodes,
+    cutSelectedNodes,
+    pasteNodes,
+    groupSelectedNodes: handleGroupSelectedNodes,
+    deleteSelectedNodes,
+  })
+
+  const handleNodesChange: OnNodesChange<GenerationFlowNode> = React.useCallback((changes) => {
+    for (const change of collectFlowPositionChanges(changes)) {
+      moveNode(change.nodeId, change.position, { persist: false, emit: false })
+    }
+  }, [moveNode])
+
+  const handleSelectionChange = React.useCallback(({ nodes: nextNodes, edges: nextEdges }: { nodes: GenerationFlowNode[]; edges: GenerationFlowEdge[] }) => {
+    if (!didMountSelectionRef.current) {
+      didMountSelectionRef.current = true
+      return
+    }
+    selectNodes(nextNodes.map((node) => node.id))
+    setSelectedEdgeId(nextEdges[0]?.id ?? null)
+  }, [selectNodes])
+
+  const handleEdgeClick = React.useCallback((_event: React.MouseEvent, edge: GenerationFlowEdge) => {
+    setSelectedEdgeId(edge.id)
+  }, [])
+
+  const handleEdgesDelete: OnEdgesDelete<GenerationFlowEdge> = React.useCallback((deletedEdges) => {
+    if (readOnly) return
+    for (const edge of deletedEdges) disconnectEdge(edge.id)
+    setSelectedEdgeId(null)
+  }, [disconnectEdge, readOnly])
+
+  const deleteActiveEdge = React.useCallback(() => {
+    if (readOnly || !selectedEdgeId) return
+    disconnectEdge(selectedEdgeId)
+    setSelectedEdgeId(null)
+  }, [disconnectEdge, readOnly, selectedEdgeId])
+
+  const handleNodeDragStart = React.useCallback(() => {
+    if (readOnly) return
+    draggingRef.current = true
+    captureHistory()
+  }, [captureHistory, readOnly])
+
+  const handleNodeDragStop: OnNodeDrag<GenerationFlowNode> = React.useCallback((_event, _node, draggedNodes) => {
+    if (readOnly || !draggingRef.current) return
+    draggingRef.current = false
+    const state = useGenerationCanvasStore.getState()
+    const movedEvents = draggedNodes
+      .map((flowNode) => state.nodes.find((node) => node.id === flowNode.id))
+      .filter((node): node is GenerationCanvasNode => Boolean(node))
+      .map((node) => ({ type: 'canvas.node.moved' as const, payload: { nodeId: node.id, position: node.position } }))
+    if (movedEvents.length) emitCanvasGesture(movedEvents)
+    commitPersistedChange()
+  }, [commitPersistedChange, readOnly])
+
+  const handleConnect = React.useCallback((connection: { source: string | null; target: string | null; sourceHandle?: string | null }) => {
+    if (readOnly || !connection.source || !connection.target) return
+    const side = connection.sourceHandle === 'source-left' ? 'left' : 'right'
+    startConnection(connection.source, side)
+    connectToNode(connection.target)
+  }, [connectToNode, readOnly, startConnection])
+
+  const handleConnectStart: OnConnectStart = React.useCallback((_event, params) => {
+    if (readOnly || !params.nodeId || params.handleType !== 'source') return
+    const side = params.handleId === 'source-left' ? 'left' : 'right'
+    connectionStartRef.current = { nodeId: params.nodeId, side }
+    startConnection(params.nodeId, side)
+  }, [readOnly, startConnection])
+
+  const handleConnectEnd: OnConnectEnd = React.useCallback((event, connectionState) => {
+    const started = connectionStartRef.current
+    connectionStartRef.current = null
+    if (readOnly || !started || connectionState.toNode) return
+    const sourceNode = nodeById.get(started.nodeId)
+    const canCreateMedia = sourceNode?.kind === 'text' || sourceNode?.kind === 'image' || Boolean(sourceNode && isImageLikeGenerationNodeKind(sourceNode.kind))
+    if (!canCreateMedia) {
+      cancelConnection()
+      return
+    }
+    const point = 'changedTouches' in event
+      ? event.changedTouches[0]
+      : event
+    if (!point) {
+      cancelConnection()
+      return
+    }
+    const rect = hostRef.current?.getBoundingClientRect()
+    if (!rect) {
+      cancelConnection()
+      return
+    }
+    const stageX = point.clientX - rect.left
+    const stageY = point.clientY - rect.top
+    const canvasPoint = getCanvasPointFromClientPoint(point.clientX, point.clientY)
+    setConnectionCreateMenu({
+      sourceNodeId: started.nodeId,
+      sourceSide: started.side,
+      stageX: Math.max(8, Math.min(rect.width - 140, stageX)),
+      stageY: Math.max(8, Math.min(rect.height - 90, stageY)),
+      canvasX: Math.round(canvasPoint.x),
+      canvasY: Math.round(canvasPoint.y),
+    })
+  }, [cancelConnection, getCanvasPointFromClientPoint, nodeById, readOnly])
+
+  const handlePaneClick = React.useCallback(() => {
+    if (!readOnly) clearSelection()
+  }, [clearSelection, readOnly])
+
+  useCanvasShortcuts({
+    readOnly,
+    stageRef: hostRef,
+    selectedNodeCount: selectedNodeIds.length,
+    selectedGroupCount: selectedGroupIds.length,
+    activeCategoryId,
+    setActiveEdge: () => setSelectedEdgeId(null),
+    deleteActiveEdge,
+    cancelConnection,
+    deleteSelectedNodes,
+    groupSelectedNodes: handleGroupSelectedNodes,
+    ungroupSelectedNodes: handleUngroupSelectedNodes,
+    copySelectedNodes,
+    cutSelectedNodes,
+    pasteNodes,
+    getPastePosition: getInsertionPosition,
+    zoomByStep: handleZoomByStep,
+    undo,
+    redo,
+  })
+
+  const handleDragOver = React.useCallback((event: React.DragEvent<HTMLDivElement>) => {
+    if (readOnly) return
+    const types = Array.from(event.dataTransfer.types)
+    if (
+      types.includes('Files') ||
+      types.includes(WORKSPACE_FILE_DRAG_MIME) ||
+      types.includes(ASSET_LIBRARY_DRAG_MIME) ||
+      types.includes(BROWSER_ASSET_DRAG_MIME) ||
+      types.includes(LEGACY_BROWSER_ASSET_DRAG_MIME)
+    ) {
+      event.preventDefault()
+      event.dataTransfer.dropEffect = 'copy'
+    }
+  }, [readOnly])
+
+  const handleDrop = React.useCallback((event: React.DragEvent<HTMLDivElement>) => {
+    handleCanvasStageDrop(event, {
+      readOnly,
+      offset: { x: viewport.x, y: viewport.y },
+      zoom: viewport.zoom,
+      activeCategoryId,
+    })
+  }, [activeCategoryId, readOnly, viewport.x, viewport.y, viewport.zoom])
+
+  return (
+    <section
+      ref={hostRef}
+      className={cn('generation-canvas-react-flow', 'relative w-full h-full min-w-0 min-h-0 bg-workbench-bg text-workbench-ink')}
+      aria-label={t('generationCommon.canvas.aria')}
+      data-ready={isReady ? 'true' : undefined}
+      data-tidying={isTidying ? 'true' : undefined}
+      data-nomi-generation-canvas-import-target={!readOnly ? 'true' : undefined}
+      onDragOver={handleDragOver}
+      onDrop={handleDrop}
+    >
+      {hasPendingStagingCapture || hasPendingCameraMoveCapture ? (
+        <React.Suspense fallback={null}>
+          {hasPendingStagingCapture ? <StagingCaptureHost /> : null}
+          {hasPendingCameraMoveCapture ? <CameraMoveCaptureHost /> : null}
+        </React.Suspense>
+      ) : null}
+      {!readOnly ? <CanvasToolbar getInsertionPosition={getInsertionPosition} categoryId={activeCategoryId} /> : null}
+      <ReactFlow
+        nodes={flowNodes}
+        edges={flowEdges}
+        nodeTypes={nodeTypes}
+        edgeTypes={edgeTypes}
+        viewport={viewport}
+        nodesDraggable={!readOnly}
+        nodesConnectable={!readOnly}
+        elementsSelectable
+        panOnDrag={[1, 2]}
+        selectionOnDrag
+        deleteKeyCode={null}
+        fitView={false}
+        onNodesChange={handleNodesChange}
+        onNodeDragStart={handleNodeDragStart}
+        onNodeDragStop={handleNodeDragStop}
+        onSelectionChange={handleSelectionChange}
+        onEdgeClick={handleEdgeClick}
+        onEdgesDelete={handleEdgesDelete}
+        onNodeContextMenu={handleNodeContextMenu}
+        onPaneContextMenu={handlePaneContextMenu}
+        onPaneClick={handlePaneClick}
+        onConnect={handleConnect}
+        onConnectStart={handleConnectStart}
+        onConnectEnd={handleConnectEnd}
+        onMoveEnd={(_event, nextViewport) => rememberCategoryViewport(activeCategoryId, canvasViewportFromFlow(nextViewport))}
+        proOptions={{ hideAttribution: true }}
+      >
+        <ViewportPortal>
+          <GroupFrameList
+            boxes={groupBoxes}
+            onPointerDown={handleGroupFramePointerDown}
+            pendingConnection={Boolean(pendingConnectionSourceId)}
+            pendingConnectionSide={pendingConnectionSourceSide}
+            onConnectToGroup={handleConnectToGroup}
+          />
+        </ViewportPortal>
+        <ViewportPortal>
+          {selectedBounds && selectedNodeIds.length > 1 && !readOnly ? (
+            <CanvasSelectionToolbar
+              selectedCount={selectedNodeIds.length}
+              selectedGroupCount={selectedGroupIds.length}
+              transform={`translate(${Math.round(selectedBounds.minX + selectedBounds.width / 2)}px, ${Math.round(selectedBounds.minY - 16 - 58)}px) translateX(-50%)`}
+              eligibleCount={production.eligibleIds.length}
+              executionGroups={production.executionGroups}
+              concurrency={production.concurrency}
+              contactSheetCount={contactSheetCount}
+              onConcurrencyChange={production.setConcurrency}
+              onGenerate={production.generate}
+              onApplyModel={production.applyModel}
+              onGroupSelectedNodes={handleGroupSelectedNodes}
+              onUngroupSelectedNodes={handleUngroupSelectedNodes}
+              onBuildContactSheet={handleBuildContactSheet}
+              onClearSelection={clearSelection}
+            />
+          ) : null}
+        </ViewportPortal>
+      </ReactFlow>
+      {screenshotOverlay}
+      {nodes.length === 0 ? (
+        <CanvasEmptyState
+          activeCategoryId={activeCategoryId}
+          onCreate={() => useGenerationCanvasStore.getState().addNode({ kind: 'image', position: { x: 240, y: 240 }, categoryId: activeCategoryId, select: true })}
+        />
+      ) : null}
+      {contextNodeMenu?.nodeId ? (
+        <NodeContextMenu
+          className="generation-canvas-react-flow__node-context-menu z-[20]"
+          style={{ left: contextNodeMenu.stageX, top: contextNodeMenu.stageY }}
+          canPaste={hasClipboardContent()}
+          canGroup={selectedNodeIds.length >= 2}
+          onPointerDown={(event) => event.stopPropagation()}
+          onContextMenu={(event) => event.preventDefault()}
+          onAction={handleNodeContextAction}
+        />
+      ) : contextNodeMenu ? (
+        <NodeAddMenu
+          className="generation-canvas-react-flow__context-node-menu z-[20]"
+          style={{ left: contextNodeMenu.stageX, top: contextNodeMenu.stageY }}
+          onPointerDown={(event) => event.stopPropagation()}
+          onContextMenu={(event) => event.preventDefault()}
+          onAddNode={handleAddContextNode}
+        />
+      ) : null}
+      {connectionCreateMenu ? (
+        <NodeAddMenu
+          className="generation-canvas-react-flow__connection-create-menu z-[20] left-auto w-[132px]"
+          style={{ left: connectionCreateMenu.stageX, top: connectionCreateMenu.stageY }}
+          kinds={['image', 'video']}
+          onPointerDown={(event) => event.stopPropagation()}
+          onContextMenu={(event) => event.preventDefault()}
+          onAddNode={handleAddConnectedNode}
+        />
+      ) : null}
+      {batchDock.visible ? (
+        <CanvasBatchGenerateDock
+          {...production}
+          timelineCollapsed={timelineCollapsed}
+          onDismiss={batchDock.dismiss}
+        />
+      ) : null}
+      <CanvasNavigationStack
+        readOnly={readOnly}
+        nodes={nodes}
+        selectedIds={selectedSet}
+        zoom={viewport.zoom}
+        zoomPercent={Math.round(viewport.zoom * 100)}
+        offset={{ x: viewport.x, y: viewport.y }}
+        stageSize={stageSize}
+        minimapVisible={minimapVisible}
+        onToggleMinimap={() => setMinimapVisible((visible) => !visible)}
+        onJumpToCanvasPoint={handleMinimapJump}
+        onFitView={() => fitView(true)}
+        onResetView={() => void flow.setViewport({ x: 0, y: 0, zoom: 1 }, { duration: 200 })}
+        onTidy={() => tidy(stageSize.width / Math.max(1, stageSize.height))}
+        onZoomTo={zoomTo}
+        batchPlanOverlay={
+          hasBatchPlanPreview ? (
+            <React.Suspense fallback={null}>
+              <BatchPlanOverlay />
+            </React.Suspense>
+          ) : null
+        }
+      />
+      <SelectionPromptSaveController nodes={allNodes} disabled={readOnly} />
+    </section>
+  )
+}
+
+export default function GenerationCanvasReactFlow(props: GenerationCanvasReactFlowProps): JSX.Element {
+  return (
+    <ReactFlowProvider>
+      <GenerationCanvasReactFlowInner {...props} />
+    </ReactFlowProvider>
+  )
+}

--- a/src/workbench/generationCanvas/reactFlow/generationCanvasEngineFlag.test.ts
+++ b/src/workbench/generationCanvas/reactFlow/generationCanvasEngineFlag.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { isReactFlowCanvasEnabled } from './generationCanvasEngineFlag'
+
+describe('isReactFlowCanvasEnabled', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.unstubAllEnvs()
+  })
+
+  it('is enabled by default in a non-browser environment', () => {
+    expect(isReactFlowCanvasEnabled()).toBe(true)
+  })
+
+  it('enables the renderer from the Vite environment flag', () => {
+    vi.stubEnv('VITE_GENERATION_CANVAS_ENGINE', 'react-flow')
+    expect(isReactFlowCanvasEnabled()).toBe(true)
+  })
+
+  it('supports the localStorage override without requiring a real DOM', () => {
+    vi.stubGlobal('window', {
+      localStorage: { getItem: vi.fn(() => 'react-flow') },
+    })
+    expect(isReactFlowCanvasEnabled()).toBe(true)
+  })
+
+  it('falls back to React Flow when localStorage is unavailable or throws', () => {
+    vi.stubGlobal('window', {
+      localStorage: { getItem: vi.fn(() => { throw new Error('blocked') }) },
+    })
+    expect(isReactFlowCanvasEnabled()).toBe(true)
+  })
+
+  it('allows an explicit legacy fallback', () => {
+    vi.stubGlobal('window', {
+      localStorage: { getItem: vi.fn(() => 'legacy') },
+    })
+    expect(isReactFlowCanvasEnabled()).toBe(false)
+  })
+})

--- a/src/workbench/generationCanvas/reactFlow/generationCanvasEngineFlag.ts
+++ b/src/workbench/generationCanvas/reactFlow/generationCanvasEngineFlag.ts
@@ -1,0 +1,16 @@
+/**
+ * React Flow is the production renderer. The legacy canvas remains available
+ * as an explicit emergency fallback while downstream projects migrate.
+ */
+export function isReactFlowCanvasEnabled(): boolean {
+  const meta = import.meta as unknown as { env?: Record<string, string | undefined> }
+  if (meta.env?.VITE_GENERATION_CANVAS_ENGINE === 'legacy') return false
+  if (meta.env?.VITE_GENERATION_CANVAS_ENGINE === 'react-flow') return true
+
+  if (typeof window === 'undefined') return true
+  try {
+    return window.localStorage.getItem('nomi:canvas-engine') !== 'legacy'
+  } catch {
+    return true
+  }
+}

--- a/src/workbench/generationCanvas/reactFlow/generationCanvasReactFlow.css
+++ b/src/workbench/generationCanvas/reactFlow/generationCanvasReactFlow.css
@@ -1,0 +1,137 @@
+.generation-canvas-react-flow {
+  --xy-node-border-radius: 0;
+}
+
+.generation-canvas-react-flow .react-flow {
+  width: 100%;
+  height: 100%;
+  background: transparent;
+}
+
+.generation-canvas-react-flow .react-flow__node {
+  padding: 0;
+  border: 0;
+  background: transparent;
+  box-shadow: none;
+}
+
+.generation-canvas-react-flow .generation-canvas-react-flow__node-shell {
+  position: relative;
+  min-width: 1px;
+  min-height: 1px;
+}
+
+/* Existing node cards still contain their legacy canvas positioning and handles.
+ * React Flow owns the outer transform and connection ports in this experiment. */
+.generation-canvas-react-flow .generation-canvas-v2-node {
+  position: relative !important;
+  inset: auto !important;
+  transform: none !important;
+  width: 100% !important;
+  height: 100% !important;
+}
+
+.generation-canvas-react-flow .generation-canvas-v2-node__magnetic-handle,
+.generation-canvas-react-flow .generation-canvas-v2-node__handle,
+.generation-canvas-react-flow .generation-canvas-v2-node__resize-zone {
+  display: none !important;
+}
+
+.generation-canvas-react-flow .generation-canvas-react-flow__handle {
+  width: 12px;
+  height: 12px;
+  border: 0;
+  border-radius: 999px;
+  background: var(--nomi-accent);
+  opacity: 0;
+  transition: opacity 120ms ease;
+  z-index: 6;
+}
+
+.generation-canvas-react-flow .generation-canvas-react-flow__node-shell:hover .generation-canvas-react-flow__handle,
+.generation-canvas-react-flow .generation-canvas-react-flow__handle.connecting {
+  opacity: 0.7;
+}
+
+.generation-canvas-react-flow .react-flow__edge-path {
+  stroke: color-mix(in srgb, var(--nomi-accent) 68%, var(--nomi-ink));
+  stroke-width: 1.8;
+}
+
+.generation-canvas-react-flow .generation-canvas-react-flow__edge--selected {
+  stroke: var(--nomi-accent);
+  stroke-width: 2.6;
+}
+
+.generation-canvas-react-flow__edge-label {
+  position: absolute;
+  border: 1px solid var(--workbench-border);
+  border-radius: 999px;
+  background: var(--nomi-paper);
+  color: var(--workbench-muted);
+  font-size: 10px;
+  line-height: 1.2;
+  white-space: nowrap;
+  pointer-events: auto;
+}
+
+.generation-canvas-react-flow__edge-label-button {
+  display: block;
+  padding: 2px 6px;
+  border: 0;
+  border-radius: inherit;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+}
+
+.generation-canvas-react-flow__edge-menu {
+  position: absolute;
+  top: 24px;
+  left: 50%;
+  z-index: 3;
+  display: grid;
+  width: 176px;
+  gap: 2px;
+  padding: 4px;
+  transform: translateX(-50%);
+  border: 1px solid var(--workbench-border);
+  border-radius: 6px;
+  background: var(--nomi-paper);
+  box-shadow: 0 8px 24px rgba(18, 24, 38, 0.12);
+}
+
+.generation-canvas-react-flow__edge-menu button {
+  min-height: 28px;
+  padding: 4px 8px;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--nomi-ink);
+  text-align: left;
+  font: inherit;
+  font-size: 11px;
+  cursor: pointer;
+}
+
+.generation-canvas-react-flow__edge-menu button:hover,
+.generation-canvas-react-flow__edge-menu button[aria-checked='true'] {
+  background: color-mix(in srgb, var(--nomi-accent) 14%, transparent);
+}
+
+.generation-canvas-react-flow__edge-menu .generation-canvas-react-flow__edge-menu-delete {
+  margin-top: 3px;
+  border-top: 1px solid var(--workbench-border);
+  color: var(--workbench-danger);
+}
+
+.generation-canvas-react-flow .react-flow__controls,
+.generation-canvas-react-flow .react-flow__minimap {
+  border: 1px solid var(--workbench-border);
+  box-shadow: 0 8px 24px rgba(18, 24, 38, 0.08);
+}
+
+.generation-canvas-react-flow .react-flow__attribution {
+  display: none;
+}

--- a/src/workbench/generationCanvas/reactFlow/generationCanvasReactFlowAdapter.test.ts
+++ b/src/workbench/generationCanvas/reactFlow/generationCanvasReactFlowAdapter.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest'
+import type { NodeChange } from '@xyflow/react'
+import {
+  FLOW_SOURCE_LEFT,
+  FLOW_SOURCE_RIGHT,
+  FLOW_TARGET_LEFT,
+  FLOW_TARGET_RIGHT,
+  canvasViewportFromFlow,
+  collectFlowPositionChanges,
+  collectFlowSelectionChanges,
+  flowViewportFromCanvas,
+  toGenerationFlowEdges,
+  toGenerationFlowNode,
+  toGenerationFlowNodes,
+} from './generationCanvasReactFlowAdapter'
+import type { GenerationCanvasEdge, GenerationCanvasNode } from '../model/generationCanvasTypes'
+
+function node(id: string, x: number, y = 0): GenerationCanvasNode {
+  return {
+    id,
+    kind: 'image',
+    title: id,
+    position: { x, y },
+    size: { width: 100, height: 80 },
+  }
+}
+
+describe('generation canvas React Flow adapter', () => {
+  it('maps nodes without mutating the domain object', () => {
+    const source = node('source', 10, 20)
+    const mapped = toGenerationFlowNode(source, true, false)
+
+    expect(mapped).toMatchObject({
+      id: 'source',
+      type: 'generation',
+      position: { x: 10, y: 20 },
+      selected: true,
+      draggable: true,
+      connectable: true,
+      data: { generationNode: source, readOnly: false },
+    })
+    expect(mapped.style).toMatchObject({ width: 240, height: 120 })
+    expect(source).toEqual(node('source', 10, 20))
+  })
+
+  it('maps read-only nodes and selected state for a collection', () => {
+    const mapped = toGenerationFlowNodes([node('a', 0), node('b', 200)], new Set(['b']), true)
+    expect(mapped.map((item) => [item.id, item.selected, item.draggable, item.connectable])).toEqual([
+      ['a', false, false, false],
+      ['b', true, false, false],
+    ])
+  })
+
+  it('preserves edge semantics and derives handle direction', () => {
+    const left = node('left', 0)
+    const right = node('right', 300)
+    const edges: GenerationCanvasEdge[] = [
+      { id: 'e1', source: 'left', target: 'right', mode: 'character_ref', order: 2, viaGroupId: 'group-1' },
+      { id: 'e2', source: 'right', target: 'left', mode: 'first_frame', order: 1 },
+    ]
+    const mapped = toGenerationFlowEdges(edges, new Map([left, right].map((item) => [item.id, item])))
+    expect(mapped[0]).toMatchObject({
+      sourceHandle: FLOW_SOURCE_RIGHT,
+      targetHandle: FLOW_TARGET_LEFT,
+      data: { generationEdge: edges[0] },
+    })
+    expect(mapped[1]).toMatchObject({
+      sourceHandle: FLOW_SOURCE_LEFT,
+      targetHandle: FLOW_TARGET_RIGHT,
+      data: { generationEdge: edges[1] },
+    })
+  })
+
+  it('filters dangling edges instead of handing invalid graph data to Flow', () => {
+    const valid = node('valid', 0)
+    const mapped = toGenerationFlowEdges(
+      [
+        { id: 'valid-edge', source: 'valid', target: 'valid' },
+        { id: 'dangling', source: 'valid', target: 'missing' },
+      ],
+      new Map([[valid.id, valid]]),
+    )
+    expect(mapped.map((item) => item.id)).toEqual(['valid-edge'])
+  })
+
+  it('extracts position and selection changes while ignoring unrelated changes', () => {
+    const changes = [
+      { type: 'position', id: 'a', position: { x: 14, y: 22 }, dragging: true },
+      { type: 'select', id: 'b', selected: true },
+      { type: 'dimensions', id: 'a', dimensions: { width: 20, height: 30 } },
+    ] as NodeChange[]
+    expect(collectFlowPositionChanges(changes)).toEqual([{ nodeId: 'a', position: { x: 14, y: 22 } }])
+    expect(collectFlowSelectionChanges(changes)).toEqual([{ nodeId: 'b', selected: true }])
+  })
+
+  it('converts viewport in both directions', () => {
+    const canvas = { zoom: 1.25, offset: { x: -42, y: 18 } }
+    const flow = flowViewportFromCanvas(canvas)
+    expect(flow).toEqual({ x: -42, y: 18, zoom: 1.25 })
+    expect(canvasViewportFromFlow(flow)).toEqual(canvas)
+  })
+})

--- a/src/workbench/generationCanvas/reactFlow/generationCanvasReactFlowAdapter.ts
+++ b/src/workbench/generationCanvas/reactFlow/generationCanvasReactFlowAdapter.ts
@@ -1,0 +1,135 @@
+import type { Edge as FlowEdge, Node as FlowNode, NodeChange, Viewport } from '@xyflow/react'
+import type {
+  GenerationCanvasEdge,
+  GenerationCanvasNode,
+  GenerationNodeKind,
+} from '../model/generationCanvasTypes'
+import { resolveNodeVisualSize } from '../nodes/nodeSizing'
+
+/**
+ * React Flow is a rendering adapter. The persisted canvas model remains the
+ * source of truth and is deliberately kept out of Flow's internal store.
+ */
+export type GenerationFlowNodeData = {
+  generationNode: GenerationCanvasNode
+  readOnly: boolean
+}
+
+export type GenerationFlowNode = FlowNode<GenerationFlowNodeData, 'generation'>
+
+export type GenerationFlowEdgeData = {
+  generationEdge: GenerationCanvasEdge
+}
+
+export type GenerationFlowEdge = FlowEdge<GenerationFlowEdgeData, 'generation'>
+
+export const FLOW_SOURCE_LEFT = 'source-left'
+export const FLOW_SOURCE_RIGHT = 'source-right'
+export const FLOW_TARGET_LEFT = 'target-left'
+export const FLOW_TARGET_RIGHT = 'target-right'
+
+function resolveHandleIds(
+  source: GenerationCanvasNode,
+  target: GenerationCanvasNode,
+): { sourceHandle: string; targetHandle: string } {
+  const sourceSize = resolveNodeVisualSize(source)
+  const targetSize = resolveNodeVisualSize(target)
+  const targetIsLeft = target.position.x + targetSize.width / 2 < source.position.x + sourceSize.width / 2
+  return targetIsLeft
+    ? { sourceHandle: FLOW_SOURCE_LEFT, targetHandle: FLOW_TARGET_RIGHT }
+    : { sourceHandle: FLOW_SOURCE_RIGHT, targetHandle: FLOW_TARGET_LEFT }
+}
+
+export function toGenerationFlowNode(
+  node: GenerationCanvasNode,
+  selected: boolean,
+  readOnly: boolean,
+): GenerationFlowNode {
+  const size = resolveNodeVisualSize(node)
+  return {
+    id: node.id,
+    type: 'generation',
+    position: { ...node.position },
+    data: { generationNode: node, readOnly },
+    selected,
+    draggable: !readOnly,
+    selectable: true,
+    connectable: !readOnly,
+    focusable: true,
+    style: { width: size.width, height: size.height },
+    className: 'generation-canvas-react-flow__node',
+  }
+}
+
+export function toGenerationFlowNodes(
+  nodes: readonly GenerationCanvasNode[],
+  selectedNodeIds: ReadonlySet<string>,
+  readOnly: boolean,
+): GenerationFlowNode[] {
+  return nodes.map((node) => toGenerationFlowNode(node, selectedNodeIds.has(node.id), readOnly))
+}
+
+export function toGenerationFlowEdge(
+  edge: GenerationCanvasEdge,
+  nodeById: ReadonlyMap<string, GenerationCanvasNode>,
+): GenerationFlowEdge {
+  const source = nodeById.get(edge.source)
+  const target = nodeById.get(edge.target)
+  const handles = source && target ? resolveHandleIds(source, target) : {
+    sourceHandle: FLOW_SOURCE_RIGHT,
+    targetHandle: FLOW_TARGET_LEFT,
+  }
+  return {
+    id: edge.id,
+    type: 'generation',
+    source: edge.source,
+    target: edge.target,
+    sourceHandle: handles.sourceHandle,
+    targetHandle: handles.targetHandle,
+    data: { generationEdge: edge },
+    selectable: true,
+    focusable: true,
+    reconnectable: false,
+    interactionWidth: 30,
+    className: 'generation-canvas-react-flow__edge',
+  }
+}
+
+export function toGenerationFlowEdges(
+  edges: readonly GenerationCanvasEdge[],
+  nodeById: ReadonlyMap<string, GenerationCanvasNode>,
+): GenerationFlowEdge[] {
+  return edges
+    .filter((edge) => nodeById.has(edge.source) && nodeById.has(edge.target))
+    .map((edge) => toGenerationFlowEdge(edge, nodeById))
+}
+
+export function collectFlowPositionChanges(
+  changes: readonly NodeChange<GenerationFlowNode>[],
+): Array<{ nodeId: string; position: { x: number; y: number } }> {
+  return changes.flatMap((change) => {
+    if (change.type !== 'position' || !change.position) return []
+    return [{ nodeId: change.id, position: { x: change.position.x, y: change.position.y } }]
+  })
+}
+
+export function collectFlowSelectionChanges(
+  changes: readonly NodeChange<GenerationFlowNode>[],
+): Array<{ nodeId: string; selected: boolean }> {
+  return changes.flatMap((change) => {
+    if (change.type !== 'select') return []
+    return [{ nodeId: change.id, selected: change.selected }]
+  })
+}
+
+export function flowViewportFromCanvas(viewport: { zoom: number; offset: { x: number; y: number } }): Viewport {
+  return { x: viewport.offset.x, y: viewport.offset.y, zoom: viewport.zoom }
+}
+
+export function canvasViewportFromFlow(viewport: Viewport): { zoom: number; offset: { x: number; y: number } } {
+  return { zoom: viewport.zoom, offset: { x: viewport.x, y: viewport.y } }
+}
+
+export function getFlowNodeKind(node: GenerationFlowNode): GenerationNodeKind {
+  return node.data.generationNode.kind
+}

--- a/src/workbench/generationCanvas/reactFlow/generationFlowNodeContext.tsx
+++ b/src/workbench/generationCanvas/reactFlow/generationFlowNodeContext.tsx
@@ -1,0 +1,12 @@
+/* eslint-disable react-refresh/only-export-components */
+import React from 'react'
+
+const GenerationFlowNodeContext = React.createContext(false)
+
+export function GenerationFlowNodeScope({ children }: { children: React.ReactNode }): JSX.Element {
+  return <GenerationFlowNodeContext.Provider value>{children}</GenerationFlowNodeContext.Provider>
+}
+
+export function useGenerationFlowNodeManagedDrag(): boolean {
+  return React.useContext(GenerationFlowNodeContext)
+}

--- a/src/workbench/generationCanvas/store/canvasNodeActions.ts
+++ b/src/workbench/generationCanvas/store/canvasNodeActions.ts
@@ -101,7 +101,9 @@ export const createCanvasNodeActions: CanvasSliceCreator<CanvasNodeActions> = (s
       Object.assign(node, patch)
       if (shouldPersistCanvasMutation(options)) bumpPersistRevision(state)
     })
-    emitCanvasGesture([{ type: 'canvas.node.updated', payload: { nodeId, patch } }])
+    if (shouldEmitCanvasMutation(options)) {
+      emitCanvasGesture([{ type: 'canvas.node.updated', payload: { nodeId, patch } }])
+    }
   },
   updateNodes: (updates) => {
     const currentState = get()


### PR DESCRIPTION
## Summary
- replace the generation canvas renderer with React Flow by default
- keep the existing canvas model and persistence in the Zustand store
- migrate node/group drag, resize, viewport persistence, connections, edge mode editing, menus, navigation, selection tools, batch generation, and capture overlays
- retain the legacy renderer as an explicit `legacy` fallback via `VITE_GENERATION_CANVAS_ENGINE` or localStorage

## Verification
- `pnpm exec vitest run src/workbench/generationCanvas/reactFlow` (11 passed)
- `pnpm exec vitest run src/workbench/generationCanvas` (2064 passed, 1 skipped)
- `pnpm run typecheck`
- `pnpm exec eslint src/workbench/generationCanvas/reactFlow src/workbench/generationCanvas/components/useCanvasShortcuts.ts`
- `pnpm run build:renderer`