### PR TITLE
fix(delivery): accept pnpm argument delimiter

### DIFF
--- a/docs/fixes/2026-08-29-git-delivery-identity.root-cause.json
+++ b/docs/fixes/2026-08-29-git-delivery-identity.root-cause.json
@@ -2,8 +2,8 @@
   "schema_version": 3,
   "id": "2026-08-29-git-delivery-identity",
   "problem_type": "Git delivery identity, transport, and merged-main verification divergence",
-  "symptom": "A ReactFlow delivery repeatedly stalled during Git transport, reported expected PR-head/merge-commit SHA differences as mismatches, failed to reconstruct the merged tree through the GitHub compare API, and risked rerunning the same complete test suite on one merged SHA.",
-  "direct_cause": "Delivery steps used independent ad hoc Git and REST operations without a bounded fetch or stage model; the fallback tree materializer consumed a compare file list capped at 300 changed files; commit identity was compared without separating commit metadata from tree identity; complete merged-main runs had no durable per-SHA receipt.",
+  "symptom": "A ReactFlow delivery repeatedly stalled during Git transport, reported expected PR-head/merge-commit SHA differences as mismatches, failed to reconstruct the merged tree through the GitHub compare API, risked rerunning the same complete test suite on one merged SHA, and initially rejected the documented pnpm argument separator before final validation could start.",
+  "direct_cause": "Delivery steps used independent ad hoc Git and REST operations without a bounded fetch or stage model; the fallback tree materializer consumed a compare file list capped at 300 changed files; commit identity was compared without separating commit metadata from tree identity; complete merged-main runs had no durable per-SHA receipt; and the first CLI parser treated pnpm's standalone -- delimiter as a delivery option because tests covered internal commands but not the documented argv boundary.",
   "class_root": "The repository had prose about branches and testing but no executable shared boundary that bound each delivery phase to its authoritative Git identity, bounded its only remote refresh, prohibited synthesized remote objects, and made final full validation idempotent per merged commit.",
   "affected_population": [
     "Agents and maintainers delivering any Nomi task through a pull request",
@@ -35,9 +35,10 @@
     "Task commit, task tree, remote-base commit, remote-base tree and expected merge commit are reported as distinct identities.",
     "Preflight refuses protected branches, dirty worktrees and task heads that do not contain the freshly fetched remote baseline.",
     "Merged verification runs only when HEAD, the freshly fetched remote default branch and the explicit expected merge SHA are the same commit.",
+    "The documented pnpm invocation and direct Node invocation resolve to the same delivery options; a standalone package-manager argument delimiter is never interpreted as a delivery option.",
     "A per-SHA atomic lock prevents concurrent complete validations, and the durable result is idempotent for one commit SHA unless a human explicitly chooses a rerun."
   ],
-  "generality_proof": "Both task-start and merged-main entry points converge on the same bounded Git transport and identity inspector. The inspector derives commit and tree identities from fetched Git objects, so API pagination, commit-message normalization, GitHub merge metadata and equivalent future hosting differences cannot be mistaken for file-content divergence. The common-dir atomic lock and receipt key full validation by exact merged SHA across worktrees, preventing concurrent and sequential duplicate full runs.",
+  "generality_proof": "Both task-start and merged-main entry points converge on the same CLI parser, bounded Git transport and identity inspector. The parser accepts the standard package-manager delimiter for every delivery subcommand. The inspector derives commit and tree identities from fetched Git objects, so API pagination, commit-message normalization, GitHub merge metadata and equivalent future hosting differences cannot be mistaken for file-content divergence. The common-dir atomic lock and receipt key full validation by exact merged SHA across worktrees, preventing concurrent and sequential duplicate full runs.",
   "shared_boundaries": [
     {
       "path": "scripts/git-delivery.mjs",
@@ -72,7 +73,8 @@
       "Searched CLAUDE.md and docs/engineering-rules.md for worktree, remote baseline, merge and solved-state instructions; found prose but no executable stage authority.",
       "Searched scripts and package.json for delivery, worktree, commit SHA, tree SHA and merged-main commands; release-contract validates release manifests but no PR delivery command exists.",
       "Inspected scripts/test-system.mjs and tests/system/profiles.mjs; full-local already includes canvas acceptance and CI-safe J3/J5 but has no Git identity or per-SHA idempotency boundary.",
-      "Reproduced the out-of-repository REST materializer mismatch and checked the official compare API 300-file limit against the large comparison."
+      "Reproduced the out-of-repository REST materializer mismatch and checked the official compare API 300-file limit against the large comparison.",
+      "Ran the documented pnpm merged-main command on the actual PR #227 merge SHA; it failed before fetch or tests with unknown_argument for the standalone -- delimiter, proving the package-manager argv boundary needed direct regression coverage."
     ]
   },
   "prevention": {

--- a/docs/plan/2026-08-29-git-delivery-integrity.md
+++ b/docs/plan/2026-08-29-git-delivery-integrity.md
@@ -43,6 +43,10 @@
 
 本地先跑上述聚焦测试、根因合同、规则同步和 diff 检查；PR CI 负责高风险完整验证。PR 合并后，使用真实 `origin/main` merge SHA 调用 `verify-merged` 一次，现有 `full-local` 会覆盖完整系统门禁、canvas acceptance 与 CI-safe J3/J5。
 
+### merged-main 首次调用发现
+
+PR #227 合并后的真实调用在进入 fetch 和测试前失败：pnpm 把命令行分隔符 `--` 原样传给脚本，而解析器误把它当成未知 delivery 参数。该次没有启动 `full-local`、没有写收据，因此不构成重复完整测试。修复落在共享 `parseCli` 边界，并以文档中的完整 argv 形状补回归测试；pnpm 与直接 Node 调用现在解析成同一组选项。
+
 ## 不动项
 
 - 不修改 ReactFlow 产品交互；PR #221 已恢复的连接点、连线与画布行为保持不变。

--- a/scripts/git-delivery.mjs
+++ b/scripts/git-delivery.mjs
@@ -450,11 +450,12 @@ export async function verifyMergedDelivery({
   }
 }
 
-function parseCli(argv) {
+export function parseCli(argv) {
   const [command, ...args] = argv
   const options = {}
   for (let index = 0; index < args.length; index += 1) {
     const arg = args[index]
+    if (arg === '--') continue
     if (arg === '--rerun') options.rerun = true
     else if (arg === '--expected-sha') options.expectedSha = args[++index]
     else if (arg === '--remote') options.remote = args[++index]

--- a/scripts/git-delivery.node-test.mjs
+++ b/scripts/git-delivery.node-test.mjs
@@ -11,6 +11,7 @@ import {
   assertPreflightState,
   classifyIdentity,
   inspectDeliveryState,
+  parseCli,
   preflightDelivery,
   runBoundedCommand,
   verifyMergedDelivery,
@@ -73,6 +74,29 @@ test('identity classification keeps commit identity separate from tree identity'
   assert.equal(
     classifyIdentity({ headCommit: 'a', headTree: 't1', remoteCommit: 'b', remoteTree: 't2' }),
     'different-tree',
+  )
+})
+
+test('documented pnpm argument separator is transparent to delivery commands', () => {
+  assert.deepEqual(
+    parseCli([
+      'verify-merged',
+      '--',
+      '--expected-sha',
+      '0123456789abcdef0123456789abcdef01234567',
+      '--remote',
+      'upstream',
+      '--base',
+      'trunk',
+    ]),
+    {
+      command: 'verify-merged',
+      options: {
+        expectedSha: '0123456789abcdef0123456789abcdef01234567',
+        remote: 'upstream',
+        base: 'trunk',
+      },
+    },
   )
 })
 


### PR DESCRIPTION
## Why

The first real merged-main invocation after PR #227 failed before fetch or tests because pnpm forwarded the documented standalone -- delimiter and the delivery parser treated it as an unknown option. No full-local stage ran and no receipt was written.

## Root fix

- make the standard package-runner delimiter transparent at the shared parseCli boundary
- test the exact documented argv shape, including expected SHA, remote, and base options
- record the discovery in the existing schema-v3 contract and delivery plan

This covers every delivery subcommand using the shared parser instead of changing one command example.

## Verification

- pnpm run check:git-delivery: 10/10 passed
- pnpm run check:root-cause-contracts: 18/18 passed
- diff check passed
- post-commit delivery:preflight passed once on c6e46450640c4e97011b3e353bd36b2c40c7f37b

## Final acceptance

After this PR merges, run the documented delivery:verify-merged command exactly once on the new actual main merge SHA.