### PR TITLE
docs: README 大修——三答定位 + AI 代接手册 + 反馈共建

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,54 +4,50 @@
 
 # Nomi
 
-**Bring your own models. Let your AI assistant direct them.**
+**Bring the cost of AI video down.**
 
-Nomi is an open-source desktop workbench for AI video. Connect any OpenAI-compatible endpoint or your local ComfyUI, then let Claude Code, Codex, or Cursor drive it over MCP — storyboard, references, generation, and an editable first cut on a real timeline.
+Nomi is an open-source, local-first desktop workbench for AI video. Use the models, membership credits, APIs, or local ComfyUI you already have to run the whole pipeline — script, storyboard, generation, and editing — with your footage, generated takes, and workflows all on your own machine. No account. No telemetry.
 
-Your projects, prompts, and API keys stay on your machine. No account. No telemetry.
-
-[简体中文](README.zh-CN.md) · [Website](https://nomiaqm.com/en/) · [Download](#download) · [Tutorial](docs/guide/model-connection-en.md) · [Community](https://github.com/aqm857886159/Nomi/discussions) · [Follow on X](https://x.com/sdf297417627618) · [For Teams](https://nomiaqm.com/en/#teams) · [Watch the 60s film](https://nomiaqm.com/assets/video/launch-film-en.mp4) · [Documentation](docs/user-guide.md)
-
-Workflow support: **2373272608@qq.com** · [X/Twitter](https://x.com/sdf297417627618)
-
-## WeChat / 微信联系
-
-### Join the Nomi user group / 加入 Nomi 用户群
-
-<p align="center">
-  <a href="docs/media/nomi-canvas-group-wechat-2026-08-25.jpg"><img src="docs/media/nomi-canvas-group-wechat-2026-08-25.jpg" alt="Nomi 用户群微信二维码" width="220" /></a>
-</p>
-
-<p align="center">
-  <strong>Scan to join the user group. / 扫码加入 Nomi 用户群</strong><br />
-  Product feedback from the group goes directly into ongoing iteration. / 群内反馈会直接进入产品迭代。
-</p>
-
-### Maintainer & project collaboration / 添加作者与项目合作
-
-<p align="center">
-  <a href="docs/media/qingyang-wechat.jpg"><img src="docs/media/qingyang-wechat.jpg" alt="Nomi 作者青阳的微信二维码" width="180" /></a>
-</p>
-
-<p align="center">
-  If the group QR expires, or for AGPL-compliant custom development, integrations, deployment, and ongoing iteration, add <strong>TZ857886159</strong>.<br />
-  群码失效，或沟通遵守 AGPL 的定制开发、系统集成、部署与持续迭代，请添加作者微信 <strong>TZ857886159</strong>。
-</p>
-
-International community: [GitHub Discussions](https://github.com/aqm857886159/Nomi/discussions) · Project inquiry: [Business Inquiry](https://github.com/aqm857886159/Nomi/issues/new?template=business_inquiry.yml)
+[简体中文](README.zh-CN.md) · [Website](https://nomiaqm.com/en/) · [Download](#download) · [Video tutorial (Bilibili)](https://www.bilibili.com/video/BV1Lf8b6nEjf/) · [Let your AI connect it](docs/integrate-with-your-agent-en.md) · [Community](https://github.com/aqm857886159/Nomi/discussions) · [For Teams](https://nomiaqm.com/en/#teams) · [Watch the 60s film](https://nomiaqm.com/assets/video/launch-film-en.mp4) · [X/Twitter](https://x.com/sdf297417627618)
 
 [![Latest release](https://img.shields.io/github/v/release/aqm857886159/Nomi?label=release)](https://github.com/aqm857886159/Nomi/releases/latest)
 ![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Windows-1a1816)
 [![License](https://img.shields.io/badge/license-AGPL--3.0--only-1a1816)](LICENSE)
 
+## WeChat / 微信联系
+
+<p align="center">
+  <a href="docs/media/nomi-canvas-group-wechat-2026-08-25.jpg"><img src="docs/media/nomi-canvas-group-wechat-2026-08-25.jpg" alt="Nomi user group WeChat QR" width="220" /></a>
+  &nbsp;&nbsp;
+  <a href="docs/media/qingyang-wechat.jpg"><img src="docs/media/qingyang-wechat.jpg" alt="Nomi maintainer WeChat QR" width="180" /></a>
+</p>
+
+<p align="center">
+  <strong>Scan to join the Nomi user group</strong> (left) — feedback goes straight into iteration.<br />
+  If the group QR expires, or for AGPL-compliant custom development, deployment, and ongoing iteration, add the maintainer (right) at <strong>TZ857886159</strong>.
+</p>
+
 [![Nomi director workflow](marketing/assets/video/hero-poster.jpg)](https://nomiaqm.com/assets/video/launch-film-en.mp4)
 
 ## Why Nomi
 
-- **One project, not eleven tabs.** Story, shots, references, generated takes, and the timeline live in the same file on your disk instead of being copied between disconnected tools.
-- **Shot 4 and shot 9 should be the same person.** Lock characters, locations, props, camera, and style once; later shots inherit them instead of restarting from a new prompt.
-- **Bring your own stack.** Around ten curated providers are pre-wired, and any OpenAI-compatible, Anthropic, Responses, or relay endpoint can be added by pasting a URL and a key — no rebuild. A local ComfyUI is a provider like any other: Nomi converts the normal "Save" workflow format, so the workflows you download actually import, and it diffs the graph against `/object_info` to tell you which custom nodes and model files you are missing before you run it.
-- **Your agent can operate it.** Thirty-three MCP tools let Claude Code, Codex, or Cursor converge on a direction in one pass, create projects, import local assets, lay out shots, materialize an approved storyboard into the Nomi canvas, wire references, run generation, and control a durable production run. The staged semantic generation tools make model, provider, mode, parameters, and references editable before sealing; they remain zero-credit and feature-gated until the Run/recovery checks pass. Reversible direction and sample choices receive a server-issued human confirmation in the originating client; budgets, per-shot paid submissions, rough-cut acceptance, and export stay in Nomi, enforced in the main process.
+People generating AI video at scale — and companies that want to put AI video to work — increasingly need an **open-source, local** canvas. Three reasons:
+
+**① Cost** — the real spend in AI video is generation. Nomi lets you **freely combine cheap generation sources**: relay wholesale prices, time-limited platform promotions, the free image credits bundled with your agent membership, free sources like ModelScope, and your own local ComfyUI — whichever is cheapest. Layer the "draft → reference → finish" workflow on top: use cheap / free models for storyboard sketches, pose frames, and reference videos (regenerate freely), then feed the good ones as references into a high-quality model, spending the expensive credits only on the final step. Per-unit cost drops sharply.
+
+**② Customization** — the code is open. Use your own Codex / Claude Code to bend it into what you want and add your own skills; a company can customize it into an internal AI-video platform, and the whole team's cost comes down with it.
+
+**③ Local** — your footage, generated takes, workflows, and provider setup all live on your machine. When you call an external model API, only the inputs required to complete the task are sent to the provider you configured.
+
+And a structural difference: **use Nomi as your agent's generation backend.** Thirty-three MCP tools let Codex / Claude Code / Cursor drive Nomi over MCP for generation, orchestration, and editing, reusing the credits bundled with your agent membership. Online platforms make their money on compute, so structurally they can't offer this; an open-source local app is naturally happy to be driven by an agent.
+
+## Connecting your own stack
+
+"Connecting my own stuff is a hassle" is the one big pain point. Nomi gives you two paths:
+
+**① Works out of the box** — **APIMart** and **Kie.ai** are wired in as the two cores, alongside around ten more ready-to-use providers (ModelScope, Volcengine, Runway, fal, Replicate, MiniMax, ElevenLabs, and more); flagship models have a continuously growing integration-certification ledger (currently 66 certified entries). Any OpenAI-compatible, Anthropic, Responses, or relay endpoint can be added by pasting a URL and a key — no rebuild. A local ComfyUI is a provider like any other: Nomi converts the normal "Save" workflow format, so the workflows you download actually import, and it diffs the graph against `/object_info` to tell you which custom nodes and model files you are missing before you run it.
+
+**② Let your AI connect it for you** — you don't have to figure out integration yourself. Clone the repo, hand the **[Let your AI connect Nomi for you](docs/integrate-with-your-agent-en.md)** document to your Codex / Claude Code, and tell it what you want to connect (a relay, DeepSeek, a local ComfyUI…) — it will walk you through it step by step. The doc covers four paths: custom / relay providers, local ComfyUI, MCP driven by an agent, and skill import — each with its "success signal" and a recommended combo that drives cost to the floor.
 
 ## Download
 
@@ -85,17 +81,25 @@ The installer has no Authenticode signature. In the SmartScreen prompt, choose *
 
 ## Quick start
 
-1. **Connect a model.** Choose a curated provider and enter one API key, or add your own OpenAI-, Responses-, or Anthropic-compatible endpoint.
+1. **Connect a model.** Choose a curated provider and enter one API key, or add your own OpenAI-, Responses-, or Anthropic-compatible endpoint. Connecting your own stuff a hassle? Hand [Let your AI connect Nomi for you](docs/integrate-with-your-agent-en.md) to your Codex / Claude Code and let it do it.
 2. **Write the intent.** Start with a story or one shot. Ask Nomi—or a connected AI assistant over MCP—to build an editable storyboard and canvas plan.
 3. **Direct and export.** Review visual anchors, generate images or video with your configured models, choose the results, arrange the timeline, and export MP4.
 
 > **Disclosure:** one curated provider (APImart) is linked with a referral code. You always pay providers directly with your own key at their price — Nomi never proxies or resells inference, and every provider can be replaced by your own endpoint.
 
-Read the [English model connection tutorial](docs/guide/model-connection-en.md), [urgent Codex / Claude Code provider-setup prompt](docs/guide/model-integration-prompt-en.md), [copy-paste Codex issue-fix prompt](docs/guide/codex-issue-fix-prompt-en.md), [user guide](docs/user-guide.md), [provider guide](docs/provider-integration.md), [conversational model integration guide](docs/guide/conversational-model-integration.md), or [CLI + MCP guide](docs/guide/capability-core-cli-mcp.md).
+Read [Let your AI connect Nomi](docs/integrate-with-your-agent-en.md), the [English model connection tutorial](docs/guide/model-connection-en.md), [urgent Codex / Claude Code provider-setup prompt](docs/guide/model-integration-prompt-en.md), [copy-paste Codex issue-fix prompt](docs/guide/codex-issue-fix-prompt-en.md), [user guide](docs/user-guide.md), [provider guide](docs/provider-integration.md), [conversational model integration guide](docs/guide/conversational-model-integration.md), or [CLI + MCP guide](docs/guide/capability-core-cli-mcp.md).
+
+## Feedback & building it together
+
+Nomi is built by one person, and it moves fast — features land quickly, sometimes a little rough around the edges, but it's genuinely moving forward and the commits never stop.
+
+- **Hit a problem? Let your AI fix it first.** The code is open source — send the error along with the [Codex issue-fix prompt](docs/guide/codex-issue-fix-prompt-en.md) to your Codex / Claude Code, and it can patch many issues for you directly.
+- **Tell me the general ones and I'll iterate them away.** Say so in the [community](https://github.com/aqm857886159/Nomi/discussions) or open an [Issue](https://github.com/aqm857886159/Nomi/issues); anything everyone runs into, I fold into the mainline.
+- Bug reports, feature proposals, docs, and code are all welcome — see [Contributing](#contributing) below.
 
 ## Community
 
-Use [GitHub Discussions](https://github.com/aqm857886159/Nomi/discussions) to ask questions, share workflows, and follow what is being built next, and [GitHub Issues](https://github.com/aqm857886159/Nomi/issues) to report bugs and request features. Follow the project on [X / Twitter](https://x.com/sdf297417627618) for release notes and short demos; workflow support is available at **2373272608@qq.com**. WeChat users can use the group and maintainer QR codes at the top of this README; the [Chinese README](README.zh-CN.md#用户群) contains the full Chinese guide.
+Use [GitHub Discussions](https://github.com/aqm857886159/Nomi/discussions) to ask questions, share workflows, and follow what is being built next, and [GitHub Issues](https://github.com/aqm857886159/Nomi/issues) to report bugs and request features. Follow the project on [X / Twitter](https://x.com/sdf297417627618) for release notes and short demos; workflow support is available at **2373272608@qq.com**. WeChat users can use the group and maintainer QR codes in the [Chinese README](README.zh-CN.md#微信联系).
 
 ## For Teams
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -4,53 +4,50 @@
 
 # Nomi
 
-**模型你自己带，让你的 AI 助手替你导演。**
+**把 AI 视频的成本打下来。**
 
-Nomi 是一个开源的 AI 视频创作桌面工作台。接任何 OpenAI 兼容接口，或者你本机跑着的 ComfyUI；然后让 Claude Code / Codex / Cursor 经 MCP 直接开工——搭分镜、连参考、跑生成，在真实时间线上给你一版能改的初稿。
+Nomi 是一个开源、本地优先的 AI 视频创作桌面工作台。用你已有的模型、会员额度、API 或本机 ComfyUI，从脚本、分镜、生成到剪辑跑通全流程——素材、生成物、工作流全在你自己电脑上。不用注册，没有埋点。
 
-项目、提示词和密钥都在你自己电脑上。不用注册，没有埋点。
-
-[English](README.md) · [官网](https://nomiaqm.com/) · [下载](#下载) · [夸克网盘镜像](https://pan.quark.cn/s/d3322c17e7b6) · [加入用户群](#用户群) · [团队合作](#团队服务) · [看 60 秒宣传片](https://nomiaqm.com/assets/demo.mp4)
-
-## 微信联系
-
-### 加入 Nomi 用户群
-
-<p align="center">
-  <a href="docs/media/nomi-canvas-group-wechat-2026-08-25.jpg"><img src="docs/media/nomi-canvas-group-wechat-2026-08-25.jpg" alt="Nomi 用户群微信二维码" width="220" /></a>
-</p>
-
-<p align="center">
-  <strong>扫码加入 Nomi 用户群</strong><br />
-  群内反馈会直接进入产品迭代。
-</p>
-
-### 群码失效 / 项目合作
-
-<p align="center">
-  <a href="docs/media/qingyang-wechat.jpg"><img src="docs/media/qingyang-wechat.jpg" alt="Nomi 作者青阳的微信二维码" width="180" /></a>
-</p>
-
-<p align="center">
-  群码失效，或沟通遵守 AGPL 的定制开发、系统集成、部署与持续迭代，请添加作者微信 <strong>TZ857886159</strong>。
-</p>
-
-[参与 GitHub Discussions](https://github.com/aqm857886159/Nomi/discussions) · [提交商务咨询](https://github.com/aqm857886159/Nomi/issues/new?template=business_inquiry.yml)
-
-工作流接入支持：**2373272608@qq.com** · [X/Twitter](https://x.com/sdf297417627618)
+[English](README.md) · [官网](https://nomiaqm.com/) · [下载](#下载) · [B 站视频教程](https://www.bilibili.com/video/BV1Lf8b6nEjf/) · [夸克网盘镜像](https://pan.quark.cn/s/d3322c17e7b6) · [让 AI 替你接入](docs/integrate-with-your-agent.md) · [加入用户群](#用户群) · [团队合作](#团队服务) · [看 60 秒宣传片](https://nomiaqm.com/assets/demo.mp4) · [X/Twitter](https://x.com/sdf297417627618)
 
 [![最新版本](https://img.shields.io/github/v/release/aqm857886159/Nomi?label=release)](https://github.com/aqm857886159/Nomi/releases/latest)
 ![平台](https://img.shields.io/badge/platform-macOS%20%7C%20Windows-1a1816)
 [![许可证](https://img.shields.io/badge/license-AGPL--3.0--only-1a1816)](LICENSE)
 
+## 微信联系
+
+<p align="center">
+  <a href="docs/media/nomi-canvas-group-wechat-2026-08-25.jpg"><img src="docs/media/nomi-canvas-group-wechat-2026-08-25.jpg" alt="Nomi 用户群微信二维码" width="220" /></a>
+  &nbsp;&nbsp;
+  <a href="docs/media/qingyang-wechat.jpg"><img src="docs/media/qingyang-wechat.jpg" alt="Nomi 作者青阳的微信二维码" width="180" /></a>
+</p>
+
+<p align="center">
+  <strong>扫码加入 Nomi 用户群</strong>（左，反馈会直接进入产品迭代）。<br />
+  群码失效，或沟通遵守 AGPL 的定制开发、部署与持续迭代，请添加作者微信（右）<strong>TZ857886159</strong>。
+</p>
+
 [![Nomi 导演工作流](marketing/assets/video/hero-poster.jpg)](https://nomiaqm.com/assets/demo.mp4)
 
 ## 为什么是 Nomi
 
-- **一个项目，不是十一个标签页**：故事、镜头、参考、生成结果和时间线在你自己盘上的同一个文件里，不用在多个工具之间反复搬运。
-- **第 4 个镜头和第 9 个镜头得是同一个人**：人物、场景、道具、机位和风格先锁一次，后面的镜头继承它，而不是重新赌一次提示词。
-- **自带全套**：内置约 10 家可直接用的供应商；任何 OpenAI 兼容 / Anthropic / Responses / 中转接口，粘贴地址和密钥就能加，不用重新编译。本机 ComfyUI 和云端模型一样是一个供应商：Nomi 会转换 ComfyUI 常规「保存」格式的工作流，你从网上下载的工作流能直接导入；并且会拿工作流和 `/object_info` 对账，在你按下运行之前就告诉你缺哪些自定义节点和模型文件。
-- **你的 AI 助手能真的操作它**：15 个 MCP 工具，让 Claude Code / Codex / Cursor 建项目、排镜头、连参考、跑生成并发起可恢复的完整制作。创作方向、付费生成、粗剪采用和导出都必须回到 Nomi 明确批准；审批由主进程强制执行，助手无法越权。
+大量批量做 AI 视频的人，和想把 AI 视频用起来的公司，越来越需要一个**开源、本地**的画布项目。三个原因：
+
+**① 成本**——AI 视频真正的大头是生成费。Nomi 让你**自由组合便宜的生成来源**：中转站的批发价、平台的限时活动、agent 会员自带的免费生图额度、魔搭一类免费源、你本机的 ComfyUI——哪个便宜用哪个。再叠加「草稿→参考→精修」的姿势：用便宜 / 免费的模型出分镜草图、动作图、参考视频（反复生成不心疼），挑好的当参考喂给高质量模型只在最后一步花贵额度出成品。单位成本因此大幅下降。
+
+**② 定制**——代码开源。用你自己的 Codex / Claude Code 把它改成你要的样子、加你自己的 skills；公司可以把它定制成一套自家的内部 AI 视频平台，整个团队的成本随之下降。
+
+**③ 本地**——素材、生成物、工作流、模型接入全在你本机，更安全。用外部模型 API 时，只有完成任务所必需的输入才会发给你配置的供应商。
+
+还有一个结构性差异：**把 Nomi 当你 agent 的生成后端**。让 Codex / Claude Code 经 MCP 直接调用 Nomi 做生成、编排、剪辑，你 agent 会员自带的额度可以直接复用。在线平台靠算力赚钱，结构上做不了这件事；开源本地端天然愿意被 agent 接入。
+
+## 怎么接你自己的东西
+
+「接自己的很麻烦」是唯一的大痛点。Nomi 给两条路：
+
+**① 开箱即用**——内置 **APIMart** 与 **Kie.ai** 双核心，另有约 10 家可直接用的供应商（魔搭、火山、Runway、fal、Replicate、MiniMax、ElevenLabs 等）；旗舰模型有持续扩充的接入认证台账（当前 66 条认证条目）。任何 OpenAI 兼容 / Anthropic / Responses / 中转接口，粘贴地址和密钥就能加，不用重新编译。本机 ComfyUI 和云端模型一样是一个供应商：Nomi 会转换 ComfyUI 常规「保存」格式的工作流，你从网上下载的工作流能直接导入；并且会拿工作流和 `/object_info` 对账，在你按下运行之前就告诉你缺哪些自定义节点和模型文件。
+
+**② 让你的 AI 替你接**——你不用自己啃接入。把仓库克隆下来，把 **[《让你的 AI 替你接入 Nomi》](docs/integrate-with-your-agent.md)** 这份文档发给你的 Codex / Claude Code，告诉它你要接什么（某个中转站、DeepSeek、本机 ComfyUI…），它会照文档一步步带你接完。文档覆盖四条路：自定义 / 中转供应商、本机 ComfyUI、MCP 被 agent 调用、技能导入，每条都写了「验证成功的标志」和一个把成本打到最低的推荐组合。
 
 ## 下载
 
@@ -86,13 +83,27 @@ Windows 安装包未使用 Authenticode 签名。SmartScreen 弹窗选择“更�
 
 ## 三步开始
 
-1. **接入模型**：选择预置供应商并填写一个 Key，或添加自己的 OpenAI / Responses / Anthropic 兼容接口。
+1. **接入模型**：选择预置供应商并填写一个 Key，或添加自己的 OpenAI / Responses / Anthropic 兼容接口。接自己的东西很麻烦？把 [《让你的 AI 替你接入 Nomi》](docs/integrate-with-your-agent.md) 发给你的 Codex / Claude Code，让它替你接。
 2. **说出镜头意图**：写一个故事或一句镜头描述，让 Nomi 或已接入的 AI 助手生成可编辑的分镜与画布方案。
 3. **导演并导出**：检查视觉锚点，用自己配置的模型生成图片或视频，选择结果、排上时间线并导出 MP4。
 
 > **利益披露**：预置供应商中有一家（APImart）的注册链接带推广码。你始终用自己的密钥、按供应商原价直接付给他们——Nomi 不代理、不转售任何推理服务，任何一家供应商都可以换成你自己的接口。
 
-详细说明：[使用指南](docs/user-guide.md) · [模型接入](docs/provider-integration.md) · [英文 Codex / Claude Code 接入提示词](docs/guide/model-integration-prompt-en.md) · [对话式模型接入](docs/guide/conversational-model-integration.md) · [CLI + MCP 指南](docs/guide/capability-core-cli-mcp.md)
+详细说明：[让你的 AI 替你接入](docs/integrate-with-your-agent.md) · [使用指南](docs/user-guide.md) · [模型接入](docs/provider-integration.md) · [英文 Codex / Claude Code 接入提示词](docs/guide/model-integration-prompt-en.md) · [对话式模型接入](docs/guide/conversational-model-integration.md) · [CLI + MCP 指南](docs/guide/capability-core-cli-mcp.md)
+
+## 反馈与共建
+
+Nomi 是我一个人在做，迭代很快——功能上得快，偶尔也带点毛边，但都是真的在往前跑，代码提交一直没停。
+
+- **遇到问题，可以先让你的 AI 帮你解**：代码是开源的，把报错和 [Codex 修复提示词](docs/guide/codex-issue-fix-prompt-en.md) 一起发给你的 Codex / Claude Code，很多问题它能直接帮你改。
+- **通用的问题告诉我，我直接迭代掉**：进[用户群](#用户群)或提 [Issue](https://github.com/aqm857886159/Nomi/issues) 说一声，凡是大家都会碰到的，我会直接修进主线。
+- 欢迎提 Bug、需求、文档和代码 —— 见下方[贡献与许可证](#贡献与许可证)。
+
+## 社区与联系
+
+微信群与作者二维码在 README 首屏（[群二维码](docs/media/nomi-canvas-group-wechat-2026-08-25.jpg) · [作者二维码](docs/media/qingyang-wechat.jpg)，或直接加微信 **TZ857886159**）。
+
+[参与 GitHub Discussions](https://github.com/aqm857886159/Nomi/discussions) · [提交商务咨询](https://github.com/aqm857886159/Nomi/issues/new?template=business_inquiry.yml) · 工作流接入支持：**2373272608@qq.com** · [X/Twitter](https://x.com/sdf297417627618)
 
 ## 团队服务
 

--- a/docs/integrate-with-your-agent-en.md
+++ b/docs/integrate-with-your-agent-en.md
@@ -1,0 +1,151 @@
+# Let your AI connect Nomi for you (hand this doc to your agent)
+
+> **You are the user's agent (Codex / Claude Code / Cursor / a local CLI, etc.). The user handed you this document because they want you to connect a model, a local ComfyUI, or a skill into the Nomi running on their machine.**
+> **Walk the user through it step by step**: first find out what they want to connect, then follow the matching section, and at every step tell them what they should be seeing and what to click next. Finish each path with its "success signal" so you both know it actually works.
+>
+> Nomi is an open-source local desktop workbench — the code is on the user's machine. Wherever this doc doesn't cover something, or the user's UI doesn't match what's written here, **read the source, don't guess.** Repo landmarks are at the end.
+
+Clone the repo (only needed if the user wants to change code; connecting models works from the packaged app):
+
+```bash
+git clone https://github.com/aqm857886159/Nomi.git
+```
+
+---
+
+## 0. First ask: which of the four is the user connecting?
+
+Four paths, one per "connect my own thing" scenario. Decide, then jump to the section:
+
+| What the user wants to connect | Path | In one line |
+|---|---|---|
+| An OpenAI-compatible / Anthropic / relay API (DeepSeek, self-hosted vLLM, some relay…) | **§1** | Paste a URL + key, no rebuild |
+| Their local ComfyUI (or a cloud ComfyUI) | **§2** | Keyless backend, import "Save"-format workflows |
+| Letting you (the agent) drive Nomi over MCP for generation / orchestration | **§3** | One-click connect, then just talk to it |
+| A skill that extends Nomi's Agent | **§4** | Drop it into `skills/`, it gets discovered |
+
+> **Cost lens (throughout)**: Nomi's whole point is letting you **freely combine cheap generation sources** — relay wholesale prices, time-limited platform promotions, the free image credits bundled with your agent membership, free sources like ModelScope, and your local ComfyUI — whichever is cheapest at the moment. Layer the "draft → reference → finish" workflow (see §5) on top and per-unit cost drops hard. Connecting is where you wire all those cheap sources in.
+
+---
+
+## 1. Connect a custom / relay provider (OpenAI-compatible / Anthropic / Responses)
+
+**For**: anything that exposes a standard interface — DeepSeek, Qwen, a self-hosted vLLM, any "API relay". Source of truth: `src/ui/onboarding/CustomVendorCard.tsx` and `src/ui/onboarding/VendorBaseUrlField.tsx`.
+
+**Walk the user through it:**
+
+1. Open Nomi → go to **Model Connection** (the onboarding drawer in settings).
+2. Find the **"Other models / Custom provider"** entry and add one. Each provider renders as a `CustomVendorCard`.
+3. This card's subject is the **connection** — the top row is the **base URL** (`VendorBaseUrlField`). Click **"Edit"** on the right to fill it in:
+   - It must be a full `http(s)://…` base URL (validated as `^https?://\S+$`; a trailing `/` is stripped). For OpenAI-compatible endpoints this is usually up to `.../v1`.
+   - Press Enter or click Save. After saving, Nomi **re-probes the connection automatically** (changing the URL changes the health fingerprint, which re-triggers the probe) — no manual re-check needed.
+4. In the same card's **Models** section, add / enable the models you want. If Nomi guessed the type (image / video / text) wrong from the model name, fix it here (`onRetype`).
+5. If the provider needs a key, enter the API Key on the card (keys are encrypted under the app identity, stored locally, never logged).
+
+> **Card pill semantics**: **unreachable overrides everything.** Even if parameter adaptation shows "configured", a bad URL / key paints the card header red and tells you "unreachable". So don't just watch for "configured" — watch the connection go green.
+
+**✅ Success signal:**
+- The card's connection pill shows **Connected / OK** (not the red "unreachable").
+- The models you enabled appear in the available list. `node scripts/nomi.mjs models` also lists them (vendor / modelKey / kind / label).
+
+---
+
+## 2. Connect a local ComfyUI (as a generation backend)
+
+**For**: the user runs ComfyUI locally (or in the cloud) and wants it as a cheap / free generation backend. Source of truth: `src/ui/onboarding/ComfyuiLocalCard.tsx` and `electron/catalog/comfyuiLocal.ts`.
+
+**Key premise (tell the user first)**: ComfyUI is a **keyless** local service. This provider is **disabled by default** in Nomi — because 99% of users don't run a local ComfyUI, and shipping it on would just add a pile of failing workflows. So the user must **enable it explicitly under "Connectable"**.
+
+**Walk the user through it:**
+
+1. Confirm ComfyUI is running. The default address is **`http://127.0.0.1:8188`**; if it's on another port / host (or a cloud ComfyUI like cnb.cool, cloudstudio.net), change the card's **address** row to that URL — same card, same address row, the cloud case just swaps the URL, no separate card.
+2. Open Nomi → Model Connection → find the **"Local ComfyUI"** card (`ComfyuiLocalCard`).
+3. **Import a workflow**: click "Import workflow" and paste the workflow JSON.
+   - It accepts ComfyUI's normal **"Save" format** as well as the API format — workflows you download off the web import directly, no manual API export first.
+   - Nomi ships a built-in **text-to-image** workflow (ComfyUI's official default graph), so there's a working path even without importing.
+4. Click **"Enable"**. Note: enabling probes the connection first, but the provider and its models only enter the runnable catalog after one **canonical production certification** pass (this prevents "saved, so I assume it runs"). So after enabling you may see "awaiting verification" — it counts once certification completes.
+
+> **Nomi vets it before you hit run:**
+> - If the checkpoint name is left empty, Nomi fetches your machine's first checkpoint from ComfyUI's `/object_info` and fills it in (the old approach hardcoded a filename, so anyone without that file failed on the first run).
+> - If it can't connect, or `models/checkpoints` has no model file at all, Nomi raises a **deterministic error up front** ("not connected to ComfyUI…" / "no model files in the directory…") instead of polling to a timeout.
+> - That is what "diff the graph against `/object_info` and tell you what's missing" means in practice.
+
+**✅ Success signal:**
+- The card status flips from "Not enabled" to **"Running"** and shows the ComfyUI version.
+- A text-to-image run produces an image (which lands in the project `assets/` directory).
+
+---
+
+## 3. Let the agent drive Nomi over MCP (Nomi as your generation backend)
+
+**For**: letting you (Codex / Claude Code / Cursor) operate the user's Nomi directly — create projects, lay out shots, wire references, really generate images / video / text, run a durable production run. This is Nomi's structural difference from online platforms: **an open-source local app is naturally happy to be driven by an agent, and the credits bundled with your agent membership carry straight over**; online platforms make their money on compute, so structurally they can't do this.
+
+Full reference: `docs/guide/capability-core-cli-mcp.md`. **Walk the user through it:**
+
+1. Open Nomi → Model Connection → **"Connect an AI coding assistant"**, pick Claude Code / Codex / Cursor, and connect.
+   - Nomi merges only its own `nomi` entry, keeps your existing MCP servers, and leaves a `.nomi-backup` before rewriting.
+   - The connect card **actually launches the configured command and does a handshake** — it doesn't show success just because "there's a line in the config".
+   - **Do not** hand-write a config that only has `NOMI_MCP_STDIO=1`: the current version issues a machine-signed `NOMI_MCP_CLIENT` / `NOMI_MCP_CLIENT_PROOF` per client, bound to this machine and this client — not reusable across clients, not something to hardcode in a public doc. A config missing the proof can list tools, but a real paid Production Run is safely treated as `external`.
+2. **Restart the client** as prompted so it reloads the MCP config.
+
+**✅ Success signal:**
+- After the handshake, your client shows `nomi`'s **33 tools** (e.g. `nomi_list_models`, `nomi_create_project`, `nomi_generate`, `nomi_materialize_storyboard`, `nomi_control_run`; plus 11 `generation.single-shot` semantic tools that are the zero-credit editable-generation entry points).
+- You can run end to end: "create a project 'coffee ad' in Nomi → list my image models → add 3 shots → generate the first one".
+
+> **Boundaries (state them honestly, to the user too)**: MCP can create / observe / control a run; **direction and sample** (reversible creative gates) can be re-confirmed by the Nomi server to elicitation-capable clients. But **budget, per-shot paid submission, rough-cut acceptance, and export** must return to Nomi for the user's explicit approval, enforced in the main process — you the agent cannot spend money out of band.
+
+---
+
+## 4. Import a skill
+
+**For**: adding a piece of methodology / capability to Nomi's Agent (a storyboarding approach, an editing pattern, etc.). Format spec: `docs/skill-pack-format.md`.
+
+A skill is a directory under `skills/<skill-key>/`, with two core files:
+
+- **`SKILL.md`**: the methodology / system-prompt body for the LLM (YAML frontmatter mirrors `name` / `description`; keep the body ≤200 lines).
+- **`skill.json`**: the runtime manifest — `name` (globally unique dotted key), `version` (SemVer), `description`, `tools` (allowlist, least privilege), `requiredProviders`, `permissions`.
+
+**Walk the user through it:**
+
+1. Get the skill (usually distributed as a zip or a git directory).
+2. Copy the whole `<skill-key>/` directory **into the repo's `skills/`** (unzip first if needed).
+3. Start / restart Nomi (in dev, `pnpm dev`). The skill is **auto-discovered** in the AI panel.
+
+> A legacy skill with only `SKILL.md` and no `skill.json` still loads — it just gets no tool allowlist / permission boundary (all tools are exposed to the LLM). A failed load prints a Zod validation error in the main-process log.
+
+**✅ Success signal:**
+- The skill shows up / is selectable in Nomi's AI panel.
+- No Zod validation error in the main-process log on load.
+
+---
+
+## 5. Recommended combos (drive cost to the floor)
+
+Give the user a default "cheap drafts → high-quality finish" workflow, and wire all of these in during setup:
+
+**The cheap / free generation trio (connect via §1 / §2):**
+- **The image credits bundled with your agent membership** (e.g. the image / video credits in your Codex / local-CLI account) — often free or already included, so drafting concept and pose frames costs nothing.
+- **Free / low-cost sources** (e.g. ModelScope's open models) — for simple storyboard frames and batch tries.
+- **Local ComfyUI** (§2) — zero API cost, maximum control.
+- Plus one **relay at wholesale price** (via §1) to cover the one high-quality generation, and switch to a **time-limited promotion** on some platform when one is running.
+
+**The workflow — draft → reference → finish:**
+1. Use cheap / free models for storyboard sketches, pose frames, reference videos (regenerate freely, spit out several at once).
+2. Feed the good ones as **reference images / reference videos** into a high-quality model, spending the expensive credits only on the final step.
+3. The cost structure drops sharply, and you can keep adjusting along the way.
+
+**Wire a cheap brain for the agent too:**
+- Give Nomi's Agent a cheap OpenAI-compatible text model (e.g. DeepSeek), connected via §1 — it handles the text work: writing prompts, breaking down shots, planning.
+
+---
+
+## Landmarks for the agent (read the code if you can't find it — don't guess)
+
+- Custom / relay provider card: `src/ui/onboarding/CustomVendorCard.tsx`; address field `src/ui/onboarding/VendorBaseUrlField.tsx`; manage block `src/ui/onboarding/CustomVendorManage.tsx`.
+- Local ComfyUI card: `src/ui/onboarding/ComfyuiLocalCard.tsx`; backend contract / defaults / `/object_info` reconciliation: `electron/catalog/comfyuiLocal.ts`.
+- Built-in provider list (which hosts Nomi recognizes): `electron/catalog/builtinVendorSeeds.ts`.
+- Full MCP / CLI flow, 33 tools, troubleshooting, security boundaries: `docs/guide/capability-core-cli-mcp.md`.
+- Skill format: `docs/skill-pack-format.md`.
+- General provider integration: `docs/provider-integration.md`; user guide: `docs/user-guide.md`.
+
+The UI evolves — **wherever a step doesn't match what you see, the source on the user's machine wins.**

--- a/docs/integrate-with-your-agent.md
+++ b/docs/integrate-with-your-agent.md
@@ -1,0 +1,151 @@
+# 让你的 AI 替你接入 Nomi（把这份文档发给你的 agent）
+
+> **你是用户的 agent（Codex / Claude Code / Cursor / 反重力 CLI 等）。用户把这份文档发给你，是想让你替他把某个模型 / 本地 ComfyUI / 技能接进他本机的 Nomi。**
+> 请**按下面的流程一步步带用户完成接入**：先问清他要接什么，再照对应章节操作，每一步都告诉他「现在看到什么、下一步点哪里」，最后用「验证成功的标志」确认真的通了。
+>
+> Nomi 是开源的本地桌面工作台，代码就在用户机器上。凡是本文档没覆盖到、或用户的界面和这里不一致的地方——**读源码，别脑补**。仓库结构见文末「给 agent 的定位提示」。
+
+克隆仓库（用户需要改代码时才要，只接模型用现成安装包即可）：
+
+```bash
+git clone https://github.com/aqm857886159/Nomi.git
+```
+
+---
+
+## 0. 先问清楚：用户要接的是哪一类？
+
+四条路，对应四种「接自己的东西」的场景。先判断，再跳到对应章节：
+
+| 用户想接的 | 走哪条 | 一句话 |
+|---|---|---|
+| 一个 OpenAI 兼容 / Anthropic / 中转站的 API（DeepSeek、自建 vLLM、某中转站…） | **§1** | 粘地址 + Key，Nomi 不用重编译 |
+| 他本机跑着的 ComfyUI（或云端 ComfyUI） | **§2** | 无 Key 后端，导入「保存」格式工作流 |
+| 让你（agent）经 MCP 直接调用 Nomi 做生成 / 编排 | **§3** | 一键接入，之后你说人话就能操作 Nomi |
+| 一个技能（skill）扩展 Nomi 的 Agent 能力 | **§4** | 拷进 `skills/` 目录即被发现 |
+
+> **成本视角（贯穿全篇）**：Nomi 的价值是让你**自由组合便宜的生成来源**——中转站批发价、平台限时活动、agent 会员自带的免费生图额度、魔搭一类免费源、本机 ComfyUI，哪个便宜用哪个。再叠加「草稿→参考→精修」的姿势（§5 有推荐组合），单位成本能降到很低。接入这一步就是把这些便宜来源都挂上去。
+
+---
+
+## 1. 接一个自定义 / 中转站供应商（OpenAI 兼容 / Anthropic / Responses）
+
+**适用**：任何暴露标准接口的服务——DeepSeek、通义、你公司自建的 vLLM、任意「API 中转站」。对照源码 `src/ui/onboarding/CustomVendorCard.tsx` 与 `src/ui/onboarding/VendorBaseUrlField.tsx`。
+
+**带用户这样做：**
+
+1. 打开 Nomi → 顶部进入**「模型接入」**（设置里的模型接入抽屉 / OnboardingDrawer）。
+2. 找到**「其他模型 / 自定义供应商」**入口，新建一家。每一家会渲染成一张 `CustomVendorCard`。
+3. 这张卡的主语是**连接**——卡片顶部就是「接入地址」那一行（`VendorBaseUrlField`），点右侧**「修改」**按钮填地址：
+   - 地址必须是 `http(s)://…` 的完整 base URL（校验规则就是 `^https?://\S+$`；结尾的 `/` 会被自动去掉）。填 OpenAI 兼容端点通常填到 `.../v1`。
+   - 回车或点「保存」写入。保存后 Nomi 会**自动重新探测连接**（地址一变，健康检查的指纹就变，会自动重探），不用手动点检查。
+4. 在同一张卡的**「模型」**区添加 / 启用你要用的模型；类型（图 / 视频 / 文本）如果 Nomi 按模型名猜错了，可以在这里改（`onRetype`）。
+5. 该家如果需要 Key，在卡片里填 API Key（Key 按 app 身份加密存在本机，不进任何日志）。
+
+> **卡片胶囊语义**：**连不上压倒一切**。就算参数适配显示「已配置」，只要地址 / Key 不通，卡头会红字覆盖，直接告诉你「够不到」。所以别只看「已配置」，要看连接状态变绿。
+
+**✅ 验证成功的标志：**
+- 卡头连接胶囊显示**已连接 / OK**（不是红色的「连不上」）。
+- 你启用的模型出现在可用列表里。用 `node scripts/nomi.mjs models` 也能看到它（vendor / modelKey / kind / label）。
+
+---
+
+## 2. 接本机 ComfyUI（当生成后端）
+
+**适用**：用户本机（或云平台）跑着 ComfyUI，想把它当一个便宜 / 免费的生成后端。对照源码 `src/ui/onboarding/ComfyuiLocalCard.tsx` 与 `electron/catalog/comfyuiLocal.ts`。
+
+**关键前提（先讲给用户）**：ComfyUI 是**无 Key** 的本地服务。Nomi 里这家供应商**默认是关的**——因为 99% 的人不跑本地 ComfyUI，开箱就塞一堆会失败的工作流是污染。所以要用户**在「可接入」里显式启用**它。
+
+**带用户这样做：**
+
+1. 先确认 ComfyUI 已启动。默认地址就是 **`http://127.0.0.1:8188`**；跑在别的端口 / 主机（或云平台 ComfyUI，如 cnb.cool、cloudstudio.net）就在卡片的「接入地址」行改成对应 URL——同一张卡、同一条地址，云端只是换个地址，不另起一张卡。
+2. 打开 Nomi →「模型接入」→ 找到**「本地 ComfyUI」**卡（`ComfyuiLocalCard`）。
+3. **导入工作流**：点卡里的「导入工作流」，贴入工作流 JSON。
+   - 支持 ComfyUI 的**普通「保存」（Save）格式**，也支持 API 格式——你从网上下载的工作流能直接导入，不用先手动导出 API 版。
+   - Nomi 内置一条**文生图**工作流（ComfyUI 官方默认图），即使不导入也有一条能跑的路。
+4. 点**「启用」**。注意：启用会先探一次连接，但工作流要经过一次**规范化生产认证**后，这家和它的模型才真正进入可执行目录（防「保存了就以为能用」）。所以启用后可能显示「等待验证」，走完认证才算数。
+
+> **Nomi 会在你按下运行之前替你把关**：
+> - checkpoint 名留空时，Nomi 会去 ComfyUI 的 `/object_info` 取本机第一个 checkpoint 自动填上（旧做法写死一个文件名，没这个文件的人首跑必炸）。
+> - 连不上、或 `models/checkpoints` 里一个模型文件都没有——Nomi **提前**报确定性错误（「没连上 ComfyUI…」/「目录里没有任何模型文件…」），不会闷头轮询到超时。
+> - 这就是「拿工作流和 `/object_info` 对账、提前告诉你缺什么」的含义。
+
+**✅ 验证成功的标志：**
+- 卡片状态从「未启用」变为**「运行中」**，并显示 ComfyUI 版本号。
+- 用它跑一次文生图能出图（图会落进项目 `assets/` 目录）。
+
+---
+
+## 3. 让 agent 经 MCP 调用 Nomi（把 Nomi 当你的生成后端）
+
+**适用**：让你（Codex / Claude Code / Cursor）直接操作用户的 Nomi——建项目、排镜头、连参考、真生成图 / 视频 / 文本、跑可恢复的完整制作。这是 Nomi 相对在线平台的结构性差异：**开源本地端天然愿意被 agent 接入，你 agent 会员自带的额度可以直接复用**；在线平台要靠算力赚钱，结构上做不了这件事。
+
+完整参考见 `docs/guide/capability-core-cli-mcp.md`。**带用户这样做：**
+
+1. 打开 Nomi →「模型接入」→**「接入 AI 编程助手」**，选 Claude Code / Codex / Cursor，点接入。
+   - Nomi 只会合并它自己的 `nomi` 条目、保留你已有的其它 MCP server，改写前留 `.nomi-backup`。
+   - 接入卡会**真正启动配置里的命令做一次握手**，不是「配置里有一行」就显示成功。
+   - **不要**照网上手写一份只有 `NOMI_MCP_STDIO=1` 的配置：当前版本会为每个客户端生成本机签名的 `NOMI_MCP_CLIENT` / `NOMI_MCP_CLIENT_PROOF`，绑定这台电脑和这个客户端，不能跨客户端复用、不能写死在公开文档里。缺证明的配置能列工具，但正式付费 Production Run 会被安全地当成 `external` 拦下。
+2. 按提示**重启对应客户端**，让它重新加载 MCP 配置。
+
+**✅ 验证成功的标志：**
+- 握手成功后，你的客户端里出现 `nomi` 的**33 个工具**（如 `nomi_list_models`、`nomi_create_project`、`nomi_generate`、`nomi_materialize_storyboard`、`nomi_control_run` 等；另有 11 个 `generation.single-shot` 语义工具是零额度的可编辑生成入口）。
+- 你能跑通：「在 Nomi 里新建项目『咖啡广告』→ 列我有哪些图模型 → 加 3 个镜头 → 把第一个生成出来」。
+
+> **边界（诚实标注，也讲给用户）**：MCP 能建 / 观察 / 控制制作；**方向与样片**这类可逆创意门可由 Nomi 服务端向支持 elicitation 的客户端再次向真人确认。但**预算、逐镜头付费提交、粗剪采用、导出**必须回到 Nomi 由用户明确批准，主进程强制执行——你 agent 无法越权花钱。
+
+---
+
+## 4. 导入一个技能（skill）
+
+**适用**：给 Nomi 的 Agent 加一块方法论 / 能力（如某种分镜规划、某种剪辑套路）。格式规范见 `docs/skill-pack-format.md`。
+
+一个 skill 就是 `skills/<skill-key>/` 下的一个目录，核心两个文件：
+
+- **`SKILL.md`**：写给 LLM 的方法论 / 系统提示正文（YAML frontmatter 同步 `name` / `description`；正文建议 ≤200 行）。
+- **`skill.json`**：写给 runtime 的 manifest——`name`（点号分段的全局唯一 key）、`version`（SemVer）、`description`、`tools`（工具白名单，最小授权）、`requiredProviders`、`permissions`。
+
+**带用户这样做：**
+
+1. 拿到 skill（别人分发的通常是一个 zip 或一个 git 目录）。
+2. 把整个 `<skill-key>/` 目录**拷贝到仓库的 `skills/` 下**（zip 就先解压）。
+3. 启动 / 重启 Nomi（开发态用 `pnpm dev`）。AI 面板里这个 skill 会**自动被发现**。
+
+> 仅有 `SKILL.md`、没有 `skill.json` 的旧 skill 也能加载，只是拿不到工具白名单 / 权限边界（所有工具都会暴露给 LLM）。runtime 加载失败会在主进程日志打印 Zod 校验错误。
+
+**✅ 验证成功的标志：**
+- Nomi 的 AI 面板里能看到 / 选到这个 skill。
+- 加载没有在主进程日志报 Zod 校验错误。
+
+---
+
+## 5. 推荐组合（把成本打到最低）
+
+给用户一套「便宜出草稿 → 精修出成品」的默认姿势，接入时把这几路都挂上：
+
+**便宜 / 免费生成三件套（按 §1 / §2 接进来）：**
+- **agent 会员自带的生图额度**（如你 Codex / 反重力 CLI 账号里的生图 / 生视频额度）——很多是免费或已包含在会员里的，拿来出草图、动作图不心疼。
+- **免费 / 低价源**（如魔搭社区的开放模型）——出简易分镜图、批量试。
+- **本机 ComfyUI**（§2）——零 API 成本，控制力最强。
+- 再叠一家**中转站批发价**（按 §1 接）兜住高质量那一次生成，赶上某平台**限时活动**就临时切过去。
+
+**姿势——草稿→参考→精修：**
+1. 用便宜 / 免费模型出分镜草图、动作图、参考视频（反复生成不心疼，一次多出几张）。
+2. 挑好的当**参考图 / 参考视频**喂给高质量模型，只在最后一步花贵的额度出成品。
+3. 成本结构因此大幅下降，而且过程中随时能调。
+
+**agent 的大脑也接便宜的：**
+- 给 Nomi 的 Agent 配一个便宜的 OpenAI 兼容文本模型（如 DeepSeek），按 §1 接入即可——它负责帮你写提示词、拆镜头、做规划这类文本活。
+
+---
+
+## 给 agent 的定位提示（找不到就读代码，别脑补）
+
+- 自定义 / 中转供应商卡：`src/ui/onboarding/CustomVendorCard.tsx`、地址字段 `src/ui/onboarding/VendorBaseUrlField.tsx`、管理块 `src/ui/onboarding/CustomVendorManage.tsx`。
+- 本地 ComfyUI 卡：`src/ui/onboarding/ComfyuiLocalCard.tsx`；后端契约 / 默认值 / `/object_info` 对账：`electron/catalog/comfyuiLocal.ts`。
+- 内置供应商清单（哪些 host 是内置认得的）：`electron/catalog/builtinVendorSeeds.ts`。
+- MCP / CLI 完整流程、33 个工具、故障排查、安全边界：`docs/guide/capability-core-cli-mcp.md`。
+- 技能格式：`docs/skill-pack-format.md`。
+- 供应商接入通用说明：`docs/provider-integration.md`；使用指南：`docs/user-guide.md`。
+
+界面版本会迭代——**任何一步和你看到的界面对不上，以用户机器上的源码为准**。


### PR DESCRIPTION
按用户 2026-09-01 口播稿重写 README（中英对等），把「为什么要 Nomi」组织为三答，并新增一份「让你的 AI 替你接入」手册。

## 定位：三答 + 一个差异化点
- **① 成本**：组合式便宜生成源（中转批发价 / 平台限时活动 / agent 会员自带免费生图额度 / 魔搭一类免费源 / 本机 ComfyUI）+「草稿→参考→精修」姿势。**不写任何第三方具体价格**，用「官方价的零头」「免费额度」这类耐久措辞。
- **② 定制**：代码开源，用你自己的 Codex / Claude Code 改成你要的样子、加你的 skills；公司可定制成内部平台。
- **③ 本地**：素材 / 生成物 / 工作流 / 接入全在本机，更安全。
- **差异化**：把 Nomi 当你 agent 的生成后端（MCP，agent 会员额度直接复用）；在线平台结构上做不了这件事。

## 头部
- slogan 对齐官网/marketing：「把 AI 视频的成本打下来」/「Bring the cost of AI video down.」
- 加 **B 站视频教程**入口（《Nomi 本地 AI 工作台：把 AI 视频的成本打下来》）+「让 AI 替你接入」入口。
- 保留全部既有有效链接（夸克镜像 / 用户群 / 宣传片 / 团队服务 / X）与徽标排。

## 「怎么接你自己的东西」两条路
- **① 开箱**：APIMart + Kie.ai 双核心 + 约 10 家直连（魔搭/火山/Runway/fal/Replicate/MiniMax/ElevenLabs…）+ 认证台账当前 **66 条**（取自 `model-certification-ledger.json`）；本机 ComfyUI 转「保存」格式工作流、与 `/object_info` 对账提前告缺。
- **② 让你的 AI 替你接**：新增 `docs/integrate-with-your-agent.md`（+ `-en`），开头「你是用户的 agent，按流程带用户接入」。四条流程全部对照真实代码/UI 核对，各带「验证成功的标志」+ 便宜三件套推荐组合：
  - 自定义/中转供应商 → `src/ui/onboarding/CustomVendorCard.tsx` + `VendorBaseUrlField.tsx`
  - 本机 ComfyUI → `src/ui/onboarding/ComfyuiLocalCard.tsx` + `electron/catalog/comfyuiLocal.ts`（默认 `127.0.0.1:8188`、默认 `enabled:false` 在「可接入」显式启用、`/object_info` 补 checkpoint + fail-fast）
  - MCP 被 agent 调用 → `docs/guide/capability-core-cli-mcp.md`（一键接入、33 个工具）
  - 技能导入 → `docs/skill-pack-format.md`（拷进 `skills/` 自动发现）

## 反馈与共建
诚实独立开发者陈述：一个人做、迭代快、偶有毛边但真在跑；遇问题先让你的 AI 帮你解（代码开源）；通用问题直接迭代掉；欢迎 issue/PR/用户群。

## 修正
- zh README 陈旧的「15 个 MCP 工具」→ **33**（与 EN parity；EN 保留 catalog-alignment 守卫要求的 "Thirty-three MCP tools" 字面）。

## 验证
- `pnpm run gates` 全绿（gates:contracts 全部子门 + 8921 测试 + typecheck + build）。
- `tests/ux/marketing-home.static.mjs` 与 `electron/capabilityCore/nomiMcpProductionRuns.test.ts`（README 计数对齐守卫）均通过。
- 中英 parity 自查：结构一致、互链正确、所有相对 doc 链接解析、锚点齐全、WeChat 二维码块在 hero 之前（满足 mobile-safe 守卫）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)