### PR TITLE
fix(ai): align Anthropic runtime and verification protocol

### DIFF
--- a/docs/fixes/2026-08-28-anthropic-endpoint-derivation.root-cause.json
+++ b/docs/fixes/2026-08-28-anthropic-endpoint-derivation.root-cause.json
@@ -1,0 +1,52 @@
+{
+  "schema_version": 1,
+  "id": "2026-08-28-anthropic-endpoint-derivation",
+  "problem_type": "provider protocol contract regression (endpoint derived for the wrong wire protocol)",
+  "symptom": "After connecting an Anthropic (Claude) provider, the onboarding connection check passed but nothing worked: every canvas agent turn failed with HTTP 404, and Settings → Models → 'Verify all again' hung until a 90s timeout and reported 'No capability passed verification / cannot be used on the canvas yet'.",
+  "direct_cause": "Two consumers derived the Anthropic endpoint incorrectly from the same stored vendor record. (1) buildAiSdkModel passed the stored base URL straight to @ai-sdk/anthropic's createAnthropic, whose baseURL must already carry the version segment (its default is https://api.anthropic.com/v1) and which appends only '/messages' — so requests went to {root}/messages and returned 404. (2) The built-in verification draft emitted an OpenAI chat operation ('/v1/chat/completions' with an OpenAI body) for every text model regardless of providerKind, so verification requests hit a path that does not exist on Anthropic and never succeeded before the 90s cap.",
+  "class_root": "The wire protocol was not treated as the thing that determines the request shape. A vendor record carries providerKind, and the onboarding probe honours it — but every other consumer re-derived the endpoint from its own assumption (the AI SDK's baseURL convention in one case, a hardcoded OpenAI contract in the other). Whenever endpoint, auth, and body are derived independently per call site instead of from the declared protocol, the paths silently disagree, and the one path that is right (the probe) masks the failure by reporting a healthy connection.",
+  "affected_population": [
+    "Every user who connects an Anthropic/Claude provider: the connection verifies, then all canvas agent turns fail with 404",
+    "The same users' model verification, which cannot pass for any Claude model and leaves every model badged as unusable",
+    "Any future first-party (non-OpenAI-shaped) protocol added to AiSdkProviderKind would hit the identical failure in both consumers"
+  ],
+  "scope_paths": [
+    "electron/ai/buildAiSdkModel.ts",
+    "electron/providerAdapter/builtinOpenAiCompatibleDraft.ts"
+  ],
+  "entry_points": [
+    "buildAiSdkModel — the runtime path that builds the language model for every canvas agent turn and every generation request",
+    "buildOpenAiCompatibleDraft / modesForKind — the built-in verification draft used by the provider-adapter 'testing' stage",
+    "onboardingIpc.probeOneProtocol — the third consumer, already correct; it is the reference for what the stored base URL means (host root, with '/v1/messages' appended by the caller)"
+  ],
+  "external_sources": [
+    {
+      "kind": "source-code",
+      "url": "https://github.com/vercel/ai",
+      "checked_at": "2026-08-28",
+      "purpose": "Confirm @ai-sdk/anthropic@1.2.12 defaults baseURL to 'https://api.anthropic.com/v1' and appends only '/messages', so the version segment must be part of baseURL. Verified against the installed dist in node_modules rather than from memory."
+    },
+    {
+      "kind": "official-doc",
+      "url": "https://platform.claude.com/docs/en/api/errors.md",
+      "checked_at": "2026-08-28",
+      "purpose": "Confirm the Messages endpoint is POST /v1/messages with x-api-key and anthropic-version, that max_tokens is required, and that 404 indicates an invalid endpoint or model ID rather than an auth failure (auth failures are 401)."
+    }
+  ],
+  "invariants": [
+    "A vendor's providerKind determines endpoint, auth scheme, and body shape at every consumer; no consumer hardcodes one protocol's contract for a model whose vendor declares another.",
+    "The stored base URL means the host root. Consumers that hand it to a client expecting a versioned base normalize it first, and normalization is idempotent — a base already ending in a version segment is never re-suffixed.",
+    "The built-in verification draft exercises the same endpoint and auth the runtime will use, so a passing verification implies a working runtime call rather than merely a reachable host."
+  ],
+  "regression_tests": [
+    "electron/ai/anthropicBaseUrl.test.ts",
+    "electron/ai/buildAiSdkModel.test.ts",
+    "electron/providerAdapter/anthropicChatDraft.test.ts"
+  ],
+  "migration": "No stored data is rewritten. Existing catalogs already hold the host-root form, so both fixes normalize on read: saved Claude connections start working without being re-added and without the API key being re-entered. buildAiSdkModel.test.ts previously asserted that a base without '/v1' routes to '/messages' — that assertion had pinned the defect as the contract and is corrected to '/v1/messages'; the '/v1'-suffixed row is unchanged and still proves no double-suffixing.",
+  "residual_risks": [
+    "A separate 'Model verification timed out after 90000 ms' was observed before this fix. The timeout is consistent with verification requests never succeeding against the wrong endpoint, but it was not reproduced end to end after the fix — if verification still times out with the correct endpoint, the timeout has an independent cause in the provider-adapter testing stage that this contract does not cover.",
+    "openai-responses shares the same per-call-site derivation shape and was not changed here; it was already correct for its own contract, but it is not covered by the new protocol-branch test beyond the negative case asserting the OpenAI path is unaffected.",
+    "Anthropic model availability per API key is not validated. A key without access to a given model still returns 404 from Anthropic itself, which is indistinguishable in the UI from the endpoint bug this contract fixes."
+  ]
+}

--- a/docs/fixes/2026-08-28-anthropic-endpoint-derivation.root-cause.json
+++ b/docs/fixes/2026-08-28-anthropic-endpoint-derivation.root-cause.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "id": "2026-08-28-anthropic-endpoint-derivation",
   "problem_type": "provider protocol contract regression (endpoint derived for the wrong wire protocol)",
   "symptom": "After connecting an Anthropic (Claude) provider, the onboarding connection check passed but nothing worked: every canvas agent turn failed with HTTP 404, and Settings → Models → 'Verify all again' hung until a 90s timeout and reported 'No capability passed verification / cannot be used on the canvas yet'.",
@@ -43,6 +43,24 @@
     "electron/ai/buildAiSdkModel.test.ts",
     "electron/providerAdapter/anthropicChatDraft.test.ts"
   ],
+  "recurrence": {
+    "classification": "recurring",
+    "reason": "Every provider connection and model verification can cross the same protocol boundary, so a future non-OpenAI provider would regress if each consumer derives endpoint and request shape independently.",
+    "same_class_scan": [
+      "Scanned provider adapter drafts and runtime model construction for all AiSdkProviderKind branches and confirmed Anthropic is the only first-party non-OpenAI text protocol currently supported.",
+      "Compared onboarding probing, runtime SDK construction, and built-in verification to ensure all three consumers agree on the stored host-root base URL and provider-specific request contract.",
+      "Added focused endpoint, auth, body, and negative OpenAI regression tests covering the affected entry points."
+    ]
+  },
+  "prevention": {
+    "strategy": "Derive provider-specific endpoint and request shape from providerKind at every boundary, normalize versioned bases in one runtime helper, and keep protocol-specific verification contracts next to their adapter implementation.",
+    "artifacts": [
+      "electron/ai/buildAiSdkModel.ts",
+      "electron/ai/anthropicBaseUrl.test.ts",
+      "electron/providerAdapter/builtinOpenAiCompatibleDraft.ts",
+      "electron/providerAdapter/anthropicChatDraft.test.ts"
+    ]
+  },
   "migration": "No stored data is rewritten. Existing catalogs already hold the host-root form, so both fixes normalize on read: saved Claude connections start working without being re-added and without the API key being re-entered. buildAiSdkModel.test.ts previously asserted that a base without '/v1' routes to '/messages' — that assertion had pinned the defect as the contract and is corrected to '/v1/messages'; the '/v1'-suffixed row is unchanged and still proves no double-suffixing.",
   "residual_risks": [
     "A separate 'Model verification timed out after 90000 ms' was observed before this fix. The timeout is consistent with verification requests never succeeding against the wrong endpoint, but it was not reproduced end to end after the fix — if verification still times out with the correct endpoint, the timeout has an independent cause in the provider-adapter testing stage that this contract does not cover.",

--- a/electron/ai/anthropicBaseUrl.test.ts
+++ b/electron/ai/anthropicBaseUrl.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { anthropicBaseUrl } from "./buildAiSdkModel";
+
+// 2026-08-28 用户实测:接上 Claude 后 onboarding 连接检查能过,但画布 Agent 每次 HTTP 404。
+//
+// 根因是**同一个存储值的两套相反约定**:
+//   · onboarding 探测(onboardingIpc.probeOneProtocol)剥掉尾随 /v1,自己拼 `${root}/v1/messages`
+//     → 落库的 baseUrl 是 host root(`https://api.anthropic.com`)
+//   · 运行时把这个 root 原样交给 `@ai-sdk/anthropic` 的 createAnthropic,而它的 baseURL **必须自带版本段**
+//     (默认值就是 `https://api.anthropic.com/v1`),只在其后接 `/messages`
+// → 运行时 POST 到 `{root}/messages`,Anthropic 返回 404 Not Found。
+//
+// 这条把归一钉死:无论库里存的是 root 还是带 /v1,运行时拿到的 base 都必须以版本段结尾。
+describe("anthropicBaseUrl — 运行时 base 必须带版本段", () => {
+  it("host root 补上 /v1(存量库里就是这个形态)", () => {
+    expect(anthropicBaseUrl("https://api.anthropic.com")).toBe("https://api.anthropic.com/v1");
+  });
+
+  it("已带 /v1 的不重复拼(否则变成 /v1/v1/messages)", () => {
+    expect(anthropicBaseUrl("https://api.anthropic.com/v1")).toBe("https://api.anthropic.com/v1");
+  });
+
+  it("尾随斜杠先归一,再判版本段", () => {
+    expect(anthropicBaseUrl("https://api.anthropic.com/")).toBe("https://api.anthropic.com/v1");
+    expect(anthropicBaseUrl("https://api.anthropic.com/v1/")).toBe("https://api.anthropic.com/v1");
+    expect(anthropicBaseUrl("  https://api.anthropic.com  ")).toBe("https://api.anthropic.com/v1");
+  });
+
+  it("自建网关/中转的路径前缀原样保留,只补版本段", () => {
+    expect(anthropicBaseUrl("https://gw.example.com/anthropic")).toBe("https://gw.example.com/anthropic/v1");
+    expect(anthropicBaseUrl("https://gw.example.com/anthropic/v1")).toBe("https://gw.example.com/anthropic/v1");
+  });
+
+  // 别的版本段(未来 /v2)也算「已带版本」,不能再往后拼 /v1。
+  it("非 v1 的版本段同样视作已带版本", () => {
+    expect(anthropicBaseUrl("https://api.anthropic.com/v2")).toBe("https://api.anthropic.com/v2");
+  });
+
+  // 最终落到 SDK 的请求路径必须是 {base}/messages —— 这才是 404 的判据。
+  it("拼出的最终端点是 /v1/messages,不是 /messages", () => {
+    expect(`${anthropicBaseUrl("https://api.anthropic.com")}/messages`).toBe(
+      "https://api.anthropic.com/v1/messages",
+    );
+  });
+});

--- a/electron/ai/buildAiSdkModel.test.ts
+++ b/electron/ai/buildAiSdkModel.test.ts
@@ -84,8 +84,12 @@ describe("buildAiSdkModel", () => {
     expect(observedUrl).toBe(expectedPath);
   });
 
+  // anthropic 的两行都必须落在 `/v1/messages`：库里存的是 host root（onboarding 探测会剥掉尾随 /v1），
+  // 而 @ai-sdk/anthropic 的 baseURL 必须自带版本段。此前第一行断言的是 `/messages`，把 bug 钉成了契约——
+  // 连接检查过、画布 Agent 每次 404（2026-08-28 用户实测）。补 /v1 后两种存储形态都收敛到同一个端点，
+  // 且已带 /v1 的不会被拼成 /v1/v1。
   it.each([
-    ["anthropic", "", "/messages"],
+    ["anthropic", "", "/v1/messages"],
     ["anthropic", "/v1/", "/v1/messages"],
     ["openai-responses", "", "/v1/responses"],
     ["openai-responses", "/custom/v3/", "/custom/v3/responses"],

--- a/electron/ai/buildAiSdkModel.ts
+++ b/electron/ai/buildAiSdkModel.ts
@@ -99,6 +99,23 @@ function sanitizeHeaders(
   return Object.keys(out).length > 0 ? out : undefined;
 }
 
+/**
+ * Anthropic 的 baseURL **必须自带版本段**：`@ai-sdk/anthropic` 的默认值就是
+ * `https://api.anthropic.com/v1`，它只在这个 base 后面接 `/messages`。
+ *
+ * 而我们**存的是 host root**——onboarding 探测（onboardingIpc.probeOneProtocol）会主动剥掉尾随的
+ * `/v1`（防止和它自己拼的 `/v1/messages` 双拼），落库的 baseUrl 因此是 `https://api.anthropic.com`。
+ * 两条路径对同一个存储值的约定相反：探测端「root，自己补 /v1」，运行端「base 里得有 /v1」。
+ *
+ * 不补这一段，运行时就会 POST 到 `{root}/messages` → **404 Not Found**，而 onboarding 探测却是通的，
+ * 于是表现成「连接能过、一到画布就 404」（2026-08-28 用户实测：接 Claude 后 Agent 每次 HTTP 404）。
+ * 归一放在这里而不是改存储：存量库里已经是 root 形态，读侧补齐才能同时救老数据和新接入。
+ */
+export function anthropicBaseUrl(baseURL: string): string {
+  const trimmed = baseURL.trim().replace(/\/+$/, "");
+  return /\/v\d+$/i.test(trimmed) ? trimmed : `${trimmed}/v1`;
+}
+
 export function buildAiSdkModel(input: BuildAiSdkModelInput): LanguageModelV1 {
   const apiKey = (input.apiKey || "").trim();
   const unauthenticated = input.authType === "none";
@@ -117,7 +134,7 @@ export function buildAiSdkModel(input: BuildAiSdkModelInput): LanguageModelV1 {
     const provider = createAnthropic({
       apiKey,
       fetch: appFetch,
-      ...(baseURL ? { baseURL } : {}),
+      ...(baseURL ? { baseURL: anthropicBaseUrl(baseURL) } : {}),
       ...(headers ? { headers } : {}),
     });
     return provider.languageModel(modelId);

--- a/electron/providerAdapter/anthropicChatDraft.test.ts
+++ b/electron/providerAdapter/anthropicChatDraft.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { buildOpenAiCompatibleDraft } from "./builtinOpenAiCompatibleDraft";
+
+// 2026-08-28 用户接 Claude 实测:连接检查通过,但「验证全部」每次卡到 90s 超时,面板报
+// 「没有能力通过验证 / 还不能在画布上使用」。
+//
+// 根因:文字模型的验证通道写死了 OpenAI 契约(`/v1/chat/completions` + OpenAI body),不看 providerKind。
+// 对 Anthropic 端点那个路径不存在 → 验证一直失败到超时。而 onboarding 的协议探测是另一条代码路径,
+// 它自己拼对了 `/v1/messages`,所以「连接能过、验证过不了」。
+//
+// 这条把「验证通道随协议 derive」钉死。
+const textModel = [{ modelKey: "claude-opus-5", labelZh: "claude-opus-5", kind: "text" as const }];
+
+function chatOpFor(providerKind: "anthropic" | "openai-compatible", authType: "bearer" | "x-api-key") {
+  const draft = buildOpenAiCompatibleDraft({
+    baseUrl: "https://api.anthropic.com",
+    authType,
+    providerKind,
+    models: textModel,
+  });
+  const mode = draft.models[0]?.modes?.find((m) => m.taskKind === "chat");
+  if (!mode) throw new Error("no chat mode in draft");
+  return mode.create;
+}
+
+describe("内置验证草案 — 文字模型的聊天通道随协议 derive", () => {
+  it("anthropic 走 /v1/messages,不是 /chat/completions", () => {
+    const op = chatOpFor("anthropic", "x-api-key");
+    expect(op.path).toBe("/v1/messages");
+    expect(op.path).not.toContain("chat/completions");
+  });
+
+  it("anthropic 带 anthropic-version,且 max_tokens 必填(缺了 Anthropic 直接 400)", () => {
+    const op = chatOpFor("anthropic", "x-api-key");
+    expect(op.headers?.["anthropic-version"]).toBe("2023-06-01");
+    expect((op.body as Record<string, unknown>).max_tokens).toBeTypeOf("number");
+  });
+
+  // 鉴权头由 withAuthHeader 按 authType 补:anthropic 用 x-api-key,且不能残留 Bearer。
+  it("anthropic 用 x-api-key,不留 Authorization", () => {
+    const op = chatOpFor("anthropic", "x-api-key");
+    expect(op.headers?.["x-api-key"]).toBe("{{user_api_key}}");
+    expect(op.headers?.Authorization).toBeUndefined();
+  });
+
+  it("非 anthropic 协议照旧走 OpenAI 契约(没被这次改动带偏)", () => {
+    const op = chatOpFor("openai-compatible", "bearer");
+    expect(op.path).toBe("/v1/chat/completions");
+    expect(op.headers?.Authorization).toBe("Bearer {{user_api_key}}");
+    expect(op.headers?.["anthropic-version"]).toBeUndefined();
+  });
+});

--- a/electron/providerAdapter/builtinOpenAiCompatibleDraft.ts
+++ b/electron/providerAdapter/builtinOpenAiCompatibleDraft.ts
@@ -29,6 +29,22 @@ const OPENAI_COMPATIBLE_CHAT_OP: HttpOperation = {
   },
 };
 
+/**
+ * Anthropic Messages 契约（与 onboardingIpc 的协议探测、buildAiSdkModel 的运行时同一条线）：
+ * `POST {base}/v1/messages`，`x-api-key` + `anthropic-version`，且 **max_tokens 必填**——
+ * 缺它 Anthropic 直接 400，不是可选项。鉴权头由 withAuthHeader 按 authType 补，这里只声明版本头。
+ */
+const ANTHROPIC_CHAT_OP: HttpOperation = {
+  method: "POST",
+  path: "/v1/messages",
+  headers: { "anthropic-version": "2023-06-01", "Content-Type": "application/json" },
+  body: {
+    model: "{{model.modelKey}}",
+    max_tokens: 16,
+    messages: [{ role: "user", content: "{{request.prompt}}" }],
+  },
+};
+
 type ParamControl = ReturnType<typeof newapiTransportFor>["params"][number];
 type DraftParameters = NonNullable<AdapterModelDraft["parameters"]>;
 
@@ -67,11 +83,22 @@ function withAuthHeader(operation: HttpOperation, authType: AdapterAuthType): Ht
   return next;
 }
 
-function modesForKind(kind: BillingModelKind, authType: AdapterAuthType): AdapterModeDraft[] {
+function modesForKind(
+  kind: BillingModelKind,
+  authType: AdapterAuthType,
+  providerKind?: AiSdkProviderKind,
+): AdapterModeDraft[] {
   // 没有文档出处就诚实留空——这张卡来自内置标准契约，不是从某个页面读出来的（D4 缺口明着标）。
   const noSources = { sourceUrls: [] as string[] };
   const auth = (operation: HttpOperation) => withAuthHeader(operation, authType);
-  if (kind === "text") return [{ taskKind: "chat", create: auth(OPENAI_COMPATIBLE_CHAT_OP), ...noSources }];
+  // 文字模型的验证通道必须**随协议 derive**，不能一律按 OpenAI 发。
+  // anthropic 的聊天端点是 /v1/messages（不是 /chat/completions）且 max_tokens 必填，
+  // 照 OpenAI 那份发过去只会 404 → 验证卡在 testing 直到 90s 超时，界面报「没有能力通过验证」，
+  // 而连接检查本身是通的（那条路自己拼对了 /v1/messages）。2026-08-28 用户接 Claude 实测。
+  if (kind === "text") {
+    const chatOp = providerKind === "anthropic" ? ANTHROPIC_CHAT_OP : OPENAI_COMPATIBLE_CHAT_OP;
+    return [{ taskKind: "chat", create: auth(chatOp), ...noSources }];
+  }
   // 3D 没有通用 OpenAI 兼容契约 → 不编造。返回空 modes，验证阶段如实报「这个模型没有可用通道」。
   if (kind !== "image" && kind !== "video" && kind !== "audio") return [];
   const transport = newapiTransportFor(kind);
@@ -131,7 +158,7 @@ export function buildOpenAiCompatibleDraft(input: {
         labelZh: model.labelZh,
         kind: model.kind,
         ...(parameters.length > 0 ? { parameters } : {}),
-        modes: modesForKind(model.kind, input.authType),
+        modes: modesForKind(model.kind, input.authType, input.providerKind),
       };
     }),
   };


### PR DESCRIPTION
## Context
PR #214 contains several useful fixes but its branch is conflicting and cannot be merged as-is. This focused maintainer PR carries the two independent Anthropic protocol fixes that directly affect connected Claude users.

## Changes
- Normalize stored Anthropic host-root URLs to the versioned SDK base so runtime calls use /v1/messages instead of /messages.
- Derive built-in text-model verification from providerKind; Anthropic uses Messages API headers and required max_tokens, while OpenAI-compatible verification remains unchanged.
- Add focused regression tests for endpoint normalization, auth/body shape, and the negative OpenAI contract.
- Upgrade the root-cause contract to the current schema and recurring-prevention format.

## Scope
This does not touch the Agent/MCPSQ migration, timeline kernel, MCP schema, or the rest of #214 localization work. #214 remains open for the author to rebase, sign CLA, and continue the independent changes.

## Verification
- pnpm exec vitest run electron/ai/anthropicBaseUrl.test.ts electron/ai/buildAiSdkModel.test.ts electron/providerAdapter/anthropicChatDraft.test.ts (30 passed)
- pnpm run check:root-cause-contracts passed
- pnpm run typecheck passed
- pnpm run lint:ci passed (existing warnings only)

This PR is intentionally separate from #214 so it can be reviewed and merged without waiting for the contributor branch.