### PR TITLE
fix(docs): point README feature request link at the real issue template

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ pnpm run gates
 Bug reports, feature proposals, documentation, and code contributions are welcome. External contributors sign the one-time [Contributor License Agreement](CLA.md) when a pull request is opened.
 
 - [Report a bug](https://github.com/aqm857886159/Nomi/issues/new?template=bug_report.yml)
-- [Request a feature](https://github.com/aqm857886159/Nomi/issues/new?template=feedback.yml)
+- [Request a feature](https://github.com/aqm857886159/Nomi/issues/new?template=feature_request.yml)
 - [Ask a question or share an idea](https://github.com/aqm857886159/Nomi/issues)
 
 ## License


### PR DESCRIPTION
## What

README's Contributing section linked to `?template=feedback.yml`, which does not exist in `.github/ISSUE_TEMPLATE/`. Repointed at `feature_request.yml`.

## Why it matters

`config.yml` sets `blank_issues_enabled: false`, so an unknown `template=` value does not hard-404 — GitHub falls back to the template chooser. The practical damage: "Request a feature" dropped visitors on a picker screen instead of the pre-filled feature request form, exactly at the moment they had decided to give feedback.

This is being fixed ahead of a public post that will drive traffic to that link.

## Verification

- Every `template=` reference across `*.md`, `*.html`, `*.ts`, `*.tsx`, `*.mjs`, `*.json` now resolves to a file on disk (`bug_report.yml`, `business_inquiry.yml`, `feature_request.yml` — all OK).
- Reverse check: no issue template is orphaned/unreachable from docs.
- `README.zh-CN.md` has no feature-request link at all, so nothing to change there.
- `pnpm run gates` passes on this branch, rebased on latest `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)