### PR TITLE
fix(docs): route questions and community traffic to GitHub Discussions

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: false
 contact_links:
   - name: Questions and ideas
-    url: https://github.com/aqm857886159/Nomi/issues
-    about: Ask usage questions or share ideas in GitHub Issues.
+    url: https://github.com/aqm857886159/Nomi/discussions
+    about: Ask usage questions or share ideas in GitHub Discussions.
   - name: Private security report
     url: https://github.com/aqm857886159/Nomi/security/advisories/new
     about: Do not disclose vulnerabilities in a public issue.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Nomi is an open-source desktop workbench for AI video. Connect any OpenAI-compat
 
 Your projects, prompts, and API keys stay on your machine. No account. No telemetry.
 
-[简体中文](README.zh-CN.md) · [Website](https://nomiaqm.com/en/) · [Download](#download) · [Community](https://github.com/aqm857886159/Nomi/issues) · [For Teams](https://nomiaqm.com/en/#teams) · [Watch the 60s film](https://nomiaqm.com/assets/video/launch-film-en.mp4) · [Documentation](docs/user-guide.md)
+[简体中文](README.zh-CN.md) · [Website](https://nomiaqm.com/en/) · [Download](#download) · [Community](https://github.com/aqm857886159/Nomi/discussions) · [For Teams](https://nomiaqm.com/en/#teams) · [Watch the 60s film](https://nomiaqm.com/assets/video/launch-film-en.mp4) · [Documentation](docs/user-guide.md)
 
 ## WeChat / 微信联系
 
@@ -36,7 +36,7 @@ Your projects, prompts, and API keys stay on your machine. No account. No teleme
   群码失效，或沟通定制开发、系统集成、贴牌交付与持续迭代，请添加作者微信 <strong>TZ857886159</strong>。
 </p>
 
-International community: [GitHub Issues](https://github.com/aqm857886159/Nomi/issues) · Project inquiry: [Business Inquiry](https://github.com/aqm857886159/Nomi/issues/new?template=business_inquiry.yml)
+International community: [GitHub Discussions](https://github.com/aqm857886159/Nomi/discussions) · Project inquiry: [Business Inquiry](https://github.com/aqm857886159/Nomi/issues/new?template=business_inquiry.yml)
 
 [![Latest release](https://img.shields.io/github/v/release/aqm857886159/Nomi?label=release)](https://github.com/aqm857886159/Nomi/releases/latest)
 ![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Windows-1a1816)
@@ -93,7 +93,7 @@ Read the [user guide](docs/user-guide.md), [provider guide](docs/provider-integr
 
 ## Community
 
-Use [GitHub Issues](https://github.com/aqm857886159/Nomi/issues) to share workflows, report friction, and follow what is being built next. WeChat users can use the group and maintainer QR codes at the top of this README; the [Chinese README](README.zh-CN.md#用户群) contains the full Chinese guide.
+Use [GitHub Discussions](https://github.com/aqm857886159/Nomi/discussions) to ask questions, share workflows, and follow what is being built next, and [GitHub Issues](https://github.com/aqm857886159/Nomi/issues) to report bugs and request features. WeChat users can use the group and maintainer QR codes at the top of this README; the [Chinese README](README.zh-CN.md#用户群) contains the full Chinese guide.
 
 ## For Teams
 
@@ -133,7 +133,7 @@ Bug reports, feature proposals, documentation, and code contributions are welcom
 
 - [Report a bug](https://github.com/aqm857886159/Nomi/issues/new?template=bug_report.yml)
 - [Request a feature](https://github.com/aqm857886159/Nomi/issues/new?template=feature_request.yml)
-- [Ask a question or share an idea](https://github.com/aqm857886159/Nomi/issues)
+- [Ask a question or share an idea](https://github.com/aqm857886159/Nomi/discussions)
 
 ## License
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -35,7 +35,7 @@ Nomi 是一个开源的 AI 视频创作桌面工作台。接任何 OpenAI 兼容
   群码失效，或沟通定制开发、系统集成、贴牌交付与持续迭代，请添加作者微信 <strong>TZ857886159</strong>。
 </p>
 
-[参与 GitHub Issues](https://github.com/aqm857886159/Nomi/issues) · [提交商务咨询](https://github.com/aqm857886159/Nomi/issues/new?template=business_inquiry.yml)
+[参与 GitHub Discussions](https://github.com/aqm857886159/Nomi/discussions) · [提交商务咨询](https://github.com/aqm857886159/Nomi/issues/new?template=business_inquiry.yml)
 
 [![最新版本](https://img.shields.io/github/v/release/aqm857886159/Nomi?label=release)](https://github.com/aqm857886159/Nomi/releases/latest)
 ![平台](https://img.shields.io/badge/platform-macOS%20%7C%20Windows-1a1816)


### PR DESCRIPTION
## What

GitHub Discussions was disabled on this repository, so every "ask a question" / "share a workflow" / "Community" link pointed at the **issue tracker**. Discussions is now enabled, and this repoints the routing.

## Why now

A public post is live and driving cold traffic to the repo. Without this, usage questions ("how do I connect my ComfyUI?") land in Issues next to real bug reports, and the tracker stops being a signal.

## Changes

| Where | Was | Now |
|---|---|---|
| `README.md` header nav — **Community** | `/issues` | `/discussions` |
| `README.md` — "International community" | `/issues` | `/discussions` |
| `README.md` — Community section | Issues for everything | Discussions for questions/workflows, Issues for bugs/features — split stated explicitly |
| `README.md` — "Ask a question or share an idea" | `/issues` | `/discussions` |
| `README.zh-CN.md` header | `参与 GitHub Issues` | `参与 GitHub Discussions` |
| `.github/ISSUE_TEMPLATE/config.yml` — "Questions and ideas" | `/issues` | `/discussions` |

That last one matters most: it is the deflection link people see the moment they click **New issue**, so it catches questions before they become issues.

Bug reports and feature requests are untouched and still go to Issues.

## Verification

- `/discussions` → 200, live with default categories (Q&A, Ideas, Show and tell, …)
- `/issues` → 200; security advisory link still redirects as expected
- All `template=` references across the repo still resolve to real files
- `pnpm run gates` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)