### PR TITLE
fix(ai): derive Anthropic protocol at runtime boundaries

### DIFF
--- a/docs/fixes/2026-08-29-anthropic-protocol-boundary.root-cause.json
+++ b/docs/fixes/2026-08-29-anthropic-protocol-boundary.root-cause.json
@@ -1,0 +1,118 @@
+{
+  "schema_version": 3,
+  "id": "2026-08-29-anthropic-protocol-boundary",
+  "problem_type": "provider protocol mismatch",
+  "symptom": "Anthropic connections could pass onboarding but fail in the canvas with HTTP 404; built-in model verification used the OpenAI chat contract and could time out.",
+  "direct_cause": "The runtime passed a host-root URL to an SDK that appends /messages, and the verification draft selected /v1/chat/completions for every text provider regardless of providerKind.",
+  "class_root": "Provider protocol metadata was not the single source for endpoint and request shape at every consumer boundary.",
+  "affected_population": [
+    "Users connecting Anthropic or Claude-compatible providers",
+    "Maintainers adding another non-OpenAI text protocol"
+  ],
+  "scope_paths": [
+    "electron/ai/buildAiSdkModel.ts",
+    "electron/providerAdapter/builtinOpenAiCompatibleDraft.ts"
+  ],
+  "entry_points": [
+    "buildAiSdkModel runtime model construction",
+    "buildOpenAiCompatibleDraft provider verification construction"
+  ],
+  "external_sources": [
+    {
+      "kind": "official-doc",
+      "url": "https://platform.claude.com/docs/en/api/messages",
+      "checked_at": "2026-08-29",
+      "purpose": "Confirm Anthropic Messages uses POST /v1/messages, x-api-key, anthropic-version, and required max_tokens."
+    },
+    {
+      "kind": "source-code",
+      "url": "https://github.com/vercel/ai",
+      "checked_at": "2026-08-29",
+      "purpose": "Confirm the Anthropic SDK base URL is versioned and appends /messages."
+    }
+  ],
+  "invariants": [
+    "Anthropic runtime requests use a versioned base and resolve to /v1/messages.",
+    "Provider verification selects endpoint, authentication headers, and body shape from providerKind.",
+    "OpenAI-compatible verification remains on /v1/chat/completions with bearer authentication."
+  ],
+  "regression_tests": [
+    "electron/ai/buildAiSdkModel.test.ts",
+    "electron/providerAdapter/builtinOpenAiCompatibleDraft.test.ts"
+  ],
+  "generality_proof": "Runtime model construction and provider verification are separate consumers of the same provider metadata; both now derive the protocol boundary from providerKind instead of carrying an implicit OpenAI assumption.",
+  "shared_boundaries": [
+    {
+      "path": "electron/ai/buildAiSdkModel.ts",
+      "symbol": "buildAiSdkModel",
+      "responsibility": "Normalize provider-specific runtime base URLs before constructing the language model."
+    },
+    {
+      "path": "electron/providerAdapter/builtinOpenAiCompatibleDraft.ts",
+      "symbol": "modesForKind",
+      "responsibility": "Create provider-specific verification operations, including endpoint, auth headers, and body shape."
+    }
+  ],
+  "same_class_entry_points": [
+    {
+      "path": "electron/ai/buildAiSdkModel.ts",
+      "entry_point": "Anthropic runtime model construction",
+      "disposition": "enforced",
+      "evidence": "Anthropic bases are normalized to a versioned SDK base before every runtime request."
+    },
+    {
+      "path": "electron/providerAdapter/builtinOpenAiCompatibleDraft.ts",
+      "entry_point": "Anthropic model verification draft",
+      "disposition": "enforced",
+      "evidence": "The verification operation is selected from providerKind and uses the Messages API contract."
+    },
+    {
+      "path": "electron/providerAdapter/builtinOpenAiCompatibleDraft.ts",
+      "entry_point": "OpenAI-compatible model verification draft",
+      "disposition": "enforced",
+      "evidence": "The default branch retains the OpenAI-compatible chat operation and bearer auth."
+    }
+  ],
+  "recurrence": {
+    "classification": "recurring",
+    "reason": "Every provider runtime and verification path can repeat this mismatch when a protocol is introduced or its URL convention changes.",
+    "same_class_scan": [
+      "Scanned all AiSdkProviderKind branches in runtime model construction.",
+      "Scanned provider adapter draft construction and auth-header derivation.",
+      "Added positive Anthropic and negative OpenAI contract tests at both affected boundaries."
+    ]
+  },
+  "prevention": {
+    "kind": "centralized-boundary",
+    "enforcement_path": "electron/providerAdapter/builtinOpenAiCompatibleDraft.ts",
+    "invariant": "A provider verification operation never sends a request shape belonging to a different provider protocol.",
+    "failure_mode": "The provider-specific operation is selected at the shared draft boundary and contract tests fail if endpoint, auth, or body shape drifts.",
+    "exception_policy": "none",
+    "strategy": "Centralize Anthropic base normalization and derive verification operations from providerKind, with focused contract tests for endpoint, auth, and body shape.",
+    "artifacts": [
+      "electron/ai/buildAiSdkModel.ts",
+      "electron/ai/buildAiSdkModel.test.ts",
+      "electron/providerAdapter/builtinOpenAiCompatibleDraft.ts",
+      "electron/providerAdapter/builtinOpenAiCompatibleDraft.test.ts"
+    ]
+  },
+  "class_regression_tests": [
+    "electron/ai/buildAiSdkModel.test.ts",
+    "electron/providerAdapter/builtinOpenAiCompatibleDraft.test.ts"
+  ],
+  "legacy_paths": {
+    "status": "not-applicable",
+    "removed_paths": [],
+    "rationale": "The affected runtime and verification boundaries remain the supported implementations; no legacy implementation is retained."
+  },
+  "dependency_lifecycle": {
+    "decision": "not-applicable",
+    "rationale": "This change uses the existing provider SDKs and does not add or retain an aging dependency.",
+    "exit_criteria": []
+  },
+  "migration": "No persisted catalog data changes. Existing host-root Anthropic URLs are normalized when read; explicitly versioned URLs remain idempotent.",
+  "residual_risks": [
+    "A valid endpoint can still return 404 for a model unavailable to the configured API key.",
+    "End-to-end verification against a live Anthropic key is not part of CI."
+  ]
+}

--- a/electron/ai/buildAiSdkModel.test.ts
+++ b/electron/ai/buildAiSdkModel.test.ts
@@ -2,7 +2,7 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import http from "node:http";
 import type { AddressInfo } from "node:net";
 import { generateText } from "ai";
-import { buildAiSdkModel } from "./buildAiSdkModel";
+import { anthropicBaseUrl, buildAiSdkModel } from "./buildAiSdkModel";
 import { buildLanguageModelForVendor } from "./vendorLanguageModel";
 import type { Model, Vendor } from "../catalog/types";
 
@@ -85,7 +85,7 @@ describe("buildAiSdkModel", () => {
   });
 
   it.each([
-    ["anthropic", "", "/messages"],
+    ["anthropic", "", "/v1/messages"],
     ["anthropic", "/v1/", "/v1/messages"],
     ["openai-responses", "", "/v1/responses"],
     ["openai-responses", "/custom/v3/", "/custom/v3/responses"],
@@ -129,6 +129,13 @@ describe("buildAiSdkModel", () => {
     expect(model.specificationVersion).toBe("v1");
     expect(model.modelId).toBe("claude-3-5-sonnet-latest");
     expect(model.provider).toMatch(/anthropic/);
+  });
+
+  it("normalizes Anthropic host roots without double-versioning", () => {
+    expect(anthropicBaseUrl("https://api.anthropic.com")).toBe("https://api.anthropic.com/v1");
+    expect(anthropicBaseUrl("https://api.anthropic.com/v1/")).toBe("https://api.anthropic.com/v1");
+    expect(anthropicBaseUrl("https://relay.example.com/anthropic")).toBe("https://relay.example.com/anthropic/v1");
+    expect(anthropicBaseUrl("https://relay.example.com/anthropic/v2")).toBe("https://relay.example.com/anthropic/v2");
   });
 
   it("accepts custom request headers without breaking model construction", () => {

--- a/electron/ai/buildAiSdkModel.ts
+++ b/electron/ai/buildAiSdkModel.ts
@@ -99,6 +99,12 @@ function sanitizeHeaders(
   return Object.keys(out).length > 0 ? out : undefined;
 }
 
+/** Catalogs store an Anthropic host root; the SDK appends only `/messages`. */
+export function anthropicBaseUrl(baseURL: string): string {
+  const trimmed = baseURL.trim().replace(/\/+$/, "");
+  return /\/v\d+$/i.test(trimmed) ? trimmed : `${trimmed}/v1`;
+}
+
 export function buildAiSdkModel(input: BuildAiSdkModelInput): LanguageModelV1 {
   const apiKey = (input.apiKey || "").trim();
   const unauthenticated = input.authType === "none";
@@ -117,7 +123,7 @@ export function buildAiSdkModel(input: BuildAiSdkModelInput): LanguageModelV1 {
     const provider = createAnthropic({
       apiKey,
       fetch: appFetch,
-      ...(baseURL ? { baseURL } : {}),
+      ...(baseURL ? { baseURL: anthropicBaseUrl(baseURL) } : {}),
       ...(headers ? { headers } : {}),
     });
     return provider.languageModel(modelId);

--- a/electron/providerAdapter/builtinOpenAiCompatibleDraft.test.ts
+++ b/electron/providerAdapter/builtinOpenAiCompatibleDraft.test.ts
@@ -75,4 +75,32 @@ describe("buildOpenAiCompatibleDraft", () => {
     expect(draft.sources).toEqual([]);
     expect(draft.models[0].modes.every((mode) => mode.sourceUrls.length === 0)).toBe(true);
   });
+
+  it("uses the Anthropic Messages contract when the provider declares Anthropic", () => {
+    const mode = buildOpenAiCompatibleDraft({
+      baseUrl: "https://api.anthropic.com",
+      authType: "x-api-key",
+      providerKind: "anthropic",
+      models: [{ modelKey: "claude-test", labelZh: "Claude", kind: "text" }],
+    }).models[0].modes[0];
+
+    expect(mode.create.path).toBe("/v1/messages");
+    expect(mode.create.headers?.["anthropic-version"]).toBe("2023-06-01");
+    expect(mode.create.headers?.["x-api-key"]).toBe("{{user_api_key}}");
+    expect(mode.create.headers?.Authorization).toBeUndefined();
+    expect((mode.create.body as Record<string, unknown>).max_tokens).toBe(16);
+  });
+
+  it("keeps the OpenAI-compatible contract for other providers", () => {
+    const mode = buildOpenAiCompatibleDraft({
+      baseUrl: "https://api.example.com/v1",
+      authType: "bearer",
+      providerKind: "openai-compatible",
+      models: [{ modelKey: "gpt-test", labelZh: "GPT", kind: "text" }],
+    }).models[0].modes[0];
+
+    expect(mode.create.path).toBe("/v1/chat/completions");
+    expect(mode.create.headers?.Authorization).toBe("Bearer {{user_api_key}}");
+    expect(mode.create.headers?.["anthropic-version"]).toBeUndefined();
+  });
 });

--- a/electron/providerAdapter/builtinOpenAiCompatibleDraft.ts
+++ b/electron/providerAdapter/builtinOpenAiCompatibleDraft.ts
@@ -29,6 +29,17 @@ const OPENAI_COMPATIBLE_CHAT_OP: HttpOperation = {
   },
 };
 
+const ANTHROPIC_CHAT_OP: HttpOperation = {
+  method: "POST",
+  path: "/v1/messages",
+  headers: { "anthropic-version": "2023-06-01", "Content-Type": "application/json" },
+  body: {
+    model: "{{model.modelKey}}",
+    max_tokens: 16,
+    messages: [{ role: "user", content: "{{request.prompt}}" }],
+  },
+};
+
 type ParamControl = ReturnType<typeof newapiTransportFor>["params"][number];
 type DraftParameters = NonNullable<AdapterModelDraft["parameters"]>;
 
@@ -67,11 +78,18 @@ function withAuthHeader(operation: HttpOperation, authType: AdapterAuthType): Ht
   return next;
 }
 
-function modesForKind(kind: BillingModelKind, authType: AdapterAuthType): AdapterModeDraft[] {
+function modesForKind(
+  kind: BillingModelKind,
+  authType: AdapterAuthType,
+  providerKind?: AiSdkProviderKind,
+): AdapterModeDraft[] {
   // 没有文档出处就诚实留空——这张卡来自内置标准契约，不是从某个页面读出来的（D4 缺口明着标）。
   const noSources = { sourceUrls: [] as string[] };
   const auth = (operation: HttpOperation) => withAuthHeader(operation, authType);
-  if (kind === "text") return [{ taskKind: "chat", create: auth(OPENAI_COMPATIBLE_CHAT_OP), ...noSources }];
+  if (kind === "text") {
+    const operation = providerKind === "anthropic" ? ANTHROPIC_CHAT_OP : OPENAI_COMPATIBLE_CHAT_OP;
+    return [{ taskKind: "chat", create: auth(operation), ...noSources }];
+  }
   // 3D 没有通用 OpenAI 兼容契约 → 不编造。返回空 modes，验证阶段如实报「这个模型没有可用通道」。
   if (kind !== "image" && kind !== "video" && kind !== "audio") return [];
   const transport = newapiTransportFor(kind);
@@ -131,7 +149,7 @@ export function buildOpenAiCompatibleDraft(input: {
         labelZh: model.labelZh,
         kind: model.kind,
         ...(parameters.length > 0 ? { parameters } : {}),
-        modes: modesForKind(model.kind, input.authType),
+        modes: modesForKind(model.kind, input.authType, input.providerKind),
       };
     }),
   };


### PR DESCRIPTION
## Why this is separate from #214\n#214 contains useful but unrelated localization and agent changes, and its branch is currently conflicting and awaiting contributor CLA. This PR is a fresh maintainer-authored implementation of the independent Anthropic protocol fixes, so it does not bypass contributor attribution or depend on #214.\n\n## User impact\n- Fixes Claude/Anthropic connections that pass onboarding but fail every canvas request with 404 because the runtime used /messages instead of /v1/messages.\n- Fixes built-in model verification that sent Anthropic models to the OpenAI /v1/chat/completions contract and could time out.\n\n## Changes\n- Normalize stored Anthropic host-root URLs at the SDK boundary, idempotently preserving explicit version paths.\n- Select Anthropic Messages verification from providerKind, including anthropic-version, x-api-key, and required max_tokens.\n- Keep OpenAI-compatible verification unchanged.\n- Add v3 root-cause evidence and regression coverage.\n\n## Scope\nNo Agent/MCPSQ migration, MCP schema, timeline kernel, or UI components are changed. #214 remains open for its author to rebase, sign CLA, and continue its separate localization work.\n\n## Verification\n- vitest targeted suite: 32 passed\n- check:root-cause-contracts passed\n- typecheck passed\n- lint:ci passed with existing warnings only