### PR TITLE
docs: 收编四份决策文档——A+B 计划（带现状标注）+ 三份拆项评估

### DIFF
--- a/docs/DELIVERY-LEDGER.md
+++ b/docs/DELIVERY-LEDGER.md
@@ -9,12 +9,13 @@
 
 ---
 
-## 现役欠账（20）
+## 现役欠账（21）
 
 | 状态 | 文档 | 标题 |
 |---|---|---|
 | 📋 方案待拍板 | [2026-08-13-video-deconstruction-storyboard-table.md](plan/2026-08-13-video-deconstruction-storyboard-table.md) | 视频拆解 → 分镜表 → 复刻生成（方案已拍板，待实施） |
 | 📋 方案待拍板 | [2026-08-27-unified-tool-surface.md](plan/2026-08-27-unified-tool-surface.md) | 内外工具面统一 —— 我们造了第二套 |
+| 📋 方案待拍板 | [2026-08-31-agent-material-channels-and-local-endpoints.md](plan/2026-08-31-agent-material-channels-and-local-endpoints.md) | 执行计划：Pi Agent 的素材获取三通道 + 本地文本模型通用端点 |
 | ⏳ 已拍板·未开工 | [2026-09-01-agent-m0-baseline-freeze.md](plan/2026-09-01-agent-m0-baseline-freeze.md) | M0：Agent 架构基线冻结 |
 | 🚧 进行中 | [2026-08-15-model-access-exhaustive-user-journeys.md](plan/2026-08-15-model-access-exhaustive-user-journeys.md) | 模型接入全集用户旅途测试 |
 | 🚧 进行中 | [2026-08-15-model-integration-no-dead-end-master-plan.md](plan/2026-08-15-model-integration-no-dead-end-master-plan.md) | 模型接入“无死路”架构与全集验证执行总方案 |
@@ -47,7 +48,7 @@
 
 ## 其余
 
-- **已结案**：33 篇（✅ 已交付 / ⛔ 已废弃 / 📎 交接日志）
+- **已结案**：35 篇（✅ 已交付 / ⛔ 已废弃 / 📎 交接日志）
 - **未登记存量**：423 篇。这些是历史文件，**有意不进现役区**——其中很多离得很远、或已经不需要做。
   想分诊就挑一篇加状态标记；不分诊也不会有人催。`check:doc-status` 只拦**新增**文档缺标记，不逼你清存量。
 
@@ -64,7 +65,7 @@
 
 </details>
 
-- 合计扫描：482 篇方案文档（docs/plan/ 与 docs/superpowers/plans/，不含 INDEX.md）
+- 合计扫描：485 篇方案文档（docs/plan/ 与 docs/superpowers/plans/，不含 INDEX.md）
 
 ---
 

--- a/docs/plan/2026-08-31-agent-material-channels-and-local-endpoints.md
+++ b/docs/plan/2026-08-31-agent-material-channels-and-local-endpoints.md
@@ -1,0 +1,183 @@
+# 执行计划：Pi Agent 的素材获取三通道 + 本地文本模型通用端点
+
+> 状态：📋 计划（部分已落地）
+>
+> **⚠️ 2026-09-01 收编时的现状标注（读旧文先看这段，防过期前提）**：
+> - **P0 本地模型预设卡已落地**（PR #281 @2026-09-01：LocalModelCard + electron/localRuntime/，探测/一键连/能力预检全闭环）——§4 P0 一节已成历史记录。
+> - **「实施等 #223 phase1 收口」前提已作废**：#223 已冻结为 M 线病历本，被 M 计划（#272/#275 起）取代；后续 P1-P3 的运行时前提以 M 线现状为准（查 docs/ARCHITECTURE-NOW.md）。
+> - P1（Connector 素材轨）/P2（pi-web-access 查资料）/P3（人挑素材）仍未实施；P2 的 license 核实仍是阻断前置。
+> - 短视频数据源（TikHub connector，2026-09-01 批 v1）是本计划之外新增的数据摄取 connector，见 `docs/research/2026-09-01-shortvideo-data-apis-eval.md`。
+>
+> Rule 4 执行计划。承接 PR #223（`project-agent-host` 线，Pi Agent 落地 Nomi 项目）**下一阶段**的两个能力：
+> **A. 素材/参考获取**（三通道分工）与 **B. 本地文本模型接入**（通用端点，非 LocalAI 专项）。
+> 方向已由用户拍板（2026-08-31），本文只把「怎么落」写清；~~实施等 #223 phase1 收口~~（见上方现状标注）。
+>
+> **背景来源（承接，不重复调研）**：
+> - 素材/浏览器/pi 生态调研：`docs/research/2026-08-29-browser-assets-pi-ecosystem-research.md`（随 #226 合并入库）。
+> - Connector 合同与提示词系统：`docs/plan/2026-08-29-creative-capability-catalog-and-prompt-system.md`（随 #226 合并入库）。
+> - 运行时 owner 边界：`docs/superpowers/plans/2026-08-24-unified-agent-master-plan.md`、`docs/specs/2026-08-22-runtime-ownership-adr.md`。
+>
+> **验证时点**：本文所有代码坐标以 `origin/main` = `b71d3c88` 为准，2026-08-31 实查核实；标「随 #226 入库」的合同/文档为**前置依赖**，尚未在 main（见「依赖与顺序」）。
+
+---
+
+## 0. 一页看懂（当前基线 + 本轮做什么）
+
+**已落地（`origin/main`，本文直接站在其上）**：
+- Pi 适配层已在 `electron/harness/runtime/pi/`（`session.mts` / `run.mts` / `tools.mts` / `model.mts` / `attachments.mts` 等，注意是 `.mts`），#223 把 Pi Agent 接进 Nomi 项目宿主。
+- 内置浏览器已通：`electron/browser/core/browserViews.ts:251` 起用 `WebContentsView`（`contextIsolation`+`sandbox`）；截图入库管道已闭环——`electron/browser/media/browserMediaVisualCapture.ts`（视频抽帧/截屏兜底）+ `electron/browser/media/browserPromptScreenshotSelection.ts`（框选入库）。
+- 本地文本模型的**原语已存在**：`electron/ai/buildAiSdkModel.ts` 的 `createOpenAICompatible({ baseURL, apiKey? })` 已支持 `authType: "none"`（`buildAiSdkModel.ts:110/149`）；自定义供应商 UI 在 `src/ui/onboarding/CustomVendorCard.tsx` + `src/ui/onboarding/VendorBaseUrlField.tsx`。
+- 本地图像/视频已归 ComfyUI：`electron/catalog/comfyuiLocal.ts`（探测/连接）+ 预设卡 `src/ui/onboarding/ComfyuiLocalCard.tsx`。
+
+**本轮做什么（一句话）**：给 Pi Agent 补上「拿素材」和「用本地文本模型」两件能力——
+**A** 用三条**职能不重叠**的通道解决素材获取（机器拿结构化 / 人挑内置浏览器 / agent 查资料），
+**B** 把已有的 OpenAI-兼容原语包成一张「本地模型」预设卡（探测→一键连→能力预检），让本地 Ollama / LM Studio / LocalAI 可发现、可用。
+**两件都是「装配已有原语 + 补可发现性/合同」，不新造运行时、不写供应商专有代码。**
+
+**用户已拍板的方向（本文不再重开）**：A 的三通道分工、"agent 不模拟点击爬素材站"、B 做通用端点而非 LocalAI 专项。
+
+---
+
+## 1. 背景与用户摩擦（为什么做——D1/D6）
+
+**A. 素材获取——现在 Pi Agent「巧妇难为无米之炊」。** Agent 能规划、能生成，但一到「找一张参考图 / 一段空镜 / 一个音效」就断档：要么让用户手动去外部网站下载再拖进来（多读多操作，D1 砍的对象），要么 agent 只能凭空描述。三种「拿素材」的**真实场景本就不同**，硬塞进一条通道会互相打架：
+- 「给我一张海边日落的空镜」→ 机器应当**直接拿到带许可的结构化素材**，不该让用户去翻网站。
+- 「我想自己挑一张更有感觉的」→ 人应当在**熟悉的浏览器里挑**，agent 只负责搜好、打开。
+- 「查一下这个转场怎么做 / 这个导演的分镜风格」→ agent 要的是**资料**，不是入库素材。
+
+**B. 本地文本模型——能力在、但等于没有。** `buildAiSdkModel.ts` 早就能连任意 OpenAI-兼容端点（含免鉴权），可普通用户根本不知道「自定义供应商」能填 `http://localhost:11434/v1`——这是**可发现性缺口**，不是能力缺口（对标记忆：`vendor-manage-is-a-discoverability-problem.md`——功能在、只是没入口）。跑本地模型的人（Ollama / LM Studio 桌面主流、LocalAI 自托管）想让 Agent 用自己的模型省额度/保隐私，却卡在「不知道怎么连、连了不知道行不行」。
+
+**共同的底层逻辑**：这两件都不是「造新能力」，是**把已有原语接到用户摸得着的地方**，并诚实告诉用户边界（拿不到的素材标出来、跑不动 agent 的模型明说）。
+
+---
+
+## 2. 范围（本轮做什么）
+
+### A. 素材/参考获取——三通道分工
+
+> 核心判断：**一个「拿素材」需求，按「谁来拿、拿来干嘛」分三条职能不重叠的通道**；P1 不留并行版——同一职能只有一个家。
+
+**通道 1 · 机器拿素材 = Connector 轨（结构化 API）**
+- 数据源：Pexels / Pixabay / Freesound（免费 key、结构化响应、**自带许可信息**）；参考视频走 **Pexels Videos**。
+- 实现：**复用 #226 的 `ConnectorDefinition` + `AssetSourceEvidence` 合同**（不新造素材抽象）——connector 声明「搜什么、返回什么、许可怎么记」，通用系统负责调用与入库，`AssetSourceEvidence` 记录来源/许可作为凭证。
+- Unsplash **延后**：其条款要求 hotlink（不得转存/代理），与我们「入库=本地留存」冲突，本轮不接。
+
+**通道 2 · 人挑素材 = 内置浏览器轨**
+- 复用**已存在**的浏览器（`browserViews.ts:251` `WebContentsView`）+ 已通的截图入库管道（`browserMediaVisualCapture.ts` / `browserPromptScreenshotSelection.ts`）。
+- Agent 职责**收窄到「搜好、打开」**——把用户意图变成搜索、把浏览器开到对的页；**人**在页面里圈选/截图入库。
+- **明确不做 agent 模拟点击的浏览器自动化**（理由见 §3 不动项 / §6 风险）。
+
+**通道 3 · agent 查资料 = web 搜索/抓取工具**
+- 复用 pi 生态 **`pi-web-access`**（npm，钉版本；4 个工具 `web_search` / `fetch_content` / `get_search_content` / `source_check`；免 key 走 Exa 起步、HTTP-only）。
+- 落地方式：**钉版本 + 源码审计后，作为内置能力 vendor 进 #223 的 pi 适配层**（`electron/harness/runtime/pi/`）——**不开放任意第三方 extension 安装**（遵 #226 安全判定「不原样交出系统权限」）。
+- 产出**只当参考/调研**，**不入素材库**（与通道 1 的产物泾渭分明）。
+- **前置检查项（阻断性）**：落地前必须核实 `pi-web-access` 的 license 允许 vendoring（见 §5 依赖 / §6 风险）。
+
+### B. 本地文本模型——通用端点预设卡
+
+> 核心判断：**做可发现性，不做 LocalAI 专项**；三家都是 OpenAI-兼容，走同一张卡，零供应商专有代码（P4 通用第一）。
+
+- 仿 `ComfyuiLocalCard.tsx` 出一张**「本地模型」预设卡**（`src/ui/onboarding/`），能力：
+  - **探测常见端口**：Ollama `11434` / LM Studio `1234` / LocalAI `8080`；
+  - **一键连**：命中即用已有 `createOpenAICompatible({ baseURL, authType: "none" })` 建档；
+  - **拉 `/v1/models`** 列出可用模型 + **连通测试**。
+- **配「能力预检」**：一个 **function-calling 探针**——本地模型若跑不动 agent loop（不支持工具调用），**当场明说**「此模型可对话、但带不动 Agent 编排」（D4 诚实交付），不让用户事后踩坑。
+- 三家定位（写进卡片说明，帮用户判断）：Ollama / LM Studio = 桌面主流；LocalAI = 自托管、偏多模态。
+
+---
+
+## 3. 不动项（P1 不碰 / 边界红线）
+
+明确**不动**，避免顺手扩面破坏已定边界：
+
+1. **#223 运行时 port 抽象**：Pi 适配层的 session/run/tools 契约与运行时 port 语义**不改**；本轮只往适配层**加内置工具**（通道 3），不改运行时 owner。
+2. **skills 纯知识包边界**：skills 仍是**纯知识包**，不因「查资料/拿素材」把可执行能力塞进 skills；能力住适配层与 connector，不住 skills。
+3. **#239 画布插件层**：画布节点/插件层**不碰**；素材入库后如何在画布消费是既有管线，本轮不改。
+4. **本地图像/视频不另开腿**：本地图像/视频**已归 ComfyUI**（`comfyuiLocal.ts`）——**不因 LocalAI 支持多模态就为本地图像/视频再开一条通道**（P1 无并行版）。B 只做**文本模型**端点。
+5. **agent 操纵浏览器爬素材站入库**：**明确不做**（脆、违 ToS、无许可证据）——它与通道 1 同职能，留着就是并行版。
+6. **不开放任意第三方 pi extension 安装**：通道 3 只 vendor **审计过的** `pi-web-access`，不给「装任意 extension」的口子。
+7. **既有 Connector 合同不改语义**：通道 1 **复用** #226 的 `ConnectorDefinition` / `AssetSourceEvidence`，只**新增 connector 定义**，不改合同形状。
+
+---
+
+## 4. 分期交付（每期一个可体验闭环）
+
+> 原则：每期收一个**用户能真跑通的闭环**（R16），独立过五门（R11）+ 用户可见的过样张/走查（R8/R13）。A 的通道 1/3 与 B **相互独立可并行**；通道 2 依赖通道 1 的 UI 骨架故稍后。
+
+### P0 · 本地文本模型预设卡（B，风险最低、最独立，建议起点）
+- **可体验闭环**：用户开着 Ollama（或 LM Studio）→ 打开接入页 → 「本地模型」卡自动探到 `11434` → 一键连 → 拉到模型列表 → 能力预检显示「支持 Agent / 仅对话」→ 建档后 Agent 能用本地模型跑一段。
+- **落点**：新预设卡（仿 `ComfyuiLocalCard.tsx`）+ function-calling 探针；建档复用 `createOpenAICompatible` + `authType none`。
+- **为何先做**：零外部合同依赖（不等 #226）、零供应商专有码、纯装配已有原语，风险最低。
+
+### P1 · Connector 轨拿结构化素材（A 通道 1）
+- **依赖**：#226 的 `ConnectorDefinition` / `AssetSourceEvidence` 已入 main。
+- **可体验闭环**：Agent 收到「海边日落空镜」→ 走 Pexels/Pixabay connector → 结构化拿图/视频 + 许可证据 → 入库 → 画布可用；音效走 Freesound；参考视频走 Pexels Videos。
+- **落点**：新增三个 connector 定义（Pexels 含 Videos / Pixabay / Freesound）+ key 配置入口；许可写进 `AssetSourceEvidence`。
+
+### P2 · agent 查资料工具（A 通道 3）
+- **前置（阻断）**：`pi-web-access` license 允许 vendoring 已核实（见 §5）。
+- **可体验闭环**：Agent 遇到「这个转场/分镜怎么做」→ 用 `web_search` / `fetch_content` 拿到资料 → 用于规划/提示词，**产物不入素材库**。
+- **落点**：钉版本 + 源码审计 → vendor 进 `electron/harness/runtime/pi/` 作内置工具；`source_check` 做来源可信度提示。
+
+### P3 · 人挑素材（A 通道 2）
+- **依赖**：P1 的素材入口 UI 骨架（复用其许可/入库路径）。
+- **可体验闭环**：Agent 把「想自己挑一张」变成搜索 → 内置浏览器开到结果页 → **人**圈选/截图入库（复用现有 `browserPromptScreenshotSelection` 管道）。
+- **落点**：Agent 侧「搜好打开」的意图→浏览器桥；**不新增自动化点击**。
+
+> 顺序可按 #226/#223 的实际到位时间调整；P0 与 P2 不依赖 #226，P1/P3 依赖 #226。
+
+---
+
+## 5. 依赖与顺序
+
+**硬前置（阻断相应期）**：
+1. **#226 合同先入 main**（`ConnectorDefinition` / `AssetSourceEvidence` + 承接的两份背景文档）→ 阻断 **P1 / P3**。#226 即将随合并列车入 main；未入之前 P1/P3 不开工。
+2. **#223 phase1 收口**（Pi 适配层稳定）→ 阻断**全部**开工时点：本轮所有期都建立在 #223 的适配层上，phase1 未收口不动手。
+3. **`pi-web-access` license 允许 vendoring**（阻断 **P2**）：落地前实查其 license（npm 包 + 仓库 LICENSE），确认允许 vendor 进闭源桌面分发；不允许则 P2 改走「独立进程/网络隔离」或换等价 HTTP-only 方案，**不得先斩后奏 vendor**。
+
+**并行关系**：
+- **P0（B）** 与 **A 的任一期相互独立**，可最先并行推进（不等 #226）。
+- **P2（通道 3）** 只依赖 #223 + license 核实，不依赖 #226，可与 P1 并行。
+- **P1 → P3**：P3 复用 P1 的素材入口/许可/入库骨架，P1 先。
+
+**建议起点**：**P0**（最独立、风险最低）+ 并行准备 **P2 的 license 核实**；#226 一入 main 立刻起 **P1**。
+
+---
+
+## 6. 验收门（每期 + 总）
+
+**每期通用门**：
+- **五门全过（R11）**：`check:filesize` → `check:tokens` → `check:i18n` → `check:heavy-path` → `lint:ci` → `typecheck` → `test` → `build`。
+- **用户可见改动**（P0 的预设卡、P1/P3 的素材入口）：先出 mockup + 用户拍板（R8），实现后与样张逐项对账；Playwright 真体感走查（R13，截图人眼判断）。
+- **可见文字国际化（R15）**：预设卡/能力预检/许可提示等全部走 i18n。
+
+**每期专项验收（R16 真实用户任务闭环——功能交付才算完成）**：
+- **P0**：建「用本地模型让 Agent 跑一段真实创作任务」端到端测试；跑不动工具调用的模型必须**在 UI 明确降级提示**（诚实交付，非静默失败）。
+- **P1**：建「Agent 自主取到带许可的参考素材并入库」闭环；`AssetSourceEvidence` 里许可字段非空、来源可追。
+- **P2**：建「Agent 查资料辅助规划」闭环；断言**产物不进素材库**（避免与通道 1 混线）。
+- **P3**：建「人在内置浏览器挑素材入库」闭环（走查法）；断言**无 agent 自动点击**路径被触发。
+
+**总验收**：三通道**职能不重叠**可从 UI/代码双向证明（一职能一个家，无并行版）；本地端点走通用原语、无供应商专有分支。
+
+---
+
+## 7. 风险与开放问题
+
+| # | 风险 / 开放问题 | 影响 | 应对 |
+|---|---|---|---|
+| R1 | **`pi-web-access` license 是否允许 vendoring** | 阻断 P2；vendor 了不合规=法律/合规风险 | **落地前实查**（§5 硬前置）；不允许则改独立进程/网络隔离或换等价 HTTP-only 方案 |
+| R2 | **素材站 rate limit**（Pexels/Pixabay/Freesound 免费 key 有配额） | Agent 高频取素材触限、任务中断 | connector 层做退避/缓存；触限时**明说**并降级（不静默卡住）；key 为用户自备资源 |
+| R3 | **本地模型质量参差**（小模型带不动 agent loop / 输出不稳） | 用户以为「连上=能用 Agent」，实际跑不动 | function-calling **能力预检** + UI 明确「仅对话 / 支持 Agent」（D4）；不承诺质量，只承诺诚实 |
+| R4 | **参考视频版权边界**（Pexels Videos 许可范围、商用/二创限制） | 用户误用于商用触权 | 许可写进 `AssetSourceEvidence` 并在 UI 可见；只接**明确免费许可**的源，Unsplash 类 hotlink 源延后 |
+| R5 | **#226 合同若在合并中形变** | P1/P3 依赖其 `ConnectorDefinition`/`AssetSourceEvidence` 形状 | #226 入 main 后**以 main 实况为准复核**合同坐标再开 P1；不基于 PR 草案写死字段 |
+| R6 | **通道边界随时间被侵蚀**（有人图省事让 agent 爬站入库） | 破坏「一职能一个家」，退回并行版 | §3 红线明文；P2/P3 验收断言「无自动点击爬站路径」作结构保证 |
+
+**开放问题（需在对应期开工前定/或用户拍板）**：
+- 通道 1 的三个 connector key：走**用户自备**（接入页填）还是 Nomi 侧代管额度?（倾向用户自备——免费 key、避免我们扛配额；产品级取舍，留待拍板。）
+- 通道 3 的 `source_check` 结果如何呈现给用户（可信度标注的 UI 形态）——P2 出样张时定。
+
+---
+
+## 8. 执行记录（回填）
+
+> 待 #223 phase1 收口 + #226 入 main 后按期开工，逐期回填 commit / 验收结果 / 走查证据。本文当前为**方向已拍板、待实施**状态。

--- a/docs/plan/2026-09-01-pr258-derived-directions-eval.md
+++ b/docs/plan/2026-09-01-pr258-derived-directions-eval.md
@@ -1,0 +1,88 @@
+# PR #258 拆项评估 v2（provider proxy / 即梦 CLI 模型面 / onboarding）
+
+> 状态：📎 交接/日志（评估结论文档；三条建议若获批各自另立 📋 计划）
+
+日期：2026-09-01 ｜ 评估对象：PR #258 `codex/feedback-radar-20260831` ｜ 只读评估，不合并/不关闭/不评论 #258。
+
+## 0. 先把 #258 的真面目说清楚（读之前必须知道）
+
+**PR 标题「docs: recover feedback radar」是假的。** GitHub 页面显示 +1416/-217，但那是陈旧数字——分支从一个很旧的 main 拉出，之后把 `origin/main` 反复 merge 进来（吞了 #202/#226/#241 等已合 PR）。按 `main..pr258`（两点，真实反转视图）实测是 **272 文件 / +19106 / -733**；merge-base == main tip，分支严格领先 main 22 个 commit、main 无 commit 不在分支里（即三点=两点）。
+
+**它其实是一坨大杂烩**，混了三类东西，评估必须先拆开：
+- **A｜本次真正新写的三方向**（authored commit `03a4e532` + `30c4bd5a` + 两篇 docs）：provider proxy、即梦 CLI 3.x wiring、onboarding 重构/加固。← 本文评的就是这三块。
+- **B｜从已合 PR 漂回来的巨量 payload**：minimax/elevenlabs/meshy/runway/suno/lyria 一堆 archetype + 认证体系（来自 #241/#226）。**这些不是 #258 的贡献，是 merge 噪音**，不该跟着这个「反馈雷达」PR 走。
+- **C｜纯反馈 docs**：`docs/fixes/*.root-cause.json`、`docs/research/2026-08-31-*.md`、`docs/plan/2026-08-31-*.md`、handoff。这是标题声称的东西，但在 diff 里只占极小一角。
+
+真实 authored 文件清单来自 `git log --no-merges --name-only main..pr258`；下文 file:line 均指 PR 分支 tip `30c4bd5a`。
+
+---
+
+## 1. 方向①：provider proxy（按 API 单独走代理）
+
+**这是什么（file:line）**：新增 `electron/providerNetwork.ts`（21 行）+ 扩 `electron/systemProxy.ts`（加 `createExplicitProxyDispatcher`/`normalizeExplicitProxyUrl`）+ 新增 `src/ui/onboarding/ProviderProxyField.tsx` + `src/i18n/locales/modelSetup.ts` 四条文案（`proxyUrl`/`proxyUrlHint`/`proxyUrlPlaceholder`/`invalidProxyUrl`）。核心类型：`ProviderNetworkConfig = { proxyUrl?: string }`，作为**单个供应商连接**的可选字段存下，产出一个只属于该连接的 undici `ProxyAgent` dispatcher，贯穿模型发现 / 连接测试 / 适配器认证 / 生产请求 / AI SDK 请求 / 产物下载。
+
+**解决哪个真实摩擦（大白话）**：Nomi 现在的代理是**一个全局开关**（`systemProxy.ts`：system/env/custom/off，管所有厂商一刀切）。但用户常遇到「这家 API 必须挂本地代理才通、那家直连更快」的分裂需求——最典型就是**APIMart 只能走本地代理**（记忆已证：APIMart 直连 fetch failed，只有走本地代理才通），可其它官方厂商挂上同一个代理反而更慢/更容易被墙。全局开关逼你二选一。这个字段让「代理」从**全局**降到**每个连接各配一份**，APIMart 那条连接自己挂 `http://127.0.0.1:7897`，别人不受影响。
+
+**与 main 现有代理的关系**：**互补、不重复、不违 P1**。全局 `systemProxy.ts` 继续管「没配 per-connection 字段的连接」（空值 = 走既有应用 dispatcher，行为与上线本功能前完全一致）；per-connection 只在该 vendor `network.proxyUrl` 非空时**覆盖**。本地 CLI（即梦/ComfyUI）**不继承**该 HTTP 代理（研究doc明确划界）。这是「全局默认 + 单点覆盖」的标准两层，不是两套并行代理系统。
+
+**成本/风险**：① 凭据面——代理 URL 里可能带账号密码（`socks5://user:pass@host`），要确认它和 API key 一样走加密存储、不进日志（`systemProxy.ts` 已有 `redactNetworkMessage`，需确认 per-connection 路径也覆盖）。② 私网重定向——`systemProxy.ts` 的 `appDispatcher` 每次 dispatch 都查 `isPrivateHost`，per-connection dispatcher 是否同样防「私网 URL 302 跳公网继承直连」需走查一遍（这是原 systemProxy 特意防的一族）。③ 无账号验证约束——维护者无 APIMart 之外的付费号，真实代理链路只能靠 APIMart 本地代理这一条实测 + 单测覆盖 dispatcher 选择。
+
+**档位建议：🟢 值得接（可独立小步交付）**。它是通用能力（不是 Nomi 独有）、贴真实摩擦（APIMart 那条群里已反复提）、代码面小且边界清晰、门岗友好。**建议单独拆成一个 📋 计划直接落**，不必等即梦那摊。唯一前置：补一条「代理凭据不入日志 + 私网重定向不继承代理」的走查/断言（P2 通用性）。
+
+---
+
+## 2. 方向②：即梦 CLI 模型面更新（图片5pro / seedance2.5 的群反馈）
+
+**群反馈原文**：「即梦的 cli 后续可以更新下，现在没办法用图片5pro和seedance2.5」。翻译：**Nomi 的即梦 CLI 接入把模型面接旧了**，用户要 图片 5pro 和 seedance2.5。
+
+**#258 已接到什么程度（file:line）**：
+- 新增 `electron/shared/videoCapabilities/dreaminaSeedance3.ts`：两条档案 `DREAMINA_SEEDANCE_3_I2V_ARCHETYPE`（image2video）、`DREAMINA_SEEDANCE_3_FRAMES_ARCHETYPE`（frames2video），变体 3.0/3.0fast/3.0pro/3.5pro（3.0 系时长 3–10s、3.5pro 4–12s、非 Seedance2.0 变体仅 720p），`SOURCE` 明写 `jimeng.jianying.com/cli` + `checkedAt:2026-08-31`。
+- 已 wire 进 catalog：`src/config/modelArchetypes/index.ts` 的 `MODEL_ARCHETYPES` 与 `electron/shared/videoCapabilities/registry.ts` 均已注册。
+- `src/config/modelArchetypes/dreaminaImage.ts`：把图片分辨率按 model_version 收窄（3.0/3.1→1k/2k，4.x/5.0→2k/4k），消除非法组合；图片变体仍到 **5.0**（未加 5.0pro）。
+- 时长/多帧对齐：`electron/catalog/dreaminaVideos.ts` + `dreaminaCodec.ts` 对齐多帧单段 0.5–8s 与 `--transition-duration`（有 `dreaminaCodec.test.ts`/`dreaminaMultiframe.test.ts`/`dreaminaSeed.test.ts`）。
+
+**离群反馈还差什么 / web 实查（即梦官方出处优先）**：
+- **seedance2.5**：群里说的「seedance2.5」有歧义。研究doc已实查本机官方 `dreamina` CLI（build `2026-06-18`）`-h`：CLI 的 text2video/multimodal2video **只列 Seedance 2.0 家族，没有 2.5**；而火山方舟的 Seedance 2.5（`doubao-seedance-2-5-260628`）是**另一条 HTTP API**，不归即梦 CLI 承载。**结论：即梦 CLI 侧目前给不了 seedance2.5**——要么用户其实想要的是方舟 HTTP 那条（Nomi 已有 `SEEDANCE_VOLCENGINE_2_5_ARCHETYPE`/`seedance-2.5-apimart`），要么 CLI 后续版本才会补。#258 没伪造 CLI 版 2.5，是对的（研究doc「不动项：不把方舟 2.5 伪装成 CLI 能力」）。**给用户的诚实答复应是：CLI 暂无 2.5，方舟版可走 API 接入。**
+- **图片5pro**：同样歧义。研究doc实查 CLI 图片当前列 **`5.0`，不是 `5.0 Pro`**；「Seedream 5 Pro」是 KIE/方舟侧的模型（Nomi 已有 `KIE_SEEDREAM_5_PRO`/`SEEDREAM_VOLCENGINE_5_PRO`/`SEEDREAM_5_PRO`）。**即梦 CLI 侧目前只有图片 5.0**；#258 没伪造 CLI 版 5.0pro，也是对的。**用户要的「图片5pro」大概率指的是 Seedream 5 Pro（HTTP），或把即梦图片 5.0 记成了 5pro。**
+
+**命名雷（合入前必须改，否则目录里出现一个不存在的产品名）**：#258 把这两条 image2video/frames2video 档案命名为 **`dreamina-seedance-3` / label「即梦 Seedance 3.x」**。这是**错名**：即梦 CLI 里 `--model_version 3.0/3.5pro` 是 **即梦自家的视频模型版本（即梦视频 3.x）**，`image2video`/`frames2video` 命令下根本没有「Seedance」；即梦 CLI 的 Seedance 只有挂在 text2video/multimodal2video 下的 **Seedance 2.0 家族**。把「Seedance」和「3.x」拼一起 = **凭空造出一个「Seedance 3」产品**（即梦没有、方舟也没有 Seedance 3.0——那正是第三方 SEO 站造的假名）。**修正方案**：档案 id/family/label 去掉「Seedance」，改为 `dreamina-video-3-i2v` / `dreamina-video-3-frames`、label「即梦视频 3.x 图生视频 / 首尾帧」；`identifierPatterns` 同步。（注：ARK 现役真名是 Seedance 2.5 `doubao-seedance-2-5-260628`，与此无关，别混。）
+
+**无账号验证约束下怎么交付**：维护者无即梦会员登录态，**真实生成验不了**。可交付的等级 = **契约级 + 社区验收**：① 单测锁 CLI help 矩阵（模式×变体×时长×分辨率），非法组合在 UI/请求构造前不可达（#258 已具备大部分）；② 真实即梦生成走查若缺登录态，**标 blocked、不伪报成功**（研究doc验收门已写死这条）；③ 真实生成留给有会员的社区用户验收（对齐记忆「付费验收只能靠社区/契约级」）。这套是对的，照走。
+
+**档位建议：🟡 值得接但必须先改名 + 先对齐用户预期**。技术实现质量高（有源、有测、边界清、没伪造 CLI 不存在的变体），但**命名雷是硬阻断**（会往目录塞假产品名）。且要同步给群里一个诚实回复：**CLI 侧给不了 2.5/图片5pro，那两个在方舟/KIE 的 HTTP 线上，Nomi 已支持**——否则接完用户仍会说「还是没有」。**建议拆成 📋 计划**：先改名 → 再把「即梦视频 3.x 图生/首尾帧」作为真实新增交付 → 群里回执讲清 2.5/5pro 的正确出处。
+
+---
+
+## 3. 方向③：onboarding 改法
+
+**改了什么（file:line）**：主要是**重构 + 穿线**，不是新做一套卡片。
+- `src/ui/onboarding/OnboardingWizard.tsx`：把原来内联的 `handleTestConnection`（约 80 行探测逻辑）**抽成新 hook** `src/ui/onboarding/useOnboardingConnectionTest.ts`（旧内联块同 commit 删除 = P1 干净）；把 `ProviderProxyField` 塞进表单，`proxyUrl` 贯穿发现/测试/保存。
+- `src/ui/onboarding/CodexLocalImageCard.tsx`：给本地图片开关的 toggle **补 catch**——旧安装包打开新版目录时主进程为防降级拒绝写盘，这个错以前会穿过 React 事件处理器变成「按钮点了没反应」，现在弹 toast（根因层修，配 `docs/fixes/2026-08-31-codex-local-toggle-version-skew.root-cause.json`）。
+- `src/i18n/locales/onboardingProviders.ts`：加 `clearTask`/`clearRecord` 文案（清除接入记录）+ minimax/elevenlabs/meshy 的 promo 文案（**后者属 B 类 payload，非本方向**）。
+
+**与现有卡片的关系**：main 上已有 `CustomVendorCard`/`ComfyuiLocalCard`/`CodexLocalImageCard`/`DreaminaMemberCard`/`VendorOnboardCard` 等一整排卡（含 A+B 本地模型卡 P0）。#258 **没有新增竞争性卡片、没有另起一套 onboarding 心智**——它只是①往既有 `OnboardingWizard` 表单里加一个字段（proxy）、②把测试逻辑抽 hook、③修一个既有卡的静默失败。**是互补/加固，不是重复**，不违 P1。
+
+**档位建议：🟢 低风险，直接随对应能力走**。这块本身没有独立产品决策，是①和「本地图片卡加固」的附属。`useOnboardingConnectionTest` 抽取 + CodexLocalImageCard catch 属**纯工程加固/bug 修复**，可直接并入；`ProviderProxyField` 跟着方向①走。**唯一注意**：`ProviderProxyField` 是用户可见 UI 改动（表单多一个字段），按 R8/R13 需**先出样张或对既有 OnboardingWizard 真实外壳走查一次**再交付（本文只做评估，不代替走查）。
+
+---
+
+## 4. #258 本体处置建议
+
+**核心判断：#258 不该按现状合入**——它把「反馈雷达 docs」当标题，实则夹带 272 文件的三类混合物，其中 B 类是从已合 PR 漂回来的 merge 噪音。按三档拆：
+
+| 部分 | 内容 | 去向 |
+|---|---|---|
+| **C 纯反馈 docs** | `docs/research/2026-08-31-dreamina-and-per-api-proxy.md`、`docs/plan/2026-08-31-dreamina-cli-and-provider-proxy.md`、`docs/fixes/2026-08-31-*.root-cause.json`、handoff | **保留**。质量高（研究doc实查了 CLI help + 划清即梦/方舟边界），是①②的依据。可单独归档为一个小 docs PR，或并进②的计划。 |
+| **A①provider proxy** | `providerNetwork.ts`/`systemProxy.ts` 扩展/`ProviderProxyField.tsx`/modelSetup 文案 + onboarding 穿线 | 拆到**独立 📋 计划 + PR**（🟢），补代理凭据/私网重定向断言后直接落。 |
+| **A②即梦 CLI 3.x** | `dreaminaSeedance3.ts` 两档 + `dreaminaImage.ts` 收窄 + `dreaminaVideos/Codec` 对齐 + 各 test | 拆到**独立 📋 计划 + PR**（🟡）：**先改名去掉「Seedance」**，再交付 + 群里回执 2.5/5pro 正确出处。 |
+| **A③onboarding 加固** | `useOnboardingConnectionTest` 抽取 + `CodexLocalImageCard` catch | 跟着①走（proxy 字段）或作为独立小修（catch/抽 hook）；UI 字段过 R8/R13 走查。 |
+| **B merge 噪音** | minimax/elevenlabs/meshy/runway/suno/lyria archetype + 认证体系 | **不该跟着 #258**。逐条对照 `origin/main`：已在 main 的就是 diff 幻影（合 #258 会无害地重述）；未在 main 的应回到其原始 PR（#241/#226 线）评审，别借「反馈雷达」这个壳夹带入库。 |
+
+**给 #258 的一句话建议**：以现状**不合并**；把它当「三方向 + 反馈 docs 的暂存点」，按上表把 A 拆成 2–3 个聚焦 PR、C 归档、B 退回原 PR 线。命名雷（②）是合入前的硬阻断项。
+
+---
+
+## 附：本评估未做的事（诚实边界，D4）
+- 未跑真实即梦/APIMart 生成（无账号；付费验收留社区）。
+- 未对 `ProviderProxyField` 出样张/走查（本文=拆项评估，非 UI 交付；样张/走查在②③各自计划里补）。
+- B 类 payload 未逐文件与 `origin/main` 做 present/absent 比对（超出本次三方向评估范围；拆 PR 时按上表逐条核）。

--- a/docs/plan/2026-09-01-pr271-feedback-share-center-eval.md
+++ b/docs/plan/2026-09-01-pr271-feedback-share-center-eval.md
@@ -1,0 +1,106 @@
+# PR #271 拆项评估 —— 反馈与分享中心（low-friction feedback & share center）
+
+> 状态：📎 交接/日志（只读评估结论；若获批，落地按下文各方向的落地形状另立 📋 计划）
+
+日期：2026-09-01 ｜ 评估对象：PR #271 `codex/feedback-share-center`（用户 @青阳 自开）｜ **只读评估，不合并 / 不关闭 / 不评论 #271 本体，零产品代码。**
+评估分支：`docs/pr271-eval-20260901`（从 `origin/main` 拉，不开 PR）。
+
+---
+
+## 0. 先把 #271 的真面目说清楚（读之前必须知道）
+
+**GitHub 页面数字（+964/-4，26 文件）这次是真实的**——但「behind 178 commits」的红字会让人误以为这是坨大杂烩，不是。拆开看：
+
+- **merge-base** = `7b70993b`（`git merge-base origin/main origin/codex/feedback-share-center`）。
+- 分支**严格领先 merge-base 5 个 commit**（4 个 non-merge authored + 0 merge 噪音）；main 在 merge-base 之后又走了 **178 个 commit**（这就是「behind 178」的来源）。
+- ⚠️ **两点 `origin/main..branch` 视图会骗人**：它显示「394 文件 / +9561 / −32797」，那 3 万行删除全是**分支尚未 rebase、缺掉 main 上 178 个 commit（含 agent-system harness、model-access-journeys 测试重构等）造成的「反转幻影」**，不是 #271 删的。**真实贡献只能看 authored commit**（`git log --no-merges $MB..branch`）。
+- **真实 authored 内容**（4 个 commit，核心是 `b5202dcb`）：
+  - `b5202dcb feat: add low-friction feedback and share center` —— 24 文件（含 6 个样张 png/html），这是**整个功能**。
+  - `7889d4c9 docs: index feedback share center plan` —— 计划入 INDEX。
+  - `49324bce chore: refresh delivery ledger and test fixture`
+  - `33c38966 docs: mark feedback share center delivered` —— 台账收尾。
+- **没有 B 类 merge 噪音**（对比 #258 那种从已合 PR 漂回一堆 archetype）。#271 是一个**聚焦、自洽、可整体评估的单功能 PR**。**唯一的结构债是「分支落后 178」——合入前必须先 rebase / update-branch 到最新 main**（走服务端并线，见 memory `stale-branch-merge-use-update-branch`；本地 push 追平 15-88MB diff 会撞 ponytail ENOBUFS）。
+
+下文 file:line 均指 authored tip `33c38966`（功能代码在 `b5202dcb`）。SHA：merge-base `7b70993b` · 分支 tip `33c38966` · main tip `59e1f6c0` · 功能 commit `b5202dcb`。
+
+**它到底新增了什么（一句话）**：在 App 里加了**一个**「反馈与分享中心」——从 **设置→关于** 一个规范入口 + **生成失败卡**一个情境入口打开；用户选意图/阶段、写一句话，然后 Nomi **打开系统浏览器**跳到 **私密 Tally 表单**（`https://tally.so/r/GxPrx2`）或 **公开 GitHub Issue**，**只把有界的运行时上下文（版本/平台/架构/语言/阶段/Provider/Model/错误分类）**带进 Tally hidden fields，反馈正文和截图都由用户在浏览器页面里自己填/传。本地留一个 outbox 草稿（localStorage）。
+
+---
+
+## 1. 方向①：App 内主动外发面（Tally 私密表单 + GitHub 公开 Issue）—— 这是本 PR 的核心与唯一真正需要拍板的东西
+
+**这是什么**：main 现状的用户反馈体系是**「单向情报雷达」**——`scripts/feedback-radar.mjs`（`nomi-feedback-radar` 技能）从 GitHub issue / B站评论 / 微信群**只读收集**反馈，**从不往任何渠道发消息**（技能描述原话 + 脚本里 grep 无任何 POST/create-issue/send，已核实）。#271 引入的是**方向相反的第一条通路：从 App 内主动把用户反馈外发出去**。这是一个**全新的对外暴露面**，安全/隐私必须单独评（也是本任务点名要重点看的）。
+
+**解决哪个真实摩擦（大白话 + 例子）**：现在用户遇到问题想反馈，得**自己离开 App**——去翻 GitHub 会不会用、去微信群 @、或者干脆算了。摩擦最大的一刻恰恰是**生成失败那一秒**：他正卡在「接了模型点生成没反应」，此时最该能一键说「这里坏了」，但 App 里没有任何入口，情报只能靠雷达**事后**去群里/评论区捞。#271 把「报告问题」这个动作**搬到摩擦发生的现场**（失败卡上一个「反馈此问题」链接，`NodeErrorReport.tsx:305`），并自动带上「他用的哪个模型、哪一步、什么错」——省掉用户重复描述机器已知的信息。这贴 D1（从用户真实摩擦出发、effect-first）。
+
+**外发面安全/隐私评估（逐条，file:line 实据）——结论：设计是克制且可辩护的，不是后台遥测**：
+
+1. **发什么数据**：只发一个**有界上下文信封**。`buildFeedbackDiagnostics`（`src/ui/community/feedbackDiagnostics.ts`）产出的 `FeedbackDiagnostics` 只含 `app.{version,platform,arch,locale}` + `context.{intent,stage,errorKind,provider,model}`。带进 Tally URL 的更少（`buildPrivateFeedbackUrl` in `communityLinks.ts`）：`nomi_version/platform/arch/stage/provider/model`。**每个字段都过 `safeFeedbackValue`**（`feedbackTypes.ts`：剥控制字符、`.slice(0,120)` 截断）。**反馈正文 summary/details、截图字节、项目路径、完整 prompt、API key/Authorization 一律不进 URL**——正文只在用户于浏览器 Tally/GitHub 页面里**自己敲**，截图在那两个页面**自己传**（`FeedbackShareDialog.tsx` 的 `handleOpenDestination` 只 `openExternal(url)`，不上传任何字节）。单测把这条钉死：`feedbackDiagnostics.test.ts` 断言 `JSON.stringify(result)` **不含** `'prompt'` / `'Authorization'`，并验证控制字符被脱敏、标识符截到 120。`provider/model` 只是**模型身份**（vendorKey/modelKey，如 `apimart` / `seedance-2.5`），不是凭据——泄露面可忽略。
+
+2. **发到哪**：两个**硬编码的单一真相源**（`NOMI_COMMUNITY_LINKS` + `PRIVATE_FEEDBACK_URL` in `communityLinks.ts`），不是用户可注入的任意 URL。Tally = `tally.so/r/GxPrx2`（匿名可访问、附件≤10MB，plan 已验收匿名访问）；GitHub = 仓库 issue 模板页。
+
+3. **用户知情吗 / 有没有后台上传**：**没有后台上传，全程用户可见**。① 打开动作走 `window.open(url,'_blank','noopener,noreferrer')`，而本 App 的 `electron/main.ts:320` `setWindowOpenHandler` **把每个 `window.open` 拦成 `shell.openExternal(url)` 并 deny 内嵌窗口**——所以反馈永远落在**用户自己的系统浏览器**里，用户亲眼看着 URL 打开、亲手在页面上提交，这就是 PR body 说的「browser confirmation」。② 提交前有渐进披露：`FeedbackShareDialog` 有一个 `<details>「查看将附带的脱敏信息」`，**原样 `JSON.stringify(diagnostics)` 给用户看**将要带走的每个字段（`FeedbackShareDialog.tsx` 的 diagnostics `<pre>`）。③ i18n 文案三处明写承诺：`trustLine`「默认只保存在本机；不会后台上传对话、素材或密钥」、`diagnosticsHint`「仅包含版本/系统/语言和问题分类；不包含对话、素材、路径、密钥」、`destinationHint`「两边都由你在浏览器里最后确认」。
+
+4. **本地留痕**：`feedbackOutbox.ts` 只往 `localStorage['nomi:feedback-outbox:v1']` 写用户**主动创建**的草稿（上限 20 条、正文截 4000、含 destination 标记），存满/禁用也不阻断打开 GitHub（catch 吞掉）。不落盘敏感字节。
+
+**⚠️ 需在落地阶段核实/补的三个点（不是阻断，是收口）**：
+- **(a) 「confirmation」名实**：plan doc 写「提交前再确认目的地和发送内容」，但代码里**没有独立的「即将打开外部 URL，确认？」模态**——「确认」= 提交前那一屏（选 Tally/GitHub + 可展开的 diagnostics 预览），点「私密提交/公开」后**直接** `openExternal` 打开浏览器。这在本 App 语境**可接受**（外链本就统一走系统浏览器、URL 里没有正文只有有界上下文），但**给用户/群里表述时别说成「有二次确认弹窗」**——诚实说法是「跳转前让你看清带走哪些字段、由你在浏览器里最后提交」。
+- **(b) `provider/model` 是否可能带业务敏感名**：vendorKey/modelKey 目前是通用模型身份，无凭据；仅需确认没有把「用户自定义 vendor 的私有 base-url / 别名」塞进 provider 字段的路径（错误卡走的是 `nodeSelectedModelAddress(meta)` 的 vendorKey，`NodeErrorReport.tsx:180`，看着是安全的键名，落地时 grep 一遍 custom-vendor 分支即可钉死）。
+- **(c) GitHub 公开路径的隐私提示**：私密 Tally 有「私密」措辞保护，但**公开到 GitHub = 内容永久公开**。目前 `publicOpened` 文案是「GitHub 已打开：提交前可以再次检查，内容不会自动发布」——**建议再补一句「公开可见」的明示**（用户可能不清楚 issue 是全网可搜的）。这是文案层小补，非架构问题。
+
+**成本/风险**：代码面小（~955 行含样张，纯前端 + 一条既有 Electron 外链通路复用，**零主进程新代码、零新 IPC、零后台任务**）；门岗友好（作者已主动登记 `FeedbackStage` 到 `vocabularies-baseline.json` 并给了单一-owner 理由、更新 `settingsDialogStructure` 基线**且加了正向断言**不是只换 hash、i18n 双语齐全）。真实风险集中在**表述诚实**（上面 a/c）和**第三方依赖**（Tally 免费层可用性/可访问性——plan 的「明确不做」已诚实声明不承诺 100% 可达）。
+
+**档位建议：🟢 值得接（这是三个方向里唯一真正的产品决策，也是它的招牌）**。它贴真实摩擦（失败现场反馈）、是通用能力、外发面设计克制可辩护（有界信封 + 浏览器最终确认 + 无后台上传 + 单测钉死无泄漏），与 main 的「单向雷达」**互补不重复、不违 P1**（雷达继续收、这条负责发，两条不同方向不同渠道）。**落地形状**：① 先 rebase/update-branch 到最新 main（消 178 落后）；② 补 (a)(c) 的文案诚实化 + (b) 的 custom-vendor grep；③ **这是明显的用户可见 UI，必须过 R8/R13 样张闸**——PR 已带 6 张样张（about/hub/feedback/report + html）且 PR body 声称在 v0.21.0 真机走查过 About 入口/报告页/outbox/Tally URL，但**本评估未亲眼验证走查截图**（见诚实边界），落地前需按 R13 眼见链复核一次（同构建/同入口）。
+
+---
+
+## 2. 方向②：单一入口聚合（设置→关于 的规范入口 + 失败卡情境入口 + 全局单宿主）
+
+**这是什么**：不是新功能，是**入口治理**。#271 给「反馈与分享」定了**一个家**——`AboutSection.tsx` 加一行 `AboutActionRow`（`about.feedbackShare`）作规范入口；`NodeErrorReport.tsx:305` 失败卡加「反馈此问题」作情境入口；两者都只 `window.dispatchEvent('nomi-open-feedback-share')`，由**全局唯一挂载**的 `FeedbackShareHost`（`NomiStudioApp.tsx:774`，跟付费确认卡同一「挂公共根」的姿势）接住。**没有新增常驻顶栏按钮、没有第二套反馈心智。**
+
+**解决哪个真实摩擦**：符合 CLAUDE.md「一功能一个家」+ 设计系统 §1.5 控件层级（先分组→去重→归位→最后才收纳）。反馈入口天然是低频动作，放 L4（关于页）+ 情境触发（失败卡），不占常驻预算——这是**教科书式的正确归位**，不是往顶栏塞按钮。
+
+**与现状关系**：纯新增、无重复、不违 P1。事件驱动 + 单宿主的架构和 main 既有 `globalBrowserDialog` / 付费确认卡一致（都挂公共根、任一视图可弹）。`settingsDialogStructure.test.ts` 加了正向断言锁住「About 里保留这个入口 + dispatch 逻辑 + onClose」，防意外漂移。
+
+**成本/风险**：极低。唯一注意：`FeedbackShareHost` 用全局 `window` CustomEvent 通信（非 Zustand store），和 App 里既有的 spend-confirm 等模式一致，可接受；若未来要携带更复杂状态再考虑升级到 store。
+
+**档位建议：🟢 直接随方向①走**。这块没有独立产品决策，是①的入口骨架，质量高、门岗齐、归位正确。
+
+---
+
+## 3. 方向③：本地反馈 outbox（localStorage 草稿留痕）
+
+**这是什么**：`feedbackOutbox.ts` —— 用户每次发起反馈，把草稿（intent/stage/summary/details/screenshotName + 有界 diagnostics + destination 标记）存进 `localStorage`（上限 20、正文截 4000）。success 页告诉用户「草稿已保存在本机，浏览器页面会继续提交」，并给「重新打开私密表单/GitHub」的重试入口。
+
+**解决哪个真实摩擦**：反馈这件事有「我点了但浏览器没打开 / 打开了但我关掉了 / 离线了」的断点。outbox 让草稿**不丢**，用户可重试打开目的地——对齐 plan 交互契约的 offline/error「不丢草稿、给重试」。
+
+**与现状关系**：纯新增本地能力，不违任何原则；**不是遥测/后台上传**（只写 localStorage、不外发）。
+
+**成本/风险**：极低。`localStorage` 满/禁用有 catch 兜底不阻断主流程。**一个小观察（非阻断）**：plan 的 error 恢复路径写了「导出 JSON/ZIP 两条恢复路径」，但当前实现只有 localStorage 草稿 + 重新打开目的地，**没看到导出 JSON/ZIP 的实现**——属 plan 承诺 > 实现的小缺口，落地时要么补上要么把 plan 那句删掉（别留言实不符）。
+
+**档位建议：🟢 随方向①走**。附属能力，质量 OK，唯一收口是 plan 里「导出 ZIP」的名实对齐。
+
+---
+
+## 4. #271 本体处置建议
+
+**核心判断：#271 是一个聚焦、自洽、质量高的单功能 PR，方向正确、外发面设计克制——原则上可接，但不该按现状直接合，需先做三件收口。**
+
+| 部分 | 内容 | 档位 | 去向 / 落地形状 |
+|---|---|---|---|
+| **① App 内主动外发面** | `communityLinks.ts` / `feedbackDiagnostics.ts` / `FeedbackShareDialog.tsx` + Tally/GitHub 通路 | 🟢 | **保留、接**。先 rebase 消 178 落后 → 文案诚实化(a「跳转前看清字段」不叫二次确认弹窗 / c 公开=全网可见) → custom-vendor 字段 grep(b) → **过 R8/R13 样张闸眼见链复核**。 |
+| **② 单入口聚合** | `AboutSection` 规范入口 + `NodeErrorReport` 情境入口 + `FeedbackShareHost` 单宿主 | 🟢 | 随①走。归位正确、门岗齐。 |
+| **③ 本地 outbox** | `feedbackOutbox.ts` + success/重试 | 🟢 | 随①走。补 plan「导出 ZIP」的名实对齐（补实现或删该句）。 |
+| **结构债** | 分支 behind main 178 commit | —— | **合入硬前置**：走 `gh pr update-branch` / 服务端并线 rebase 到最新 main，别本地 push 追平（15-88MB diff 撞 ponytail ENOBUFS，见 memory）。 |
+
+**给 #271 的一句话建议**：**方向对、实现干净、外发面克制可辩护 → 值得接**；合入前三步收口（rebase 178 / 三处文案诚实化 / R13 眼见链复核走查），非阻断的都是文案与名实对齐层，无架构返工。这不是 #258 那种需要大拆的杂烩，是一个可整体推进的单功能。
+
+---
+
+## 附：本评估未做的事（诚实边界，D4）
+
+- **未亲眼验证 PR body 声称的 v0.21.0 真机走查**（About 入口 / 报告页 / outbox / 生成 Tally URL）。PR 附了 6 张样张 png，但本任务是**只读拆项评估、零产品代码、不跑 App**——R13 眼见链（截图须自己 Read 过、验证物=用户所见物）留给落地阶段。故方向①的 🟢 是**基于代码 + 样张文件 + 门岗证据**的判断，**不代表已过体验走查**。
+- **未真实提交一条反馈到 Tally/GitHub**（不代用户外发、避免污染真实渠道）；Tally 匿名可访问性以 plan 自述为准，未复验。
+- **未在本地跑 #271 的测试/build/gates**（PR body 自述 937 files/8929 tests passed + 六门绿）；本评估只**静态读**了单测断言（`feedbackDiagnostics.test.ts` 的无泄漏断言、`settingsDialogStructure.test.ts` 的正向断言、`communityLinks.test.ts`/`feedbackOutbox.test.ts` 存在）确认覆盖方向对，未执行。
+- **未逐一核对 6 张样张与真实 SettingsDialog 外壳的 token/间距对账**（plan 验收门①）——留给落地阶段的 R8 对账。
+- **`provider/model` 字段的 custom-vendor 私有 base-url 泄露路径未穷尽 grep**（方向① (b)），仅从错误卡的 `nodeSelectedModelAddress` 键名判断安全；落地前需实扫。

--- a/docs/plan/INDEX.md
+++ b/docs/plan/INDEX.md
@@ -22,6 +22,9 @@
 | [2026-08-31-asset-upload-routing.md](2026-08-31-asset-upload-routing.md) | 本地图片/视频/音频统一上传路由、供应商上传 API 与可选 R2 relay | 🚧 |
 | [2026-09-01-provider-proxy-and-onboarding-hardening.md](2026-09-01-provider-proxy-and-onboarding-hardening.md) | #258 拆项①③：per-connection provider proxy（全局默认+单点覆盖，私网 bypass+凭据脱敏）+ onboarding 加固（抽 useOnboardingConnectionTest、CodexLocalImageCard 静默失败修复） | 🚧 |
 | [2026-09-01-credential-config-at-rest-encryption.md](2026-09-01-credential-config-at-rest-encryption.md) | 可携带凭据的连接配置（proxyUrl 的 user:pass、extraHeaders 的 Authorization）升到与 API key 同级的 safeStorage 加密落盘层 + 字段分级守卫（P2 类级修） | 🚧 |
+| [2026-08-31-agent-material-channels-and-local-endpoints.md](2026-08-31-agent-material-channels-and-local-endpoints.md) | A+B 计划：素材获取三通道分工 + 本地文本模型通用端点（P0 本地模型卡已随 #281 落地；#223 前提已被 M 线取代，见文首现状标注） | 📋 |
+| [2026-09-01-pr258-derived-directions-eval.md](2026-09-01-pr258-derived-directions-eval.md) | #258 拆项评估定稿：①provider proxy 🟢（已随 #282 落地）②即梦 CLI 模型面 🟡（后被 v1.4.17 对齐 #291 取代其结论）③onboarding 加固 🟢（已随 #282 落地） | 📎 |
+| [2026-09-01-pr271-feedback-share-center-eval.md](2026-09-01-pr271-feedback-share-center-eval.md) | #271 反馈分享中心拆项评估：三方向全 🟢、外发面克制可辩护；按四步收口后已合入（provider 泄露路径证实并修复） | 📎 |
 | [2026-06-07-apimart-curated-onboarding.md](2026-06-07-apimart-curated-onboarding.md) | 策展两家(kie+apimart)一键接入；战略从「通用接入」转向 | ✅ |
 | [2026-06-06-universal-model-onboarding.md](2026-06-06-universal-model-onboarding.md) | 「描述符+通用解释器接长尾」研究稿 | ⛔ |
 | [2026-05-30-onboarding-schema-first-extraction.md](2026-05-30-onboarding-schema-first-extraction.md) | 参数抽取从 curl-only 升级为 schema-first | 🚧 |

--- a/docs/research/2026-09-01-shortvideo-data-apis-eval.md
+++ b/docs/research/2026-09-01-shortvideo-data-apis-eval.md
@@ -1,0 +1,228 @@
+# 短视频数据/文稿 API 接入评估：轻抖（Qingdou）vs TikHub
+
+> 日期：2026-09-01
+> 类型：文档级调研（**未做真实付费调用**——不问用户要 key，只对官方现役文档/官网/OpenAPI 逐项对账）
+> 触发：用户诉求——「用户给链接就能拆（不用下载视频）」+「创作者拿现成文稿（替代/兜底 whisper）」+ 未来「本地短视频数据库 → 定时任务 → 数据走势 → 判断哪些文案快/慢推流」。选一家还是都接，用用户价值想。
+> 一手来源已在每节标 URL + checkedAt=2026-09-01。凡未实测调用的结论，本文明说「文档级」。
+
+---
+
+## 0. 一句话结论（先给判断，D5）
+
+**两家不是二选一，是分工互补，且分工线非常干净：**
+
+- **TikHub = 数据面**（结构化：视频元数据/统计、作者主页与作品列表、评论、榜单/热点趋势、无水印直链、分享链接解析）。**它没有把"语音转成文字"的转写能力**——抖音/TikTok 侧只给"标题/描述"字段，不给口播文稿。
+- **轻抖 = 文稿面 + 抖音数据面**（提文案=自建 ASR 转写、批量、全网平台；同时也有达人/视频/音乐榜、涨粉趋势、同领域账号监控）。**但它的开发者 API 登录/会员墙后，无公开文档**，自助接入不确定性高。
+
+**推荐（含分期，见 §7）：**
+- **v1 最小切片（链接直拆 + 文稿）**：拆解链路的「链接解析 + 无水印直链」接 **TikHub**（有公开 OpenAPI、REST 干净、按次计费、`fetch_one_video_by_share_url`）；「现成文稿」这一路，鉴于**没有任何一家给抖音原生口播字幕**（下详），**优先复用 Nomi 自己已接好的 whisper**，把外部文稿 API 作为**可选兜底/加速**而非依赖。
+- **v2（账号数据库 / 走势）**：再评估把 TikHub 榜单/作品列表做成**定时轮询 + 本地时序**的 connector；轻抖只有在拿到其**公开 API 契约**后才作为「抖音垂直数据 + 现成中文文稿」的候选补充。
+
+理由与取舍点见下。
+
+---
+
+## 1. 能力面逐项对账
+
+### 1.1 TikHub（一手：`api.tikhub.io/openapi.json`，2.56MB 规范，checkedAt 2026-09-01；docs.tikhub.io；tikhub.io/pricing）
+
+**平台覆盖（从 OpenAPI 顶层 `/api/v1/{platform}/` 统计，checkedAt 2026-09-01）**：共约 32 个平台命名空间——
+`douyin(483 端点)`、`tiktok(205)`、`instagram(94)`、`bilibili(87)`、`weibo(67)`、`xiaohongshu(45)`、`kuaishou(41)`、`zhihu(41)`、`youtube(37+)`、`wechat_channels(16 视频号)`、`lemon8(16)`、`pipixia(17)`、`threads/reddit/twitter/toutiao/xigua/...`。抖音/TikTok/小红书/快手/B站/微博/视频号全覆盖。
+
+| 能力 | TikHub 支持？ | 证据（端点，一手 OpenAPI） |
+|---|---|---|
+| **分享链接解析** | ✅ 抖音/TikTok/小红书 | `douyin/web/fetch_one_video_by_share_url`、`douyin/web/handler_shorten_url`；小红书 `xiaohongshu/web_v3/fetch_note_detail` |
+| **无水印直链** | ✅ | `douyin/web/fetch_video_high_quality_play_url`、`fetch_multi_video_high_quality_play_url`（TikTok 侧 `downloadAddr` 字段，产品页称 "No-watermark video URLs"）|
+| 直链有效期 | ⚠️ 文档未明示 | 平台直链通常是**签名短时 URL**（分钟~小时级），实测才知；建议拿到即下载，不落库久存（与 Nomi `resolveVideoLocalPath` 的即抓即用一致）|
+| **视频元数据/统计** | ✅ 播放/点赞/评论/转发 | `fetch_one_video` 返回 aweme 详情（`digg_count/comment_count/share_count/play_count` 系字段，TikTok 产品页明列）|
+| **作者主页 + 作品列表** | ✅（做"账号数据库"的积木） | `fetch_user_post_videos`、`handler_user_profile`、`fetch_user_profile_by_uid`、`fetch_user_fans_list`、`fetch_user_following_list` |
+| **评论** | ✅ | `fetch_video_comments`、`fetch_video_comment_replies` |
+| **榜单/趋势（市场级）** | ✅ **但是"市场热度"不是"你这条的历史"** | `douyin/index/fetch_content_publish_trend`、`fetch_content_interact_trend`、`fetch_content_consume_trend`、`fetch_multi_keyword_hot_trend`、`douyin/billboard/*`（hot_rise_list/hot_challenge_list…）、`douyin/creator/*` 榜单族 |
+| **单条视频/账号的时间序列（"推流快慢"）** | ❌ 无原生历史 | OpenAPI 无 per-video 历史端点。要"走势"须**自己定时轮询 `fetch_one_video`/`fetch_user_post_videos` 并落库做差**（见 §7 v2）|
+| **口播文稿/字幕转写（抖音/TikTok）** | ❌ **没有** | 全规范里 `transcript:3 / asr:4 / 转写:1 / speech:1`（近零，且都在描述里）；**字幕/caption 端点只有 YouTube（`get_video_subtitles`/`get_video_captions`）和 B站（`fetch_video_subtitle`）——这两个平台有原生 CC 轨**。抖音/TikTok 的 `caption`/`name` 字段=**视频标题/描述**，不是口播文稿 |
+
+**一句话评**：TikHub 是"给链接/给账号 → 拿到干净结构化数据"的**数据面主力**，广度和端点密度都很强；唯独**不做语音转文字**，抖音侧也**不给现成口播字幕**。
+
+### 1.2 轻抖 Qingdou（一手：qingdou.vip，checkedAt 2026-09-01；公司=杭州大焱网络科技有限公司，浙ICP备2021005782号-5）
+
+产品是**短视频创作工具箱**（Web + 微信小程序 + APP + 会员），不是纯 API 公司。功能面（从官网导航与工具页实读）：
+
+- **文案**：提文案（口播转文字）、图片提文案（OCR）、音视频提文案、**达人作品解析**、敏感词检测。提文案页明示：**"支持全网主流短视频平台（含口令）"、"单次最多 100 条批量提取"**。
+- **数据服务**（据知乎《完全免费第三方抖音数据分析工具——轻抖》checkedAt 2026-09-01）：作品数据精分析（**播放/互动/粉丝**）、**实时 Top1000 视频榜 + Top50 音乐榜**、**达人涨粉飙升榜**、**同领域优质账号监控——实时追踪其视频/直播/涨粉动向**（=账号级走势跟踪）、热点/榜单。还有账号诊断、账号估价、视频检测（测爆款潜力）、智能分镜（自动拆条）。
+- **变现**：商品/直播/短视频营销任务。
+
+| 能力 | 轻抖支持？ | 证据/说明 |
+|---|---|---|
+| **文稿提取** | ✅ 全网平台、批量 100 条 | 官网工具页；**是自建 ASR 转写，不是平台原生字幕**（见 §1.3 机制）|
+| 文稿语言/质量 | ⚠️ 文档级未标 | 中文口播为主的国内工具，中文 ASR 预期不弱于通用 Whisper；无公开质量指标 |
+| **分享链接解析 / 去水印** | ✅ | 批量去水印、视频号去水印、达人作品解析（拿标题/无水印视频/图集）|
+| **抖音元数据/统计** | ✅ 播放/互动/粉丝 | 知乎实读 |
+| **作者主页/作品列表** | ✅（达人作品解析 + 同领域账号监控）| — |
+| **时间序列/走势** | ✅ **抖音账号级**（涨粉/播放趋势、竞品监控） | 知乎实读；**这是轻抖相对 TikHub 的差异点**——它把"账号走势"做成了产品能力 |
+| 覆盖平台（数据面） | ⚠️ **抖音为主** | 文稿是全网，但数据分析/榜单是抖音生态 |
+| **公开开发者 API + 文档** | ❌ **无公开文档** | 导航有"轻抖API"入口、工具页有"API ▾"，但 `pctool/api-doc`、`/api` 全部**重定向到登录/会员墙**（`work-benches?redirect=...`）；WebSearch 亦查不到任何第三方公开的轻抖 API 端点/apikey/计费文档。**其 API 更像"会员增值/企业采购"通道，不是自助 REST** |
+
+**一句话评**：轻抖是"抖音生态的文稿 + 数据一体化产品"，**账号级走势是它的长板**；但作为**被程序调用的 API**，它公开面几乎为零——契约、计费、限流全在墙后，接入不确定性高。
+
+### 1.3 关键机制核对：这类"提文案"到底是原生字幕还是自己转写？（一手：`github.com/yzfly/douyin-mcp-server` SKILL.md，checkedAt 2026-09-01）
+
+该开源项目是"抖音视频转文案"最典型的公开实现，机制为三步：
+1. **解析抖音分享链接 → 提取真实视频 URL（无水印）**；
+2. **下载视频 → FFmpeg 抽音频（MP3）**；
+3. **调云端 ASR（硅基流动 SenseVoice API）做语音识别**。
+
+**结论（load-bearing）**：抖音**不对外暴露口播原生字幕**，所以"提文案"本质上都是**别人替你跑了一遍 ASR**（SenseVoice / Whisper 类）。轻抖的提文案几乎必然同理。**这直接回答用户的"文稿替代/兜底 whisper"问题：外部文稿 API ≈ 别人的 Whisper，质量同量级，不是"更权威的地面真值"**。它的价值是**省算力/省接线**（尤其批量、中文），不是质量碾压。**唯一例外**：YouTube/B站有原生 CC，TikHub 能直接取——但那不是用户点名的抖音场景。
+
+---
+
+## 2. 接入形态
+
+| 维度 | TikHub | 轻抖 |
+|---|---|---|
+| REST 形状 | ✅ 干净：`GET https://api.tikhub.io/api/v1/{platform}/{surface}/{action}`；OpenAPI/Swagger 全量可测（`api.tikhub.io/openapi.json`）；官方 Python SDK（PyPI `tikhub`，1106 端点，方法名 = path basename）| ❌ 无公开 REST 契约；疑似会员/企业 API，未公开 |
+| 鉴权 | API key，`Authorization: Bearer <key>`（SDK 用 `api_key` kwarg / `$TIKHUB_API_KEY`）；一把 key 通吃全部平台，无按平台分订阅 | 未知（墙后）|
+| **定价** | **按次 pay-as-you-go，多数端点 $0.001/次起**，量大自动折扣；**非 200 不计费**；无传统免费额度但注册送额度；无预设套餐上限（tikhub.io/pricing，checkedAt 2026-09-01）| 未知；产品侧是**会员订阅制**（开通会员/企业采购），API 计费未公开 |
+| 速率限制 | 文档未给硬 QPS 数字；按日用量分层折扣 | 未知 |
+| 数据实时性 | 实时抓取（产品口径）| 榜单"实时更新"（产品口径）|
+
+**接入形态判断**：TikHub 是**为开发者设计的 API 产品**（OpenAPI + SDK + 按次计费 + 一把 key），几乎零对接摩擦；轻抖是**为创作者设计的 SaaS**，API 是附属会员能力，**没有可自助对接的公开契约**——对"Nomi 里做成 connector"这件事是硬伤。
+
+---
+
+## 3. 合规与风险（D4：诚实评，不藏）
+
+**两家本质相同**：都是**第三方对平台数据的抓取/代理**（reseller-of-scraped-data），不是抖音/TikTok 官方开放平台授权数据。由此的风险是**类别风险**，不是某一家的个别毛病：
+
+1. **平台 ToS 风险**：抖音/TikTok 的 ToS 一般禁止未授权抓取。用这类 API = 站在灰产边缘。**风险主体是谁承担，取决于 key 谁持有**（见第 4 条）。
+2. **稳定性/断供风险**：抓取型 API 随平台风控更新而周期性坏点/涨价/下架端点是常态。TikHub 有一整套 `generate_ttwid/generate_verify_fp/fetch_douyin_web_guest_cookie` 等**风控对抗端点**，说明它在持续和抖音风控赛跑——能力强，但也意味着**端点可能随时变**。口碑面：TikHub Trustpilot 仅 2 条评价（均 5 星，2025-09，样本极小，不足以证明长期稳定），**不能据此下"稳定"结论**；轻抖运营多年（2020 起）产品侧稳定，但 API 面无公开 SLA。
+3. **数据合规 / 谁背风险（对 Nomi 尤其关键）**：Nomi 是**本地优先桌面应用**。
+   - **key 由用户自带（BYO-key）**：调用以用户身份发生，ToS/封号/费用风险落在用户，Nomi 只是"用户配置的一个 connector"——**风险面最小，符合 Nomi 一贯的"用户配 key"模型**（对齐 §4 的 `secretOwner: 'nomi-settings'` 用户侧存储）。
+   - **产品内置 key（Nomi 替所有用户调）**：= **Nomi 替用户背抓取风险 + 承担全量费用/被封的单点**。**强烈不建议**。
+   - **数据出境**：把用户给的链接/账号发给 TikHub/轻抖 = 一次数据出境，必须走 Nomi connector 的 `dataEgress` 声明 + 运行前预览（§4）。
+
+**诚实边界**：本文**未做真实付费调用**，未验证直链有效期、真实 QPS、断供频率、轻抖 API 是否真存在自助形态。这些只有拿 key 实跑才能坐实。
+
+---
+
+## 4. 与 Nomi 现有件的咬合
+
+### 4.1 该落成什么形态？→ **`ConnectorDefinition`（P1 复用合同，不新造）**
+
+一手：`docs/plan/2026-08-29-creative-capability-catalog-and-prompt-system.md`（#226，能力目录五合同之一）。其 §5.5 `ConnectorDefinition` 正是为"外部 API/MCP/素材源桥"设计，字段与这两个 API **天然咬合**：
+
+```ts
+type ConnectorDefinition = CatalogItemSummary & {
+  kind: 'connector'
+  transport: 'native-api' | 'mcp-stdio' | 'mcp-http'   // TikHub = native-api（REST）
+  auth: { kind: 'none'|'api-key'|'oauth'; secretOwner: 'nomi-settings' } // ← BYO-key 落在 nomi-settings，正好把风险留给用户侧
+  network: { allowedOrigins: string[]; redirectPolicy }  // allowedOrigins=['api.tikhub.io']
+  tools: Array<{ externalName; nomiName; inputSchema; outputSchema;
+    effect: 'read'|'download'|'write'|'spend'; maxBytes? }> // 解析=read/download；按次计费=spend
+  dataEgress: { categories: string[]; retention? }        // 声明"把链接/账号发给第三方"
+}
+```
+
+- **effect 语义正好用上**：`fetch_one_video_by_share_url` = `read`；`fetch_video_high_quality_play_url`→下载 = `download`；**按次计费 = `spend`**（触发 Nomi 既有费用确认卡）。
+- **文稿/取证进 `AssetSourceEvidence`**：能力目录 P0 已把 `AssetSourceEvidence`/素材 sidecar 的 `sourceEvidence`/`rightsStatus` 列为一等合同（§13 P0.1、§11.3）。外部拿来的直链/文稿/元数据应落成 `AssetSourceEvidence`（来源=connector、`rightsStatus: unknown`——**绝不推断可商用**，与既有纪律一致）。
+- **风控/rights 提醒**：这类数据是抓来的，`rightsStatus` 应缺省 `unknown` 或 `restricted`，交付时按既有"缺署名/未知许可只拦异常"处理。
+
+### 4.2 关于任务里点名的 `2026-08-31-agent-material-channels-and-local-endpoints.md`
+
+**该文件名在 origin/main（HEAD `5aab2376`）上不存在。** 最接近的是 `docs/plan/2026-08-31-asset-upload-routing.md`（"资产上传路由与公共中转"）。但**它讲的是"出站"**——把用户本地素材**上传成公网 URL 喂给模型供应商**（KIE/APIMart/fal/Replicate/Runway/RunningHub + 用户 Relay + Nomi 公共 Relay + 匿名链兜底）。**方向相反**：本评估的两家 API 是**入站数据摄取**，不是素材上传。所以**"三通道分工"合同管不到这两个 API**；正确的复用锚点是 §4.1 的 `ConnectorDefinition`。（此点提请复核：任务假设的那份"material-channels/local-endpoints"文档要么未合入、要么改名成了 asset-upload-routing。）
+
+### 4.3 拆解链路接"链接解析"的最小改动面（一手：`electron/video/deconstructVideo.ts` + `electron/video/extractVideoFrame.ts:47`）
+
+**好消息：拆解核心几乎不用改。** `deconstructVideo({ videoUrl, projectId })` 的 `videoUrl` 已经支持三态，其中 **`http(s)://` 直链会走 `resolveVideoLocalPath` → `hardenedFetch`（私网/回环拦截 + 重定向复检 + 300MB/60s 上限）下载到临时文件**（`extractVideoFrame.ts:57-70`）。
+
+因此接"链接直拆"的最小面是**在拆解上游加一步"分享链接 → 无水印直链"的解析**，把解析出的 `https://...mp4` 原样喂进现有 `videoUrl`：
+
+```text
+用户贴分享链接/口令
+  → [新增] connector.resolveShareUrl(link)  // TikHub fetch_one_video_by_share_url → play_url
+  → deconstructVideo({ videoUrl: <直链>, projectId })   // ← 现有链路，零改动
+```
+
+- **不改** `deconstructVideo` 的签名与内部；直链下载/抽帧/VLM/whisper 全复用。
+- **whisper 兜底位置已现成**：`transcribeShots()` 内 `runTask({kind:'transcribe'})` 走 whisper-1。若未来要用"外部现成文稿"替代/兜底，注入点就是这里（用 connector 返回的文稿覆盖/回填 `dialogues`），而非改画面那一路。**但按 §1.3，外部文稿≈别人的 ASR，v1 先不依赖它，保留 whisper 主路**。
+- SSRF 加固已覆盖第三方直链（hardenedFetch 与 importRemoteAsset 同源），**新 connector 出站同样应过 hardenedFetch/allowedOrigins**，别新开一个裸 fetch。
+
+---
+
+## 5. 分工判断
+
+**选一家够不够？**
+- **只接 TikHub**：数据面全、链接解析强、REST 干净、按次计费——**"链接直拆"完美满足**。缺口 = **抖音口播文稿要自己 ASR**（Nomi 已有 whisper，其实不缺）+ **单条/账号的"推流走势"要自己轮询落库**（v2 工程量）。
+- **只接轻抖**：文稿 + 抖音账号走势一体，且是中文母语工具——**但没有公开 API 契约**，做不成可自助对接的 connector；且数据面**抖音为主**，跨平台（TikTok/小红书全量作品/评论/搜索）不如 TikHub。
+- **都接**：文稿走轻抖（若拿到 API）、数据走 TikHub——功能最全，**但引入两套第三方抓取依赖 = 双倍 ToS/断供/计费面**，对 solo 维护是负担（D2：广度是敌人）。
+
+**分工线（谁管什么）**：
+- **链接解析 + 无水印直链** → **TikHub**（公开、干净、按次）。
+- **视频/账号数据、作品列表、评论、榜单/市场趋势** → **TikHub**。
+- **口播文稿** → **优先 Nomi 自有 whisper**；外部文稿（TikHub 无、轻抖有但墙后）仅作**可选兜底/中文批量加速**。
+- **抖音账号级走势跟踪（涨粉/播放/竞品监控）** → 现成产品能力在**轻抖**；但若要程序化进 Nomi 本地库，**用 TikHub 端点自己定时轮询做差**更可控（不依赖轻抖墙后 API）。
+
+**只接一家会缺什么用户价值**：只接 TikHub，短期**不缺**用户点名的两个直接价值（链接直拆 ✓、现成文稿由 whisper 兜 ✓）。真正"缺"的是**开箱即用的抖音账号走势看板**——那是 v2 的产品化命题，不是 v1 拆解闭环的阻塞项。
+
+---
+
+## 6. 对比表（速览）
+
+| 维度 | **TikHub** | **轻抖 Qingdou** |
+|---|---|---|
+| 定位 | 多平台数据 API（开发者产品）| 抖音生态创作工具箱（创作者 SaaS）|
+| 公开 API + 文档 | ✅ OpenAPI/Swagger/SDK | ❌ 登录/会员墙，无公开契约 |
+| 平台广度（数据） | ✅ 32 命名空间（抖/TT/小红书/快手/B站/微博/视频号…）| ⚠️ 数据以抖音为主；文稿全网 |
+| 分享链接解析 + 无水印直链 | ✅ `fetch_one_video_by_share_url` + `fetch_video_high_quality_play_url` | ✅ 去水印/达人作品解析 |
+| 视频统计（播放/赞/评/转） | ✅ | ✅（抖音）|
+| 作者主页 + 作品列表 | ✅ `fetch_user_post_videos` 等 | ✅ 达人作品解析 + 账号监控 |
+| **口播文稿转写** | ❌（抖/TT 无；YouTube/B站有原生 CC）| ✅ 自建 ASR、批量 100 条、全网 |
+| **单条/账号时间序列走势** | ❌ 原生无（须自轮询落库）；有**市场级**趋势/榜单端点 | ✅ **账号级**涨粉/播放趋势 + 竞品监控（产品能力）|
+| 鉴权 | Bearer API key，一把通吃 | 未知 |
+| 定价 | 按次 $0.001/起，非 200 不计费，量大折扣 | 会员订阅制；API 计费未公开 |
+| 稳定性口碑 | 样本极小（Trustpilot 2 条）；靠风控对抗端点持续追平台 | 产品运营多年稳定；API 无公开 SLA |
+| 合规本质 | 第三方抓取/代理（非官方授权）| 第三方抓取/代理（非官方授权）|
+| 与 Nomi 咬合 | `ConnectorDefinition(native-api)` 完美咬合；直链喂现有 `deconstructVideo.videoUrl` 零改核心 | 同为 connector，但无公开契约→做不成自助 connector |
+
+---
+
+## 7. 推荐与分期
+
+### v1 最小切片：链接直拆 + 文稿（贴合用户点名的两个直接价值）
+1. **只接 TikHub**，做成一个 **`ConnectorDefinition`（transport `native-api`，auth `api-key`，secretOwner `nomi-settings` = BYO-key）**。首批只暴露两三个 `read/download` 工具：`fetch_one_video_by_share_url`、`fetch_video_high_quality_play_url`（可选 `fetch_one_video` 拿元数据）。
+2. **拆解链路**：上游加"分享链接→无水印直链"一步，直链原样进 `deconstructVideo({videoUrl})`——**核心零改动**（§4.3）。出站过 hardenedFetch/allowedOrigins。
+3. **文稿**：**继续用 Nomi 现有 whisper 主路**（`transcribeShots`）；外部文稿先不接（§1.3：外部≈别人的 ASR，不值得为 v1 引第二依赖）。
+4. **风险姿态**：key 用户自带；`dataEgress` 声明"把链接发给 api.tikhub.io"；`spend` 工具走既有费用确认卡；素材落 `AssetSourceEvidence` 且 `rightsStatus: unknown`。
+5. **诚实边界给用户**：这是第三方抓取型 API（非官方授权），直链短时有效、端点可能随平台风控波动——这些照 Nomi 失败卡三段式（发生什么/为什么/下一步）呈现。
+
+**v1 出口**：用户贴一条抖音/TikTok/小红书分享链接 → Nomi 解析出直链 → 走通现有拆解出分镜表；文稿由 whisper 产出。**不引入轻抖，不内置 key，不做走势看板。**
+
+### v2：账号数据库 / 走势（用户的"定时任务→数据走势→快慢推流"）
+1. 扩 TikHub connector：加 `fetch_user_post_videos`/`handler_user_profile`/榜单趋势端点。
+2. **本地时序**：做"定时轮询 + 落本地库 + 做差"得到 per-video/账号的播放/互动增速曲线（TikHub 无原生历史，"走势"必须 Nomi 侧自建——这恰是"本地优先桌面应用"的护城河型能力：**数据攒在用户本机，不假手第三方看板**）。
+3. **轻抖**仅在**拿到其公开 API 契约（端点/鉴权/计费/限流）后**，才评估作为"抖音垂直数据 + 现成中文文稿"的补充；否则不纳入（无契约=做不成 connector）。
+4. 定时任务复用 Nomi 既有任务/调度设施，不新造第二套。
+
+**v2 决策点（留给用户拍板，产品方向）**：走势看板要不要做成 Nomi 一等功能？还是只作为"拆解前的选片辅助数据"？——这是产品广度取舍（D2），建议等 v1 拆解闭环跑顺后再定。
+
+---
+
+## 8. 诚实边界（复述）
+
+- **文档级评估**：未做任何真实付费调用，未验证直链 TTL、真实 QPS/限流数字、断供频率、轻抖 API 是否真有自助形态及其计费。
+- **轻抖 API 面全在登录/会员墙后**，本文关于其 API 的判断基于官网导航 + 工具页 + 第三方评测 + 同类开源机制的推断，非其官方 API 文档实读（因其无公开文档）。
+- **任务点名的 `2026-08-31-agent-material-channels-and-local-endpoints.md` 在 main 上不存在**（最接近=`asset-upload-routing.md`，且方向相反是出站上传）——本评估改以 `ConnectorDefinition` 为咬合锚点，提请复核该文档名。
+
+---
+
+## 附：一手来源清单（checkedAt 均 2026-09-01）
+- TikHub OpenAPI 规范（端点全量）：`https://api.tikhub.io/openapi.json`
+- TikHub 文档站：`https://docs.tikhub.io/`、`/doc-4592751`（Introduction）
+- TikHub 定价：`https://tikhub.io/pricing`
+- TikHub TikTok 产品页：`https://tikhub.io/tiktok-api`
+- TikHub Python SDK：`https://pypi.org/project/tikhub/`
+- TikHub 口碑：`https://www.trustpilot.com/review/tikhub.io`
+- 轻抖官网/工具页：`https://www.qingdou.vip/pctool/text-extract`（+ `/pctool/api-doc`、`/api` 均重定向登录）
+- 轻抖数据能力（第三方实读）：`https://zhuanlan.zhihu.com/p/340218470`
+- 抖音提文案机制（开源实现，证明 ASR 而非原生字幕）：`https://github.com/yzfly/douyin-mcp-server/blob/main/douyin-video/SKILL.md`
+- Nomi 咬合合同：`docs/plan/2026-08-29-creative-capability-catalog-and-prompt-system.md`（ConnectorDefinition/AssetSourceEvidence）
+- Nomi 拆解入口：`electron/video/deconstructVideo.ts`、`electron/video/extractVideoFrame.ts:47`（resolveVideoLocalPath 已支持 http 直链）


### PR DESCRIPTION
今日评估班实查发现 A+B 计划文档从未合入 main（只活在分支上）——正是「拿旧方案当现状」那族坑的温床，当场坑了一次调研引用。收编四份决策记录：

- **A+B 计划**（素材三通道+本地端点）：文首加 2026-09-01 现状标注——P0 本地模型卡已随 #281 落地、「等 #223 收口」前提已被 M 线取代、P1-P3 未施、TikHub 为计划外新增数据源。防过期方案陷阱。
- **#258 拆项评估**（📎）：①③已随 #282 落地；②的结论已被 v1.4.17 实拍对齐（#291）取代——历史记录如实收档。
- **#271 拆项评估**（📎）：三方向 🟢 的定稿依据；provider 泄露路径预警后被证实并修复。
- **短视频 API 评估**：TikHub v1 获批的决策依据（三硬事实+BYO-key 合规裁决）。

INDEX 收录、doc-status/docs-index 棘轮绿、ledger 再生。纯 docs。

🤖 Generated with [Claude Code](https://claude.com/claude-code)