### PR TITLE
fix: improve Issue 237 onboarding and provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Your projects, prompts, and API keys stay on your machine. No account. No teleme
 
 [简体中文](README.zh-CN.md) · [Website](https://nomiaqm.com/en/) · [Download](#download) · [Tutorial](docs/guide/model-connection-en.md) · [Community](https://github.com/aqm857886159/Nomi/discussions) · [Follow on X](https://x.com/sdf297417627618) · [For Teams](https://nomiaqm.com/en/#teams) · [Watch the 60s film](https://nomiaqm.com/assets/video/launch-film-en.mp4) · [Documentation](docs/user-guide.md)
 
+Workflow support: **2373272608@qq.com** · [X/Twitter](https://x.com/sdf297417627618)
+
 ## WeChat / 微信联系
 
 ### Join the Nomi user group / 加入 Nomi 用户群
@@ -89,11 +91,11 @@ The installer has no Authenticode signature. In the SmartScreen prompt, choose *
 
 > **Disclosure:** one curated provider (APImart) is linked with a referral code. You always pay providers directly with your own key at their price — Nomi never proxies or resells inference, and every provider can be replaced by your own endpoint.
 
-Read the [English model connection tutorial](docs/guide/model-connection-en.md), [copy-paste Codex issue-fix prompt](docs/guide/codex-issue-fix-prompt-en.md), [user guide](docs/user-guide.md), [provider guide](docs/provider-integration.md), [conversational model integration guide](docs/guide/conversational-model-integration.md), or [CLI + MCP guide](docs/guide/capability-core-cli-mcp.md).
+Read the [English model connection tutorial](docs/guide/model-connection-en.md), [urgent Codex / Claude Code provider-setup prompt](docs/guide/model-integration-prompt-en.md), [copy-paste Codex issue-fix prompt](docs/guide/codex-issue-fix-prompt-en.md), [user guide](docs/user-guide.md), [provider guide](docs/provider-integration.md), [conversational model integration guide](docs/guide/conversational-model-integration.md), or [CLI + MCP guide](docs/guide/capability-core-cli-mcp.md).
 
 ## Community
 
-Use [GitHub Discussions](https://github.com/aqm857886159/Nomi/discussions) to ask questions, share workflows, and follow what is being built next, and [GitHub Issues](https://github.com/aqm857886159/Nomi/issues) to report bugs and request features. Follow the project on [X / Twitter](https://x.com/sdf297417627618) for release notes and short demos. WeChat users can use the group and maintainer QR codes at the top of this README; the [Chinese README](README.zh-CN.md#用户群) contains the full Chinese guide.
+Use [GitHub Discussions](https://github.com/aqm857886159/Nomi/discussions) to ask questions, share workflows, and follow what is being built next, and [GitHub Issues](https://github.com/aqm857886159/Nomi/issues) to report bugs and request features. Follow the project on [X / Twitter](https://x.com/sdf297417627618) for release notes and short demos; workflow support is available at **2373272608@qq.com**. WeChat users can use the group and maintainer QR codes at the top of this README; the [Chinese README](README.zh-CN.md#用户群) contains the full Chinese guide.
 
 ## For Teams
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Nomi is an open-source desktop workbench for AI video. Connect any OpenAI-compat
 
 Your projects, prompts, and API keys stay on your machine. No account. No telemetry.
 
-[简体中文](README.zh-CN.md) · [Website](https://nomiaqm.com/en/) · [Download](#download) · [Community](https://github.com/aqm857886159/Nomi/discussions) · [For Teams](https://nomiaqm.com/en/#teams) · [Watch the 60s film](https://nomiaqm.com/assets/video/launch-film-en.mp4) · [Documentation](docs/user-guide.md)
+[简体中文](README.zh-CN.md) · [Website](https://nomiaqm.com/en/) · [Download](#download) · [Tutorial](docs/guide/model-connection-en.md) · [Community](https://github.com/aqm857886159/Nomi/discussions) · [Follow on X](https://x.com/sdf297417627618) · [For Teams](https://nomiaqm.com/en/#teams) · [Watch the 60s film](https://nomiaqm.com/assets/video/launch-film-en.mp4) · [Documentation](docs/user-guide.md)
 
 ## WeChat / 微信联系
 
@@ -89,11 +89,11 @@ The installer has no Authenticode signature. In the SmartScreen prompt, choose *
 
 > **Disclosure:** one curated provider (APImart) is linked with a referral code. You always pay providers directly with your own key at their price — Nomi never proxies or resells inference, and every provider can be replaced by your own endpoint.
 
-Read the [user guide](docs/user-guide.md), [provider guide](docs/provider-integration.md), [conversational model integration guide](docs/guide/conversational-model-integration.md), or [CLI + MCP guide](docs/guide/capability-core-cli-mcp.md).
+Read the [English model connection tutorial](docs/guide/model-connection-en.md), [copy-paste Codex issue-fix prompt](docs/guide/codex-issue-fix-prompt-en.md), [user guide](docs/user-guide.md), [provider guide](docs/provider-integration.md), [conversational model integration guide](docs/guide/conversational-model-integration.md), or [CLI + MCP guide](docs/guide/capability-core-cli-mcp.md).
 
 ## Community
 
-Use [GitHub Discussions](https://github.com/aqm857886159/Nomi/discussions) to ask questions, share workflows, and follow what is being built next, and [GitHub Issues](https://github.com/aqm857886159/Nomi/issues) to report bugs and request features. WeChat users can use the group and maintainer QR codes at the top of this README; the [Chinese README](README.zh-CN.md#用户群) contains the full Chinese guide.
+Use [GitHub Discussions](https://github.com/aqm857886159/Nomi/discussions) to ask questions, share workflows, and follow what is being built next, and [GitHub Issues](https://github.com/aqm857886159/Nomi/issues) to report bugs and request features. Follow the project on [X / Twitter](https://x.com/sdf297417627618) for release notes and short demos. WeChat users can use the group and maintainer QR codes at the top of this README; the [Chinese README](README.zh-CN.md#用户群) contains the full Chinese guide.
 
 ## For Teams
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -37,6 +37,8 @@ Nomi 是一个开源的 AI 视频创作桌面工作台。接任何 OpenAI 兼容
 
 [参与 GitHub Discussions](https://github.com/aqm857886159/Nomi/discussions) · [提交商务咨询](https://github.com/aqm857886159/Nomi/issues/new?template=business_inquiry.yml)
 
+工作流接入支持：**2373272608@qq.com** · [X/Twitter](https://x.com/sdf297417627618)
+
 [![最新版本](https://img.shields.io/github/v/release/aqm857886159/Nomi?label=release)](https://github.com/aqm857886159/Nomi/releases/latest)
 ![平台](https://img.shields.io/badge/platform-macOS%20%7C%20Windows-1a1816)
 [![许可证](https://img.shields.io/badge/license-AGPL--3.0--only-1a1816)](LICENSE)
@@ -90,7 +92,7 @@ Windows 安装包未使用 Authenticode 签名。SmartScreen 弹窗选择“更�
 
 > **利益披露**：预置供应商中有一家（APImart）的注册链接带推广码。你始终用自己的密钥、按供应商原价直接付给他们——Nomi 不代理、不转售任何推理服务，任何一家供应商都可以换成你自己的接口。
 
-详细说明：[使用指南](docs/user-guide.md) · [模型接入](docs/provider-integration.md) · [对话式模型接入](docs/guide/conversational-model-integration.md) · [CLI + MCP 指南](docs/guide/capability-core-cli-mcp.md)
+详细说明：[使用指南](docs/user-guide.md) · [模型接入](docs/provider-integration.md) · [英文 Codex / Claude Code 接入提示词](docs/guide/model-integration-prompt-en.md) · [对话式模型接入](docs/guide/conversational-model-integration.md) · [CLI + MCP 指南](docs/guide/capability-core-cli-mcp.md)
 
 ## 团队服务
 

--- a/docs/DELIVERY-LEDGER.md
+++ b/docs/DELIVERY-LEDGER.md
@@ -9,7 +9,7 @@
 
 ---
 
-## 现役欠账（6）
+## 现役欠账（7）
 
 | 状态 | 文档 | 标题 |
 |---|---|---|
@@ -17,6 +17,7 @@
 | 🚧 进行中 | [2026-08-28-conversational-model-integration-verification.md](plan/2026-08-28-conversational-model-integration-verification.md) | 对话式模型接入与认证闭环验收记录 |
 | 🚧 进行中 | [2026-08-28-editing-engine-uplift.md](plan/2026-08-28-editing-engine-uplift.md) | Nomi Editing Engine Uplift |
 | 🚧 进行中 | [2026-08-29-root-cause-contract-v2.md](plan/2026-08-29-root-cause-contract-v2.md) | 根因合同 v2 与规则收敛 |
+| 🚧 进行中 | [2026-08-30-issue-237-onboarding.md](plan/2026-08-30-issue-237-onboarding.md) | Issue #237: 接入请求与英文上手入口 |
 | 🚧 进行中 | [2026-08-27-release-media-pack-skill.md](superpowers/plans/2026-08-27-release-media-pack-skill.md) | Nomi Release Media Pack Skill Implementation Plan |
 | 🚧 进行中 | [2026-08-28-conversational-model-integration.md](superpowers/plans/2026-08-28-conversational-model-integration.md) | Conversational Model Integration Implementation Plan |
 
@@ -43,7 +44,7 @@ _没有标记为远期的方案。_
 
 </details>
 
-- 合计扫描：453 篇方案文档（docs/plan/ 与 docs/superpowers/plans/，不含 INDEX.md）
+- 合计扫描：454 篇方案文档（docs/plan/ 与 docs/superpowers/plans/，不含 INDEX.md）
 
 ---
 

--- a/docs/fixes/2026-08-30-openai-image-empty-size.root-cause.json
+++ b/docs/fixes/2026-08-30-openai-image-empty-size.root-cause.json
@@ -1,0 +1,105 @@
+{
+  "schema_version": 3,
+  "id": "2026-08-30-openai-image-empty-size",
+  "problem_type": "openai-compatible image parameter serialization regression",
+  "symptom": "Selecting Auto · 1K for gpt-image-2 produced an image request with size: \"\", and the provider rejected it with Invalid size \"\".",
+  "direct_cause": "taskTemplateParams used an empty string as the missing-size value. Exact template fields preserve empty strings, so the OpenAI-compatible image body serialized an invalid size instead of omitting the optional field.",
+  "class_root": "Optional provider parameters were not normalized at the shared task-template boundary: missing values could cross into exact request templates as empty strings and become invalid wire values.",
+  "affected_population": [
+    "Users selecting Auto for an OpenAI-compatible image model",
+    "Persisted gpt-image-2 configurations whose aspect ratio has no concrete pixel-size mapping",
+    "Any future exact-template operation that receives an unset optional value through taskTemplateParams"
+  ],
+  "scope_paths": [
+    "electron/catalog/taskParams.ts",
+    "electron/catalog/newapiImageEdit.test.ts"
+  ],
+  "entry_points": [
+    "taskTemplateParams for image-generation and image-edit operations",
+    "OpenAI-compatible image parameter mapping and exact request-body rendering",
+    "Auto aspect-ratio selections with a resolution tier"
+  ],
+  "external_sources": [
+    {
+      "kind": "official-doc",
+      "url": "https://developers.openai.com/api/docs/models/gpt-image-2",
+      "checked_at": "2026-08-30",
+      "purpose": "Confirm gpt-image-2 supports the Images API generation and edit surfaces whose optional image parameters must follow the provider contract."
+    },
+    {
+      "kind": "official-doc",
+      "url": "https://developers.openai.com/api/docs/guides/images-vision",
+      "checked_at": "2026-08-30",
+      "purpose": "Confirm the documented Images API request shape and distinguish it from Chat Completions image understanding."
+    }
+  ],
+  "invariants": [
+    "When no concrete image size is selected, the shared task-template parameter object contains undefined for size and exact request templates omit the field.",
+    "When a concrete ratio and resolution are selected, parameter mapping still produces a valid pixel WxH size.",
+    "The shared normalization boundary never serializes an empty string as an optional provider parameter value.",
+    "The regression is covered at final request-body assembly rather than only at a UI-state snapshot."
+  ],
+  "regression_tests": [
+    "electron/catalog/newapiImageEdit.test.ts"
+  ],
+  "generality_proof": "All catalog operations that derive exact template parameters call taskTemplateParams before param mapping and body rendering; normalizing the shared size value prevents the same empty optional field from entering another OpenAI-compatible operation.",
+  "shared_boundaries": [
+    {
+      "path": "electron/catalog/taskParams.ts",
+      "symbol": "taskTemplateParams",
+      "responsibility": "Normalize derived task parameters before any provider parameter map or exact request template can serialize them."
+    }
+  ],
+  "same_class_entry_points": [
+    {
+      "path": "electron/catalog/taskParams.ts",
+      "entry_point": "image create/edit template parameters",
+      "disposition": "enforced",
+      "evidence": "Both image create and multipart edit operation tests render parameters produced by taskTemplateParams."
+    },
+    {
+      "path": "electron/catalog/paramTranslate.ts",
+      "entry_point": "concrete ratio and resolution mapping",
+      "disposition": "enforced",
+      "evidence": "Existing parameter consistency and image edit tests retain concrete WxH values while the new Auto case omits size."
+    }
+  ],
+  "recurrence": {
+    "classification": "recurring",
+    "reason": "Any optional field whose missing representation is an empty string can be preserved by exact templates and rejected by a strict provider, so the shared normalization boundary must enforce the rule.",
+    "same_class_scan": [
+      "Scanned taskTemplateParams callers and the exact template renderer for image create/edit operations.",
+      "Checked concrete ratio mappings and existing parameter-consistency coverage to ensure the fix does not remove valid wire values."
+    ]
+  },
+  "prevention": {
+    "kind": "centralized-boundary",
+    "enforcement_path": "electron/catalog/taskParams.ts",
+    "invariant": "Unset optional task parameters remain undefined until the template renderer omits them.",
+    "failure_mode": "The shared builder cannot hand an empty size alias to a strict exact template.",
+    "exception_policy": "none",
+    "strategy": "Normalize empty derived size values at the shared task-template boundary and assert the final wire body.",
+    "artifacts": [
+      "electron/catalog/taskParams.ts",
+      "electron/catalog/newapiImageEdit.test.ts"
+    ]
+  },
+  "class_regression_tests": [
+    "electron/catalog/newapiImageEdit.test.ts"
+  ],
+  "legacy_paths": {
+    "status": "not-applicable",
+    "removed_paths": [],
+    "rationale": "The defect was an invalid value at an existing shared boundary, not a parallel implementation that needs removal."
+  },
+  "dependency_lifecycle": {
+    "decision": "not-applicable",
+    "rationale": "No third-party dependency controls optional parameter normalization.",
+    "exit_criteria": []
+  },
+  "migration": "No catalog migration is required. Existing saved Auto selections are normalized when their next request parameters are built.",
+  "residual_risks": [
+    "A third-party relay may expose a different image contract; its official request example is still required before adding a mapping.",
+    "Anonymous upload-host failures remain a network/transport concern and are not made reliable by this size normalization fix."
+  ]
+}

--- a/docs/guide/codex-issue-fix-prompt-en.md
+++ b/docs/guide/codex-issue-fix-prompt-en.md
@@ -60,7 +60,7 @@ Treat these as separate hypotheses and prove or disprove each one:
 1. Add a failing regression test for every confirmed code bug.
 2. Implement the smallest root-cause fix.
 3. Add or update the English model-connection tutorial so a new user can enter a provider name, base URL, key, model ID, model kind, mode, and reference-image path without guessing. Include troubleshooting for empty `size`, route mismatch, and anonymous upload failures.
-4. Link the tutorial from the English README. Keep social links factual: use only URLs explicitly supplied by the maintainer; do not invent Reddit/YouTube accounts or publish a personal mailbox as a support address.
+4. Link the tutorial from the English README. Keep contact links factual: use only URLs and contact addresses explicitly supplied or authorized by the maintainer; do not invent Reddit/YouTube accounts. The maintainer-authorized public support contacts are `2373272608@qq.com` and https://x.com/sdf297417627618.
 5. If a provider contract is still unknown, document the missing evidence and leave a precise follow-up request instead of guessing.
 
 ## Verification

--- a/docs/guide/codex-issue-fix-prompt-en.md
+++ b/docs/guide/codex-issue-fix-prompt-en.md
@@ -1,0 +1,81 @@
+# Copy-paste prompt for Codex: fix a Nomi provider issue
+
+If you can run Codex with a GitHub checkout, paste the prompt below. It gives Codex enough context to investigate the current onboarding failure without asking you to publish an API key or private contact details.
+
+```text
+===== PROMPT START =====
+
+You are contributing to the public repository https://github.com/aqm857886159/Nomi.
+
+## Goal
+
+Investigate and fix the provider-onboarding problems reported in GitHub Issue #237 and the missing English onboarding path discussed in Discussion #220. Work from evidence, find the root cause, add regression coverage, and deliver a reviewable branch/PR.
+
+## Repository setup
+
+1. If this directory is not already the Nomi checkout, clone it:
+
+   git clone https://github.com/aqm857886159/Nomi.git
+   cd Nomi
+
+2. Read `AGENTS.md` and any more-specific `AGENTS.md` files before editing.
+3. Check the current branch and worktree status. Do not discard existing user changes.
+4. Create a task branch from the latest `origin/main`, for example:
+
+   git fetch origin
+   git switch -c codex/issue-237-provider-onboarding origin/main
+
+Do not push directly to `main` and do not rewrite history.
+
+## Evidence to inspect
+
+- Issue: https://github.com/aqm857886159/Nomi/issues/237
+- Discussion: https://github.com/aqm857886159/Nomi/discussions/220
+- The current Nomi catalog, parameter translation, transport, asset-localization, and migration code.
+- The provider's official API documentation. If the provider is OpenAI, use:
+  - https://developers.openai.com/api/docs/models/gpt-image-2
+  - https://developers.openai.com/api/docs/guides/images-vision
+
+Do not infer a third-party provider's API shape from its name. If the issue author uses a relay or aggregator, ask for the provider's public request example, exact base URL host, model ID, operation, and response shape. They must redact API keys, phone numbers, private email addresses, private paths, and confidential images.
+
+## Symptoms that must be separated
+
+Treat these as separate hypotheses and prove or disprove each one:
+
+1. An OpenAI-compatible image request may serialize an empty `size` (for example, `Auto · 1K`) instead of omitting the field. An official or compatible image endpoint can reject that as `Invalid size ""`.
+2. A stale saved catalog or old build may send GPT Image editing to `chat/completions` instead of the documented Images API multipart edit route.
+3. Anonymous upload hosts such as `litterbox.catbox.moe` or `tmpfiles.org` may fail because of network/proxy/host availability. That is an asset-transport problem, not evidence that the model key is wrong. For a multipart provider route, check whether Nomi can send local bytes directly before introducing an anonymous upload dependency.
+
+## Investigation rules
+
+- Trace the real path end to end: UI selection → persisted model/parameters → template/parameter mapping → operation selection → request body or multipart fields → asset localization/upload → response parsing.
+- Reproduce with a deterministic mock or request-body test first. Never require the issue author to give you a live secret.
+- For official OpenAI GPT Image 2, verify the documented contract before editing code: `gpt-image-2`, Images API generation, multipart image edits, and the documented parameter names/types. Chat Completions is not the image-generation route.
+- Fix the root cause at the shared layer so another entry point cannot reintroduce the same empty field or wrong operation. Do not add a provider-specific parallel UI or a blind fallback.
+- Preserve existing migrations and compatibility rules. If old persisted catalog data needs migration, add or update a migration test.
+- Do not claim that an anonymous host is fixed unless you have a reproducible, in-scope transport change and a test for it. Prefer a configured provider-private upload or direct multipart bytes for sensitive references.
+
+## Required implementation
+
+1. Add a failing regression test for every confirmed code bug.
+2. Implement the smallest root-cause fix.
+3. Add or update the English model-connection tutorial so a new user can enter a provider name, base URL, key, model ID, model kind, mode, and reference-image path without guessing. Include troubleshooting for empty `size`, route mismatch, and anonymous upload failures.
+4. Link the tutorial from the English README. Keep social links factual: use only URLs explicitly supplied by the maintainer; do not invent Reddit/YouTube accounts or publish a personal mailbox as a support address.
+5. If a provider contract is still unknown, document the missing evidence and leave a precise follow-up request instead of guessing.
+
+## Verification
+
+Run the narrow tests while iterating, then run the repository gates required by `AGENTS.md` (at minimum filesize, tokens, i18n, lint, typecheck, tests, and build). Review the final diff for secrets, private issue data, unrelated files, and accidental changes to the default branch.
+
+Report:
+
+- confirmed symptoms and root causes, with `file:line` evidence;
+- changed files and why each changed;
+- tests and gates with their actual results;
+- what remains unverified (for example, a live relay requiring credentials);
+- branch name, commit SHA, and PR URL if you have permission to push a branch. If you cannot push, provide the commit/patch and exact next command.
+
+===== PROMPT END =====
+```
+
+This prompt is intentionally conservative: Codex can inspect the public code, reproduce request assembly with mocks, and prepare a PR, but only the provider account owner can supply a real key or approve a paid/live request.

--- a/docs/guide/model-connection-en.md
+++ b/docs/guide/model-connection-en.md
@@ -89,6 +89,7 @@ Never include API keys, phone numbers, private email addresses, or confidential 
 ## Official places to follow Nomi
 
 - [Nomi website](https://nomiaqm.com/en/)
+- Workflow support: **2373272608@qq.com**
 - [Nomi on X / Twitter](https://x.com/sdf297417627618)
 - [GitHub Discussions](https://github.com/aqm857886159/Nomi/discussions)
 - [Business inquiry](https://github.com/aqm857886159/Nomi/issues/new?template=business_inquiry.yml)
@@ -96,3 +97,5 @@ Never include API keys, phone numbers, private email addresses, or confidential 
 ## Want Codex to investigate a bug?
 
 If you can run Codex with a GitHub checkout, use the [copy-paste Codex issue-fix prompt](codex-issue-fix-prompt-en.md). It tells Codex how to clone the repository, inspect the provider contract, reproduce the request with a mock, protect secrets, and deliver a branch/PR instead of changing `main` directly.
+
+If you need to connect a provider urgently without opening a PR, use the [Codex / Claude Code provider-setup prompt](model-integration-prompt-en.md). It uses Nomi's `model-integration` Skill and MCP tools first; if the installed build lacks a provider-private upload route, it limits local source work to a documented Runway upload channel and does not add a Runway model adapter.

--- a/docs/guide/model-connection-en.md
+++ b/docs/guide/model-connection-en.md
@@ -1,0 +1,98 @@
+# Connect your first model
+
+This is the English tutorial for adding a model to Nomi. It covers the path that matters when you arrive with your own provider: connect one model, prove the request shape, then use it in a storyboard.
+
+Nomi stores projects, prompts, and API keys on your computer. Do not paste a key into a GitHub issue, Discussion, screenshot, or tutorial comment.
+
+## 1. Start with the latest desktop build
+
+Download the current macOS or Windows build from [GitHub Releases](https://github.com/aqm857886159/Nomi/releases/latest), then open Nomi and create or open a project.
+
+For a first test, use one text model and one image model. You can add video after the image path works.
+
+## 2. Add a provider
+
+Open **Model setup** in the top toolbar and choose **Add provider**.
+
+Fill in:
+
+1. **Provider name** — a name you will recognise, such as `My OpenAI relay`.
+2. **API Base URL** — use the base URL from that provider's official documentation. Do not guess whether `/v1` belongs in the URL; follow the provider's example request.
+3. **API key** — enter it in Nomi's secure form. It is kept in local app storage.
+4. **Model ID** — copy the exact model identifier from the provider documentation. A display name is not enough.
+
+Choose the model kind and task mode that match the documented endpoint:
+
+| You want to do | Mode | Typical request shape |
+|---|---|---|
+| Write a script or split shots | Text | Chat or Responses API |
+| Generate an image | Text to image | `POST /v1/images/generations` or the provider's documented equivalent |
+| Edit an image with references | Image edit | `POST /v1/images/edits`, multipart, or the provider's documented multimodal route |
+| Generate a video | Text to video / Image to video | The provider's documented create and polling endpoints |
+
+The route and body are a contract, not a guess. For example, an OpenAI-compatible image endpoint expects a pixel `size` such as `1024x1024`; a different provider may call the same control `aspect_ratio` or `resolution`.
+
+### OpenAI GPT Image 2
+
+For the official OpenAI API, choose the **OpenAI** preset (`https://api.openai.com/v1`), add model ID `gpt-image-2`, and choose **Image** rather than **Text**. The official image generation path is the [Images API](https://developers.openai.com/api/docs/guides/images-vision): use `POST /v1/images/generations` for text-to-image and `POST /v1/images/edits` with multipart image files for image editing. Chat Completions is the documented path for image understanding and text responses, not the path to use for creating an image.
+
+In Nomi, **Auto** means “let the image endpoint choose the size” and therefore omits the `size` field. If you choose a concrete ratio, Nomi translates it to a pixel size such as `1024x576` before sending an OpenAI-compatible request. This distinction is what prevents the `Invalid size ""` error reported in [Issue #237](https://github.com/aqm857886159/Nomi/issues/237).
+
+## 3. Test before you build a storyboard
+
+Click **Test** in the provider form before saving. The test should prove the selected model and mode, not just that the host is reachable.
+
+If the test passes, save the provider and select the model in an image or video node. Run one small generation first. Only after that should you add many references or start a long storyboard.
+
+If the test says that the guessed call shape does not match, changing the URL or key repeatedly will not fix it. Re-open the provider's official API example and check these values one by one:
+
+- base URL and API version;
+- authentication header or query parameter;
+- model ID;
+- operation path (`images/generations`, `images/edits`, chat, or another route);
+- JSON vs multipart body;
+- required parameter names and value types;
+- response field containing the image/video URL or task ID.
+
+## 4. Add references deliberately
+
+For image edit or image-to-video, add one reference first and test it. Providers differ in what they accept:
+
+- a public `https://` image URL;
+- a local file uploaded through the provider's endpoint;
+- a base64 data URL;
+- a provider-specific reference field.
+
+If Nomi reports **“All no-configuration upload hosts failed”**, that is an upload transport problem (network, proxy, or a blocked anonymous host), not proof that your model key is wrong. Use a configured provider upload path or a network that can reach the host. Do not upload confidential production references to an anonymous host.
+
+## 5. Common errors
+
+| Error | What it usually means | Next action |
+|---|---|---|
+| `Invalid size ""` | An OpenAI-compatible image request received an empty pixel size. | Update to a build containing the Issue #237 fix, or choose an explicit ratio/size such as `1:1` / `1024x1024` for now. |
+| `The model and connection are still saved` | Credentials were saved, but the production call has not passed verification. | Keep the model disabled until a real test succeeds. |
+| `call shape ... does not match theirs` | The adapter shape does not match the provider contract. | Follow the provider's official request example and correct the operation/body; do not keep rotating keys. |
+| `Provider request failed (HTTP 500)` | The upstream endpoint or relay returned a server error. | Check the exact endpoint, model ID, provider status, and a minimal request outside Nomi; redact secrets before sharing logs. |
+
+## 6. Ask for help with enough evidence
+
+Use [GitHub Discussions](https://github.com/aqm857886159/Nomi/discussions) for setup questions and [Issues](https://github.com/aqm857886159/Nomi/issues/new?template=bug_report.yml) for reproducible bugs. Include:
+
+- Nomi version and operating system;
+- provider type and API base host (omit keys and private paths);
+- model ID and task mode;
+- the redacted request shape and response/error body;
+- whether a text-only or one-image minimal test works.
+
+Never include API keys, phone numbers, private email addresses, or confidential reference images in a public post.
+
+## Official places to follow Nomi
+
+- [Nomi website](https://nomiaqm.com/en/)
+- [Nomi on X / Twitter](https://x.com/sdf297417627618)
+- [GitHub Discussions](https://github.com/aqm857886159/Nomi/discussions)
+- [Business inquiry](https://github.com/aqm857886159/Nomi/issues/new?template=business_inquiry.yml)
+
+## Want Codex to investigate a bug?
+
+If you can run Codex with a GitHub checkout, use the [copy-paste Codex issue-fix prompt](codex-issue-fix-prompt-en.md). It tells Codex how to clone the repository, inspect the provider contract, reproduce the request with a mock, protect secrets, and deliver a branch/PR instead of changing `main` directly.

--- a/docs/guide/model-integration-prompt-en.md
+++ b/docs/guide/model-integration-prompt-en.md
@@ -1,0 +1,79 @@
+# Urgent provider setup prompt for Codex or Claude Code
+
+Use this prompt when you need to connect a provider immediately. It first uses Nomi's MCP server and the built-in `model-integration` Skill. If the installed build is missing a provider-private upload capability, it gives the agent a narrowly scoped local implementation task for that upload channel—without adding a full Runway model adapter or opening a pull request.
+
+First connect Nomi to Codex or Claude Code from **Model setup → Connect AI coding assistant**. Then paste the prompt below.
+
+```text
+===== PROMPT START =====
+
+You are helping me connect an AI provider to my local Nomi installation. I need a working provider setup, not a contribution to the upstream project.
+
+## Hard boundaries
+
+- Do not open a pull request, push to any remote, or ask me to submit one.
+- If source changes are necessary, work only in my local checkout, preserve existing changes, and use a local task branch. Do not commit unrelated work.
+- Never ask me to paste an API key into chat, a tool argument, a URL, a log, or a file. Open Nomi's secure credential UI and ask me to enter the key there.
+- Never echo credentials, Authorization headers, signed URLs, private paths, phone numbers, or confidential reference images.
+- Do not guess an endpoint, model ID, authentication method, request field, response field, upload route, or capability from a provider name.
+- Do not add a full Runway model/Seedance 2.5 adapter in this task. The urgent scope is provider onboarding and, if needed, a provider-private Runway upload channel for reference assets.
+
+## Start with the existing Nomi Skill and MCP
+
+1. Confirm that the Nomi MCP server is connected and that these tools are available: `nomi_integration_begin`, `nomi_integration_open_credentials`, `nomi_integration_discover`, `nomi_integration_select`, `nomi_integration_request_confirmation`, `nomi_integration_start`, and `nomi_integration_get`.
+2. If the tools are missing, tell me to open Nomi's **Model setup → Connect AI coding assistant** card, complete its generated configuration, and restart this client. Do not hand-edit an MCP config as a workaround.
+3. Read the `model-integration` Skill if this MCP host exposes `nomi-skill://model-integration`. If a repository checkout is open, also read `skills/model-integration/SKILL.md`, `docs/provider-integration.md`, `docs/guide/model-connection-en.md`, and `docs/guide/capability-core-cli-mcp.md`. Treat the Skill and tool schemas as the source of truth.
+
+## Gather public evidence, not secrets
+
+Ask me in one short message for:
+
+- provider name;
+- the provider's official API documentation URL or public request example;
+- the exact model IDs and modes I need (text, image, video, or audio);
+- whether this is a native local ComfyUI server or an ordinary HTTP provider;
+- if reference images are needed, whether the provider documents its own upload endpoint.
+
+Do not ask for the API key. Do not ask for my phone number or private contact details. Use the official provider documentation (not a marketing page) to verify every request and upload field.
+
+## Connect and certify the provider
+
+1. Call `nomi_integration_begin` with the public connection material. Preserve the documentation URL and the provider's exact terminology as evidence.
+2. Call `nomi_integration_open_credentials` so I can enter the key in Nomi's secure UI. Wait for me to finish; never handle the key yourself.
+3. Call `nomi_integration_discover` until every result page has been covered. Keep each exact model ID, declared mode, evidence source, and classification state. Do not silently truncate results.
+4. Show me a concise list of candidates that match my requested modes. If a model or mode is unavailable, state its stable reason and one next action.
+5. Call `nomi_integration_select` with the exact candidates I choose. If it returns `unresolvedFields`, ask all of those questions together and submit all answers through `nomi_integration_resolve_input`.
+6. For native ComfyUI, use `nomi_integration_submit_workflow` and bind inputs by `nodeId`, `inputKey`, `paramKey`, and `mediaKind`. Never map `widgets_values` by array position. A cloud service that does not implement native ComfyUI routes is an ordinary HTTP provider.
+7. Before any paid or external generation, call `nomi_integration_request_confirmation`. I must confirm the exact provider, model(s), modes, and expected cost in Nomi's trusted UI; you cannot invent or bypass the receipt.
+8. After I confirm in Nomi, call `nomi_integration_start` with the opaque receipt handle returned by Nomi.
+9. Poll `nomi_integration_get` and report the real final state. Treat credential storage, successful discovery, or a staged draft as incomplete. Say “verified and available” only after the certification run completes, the bounded artifact is decoded, the journal is committed, and a fresh-process readback succeeds.
+
+## If the provider's private upload channel is missing
+
+Use this fallback only when the official documentation proves that the provider accepts a local reference through its own upload endpoint and the current Nomi build cannot use it:
+
+1. If a source checkout is not open, clone `https://github.com/aqm857886159/Nomi.git` into a local directory. Read `AGENTS.md` before editing, inspect the current branch and worktree, and create a local task branch. Do not push or open a pull request.
+2. Trace the existing shared path from asset localization to provider request construction. Reuse the existing generic `AssetIngestion` contract and upload helpers; do not create a second upload pipeline or a provider-specific UI.
+3. Add only the provider-private Runway upload declaration/adapter required by the verified official contract. Choose `upload-multipart`, `upload-url`, or `upload-stream` only when the documentation proves that strategy, exact endpoint, auth, file field, extra fields, response URL path, accepted media kinds, and URL lifetime.
+4. Make the target provider's private channel win before KIE, APIMart, or the anonymous chain for that provider's requests. Keep KIE as an existing fallback where the shared resolver requires it, but never silently send a confidential reference to an anonymous host.
+5. Add focused tests that prove: the exact endpoint and auth are used; the response URL is extracted and validated; the target Runway channel is preferred; anonymous upload is not selected when the private channel is available; transient upload failures remain bounded; and credentials never appear in logs or results.
+6. Do not add Runway model IDs, Seedance 2.5 catalog entries, or a new model UI in this urgent upload-only change. If the official upload contract is unavailable or cannot be verified, stop and report the missing evidence instead of guessing.
+7. Run the narrow tests and relevant repository gates locally. Report changed files, test results, and any unverified live-provider step. Leave the changes in my local checkout; do not create a PR.
+
+## Reference images and anonymous uploads
+
+- Start with one reference and the smallest possible test.
+- Follow the provider's documented choice of provider upload, public URL, base64 data URL, or reference field.
+- If an anonymous upload host fails, treat it as a transport/network/provider-upload problem. Do not expose confidential references and do not silently retry a different anonymous host. Prefer the verified provider-private upload channel; use a configured alternative or direct multipart bytes only when Nomi's shared workflow supports it.
+
+## Failure reporting
+
+- If the result is `partial`, list each unavailable model or mode and exactly one next action.
+- If authentication, balance, quota, or security fails, do not blindly retry.
+- If a submission result is unknown, reconcile it with the remote task ID before doing anything else.
+- At the end, summarize the connected provider, verified model/mode list, upload route and privacy level, test result, and remaining limitations. Never include secrets or private data.
+
+===== PROMPT END =====
+```
+
+If the integration is blocked, send only the redacted error and the provider's public request example to the Nomi maintainer through the support contacts in the [English model connection tutorial](model-connection-en.md). Do not publish keys, phone numbers, private URLs, or confidential assets.

--- a/docs/plan/2026-08-30-issue-237-onboarding.md
+++ b/docs/plan/2026-08-30-issue-237-onboarding.md
@@ -16,13 +16,14 @@ GitHub issue #237 与 Discussion #220 的最新追问暴露出两条不同摩擦
 - 修复请求参数构建的根因：无明确尺寸时，OpenAI-compatible 图片请求省略 `size`，不发送空字符串或 `auto`。
 - 增加英文模型接入教程，覆盖文本/图片/视频模型、OpenAI-compatible endpoint、参考图、测试失败时需要收集的信息。
 - 增加一份可复制给 Codex 的英文贡献者提示词，让没有 Nomi 内部上下文的用户也能从 issue、供应商官方文档和脱敏证据开始排查，并以分支/PR 交付。
+- 增加一份不要求开 PR 的紧急接入提示词：优先调用已内置的 `model-integration` Skill / MCP；若当前版本缺少供应商私有上传能力，只允许在用户本地补齐上传通道，不扩展 Runway 模型适配。
 - 在英文 README 增加清晰的 Tutorial、model integration guide、Discussion 和 business inquiry 入口。
 - 写入当日反馈摘要与研究雷达，保留 issue 的可追溯证据但不复制公开 issue 中的私人联系方式。
 
 ## 不做
 
 - 不猜测或公开未确认的 X/Twitter、Reddit、YouTube 账号 URL。
-- 不把个人 QQ 邮箱放进公开仓库；先使用 GitHub Discussions 和 Business Inquiry，待准备好专用支持地址后再补。
+- 按维护者明确授权，公开工作流支持邮箱 `2373272608@qq.com` 与 X/Twitter 账号；Issue 正文仍不得包含其他私人联系方式或凭据。
 - 不把匿名文件上传 host 的网络可达性伪装成代码已修复；该类失败需要用户网络、代理或已配置供应商上传能力。
 - 不重写 provider adapter 的自动猜测逻辑；没有官方 API 文档和可复现请求/响应前，不宣称某个第三方 endpoint 已支持。
 
@@ -32,6 +33,7 @@ GitHub issue #237 与 Discussion #220 的最新追问暴露出两条不同摩擦
 - 明确比例（例如 `16:9`）仍生成合法像素尺寸（例如 `1024x576`）。
 - 相关 Vitest 通过；站点/文档静态检查通过；不修改当前脏工作树中的用户变更。
 - README 能直接到达英文模型接入教程、快速启动、Discussion 和 Business Inquiry。
+- 紧急接入提示词明确使用 `model-integration` Skill / MCP、自行在本地完成接入、不提交 PR；若需代码变更，仅补经官方文档验证的 Runway 私有上传通道，不添加 Seedance 2.5 模型适配。
 - 英文教程能直接到达 Codex 修复提示词；提示词不要求用户公开 API key、私人联系方式或把代码直接推到 `main`。
 
 ## 回滚

--- a/docs/plan/2026-08-30-issue-237-onboarding.md
+++ b/docs/plan/2026-08-30-issue-237-onboarding.md
@@ -1,0 +1,39 @@
+# Issue #237: 接入请求与英文上手入口
+
+日期：2026-08-30
+
+> 状态：🚧 进行中
+
+## 背景
+
+GitHub issue #237 与 Discussion #220 的最新追问暴露出两条不同摩擦：
+
+1. OpenAI-compatible 图片请求在“Auto · 1K”时可能把空的 `size` 发给供应商，供应商因此返回 `Invalid size ""`。
+2. 英文用户第一次到达仓库后，不知道模型接入、参考图上传和排错从哪里开始。
+
+## 范围
+
+- 修复请求参数构建的根因：无明确尺寸时，OpenAI-compatible 图片请求省略 `size`，不发送空字符串或 `auto`。
+- 增加英文模型接入教程，覆盖文本/图片/视频模型、OpenAI-compatible endpoint、参考图、测试失败时需要收集的信息。
+- 增加一份可复制给 Codex 的英文贡献者提示词，让没有 Nomi 内部上下文的用户也能从 issue、供应商官方文档和脱敏证据开始排查，并以分支/PR 交付。
+- 在英文 README 增加清晰的 Tutorial、model integration guide、Discussion 和 business inquiry 入口。
+- 写入当日反馈摘要与研究雷达，保留 issue 的可追溯证据但不复制公开 issue 中的私人联系方式。
+
+## 不做
+
+- 不猜测或公开未确认的 X/Twitter、Reddit、YouTube 账号 URL。
+- 不把个人 QQ 邮箱放进公开仓库；先使用 GitHub Discussions 和 Business Inquiry，待准备好专用支持地址后再补。
+- 不把匿名文件上传 host 的网络可达性伪装成代码已修复；该类失败需要用户网络、代理或已配置供应商上传能力。
+- 不重写 provider adapter 的自动猜测逻辑；没有官方 API 文档和可复现请求/响应前，不宣称某个第三方 endpoint 已支持。
+
+## 验收
+
+- `taskTemplateParams({ extras: { aspect_ratio: "auto", resolution: "1K" } })` 经 OpenAI-compatible image mapping 后，最终 body 不含 `size`。
+- 明确比例（例如 `16:9`）仍生成合法像素尺寸（例如 `1024x576`）。
+- 相关 Vitest 通过；站点/文档静态检查通过；不修改当前脏工作树中的用户变更。
+- README 能直接到达英文模型接入教程、快速启动、Discussion 和 Business Inquiry。
+- 英文教程能直接到达 Codex 修复提示词；提示词不要求用户公开 API key、私人联系方式或把代码直接推到 `main`。
+
+## 回滚
+
+代码回滚只涉及 `electron/catalog/taskParams.ts` 与其回归测试；文档和摘要可独立删除，不触碰用户配置或远端数据。

--- a/docs/plan/INDEX.md
+++ b/docs/plan/INDEX.md
@@ -13,6 +13,7 @@
 |---|---|---|
 | [2026-06-07-model-onboarding-final-plan.md](2026-06-07-model-onboarding-final-plan.md) | **模型接入最终方案**（R7 定稿，审计+设计+计划）— 本簇主文档 | ✅ |
 | [2026-08-28-conversational-model-integration-verification.md](2026-08-28-conversational-model-integration-verification.md) | 对话式模型接入与认证闭环：J0–J5 真实验收和发布记录 | 🚧 |
+| [2026-08-30-issue-237-onboarding.md](2026-08-30-issue-237-onboarding.md) | Issue #237：OpenAI-compatible 图片请求根因修复、匿名上传分诊与英文接入入口 | 🚧 |
 | [2026-06-07-apimart-curated-onboarding.md](2026-06-07-apimart-curated-onboarding.md) | 策展两家(kie+apimart)一键接入；战略从「通用接入」转向 | ✅ |
 | [2026-06-06-universal-model-onboarding.md](2026-06-06-universal-model-onboarding.md) | 「描述符+通用解释器接长尾」研究稿 | ⛔ |
 | [2026-05-30-onboarding-schema-first-extraction.md](2026-05-30-onboarding-schema-first-extraction.md) | 参数抽取从 curl-only 升级为 schema-first | 🚧 |

--- a/docs/research/2026-08-30-radar.md
+++ b/docs/research/2026-08-30-radar.md
@@ -1,0 +1,32 @@
+# Nomi 论文雷达 · 2026-08-30
+
+本轮按固定的 8 个方向检索近 6 个月公开资料，并把“有用”与“可接入”分开。没有把没有官方实现、没有清晰复现路径的结果写成已验证能力。
+
+## 今日结论
+
+- **Green：0**。没有发现今天可以直接接进 Nomi 生产链、且证据完整的新模型实现。
+- **Amber：3**。MuSS、SAGE、InfinityStory 对跨镜一致性、故事板规划和实体记忆有启发，但仍需要 Nomi 自己做小规模验证。
+- **Blue：2**。MSVBench、VABench 更适合作为评测入口，不能替代真实用户任务走查。
+- 最值得下一步动手的是：把“镜头间一致性 + 失败归因”沉淀为评测任务，而不是继续增加 provider 数量。
+
+## 候选与落点
+
+| 等级 | 方向 | 近 6 月结果 | 对 Nomi 的实际用处 | 建议落点 |
+|---|---|---|---|---|
+| Amber | 跨镜一致性 / 视频理解 | [MuSS](https://arxiv.org/abs/2604.23789)，2026-04-26；[代码](https://github.com/zhang-haojie/MuSS)公开但成熟度仍低 | 参考它把角色、场景、动作一致性拆成可解释指标 | `evals/journeys/` 的 shot-verify fixture；先做离线指标，不接生产模型 |
+| Amber | 故事板与 Agent 自演化 | [SAGE](https://arcxiv.org/abs/2608.17468)，2026-08-18 | 把用户反馈沉淀为“下一次规划规则”，减少每轮重新解释 | 故事板计划与反馈归因；先保持可审阅、可回滚 |
+| Amber | 长视频世界/角色连续性 | [InfinityStory](https://arxiv.org/abs/2603.03646)，2026-03-04 | 提醒我们需要有边界的实体记忆与跨镜 relay，而不是把整段历史塞进 prompt | 角色/场景锁定的状态模型；不引入新的远程记忆服务 |
+| Blue | 音画/视频质量评测 | [MSVBench](https://arxiv.org/abs/2602.23969)，2026-02-27 | 可借鉴“机器指标 + 专家指标”的组合，评估生成结果是否可用 | 评测报告层；不作为单一自动放行条件 |
+| Blue | 音视频生成基准 | [VABench](https://openaccess.thecvf.com/content/CVPR2026/html/Hua_VABench_A_Comprehensive_Benchmark_for_Audio-Video_Generation_CVPR_2026_paper.html)，CVPR 2026 | 为音画同步、语义对齐补充可重复的任务定义 | `evals/` 设计基准任务；仍需真实创作闭环验收 |
+
+## 其余固定方向
+
+| 方向 | 检索结果 | 处理 |
+|---|---|---|
+| 图像/视频生成基础模型 | [WildActor](https://arxiv.org/abs/2603.00586)，2026-02-28 | 与 Nomi 当前“自带模型、接入任意 provider”的边界不直接相交，暂不接入 |
+| 训练/推理效率 | [GATO-Vid](https://arcxiv.org/abs/2608.13037)，2026-08-13 | 结果仍缺少 Nomi 可复现的工程入口，保留观察 |
+| 关键帧、转场与长程运动 | [KeyFrame-Compass](https://arxiv.org/abs/2607.14202)，2026-07-16 | 可作为后续转场评测候选，当前不改变时间线语义 |
+
+## 过滤掉的噪音
+
+没有把只有二手摘要、没有官方代码或无法确认发布日期的结果标为 SOTA；也没有因为论文声称“consistent”就推断 Nomi 已经具备该能力。下一轮若要落地，先为“一名角色跨 6 个镜头”和“参考图上传失败后的恢复”各建一个真实任务。

--- a/electron/catalog/newapiImageEdit.test.ts
+++ b/electron/catalog/newapiImageEdit.test.ts
@@ -126,6 +126,15 @@ describe("通用中转 text_to_image 分辨率派生（治「只能出 1K」）"
   it("body 不再钉死 1024：2K/4K 能选出", () => {
     expect(derive("1:1", "2K")).not.toBe("1024x1024");
   });
+
+  it("Auto · 1K → 不发送空的 size（避免 OpenAI-compatible 返回 Invalid size）", () => {
+    const params = applyParamMap(
+      NEWAPI_IMAGE_PARAM_MAP,
+      taskTemplateParams({ extras: { aspect_ratio: "auto", resolution: "1K" } }),
+    );
+    const body = renderBody(NEWAPI_IMAGE_CREATE_OP, "一只小猪", params);
+    expect(body).not.toHaveProperty("size");
+  });
 });
 
 describe("通用中转路径夯实（输出多资产 + 参数广度 + i2v 断链）", () => {

--- a/electron/catalog/taskParams.ts
+++ b/electron/catalog/taskParams.ts
@@ -139,7 +139,11 @@ export function taskTemplateParams(request: TaskParamsInput, selected?: Paramete
   const jsonEditInput = jsonImageEditInput(refInput.reference_images);
   return {
     ...extras,
-    size,
+    // An unset size must stay undefined so exact template fields are omitted.
+    // Sending the empty alias (the persisted value for the gpt-image-2
+    // `Auto` aspect-ratio choice) makes OpenAI-compatible endpoints reject the
+    // request with `Invalid size ""` instead of applying their default.
+    size: size || undefined,
     // n 强制数字（OpenAI images 要 int；UI number 参数可能存成字符串 "1"，整 token 会原样发 → 严格端点 400）。
     n: Number(extras.n) || 1,
     width: request.width,


### PR DESCRIPTION
## What changed

- Fix OpenAI-compatible image requests so an unset Auto size omits `size` instead of sending an empty string.
- Add an English model-connection tutorial and an urgent Codex / Claude Code provider-setup prompt.
- Reuse the existing model-integration Skill and MCP tools; if the official Runway upload contract is verified, the prompt allows a narrow local provider-private upload path without adding a full Runway or Seedance 2.5 model adapter.
- Publish the maintainer-authorized workflow support email and X/Twitter link in the README and tutorial.
- Keep the public Issue #237 reply as a local draft only; it is not included in this PR and has not been posted.

## Verification

- `pnpm run check:filesize`
- `pnpm run check:tokens`
- `pnpm run check:i18n`
- `pnpm run check:secrets`
- `pnpm run check:docs-index`
- `pnpm run check:doc-status`
- `pnpm run check:ledger`
- `pnpm run check:git-delivery`
- `pnpm run lint:ci` (0 errors, 82 existing warnings)
- `pnpm run typecheck`
- `pnpm run test` (916 files passed; 8,687 Vitest tests passed; agent-runtime 151/151 passed)
- `pnpm run build`
- `pnpm run delivery:preflight`
