### PR TITLE
fix(ci): run one quality gate per pull request

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - main
-      - 'feat/**'
-      - 'fix/**'
   pull_request:
+
+concurrency:
+  group: quality-gate-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read

--- a/docs/superpowers/plans/2026-08-27-quality-gate-single-run.md
+++ b/docs/superpowers/plans/2026-08-27-quality-gate-single-run.md
@@ -1,0 +1,188 @@
+# Quality Gate Single-Run Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ensure each pull-request HEAD produces one authoritative Quality Gate run, while preserving a separate post-merge main verification and fail-closed vocabulary baselines.
+
+**Architecture:** The workflow trigger becomes `pull_request` plus `push` to `main` only. Workflow-level concurrency keys PR runs by PR number and main runs by ref, so a newer run cancels only obsolete work in the same lane. A Node contract test reads the workflow source and is wired into `pnpm run gates` as a first-class `check:*` script.
+
+**Tech Stack:** GitHub Actions YAML, Node.js `node:test`, pnpm scripts.
+
+---
+
+### Task 1: Add the failing workflow contract
+
+**Files:**
+- Create: `scripts/check-quality-gate-workflow.node-test.mjs`
+- Modify: `package.json`
+
+- [ ] **Step 1: Write the failing contract test**
+
+Create `scripts/check-quality-gate-workflow.node-test.mjs`:
+
+```js
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const workflowPath = path.join(repoRoot, '.github/workflows/quality-gate.yml')
+const workflow = fs.readFileSync(workflowPath, 'utf8').replaceAll('\r\n', '\n')
+
+test('quality gate runs for pull requests and main pushes without feature-branch push duplication', () => {
+  const triggerBlock = workflow.match(/^on:\n([\s\S]*?)\npermissions:/m)?.[1]
+  assert.ok(triggerBlock, 'quality-gate.yml must keep an explicit trigger block')
+  assert.match(triggerBlock, /  push:\n    branches:\n      - main\n/)
+  assert.match(triggerBlock, /  pull_request:\n/)
+  assert.doesNotMatch(triggerBlock, /feat\/\*\*|fix\/\*\*/)
+})
+
+test('quality gate cancels only obsolete runs in the same PR or main lane', () => {
+  assert.match(
+    workflow,
+    /concurrency:\n  group: quality-gate-\$\{\{ github\.event\.pull_request\.number \|\| github\.ref \}\}\n  cancel-in-progress: true\n/,
+  )
+  assert.match(
+    workflow,
+    /VOCAB_BASE_REF: \$\{\{ github\.event\.pull_request\.base\.sha \|\| github\.event\.before \}\}/,
+  )
+})
+```
+
+Add the following script to `package.json`:
+
+```json
+"check:quality-gate-workflow": "node --test ./scripts/check-quality-gate-workflow.node-test.mjs"
+```
+
+Insert `pnpm run check:quality-gate-workflow` immediately after `pnpm run check:gates-chain` in the `gates` command.
+
+- [ ] **Step 2: Run the test and verify RED**
+
+Run:
+
+```bash
+pnpm run check:quality-gate-workflow
+```
+
+Expected: two failures. The current workflow still contains `feat/**` and `fix/**`, and has no workflow-level `concurrency` block.
+
+- [ ] **Step 3: Verify the gate-chain registration is reachable**
+
+Run:
+
+```bash
+pnpm run check:gates-chain
+```
+
+Expected: PASS with 25 reachable `check:*` scripts and one intentional exclusion.
+
+### Task 2: Make the workflow single-source
+
+**Files:**
+- Modify: `.github/workflows/quality-gate.yml`
+
+- [ ] **Step 1: Remove feature and fix branch push triggers**
+
+Change the trigger to:
+
+```yaml
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+```
+
+- [ ] **Step 2: Add workflow-level concurrency**
+
+Insert after the trigger block:
+
+```yaml
+concurrency:
+  group: quality-gate-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+```
+
+Keep the existing vocabulary baseline expression unchanged:
+
+```yaml
+VOCAB_BASE_REF: ${{ github.event.pull_request.base.sha || github.event.before }}
+```
+
+- [ ] **Step 3: Run the focused tests and verify GREEN**
+
+Run:
+
+```bash
+pnpm run check:quality-gate-workflow
+pnpm run check:gates-chain
+```
+
+Expected: both commands exit 0; the contract reports 2 passing tests and the chain reports 25 reachable checks.
+
+- [ ] **Step 4: Commit the RED/GREEN implementation**
+
+```bash
+git add .github/workflows/quality-gate.yml scripts/check-quality-gate-workflow.node-test.mjs package.json
+git diff --cached --check
+git commit -m "fix(ci): run one quality gate per pull request"
+```
+
+### Task 3: Verify, review, and deliver
+
+**Files:**
+- Modify only if verification or review exposes a scoped defect.
+
+- [ ] **Step 1: Run the complete repository gate**
+
+Run:
+
+```bash
+pnpm run gates
+```
+
+Expected: exit 0, including lint, type checks, tests, renderer build, and Electron build.
+
+- [ ] **Step 2: Review the final diff against the specification**
+
+Run:
+
+```bash
+git diff --check origin/main...HEAD
+git diff --stat origin/main...HEAD
+git diff origin/main...HEAD -- .github/workflows/quality-gate.yml scripts/check-quality-gate-workflow.node-test.mjs package.json docs/superpowers/specs/2026-08-27-quality-gate-single-run-design.md docs/superpowers/plans/2026-08-27-quality-gate-single-run.md
+```
+
+Expected: only the approved spec, plan, workflow, contract test, and package script wiring differ.
+
+- [ ] **Step 3: Push and open a pull request**
+
+```bash
+git push -u origin codex/ci-single-run-20260827
+gh pr create --base main --head codex/ci-single-run-20260827 --title "fix(ci): run one quality gate per pull request" --body-file /tmp/nomi-ci-single-run-pr.md
+```
+
+The PR body must include the #205 failure evidence, trigger/data-flow change, RED/GREEN commands, and full-gate result.
+
+- [ ] **Step 4: Validate the real GitHub event shape**
+
+For the PR HEAD, verify GitHub creates exactly one `Quality Gate` and one `Mac Package`, plus unrelated checks such as CLA/Workers. Wait for required checks to complete successfully.
+
+- [ ] **Step 5: Merge without bypass**
+
+Guard the PR head SHA, state, mergeability, and required checks, then run:
+
+```bash
+gh pr merge <number> --repo aqm857886159/Nomi --merge
+```
+
+Do not use `--admin`. Afterward verify the PR state is `MERGED` and the merge commit is reachable from live `main`.
+
+## Plan self-review
+
+- Spec coverage: trigger deduplication, concurrency, stable event-specific baseline, fail-closed behavior, automated regression coverage, full gates, live PR observation, and protected merge are all mapped to tasks.
+- Placeholder scan: no deferred implementation or ambiguous code step remains; `<number>` is a runtime value returned by PR creation, not an unspecified implementation detail.
+- Consistency: the new package script name, test filename, workflow keys, and verification commands match across all tasks.

--- a/docs/superpowers/specs/2026-08-27-quality-gate-single-run-design.md
+++ b/docs/superpowers/specs/2026-08-27-quality-gate-single-run-design.md
@@ -1,0 +1,92 @@
+# Quality Gate 单一触发与稳定基线设计
+
+日期：2026-08-27
+
+## 问题
+
+`quality-gate.yml` 同时监听 `push` 的 `feat/**`、`fix/**` 分支和 `pull_request`。当一个已开 PR 的分支更新时，同一提交会产生两套同名的 `Quality Gate` 与 `Mac Package`。
+
+PR #205 暴露了第二层问题：GitHub 的“更新分支”使用 rebase 改写了分支历史，`push` 事件仍把改写前 SHA 放进 `github.event.before`。该 SHA 已不再被任何远端引用，即使 `actions/checkout` 使用完整历史也无法取得。语义词表门岗按设计 fail closed，于是正确的 PR 检查已经通过，重复的 push 检查仍以“历史基线不可用”阻止合并。
+
+## 目标
+
+1. 一个 PR 的同一 HEAD 只有一套合并前完整门禁。
+2. PR 更新只验证最新 HEAD，过期中的 run 自动取消。
+3. 语义词表门岗始终使用与事件生命周期相符、可取得的历史基线。
+4. 合并前覆盖不减少；`main` 落地后仍做一次独立验证。
+5. 用仓库内自动化契约锁住触发器、并发键和基线表达式，防止回归。
+
+## 方案比较
+
+### A. 只加 concurrency，保留双触发
+
+让 push 与 PR 事件共享一个并发组，后到的 run 取消先到的 run。它只能降低重复消耗，无法保证哪一类事件最后到达，也无法消除同一提交上的重复检查记录；若 push run 获胜，rebase 前 SHA 仍可能不可用。因此不采用。
+
+### B. 保留分支 push，给旧 SHA 增加 fetch/retry/fallback
+
+它把“已经没有远端引用的对象”当成网络获取问题，无法可靠修复。若退回 `origin/main`，又会把 push 门岗的比较语义悄悄改成另一套规则，仍然保留两份完整 CI。因此不采用。
+
+### C. PR 单一门禁，main 落地复验（采用）
+
+- `push` 只监听 `main`。
+- `pull_request` 负责所有合并前验证。
+- PR 使用 `github.event.pull_request.base.sha` 作为词表基线。
+- `main` push 使用 `github.event.before`；受保护主线是快进/合并历史，该 SHA 仍为主线祖先。
+- workflow 级 concurrency 对同一 PR 使用 PR 编号，对主线使用 `github.ref`，并取消过期 run。
+
+代价是尚未创建 PR 的远端 `feat/**`、`fix/**` 分支不再自动运行完整远端门禁；开发者仍可运行本地 `pnpm run gates`。创建 PR 后完整验证立即恢复。
+
+## 事件流
+
+```text
+未开 PR 的功能分支 push
+  └─ 不运行远端完整 Quality Gate
+
+PR opened / synchronize / reopened
+  ├─ 取消同一 PR 的过期 run
+  └─ 对当前 PR HEAD 运行一套 Quality Gate + Mac Package
+
+PR merged -> main push
+  └─ 对落地主线运行一套 Quality Gate + Mac Package
+```
+
+## 实现边界
+
+修改范围：
+
+1. `.github/workflows/quality-gate.yml`
+   - 将 push 分支过滤收敛为 `main`。
+   - 添加 workflow 级 concurrency。
+   - 保留 PR base / push before 的事件分流，但不再让功能分支 push 消费 `before`。
+2. `scripts/check-quality-gate-workflow.node-test.mjs`
+   - 直接读取 workflow，验证触发器、并发组、取消策略和基线表达式。
+3. `package.json`
+   - 把该契约测试接入现有门岗链，使配置回归在本地与 CI 都会失败。
+
+不修改分支保护规则，不降低必需检查，不改变 `pnpm run gates` 内容，不管理员绕过失败检查。
+
+## 错误处理
+
+- PR 基线缺失时继续 fail closed；不静默改用别的提交。
+- `main` push 的 `before` 不可用时继续 fail closed，暴露受保护主线的异常历史改写。
+- 新提交到达时只取消同一 PR 的过期 run，不影响其他 PR 或主线 run。
+
+## 验证
+
+### RED
+
+在当前 workflow 上运行新契约测试，应准确失败：功能分支仍在 push 过滤中，且缺少并发控制。
+
+### GREEN
+
+1. 新契约测试通过。
+2. `pnpm run check:gates-chain` 通过，证明新测试已进入完整门岗可达链。
+3. `pnpm run gates` 与 `pnpm run build` 通过。
+4. 推送修复 PR 后，观察当前 HEAD 只产生一套 PR `Quality Gate`/`Mac Package`；若更新该 PR，旧 run 被取消，最新 run 独立完成。
+
+## 成功标准
+
+- PR 页面不再出现同一 HEAD 的两组同名必需检查。
+- rebase/更新分支不再因改写前 `push.before` 阻塞合并。
+- 合并前完整测试、构建、Mac 打包、Electron smoke 与真实用户旅程保持不变。
+- `main` 合并后仍运行完整复验。

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "radar:models": "tsx scripts/model-radar.ts",
     "build:handbook": "tsx scripts/build-handbook-html.mjs",
     "check:audit": "node ./scripts/check-audit-cadence.mjs && node ./scripts/check-eval-cadence.mjs",
-    "gates": "pnpm run check:gates-chain && pnpm run check:filesize && pnpm run check:tokens && pnpm run check:dangling-tokens && pnpm run check:archetype-defaults && pnpm run check:archetype-sources && pnpm run check:secrets && pnpm run check:symlinks && pnpm run check:i18n && pnpm run check:heavy-path && pnpm run check:adoption-bridge && pnpm run check:ipc-sender-binding && pnpm run check:batch-machines && pnpm run check:test-waits && pnpm run check:agents-sync && pnpm run check:controls && pnpm run check:vocabularies && pnpm run check:e2e-launch && pnpm run check:walkthroughs && pnpm run check:site && pnpm run lint:ci && pnpm run typecheck && pnpm run check:test-types && pnpm run test && pnpm run build && node -e \"const fs=require('fs');fs.mkdirSync('.claude',{recursive:true});fs.writeFileSync('.claude/.gates-ok',new Date().toISOString());\" && echo '✅ 全门通过，已盖 .claude/.gates-ok（push 闸放行）'",
+    "gates": "pnpm run check:gates-chain && pnpm run check:quality-gate-workflow && pnpm run check:filesize && pnpm run check:tokens && pnpm run check:dangling-tokens && pnpm run check:archetype-defaults && pnpm run check:archetype-sources && pnpm run check:secrets && pnpm run check:symlinks && pnpm run check:i18n && pnpm run check:heavy-path && pnpm run check:adoption-bridge && pnpm run check:ipc-sender-binding && pnpm run check:batch-machines && pnpm run check:test-waits && pnpm run check:agents-sync && pnpm run check:controls && pnpm run check:vocabularies && pnpm run check:e2e-launch && pnpm run check:walkthroughs && pnpm run check:site && pnpm run lint:ci && pnpm run typecheck && pnpm run check:test-types && pnpm run test && pnpm run build && node -e \"const fs=require('fs');fs.mkdirSync('.claude',{recursive:true});fs.writeFileSync('.claude/.gates-ok',new Date().toISOString());\" && echo '✅ 全门通过，已盖 .claude/.gates-ok（push 闸放行）'",
     "typecheck": "tsc -p tsconfig.app.json && tsc -p electron/tsconfig.json && tsc -p electron/tsconfig.pi.json --noEmit",
     "lint": "eslint .",
     "lint:ci": "eslint . --max-warnings=98",
@@ -98,7 +98,8 @@
     "check:adoption-bridge": "node ./scripts/check-adoption-bridge.mjs",
     "check:batch-machines": "node ./scripts/check-batch-machines.mjs",
     "check:test-types": "node ./scripts/check-test-types.mjs",
-    "check:gates-chain": "node ./scripts/check-gates-chain.mjs"
+    "check:gates-chain": "node ./scripts/check-gates-chain.mjs",
+    "check:quality-gate-workflow": "node --test ./scripts/check-quality-gate-workflow.node-test.mjs"
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^1.2.12",

--- a/scripts/check-quality-gate-workflow.node-test.mjs
+++ b/scripts/check-quality-gate-workflow.node-test.mjs
@@ -1,0 +1,28 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const workflowPath = path.join(repoRoot, '.github/workflows/quality-gate.yml')
+const workflow = fs.readFileSync(workflowPath, 'utf8').replaceAll('\r\n', '\n')
+
+test('quality gate runs for pull requests and main pushes without feature-branch push duplication', () => {
+  const triggerBlock = workflow.match(/^on:\n([\s\S]*?)\npermissions:/m)?.[1]
+  assert.ok(triggerBlock, 'quality-gate.yml must keep an explicit trigger block')
+  assert.match(triggerBlock, /  push:\n    branches:\n      - main\n/)
+  assert.match(triggerBlock, /  pull_request:\n/)
+  assert.doesNotMatch(triggerBlock, /feat\/\*\*|fix\/\*\*/)
+})
+
+test('quality gate cancels only obsolete runs in the same PR or main lane', () => {
+  assert.match(
+    workflow,
+    /concurrency:\n  group: quality-gate-\$\{\{ github\.event\.pull_request\.number \|\| github\.ref \}\}\n  cancel-in-progress: true\n/,
+  )
+  assert.match(
+    workflow,
+    /VOCAB_BASE_REF: \$\{\{ github\.event\.pull_request\.base\.sha \|\| github\.event\.before \}\}/,
+  )
+})

--- a/scripts/check-quality-gate-workflow.node-test.mjs
+++ b/scripts/check-quality-gate-workflow.node-test.mjs
@@ -3,26 +3,26 @@ import fs from 'node:fs'
 import path from 'node:path'
 import test from 'node:test'
 import { fileURLToPath } from 'node:url'
+import { load } from 'js-yaml'
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
 const workflowPath = path.join(repoRoot, '.github/workflows/quality-gate.yml')
-const workflow = fs.readFileSync(workflowPath, 'utf8').replaceAll('\r\n', '\n')
+const workflow = load(fs.readFileSync(workflowPath, 'utf8'))
 
 test('quality gate runs for pull requests and main pushes without feature-branch push duplication', () => {
-  const triggerBlock = workflow.match(/^on:\n([\s\S]*?)\npermissions:/m)?.[1]
-  assert.ok(triggerBlock, 'quality-gate.yml must keep an explicit trigger block')
-  assert.match(triggerBlock, /  push:\n    branches:\n      - main\n/)
-  assert.match(triggerBlock, /  pull_request:\n/)
-  assert.doesNotMatch(triggerBlock, /feat\/\*\*|fix\/\*\*/)
+  assert.deepEqual(workflow.on, {
+    push: { branches: ['main'] },
+    pull_request: null,
+  })
 })
 
 test('quality gate cancels only obsolete runs in the same PR or main lane', () => {
-  assert.match(
-    workflow,
-    /concurrency:\n  group: quality-gate-\$\{\{ github\.event\.pull_request\.number \|\| github\.ref \}\}\n  cancel-in-progress: true\n/,
-  )
-  assert.match(
-    workflow,
-    /VOCAB_BASE_REF: \$\{\{ github\.event\.pull_request\.base\.sha \|\| github\.event\.before \}\}/,
+  assert.deepEqual(workflow.concurrency, {
+    group: 'quality-gate-${{ github.event.pull_request.number || github.ref }}',
+    'cancel-in-progress': true,
+  })
+  assert.equal(
+    workflow.jobs.quality.env.VOCAB_BASE_REF,
+    '${{ github.event.pull_request.base.sha || github.event.before }}',
   )
 })


### PR DESCRIPTION
## What changed

- run `Quality Gate` for pull requests through `pull_request` only; branch pushes are no longer a second PR trigger
- keep the post-merge `main` push run
- cancel obsolete runs only inside the same PR or `main` lane
- preserve the PR base SHA / main previous SHA vocabulary comparison
- add an executable workflow contract test and wire it into `pnpm run gates`

## Why

PR #205 exposed the same commit being checked through both `push` and `pull_request`. That produced duplicate checks, stale-SHA noise, and made a simple merge look blocked even after the current PR head had passed.

After this change a pull request has one current Quality Gate run. A newer synchronize event cancels the obsolete run for that same PR, while different PRs remain independent.

## Verification

- RED: the two workflow contract tests failed against the old workflow
- GREEN: `pnpm run check:quality-gate-workflow` — 2/2 passed
- reviewer mutation check: adding another push branch or filtering PRs to `closed` now fails the semantic YAML assertion
- `pnpm run check:gates-chain` — 25 checks reachable, one intentional exclusion
- `pnpm run gates` — passed
  - lint: 0 errors / 87 baseline warnings
  - Vitest: 840 files passed + 1 skipped; 8044 tests passed + 1 skipped
  - agent runtime, test types, renderer build, Electron build all passed

## Scope

Job names, permissions, Quality Gate steps, Mac Package steps, signing, and packaging behavior are unchanged.
