### PR TITLE
fix(canvas): 3D 节点 composer 补模型选择器——kind 分类双边界漏 model3d（J11 真 bug）

### DIFF
--- a/src/config/modelCatalogStatus.test.ts
+++ b/src/config/modelCatalogStatus.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import { resolveCatalogKind } from './modelCatalogStatus'
+
+describe('resolveCatalogKind', () => {
+  it('maps each node kind to its own catalog bucket (never silently to text)', () => {
+    expect(resolveCatalogKind('image')).toBe('image')
+    expect(resolveCatalogKind('imageEdit')).toBe('image')
+    expect(resolveCatalogKind('video')).toBe('video')
+    expect(resolveCatalogKind('audio')).toBe('audio')
+    // Regression: a 3D node must fetch from the 'model3d' catalog bucket. Falling
+    // back to 'text' left the 3D composer's model selector permanently empty
+    // (options filtered against text models by text_to_3d mode → nothing), so the
+    // 3D generation path was stuck with no way to pick an already-onboarded model.
+    expect(resolveCatalogKind('model3d')).toBe('model3d')
+  })
+
+  it('defaults unknown/text kinds to the text bucket', () => {
+    expect(resolveCatalogKind('text')).toBe('text')
+    expect(resolveCatalogKind(undefined)).toBe('text')
+  })
+})

--- a/src/config/modelCatalogStatus.ts
+++ b/src/config/modelCatalogStatus.ts
@@ -12,6 +12,11 @@ export function resolveCatalogKind(kind?: NodeKind): BillingModelKind {
   if (kind === 'audio') {
     return 'audio'
   }
+  // 3D 模型节点：其目录桶就是 'model3d'（catalog 按 kind 拉取时才拉得到已接入的 3D 模型，
+  // 否则落回 'text' 桶 → 3D 节点的模型选择器永远空 → 生成路径断在选型）。
+  if (kind === 'model3d') {
+    return 'model3d'
+  }
   return 'text'
 }
 

--- a/src/workbench/generationCanvas/model/generationNodeKinds.test.ts
+++ b/src/workbench/generationCanvas/model/generationNodeKinds.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getGenerationNodeExecutionKind,
+  isAudioLikeGenerationNodeKind,
+  isImageLikeGenerationNodeKind,
+  isModel3dLikeGenerationNodeKind,
+  isVideoLikeGenerationNodeKind,
+} from './generationNodeKinds'
+
+// The composer's `isGenerationNode` gate is the union of these predicates. A kind
+// that no predicate claims renders no parameter bar → no model selector at all.
+// This locks in that every executable kind (incl. model3d) is claimed by exactly
+// one predicate, so the 3D node keeps its selector.
+describe('generation node kind classification', () => {
+  it('classifies the 3D model kind as a 3D-like generation node', () => {
+    expect(getGenerationNodeExecutionKind('model3d')).toBe('model3d')
+    expect(isModel3dLikeGenerationNodeKind('model3d')).toBe(true)
+  })
+
+  it('does not misclassify the 3D model kind as image/video/audio', () => {
+    expect(isImageLikeGenerationNodeKind('model3d')).toBe(false)
+    expect(isVideoLikeGenerationNodeKind('model3d')).toBe(false)
+    expect(isAudioLikeGenerationNodeKind('model3d')).toBe(false)
+  })
+
+  it('keeps the 3D predicate scoped to 3D (image/video are not 3D-like)', () => {
+    expect(isModel3dLikeGenerationNodeKind('image')).toBe(false)
+    expect(isModel3dLikeGenerationNodeKind('video')).toBe(false)
+    expect(isModel3dLikeGenerationNodeKind('text')).toBe(false)
+  })
+})

--- a/src/workbench/generationCanvas/model/generationNodeKinds.ts
+++ b/src/workbench/generationCanvas/model/generationNodeKinds.ts
@@ -109,6 +109,12 @@ export function isAudioLikeGenerationNodeKind(kind: GenerationNodeKind): boolean
   return getGenerationNodeExecutionKind(kind) === 'audio'
 }
 
+// 3D 模型节点同为可生成节点（executionKind:'model3d'，走通用 catalog 任务路径 generate3D）——
+// 要渲染模型选择器 + 自动选默认，否则接了 3D 模型（meshy/混元…）也没处在节点上选它、生成路径断在选型。
+export function isModel3dLikeGenerationNodeKind(kind: GenerationNodeKind): boolean {
+  return getGenerationNodeExecutionKind(kind) === 'model3d'
+}
+
 // kind→分类映射的实现已下沉到 generationCanvasTypes（纯模型层，迁移与创建共用，
 // 不拖 nodes/registry 的 UI 依赖链）。此处保留导出面，既有调用方 import 路径不变。
 export { getDefaultCategoryForNodeKind } from './generationCanvasTypes'

--- a/src/workbench/generationCanvas/nodes/NodeParameterControls.tsx
+++ b/src/workbench/generationCanvas/nodes/NodeParameterControls.tsx
@@ -18,6 +18,7 @@ import {
   getGenerationNodeExecutionKind,
   isAudioLikeGenerationNodeKind,
   isImageLikeGenerationNodeKind,
+  isModel3dLikeGenerationNodeKind,
   isVideoLikeGenerationNodeKind,
 } from '../model/generationNodeKinds'
 import { useGenerationCanvasStore } from '../store/generationCanvasStore'
@@ -118,7 +119,10 @@ export default function NodeParameterControls({
   const isTextLike = getGenerationNodeExecutionKind(node.kind) === 'text'
   // 声音节点同为可生成节点：要走模型自动选择(选到「声音」档案)→ ModeBar(配音/转写)+ 参数才显现。
   const isAudioLike = isAudioLikeGenerationNodeKind(node.kind)
-  const isGenerationNode = isImageLike || isVideoLike || isTextLike || isAudioLike
+  // 3D 模型节点同为可生成节点(executionKind:'model3d')：与图片/视频共用同一套模型选择器/自动选择/参数机制，
+  // 只是 catalogKind→'model3d'、requiredMode→'text_to_3d'(见 modelOptionsAdapter)把候选过滤到已接入的 3D 模型。
+  const isModel3dLike = isModel3dLikeGenerationNodeKind(node.kind)
+  const isGenerationNode = isImageLike || isVideoLike || isTextLike || isAudioLike || isModel3dLike
   const requiredMode = requiredModeForGenerationNode(node, { nodes, edges })
   const modelOptionsState = useGenerationModelOptionsState(node.kind, requiredMode)
   const modelOptions = modelOptionsState.options


### PR DESCRIPTION
旅程测试网 J11 发现的真 bug：节点切 3D 后 composer 无模型选择器，接入了 3D 模型（RunningHub meshy6/hunyuan3d）也断在选型。

**根因（两处共享边界漏 model3d）**：NodeParameterControls 的 isGenerationNode 不含 model3d→参数/模型底栏对 3D 节点整个不渲染、自动选默认模型也被 gate；resolveCatalogKind 把 model3d 落回 text 桶→过滤恒空。runner 侧早已零特判支持 3D（model3dActions 走通用 catalog 路径），git 无「3D 不需选型」拍板记录。
**修**：新增 isModel3dLikeGenerationNodeKind 谓词接入既有机制（P4 同一套选择器/自动选择/参数管线，无并行版）+ catalogKind 补 model3d 桶 + 2 个类级回归测试锁死双边界。候选由 adapter 按 text_to_3d derive，零 hardcode。
**验证**：改前 J11 红（model-picker-missing）；改后 3D composer 完整渲染（R13 截图编排者亲验：3D 占位提示词+诚实空态与图片/视频同路径）；全量 gates=0。
**诚实边界**：J11 旅程本身未在本 PR 转绿——其 fixture 走中转接 3D，而中转刻意不支持 3D（代码明文的 D4 诚实边界设计）；旅程应改测真实直连 3D 路径，裁决已记录归入旅程债返工批。

🤖 Generated with [Claude Code](https://claude.com/claude-code)