### PR TITLE
fix(catalog): 凭据写入与发布态构造级同步——粘 key 假已接入的旁路向量根修

### DIFF
--- a/docs/fixes/2026-09-01-credential-enable-honesty.root-cause.json
+++ b/docs/fixes/2026-09-01-credential-enable-honesty.root-cause.json
@@ -1,0 +1,102 @@
+{
+  "schema_version": 3,
+  "id": "2026-09-01-credential-enable-honesty",
+  "problem_type": "fake success / false-positive connection state: saving a vendor API key could leave the vendor row enabled while the credential landed disabled-pending-certification, so the model-settings home listed the vendor under '已接入 / N 个可使用' even though resolveTextBrainKeys (which requires an enabled credential) returned null — a green 'connected' state that generation could not use",
+  "symptom": "In an isolated profile, writing an APIMart key through the renderer credential path WITHOUT the paired vendor de-publish (a bare modelCatalog.upsertVendorApiKey, e.g. the shape the apimart-text-brain e2e uses) left vendor.enabled=true and hasApiKey=true, while the credential record was enabled:false (renderer sanitizer forces this — certification owns the enabled transition). projectOnboardingConnections then put the vendor in connectedKnown (filter hasApiKey && enabled) and ModelSettingsHome rendered it under '已接入 / N 个可使用'. But resolveTextBrainKeys → resolveConfiguredTextBrain requires configuredCredential(record) = record.enabled && enc==='safeStorage' && apiKey.trim(); with the credential disabled it returned null, so the text brain and every generation reported 'no usable text model'. Real-machine four-path probe: A (real UI save, which pairs upsertVendor({enabled:false})) → available section, resolver null (consistent); B (certified terminal) → connected + resolver brain (consistent); C (UI-saved terminal, vendor+cred disabled) → available, resolver null (consistent); D (bare credential write, vendor left enabled) → '已接入 / 28 个可使用' BUT resolver null (INCONSISTENT). D is the reported gap.",
+  "direct_cause": "upsertRendererCatalogVendorApiKey wrote the credential disabled-pending-certification but did not touch the vendor's enabled flag. The 'shown as connected ⟺ actually usable' invariant was therefore upheld only by convention: the three UI components that save keys (KnownVendorKeyConnectPage, VendorOnboardCard, CustomVendorManage) each ALSO call upsertVendor({enabled:false}) right before the credential write. Any caller that writes a credential without that manual pairing (a bare bridge/MCP call, the e2e harness, or a future fourth UI path) leaves vendor.enabled=true beside a disabled credential, which the home projection reads as connected/usable while the resolver reads as unusable.",
+  "class_root": "Connected/usable state for a vendor must be derived from a single source of truth, not from two flags (vendor.enabled and credential.enabled) that separate call sites are trusted to keep in sync. A renderer credential edit is always disabled-pending-certification and always invalidates any prior certification, so it must de-publish the vendor in the SAME operation at the one shared boundary every renderer credential save funnels through — rather than each UI caller remembering the paired upsertVendor({enabled:false}). Enforcing it per-card invites each new save path to skip the pairing and re-introduce the desync.",
+  "affected_population": [
+    "Every vendor whose API key is written through the renderer credential path without an accompanying vendor de-publish: it must not be listed as 已接入 / N 个可使用 while its credential is disabled-pending-certification and resolveTextBrainKeys cannot use it",
+    "Every future save path or connector that writes a vendor credential: it inherits the obligation that a disabled-pending-certification credential leaves the vendor out of the connected/executable projection, enforced at the shared boundary rather than re-implemented per caller"
+  ],
+  "scope_paths": [
+    "electron/catalog/rendererCatalogMutation.ts",
+    "electron/ai/textBrainResolver.ts",
+    "src/ui/onboarding/onboardingDrawerConnections.ts"
+  ],
+  "entry_points": [
+    "upsertRendererCatalogVendorApiKey (electron/catalog/rendererCatalogMutation.ts) — the single renderer credential-save choke point (IPC nomi:model-catalog:vendor-api-key:upsert). It sanitizes the credential to enabled:false and, in the same operation, de-publishes the vendor when it is currently enabled, so a disabled-pending-certification credential can never coexist with an enabled vendor and thus can never be rendered as 已接入/N 个可使用",
+    "resolveTextBrainKeys / configuredCredential (electron/ai/textBrainResolver.ts) — the read-side 'is this usable' authority: requires the credential record.enabled && enc==='safeStorage' && apiKey.trim(); a disabled credential yields null. This is the truth the UI must agree with",
+    "projectOnboardingConnections (src/ui/onboarding/onboardingDrawerConnections.ts) — connectedKnown = knownCards.filter(hasApiKey && enabled); once the boundary keeps vendor.enabled=false for a disabled credential, a vendor pending certification stays in availableKnown (the 可接入 section) instead of 已接入"
+  ],
+  "external_sources": [],
+  "internal_only_reason": "This is an internal state-consistency fix between two Nomi-owned catalog flags (vendor.enabled and credential.enabled) and the Nomi-owned resolver/home projection; no third-party API contract governs it. The authoritative design it aligns with is the ratified internal plan docs/plan/2026-08-30-unified-model-integration-certification.md (models stay uncertified until certification promotes them; no migration may convert an uncertified mode into enabled; only live-certified may be described as verified). De-publishing the vendor on a renderer credential edit — which invalidates any prior certification — is the correct fail-closed effect, and the next canonical certification run re-promotes it. Verified against the real Nomi build via an isolated-profile four-path probe, not against any external service.",
+  "invariants": [
+    "A renderer credential write leaves the vendor out of the connected/executable projection: upsertRendererCatalogVendorApiKey writes the credential enabled:false AND, when the vendor is currently enabled, calls upsertModelCatalogVendor({key, enabled:false}) in the same operation, so vendor.enabled=true can never coexist with a disabled-pending-certification credential written via this boundary.",
+    "The model-settings home lists a vendor under 已接入 / N 个可使用 only when resolveTextBrainKeys can actually use it: because connectedKnown gates on vendor.enabled and the boundary keeps an uncertified vendor disabled, the home 'connected' state and the resolver's 'usable' verdict agree (verified across the bare-credential and certified terminal states).",
+    "The boundary only rewrites an ENABLED vendor (vendorIsPublished guard), so an already-disabled staging vendor is not rewritten on every key edit (no needless updatedAt churn), and certification's own main-process promote path (commitPromotion), which does not go through this renderer boundary, is unaffected."
+  ],
+  "generality_proof": "The de-publish is enforced at one shared boundary, not per UI card: every renderer credential save (KnownVendorKeyConnectPage, VendorOnboardCard, CustomVendorManage, and any future or bare bridge/MCP caller) funnels through the IPC handler upsertRendererCatalogVendorApiKey, which now performs the vendor de-publish itself. The three UI components' pre-existing manual upsertVendor({enabled:false}) calls become redundant defense-in-depth (kept, and locked by manualCertificationBoundary.test.ts) rather than the only thing preventing the desync. The read-side authority (configuredCredential in textBrainResolver.ts) and the home projection (connectedKnown in onboardingDrawerConnections.ts) are each single-sourced, so 'usable' and 'shown connected' are both derived from vendor.enabled + credential.enabled in exactly one place each; the boundary keeps those two flags consistent by construction.",
+  "shared_boundaries": [
+    {
+      "path": "electron/catalog/rendererCatalogMutation.ts",
+      "symbol": "upsertRendererCatalogVendorApiKey",
+      "responsibility": "Single renderer credential-save choke point: writes the credential disabled-pending-certification and de-publishes the vendor (when enabled) in the same operation, so no caller can leave an enabled vendor beside a disabled credential and thus surface a 已接入/N 个可使用 vendor that resolveTextBrainKeys cannot use."
+    }
+  ],
+  "same_class_entry_points": [
+    {
+      "path": "electron/catalog/rendererCatalogMutation.ts",
+      "entry_point": "upsertRendererCatalogVendorApiKey de-publish-on-credential-write",
+      "disposition": "enforced",
+      "evidence": "rendererCatalogMutation.test.ts asserts: writing a credential for an ENABLED vendor calls upsertModelCatalogVendorApiKey with enabled:false AND upsertModelCatalogVendor with {key, enabled:false} exactly once; writing a credential for an already-DISABLED staging vendor still forces the credential enabled:false but does NOT rewrite the vendor. Real-machine walkthrough credential-connect-honesty.walk.mjs pins that after a bare upsertVendorApiKey the vendor.enabled=false, apimart is NOT in the 已接入 section, and resolveTextBrain is null (consistent)."
+    },
+    {
+      "path": "src/ui/onboarding/onboardingDrawerConnections.ts",
+      "entry_point": "connectedKnown = filter(hasApiKey && enabled)",
+      "disposition": "not-affected",
+      "evidence": "The home projection already gates the connected section on vendor.enabled; it needed no change. With the boundary keeping an uncertified vendor disabled, an unusable vendor stays in availableKnown. credential-connect-honesty.walk.mjs asserts the connected-section membership equals resolver usability for both the bare-credential and certified terminal states."
+    },
+    {
+      "path": "electron/ai/textBrainResolver.ts",
+      "entry_point": "configuredCredential requires record.enabled",
+      "disposition": "not-affected",
+      "evidence": "textBrainResolver.test.ts already pins that a disabled credential is treated as missing (resolveTextBrainStatus === missing, chooseTextModel throws no-usable-text-model) without touching the keychain. This is the read-side truth the UI is now made to agree with; it is unchanged by this fix."
+    }
+  ],
+  "prevention": {
+    "kind": "centralized-boundary",
+    "enforcement_path": "electron/catalog/rendererCatalogMutation.ts",
+    "invariant": "A vendor whose credential is written disabled-pending-certification through the renderer boundary is de-published in the same operation, so vendor.enabled=true cannot coexist with a disabled credential written via this path, and the home '已接入 / N 个可使用' state cannot be shown for a vendor resolveTextBrainKeys cannot use.",
+    "failure_mode": "Without the boundary-level de-publish, keeping the connected/usable state consistent depends on every credential-save caller manually pairing upsertVendor({enabled:false}); a caller that omits it (bare bridge/MCP call, e2e harness, future UI path) leaves the vendor enabled beside a disabled credential and re-introduces the '已接入 but unusable' fake success.",
+    "exception_policy": "none",
+    "strategy": "Route the vendor de-publish into the single renderer credential-save choke point (upsertRendererCatalogVendorApiKey), guarded to only touch an enabled vendor, so de-publishing structurally accompanies every renderer credential write for every current and future save path; certification's main-process promote (commitPromotion) is the only thing that re-enables the vendor.",
+    "artifacts": [
+      "electron/catalog/rendererCatalogMutation.ts",
+      "electron/catalog/rendererCatalogMutation.test.ts",
+      "tests/ux/credential-connect-honesty.walk.mjs"
+    ]
+  },
+  "class_regression_tests": [
+    "electron/catalog/rendererCatalogMutation.test.ts"
+  ],
+  "recurrence": {
+    "classification": "recurring",
+    "reason": "Deriving a vendor's connected/usable state from two flags (vendor.enabled + credential.enabled) that separate call sites keep in sync is a recurring desync class. Rather than trusting each save path to pair the vendor de-publish, the de-publish is enforced at the one renderer credential-save boundary, and the read-side usability and the home projection are each single-sourced, so a future save path inherits the guarantee.",
+    "same_class_scan": [
+      "Enumerated every renderer credential-save entry point (grep upsertVendorApiKey across src/ + electron/): the three UI components (KnownVendorKeyConnectPage, VendorOnboardCard, CustomVendorManage) all funnel through modelCatalog.upsertVendorApiKey → IPC nomi:model-catalog:vendor-api-key:upsert → upsertRendererCatalogVendorApiKey. All three ALSO call upsertVendor({enabled:false}) manually; those become redundant belt-and-suspenders after the boundary fix and are kept + locked by manualCertificationBoundary.test.ts. No renderer save path bypasses the boundary.",
+      "Checked the MCP integration path: nomi_integration_open_credentials opens the secure Nomi credentials page and never receives or echoes keys (electron/capabilityCore/mcpIntegrationTools.ts), so the MCP agent cannot write a bare credential; the only bare-credential writers are the e2e harness and any direct bridge call, which the boundary now guards.",
+      "Confirmed certification's promote path is main-process (ProviderAdapterService.commitPromotion / integrationCertification) and does NOT go through upsertRendererCatalogVendorApiKey, so the de-publish only affects renderer-initiated credential edits and does not fight a just-promoted vendor. Real-machine certified terminal state (walkthrough state ②) shows vendor.enabled=true + resolver brain + 已接入, unaffected."
+    ]
+  },
+  "regression_tests": [
+    "electron/catalog/rendererCatalogMutation.test.ts",
+    "tests/ux/credential-connect-honesty.walk.mjs"
+  ],
+  "legacy_paths": {
+    "status": "not-applicable",
+    "removed_paths": [],
+    "rationale": "No parallel or legacy save path is removed. upsertRendererCatalogVendorApiKey remains the single renderer credential-save entry point; it gains a same-operation vendor de-publish. The three UI components' manual upsertVendor({enabled:false}) calls are intentionally kept as redundant defense-in-depth (and are asserted by manualCertificationBoundary.test.ts); they are not a competing implementation of the de-publish, they are the same intent now also guaranteed at the boundary."
+  },
+  "dependency_lifecycle": {
+    "decision": "not-applicable",
+    "rationale": "No third-party dependency is added, upgraded, or retained. The fix is a same-operation catalog write through the existing store functions.",
+    "exit_criteria": []
+  },
+  "migration": "No stored data is rewritten and no schema changes. Existing catalogs are unaffected at rest: a vendor that is already enabled with a usable (safeStorage, enabled) credential — i.e. certification-promoted — is never touched by this path unless the user re-edits the credential, in which case de-publishing is the correct effect (a credential edit invalidates the prior certification and the next canonical run re-promotes). A vendor left in the desynced state by a prior bare credential write self-heals the next time its credential is written through the boundary.",
+  "residual_risks": [
+    "The de-publish only covers the RENDERER credential-save boundary. A future main-process writer that persists a credential disabled-pending-certification while leaving the vendor enabled would need the same discipline; certification's promote path is exempt by design (it intentionally enables the vendor). This is documented in the invariant so a new main-process path does not silently re-open the desync.",
+    "The connected/usable agreement is proven for the text-brain resolver (the reported failure). Media models publish through a different path (adapter modes / mappings); their per-node usability is gated by modelHasPublishedExecution, but the same vendor.enabled gate governs whether the vendor appears in the connected section, so a disabled vendor cannot show any kind as 已接入.",
+    "The walkthrough's certified terminal state is constructed by seeding a safeStorage credential via the real bridge then flipping enabled flags on disk; it faithfully reproduces the post-promote flag combination but does not run the full paid certification pipeline (covered separately). The bare-credential state IS driven entirely through the real bridge path the fix guards."
+  ]
+}

--- a/electron/catalog/rendererCatalogMutation.test.ts
+++ b/electron/catalog/rendererCatalogMutation.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { CatalogState } from "./types";
 import {
   sanitizeRendererMappingMutation,
@@ -6,7 +6,19 @@ import {
   sanitizeRendererVendorMutation,
   sanitizeRendererVendorApiKeyMutation,
   sanitizeRendererCatalogImport,
+  upsertRendererCatalogVendorApiKey,
 } from "./rendererCatalogMutation";
+import * as store from "./catalogStore";
+
+vi.mock("./catalogStore", async (importActual) => {
+  const actual = await importActual<typeof import("./catalogStore")>();
+  return {
+    ...actual,
+    readCatalog: vi.fn(),
+    upsertModelCatalogVendorApiKey: vi.fn((vendorKey: string, payload: unknown) => ({ vendorKey, payload })),
+    upsertModelCatalogVendor: vi.fn((payload: unknown) => payload),
+  };
+});
 
 function state(): CatalogState {
   return {
@@ -31,6 +43,12 @@ function state(): CatalogState {
 }
 
 describe("renderer Catalog mutation boundary", () => {
+  afterEach(() => {
+    vi.mocked(store.upsertModelCatalogVendorApiKey).mockClear();
+    vi.mocked(store.upsertModelCatalogVendor).mockClear();
+    vi.mocked(store.readCatalog).mockReset();
+  });
+
   it("cannot raw-enable or forge publication for an uncertified adapter vendor/model/mapping", () => {
     const catalog = state();
     const vendor = sanitizeRendererVendorMutation(
@@ -112,6 +130,33 @@ describe("renderer Catalog mutation boundary", () => {
         },
       ],
     });
+  });
+
+  it("de-publishes an enabled vendor in the same operation as a renderer credential write", () => {
+    // The reported honesty gap: a bare credential write left vendor.enabled === true while the
+    // credential landed disabled-pending-certification, so the model home showed the vendor as
+    // 已接入 / N 个可使用 even though resolveTextBrainKeys (needs an enabled credential) returned null.
+    const catalog = state();
+    catalog.vendors[0] = { ...catalog.vendors[0], enabled: true } as never;
+    vi.mocked(store.readCatalog).mockReturnValue(catalog);
+
+    upsertRendererCatalogVendorApiKey("relay", { apiKey: "sk-test", enabled: true });
+
+    // credential written disabled-pending-certification …
+    expect(store.upsertModelCatalogVendorApiKey).toHaveBeenCalledWith("relay", { apiKey: "sk-test", enabled: false });
+    // … and the vendor dropped out of the executable/connected projection atomically.
+    expect(store.upsertModelCatalogVendor).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(store.upsertModelCatalogVendor).mock.calls[0][0]).toMatchObject({ key: "relay", enabled: false });
+  });
+
+  it("does not rewrite an already-disabled staging vendor on a renderer credential write", () => {
+    const catalog = state(); // relay seeded enabled:false
+    vi.mocked(store.readCatalog).mockReturnValue(catalog);
+
+    upsertRendererCatalogVendorApiKey("relay", { apiKey: "sk-test", enabled: true });
+
+    expect(store.upsertModelCatalogVendorApiKey).toHaveBeenCalledWith("relay", { apiKey: "sk-test", enabled: false });
+    expect(store.upsertModelCatalogVendor).not.toHaveBeenCalled();
   });
 
   it("rejects security-scope edits on certification-owned connections", () => {

--- a/electron/catalog/rendererCatalogMutation.ts
+++ b/electron/catalog/rendererCatalogMutation.ts
@@ -123,9 +123,34 @@ export function upsertRendererCatalogVendor(payload: unknown) {
 }
 
 /** Renderer credential writes are configuration only.  A key can never promote
- * a vendor; certification owns the later enabled transition. */
+ * a vendor; certification owns the later enabled transition.
+ *
+ * The credential is written disabled-pending-certification, and the vendor is
+ * de-published in the SAME operation. This keeps the "shown as 已接入 ⟺ actually
+ * usable" invariant true at the one shared boundary every renderer credential
+ * edit funnels through — instead of trusting each UI caller to remember the
+ * paired `upsertVendor({ enabled: false })`. A bare credential write that forgot
+ * that pairing used to leave `vendor.enabled === true` while the credential was
+ * disabled, so the model settings home listed the vendor under 已接入 with
+ * "N 个可使用" even though `resolveTextBrainKeys` (which requires an enabled
+ * credential) returned null — a green "connected" state that generation could
+ * not use. Editing a credential also invalidates any prior certification, so
+ * dropping the vendor back out of the executable projection is the correct
+ * fail-closed effect; the next canonical certification run re-promotes it. */
 export function upsertRendererCatalogVendorApiKey(vendorKey: string, payload: unknown) {
-  return upsertModelCatalogVendorApiKey(vendorKey, sanitizeRendererVendorApiKeyMutation(payload))
+  const result = upsertModelCatalogVendorApiKey(vendorKey, sanitizeRendererVendorApiKeyMutation(payload))
+  const key = String(vendorKey || '').trim()
+  if (key && vendorIsPublished(readCatalog(), key)) {
+    upsertModelCatalogVendor(sanitizeRendererVendorMutation({ key, enabled: false }, readCatalog()))
+  }
+  return result
+}
+
+/** A vendor is "published" (shown/usable) when its row is enabled. Only touch an
+ * enabled vendor so an already-disabled staging vendor is not rewritten on every
+ * key edit (avoids needless writes / updatedAt churn). */
+function vendorIsPublished(state: CatalogState, vendorKey: string): boolean {
+  return state.vendors.some((vendor) => vendor.key === vendorKey && vendor.enabled)
 }
 
 export function sanitizeRendererVendorApiKeyMutation(payload: unknown): Json {

--- a/tests/ux/credential-connect-honesty.walk.mjs
+++ b/tests/ux/credential-connect-honesty.walk.mjs
@@ -1,0 +1,149 @@
+// R13/R16 走查：保存 vendor key 后，「已接入 / N 个可使用」这套「已可用」表述必须与真实可用性一致。
+//
+// 背景（2026-09-01 CERT 核实）：保存凭据落盘即 enabled:false（认证前不 promote，属正确 fail-closed），
+// 而 resolveTextBrainKeys 要求凭据 enabled===true 才算可用。若某条保存路径只写凭据、忘了把 vendor 同时
+// de-publish，就会出现「vendor.enabled=true + 凭据 enabled:false」的错位——模型设置首页据此把它列进
+// 「已接入 / N 个可使用」，可文本大脑（及一切生成）实际拿不到可用模型。根因修在 upsertRendererCatalog-
+// VendorApiKey 这唯一共享边界：写凭据的同一操作里把 enabled 的 vendor de-publish。
+//
+// 这条走查锁两态的「名实一致」——两态都用真机 resolveTextBrain（渲染口）作真相：
+//   ① 裸凭据写入（bridge upsertVendorApiKey，不配对 upsertVendor）→ vendor 必被 de-publish →
+//      apimart 落「可接入」段、不落「已接入」段；resolveTextBrain=null。
+//   ② 认证成功终态（vendor+model+凭据全 enabled + adapter verified）→ apimart 落「已接入」段；
+//      resolveTextBrain 返回 brain。
+// 判据：UI「已接入段出现」当且仅当 resolveTextBrain 可用。任一态不一致即报红。
+//
+// 用法（零额度可跑；给真 key 更贴真）：APIMART_API_KEY=... node tests/ux/credential-connect-honesty.walk.mjs
+import { clickOrFail, expect, expectVisible, screenshotSettled } from './_assert.mjs'
+import { launchNomiApp } from './_launchApp.mjs'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
+const shotsDir = path.join(repoRoot, 'tests/ux/shots/credential-connect-honesty')
+fs.rmSync(shotsDir, { recursive: true, force: true })
+fs.mkdirSync(shotsDir, { recursive: true })
+const API_KEY = process.env.APIMART_API_KEY || 'sk-walkthrough-not-a-real-key-000'
+const MODEL = 'deepseek-v4-pro'
+
+function mkProfile(name) {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), `nomi-credhon-${name}-`))
+  const p = {
+    tempRoot,
+    settingsDir: path.join(tempRoot, 'settings'),
+    userDataDir: path.join(tempRoot, 'user-data'),
+    projectsDir: path.join(tempRoot, 'projects'),
+    capabilityDir: path.join(tempRoot, 'capability'),
+    catFile: path.join(tempRoot, 'settings', 'model-catalog.json'),
+  }
+  for (const d of [p.settingsDir, p.userDataDir, p.projectsDir, p.capabilityDir]) fs.mkdirSync(d, { recursive: true })
+  return p
+}
+
+async function launch(name, p) {
+  const { app, win } = await launchNomiApp({
+    name: `credhon-${name}`, tempRoot: p.tempRoot, userDataDir: p.userDataDir, settingsDir: p.settingsDir,
+    projectsDir: p.projectsDir, capabilityDir: p.capabilityDir,
+    env: { NODE_ENV: 'production' }, args: ['--no-proxy-server', '--disable-gpu'], settleMs: 0,
+  })
+  await app.evaluate(({ BrowserWindow }) => { const w = BrowserWindow.getAllWindows()[0]; if (w) { w.setSize(1680, 1050); w.center() } }).catch(() => {})
+  await win.waitForLoadState('domcontentloaded')
+  await win.evaluate(() => { localStorage.setItem('nomi-color-scheme', 'light'); for (const k of ['nomi:splash:v1', 'nomi:journey-tour:v1', 'nomi:canvas-gesture-hint:v1']) localStorage.setItem(k, 'seen') })
+  await win.reload(); await win.waitForLoadState('domcontentloaded')
+  return { app, win }
+}
+
+async function openModelSettings(win) {
+  for (let i = 0; i < 5; i += 1) { await win.keyboard.press('Escape').catch(() => {}); await win.waitForTimeout(120) }
+  await clickOrFail(win.locator('button[aria-label*="设置"], button[aria-label*="Settings"]'), '打开设置')
+  const dialog = win.locator('[role="dialog"][aria-modal="true"]').first()
+  await expectVisible(dialog, '设置对话框没出现')
+  await clickOrFail(dialog.locator('[data-settings-tab-id="models"]'), '设置里的「模型」tab')
+  await expectVisible(dialog.locator('[data-model-settings-page]').first(), '模型设置首页没渲染出来')
+  return dialog
+}
+
+// 渲染口真相：resolveTextBrain（promptLibrary.textBrain 直连 resolveTextBrainKeys/Status）+ vendor 态。
+async function resolverUsable(win) {
+  return win.evaluate(async () => {
+    let brain = null
+    try { brain = await window.nomiDesktop.promptLibrary.textBrain() } catch (e) { brain = { error: String(e) } }
+    const v = (window.nomiDesktop.modelCatalog.listVendors() || []).find((x) => (x.key || x.vendorKey) === 'apimart')
+    return { usable: Boolean(brain && brain.brain && brain.status === 'ok'), brain, vendorEnabled: v?.enabled, hasApiKey: v?.hasApiKey }
+  })
+}
+async function apimartInConnectedSection(win) {
+  return win.evaluate(() => Boolean(document.querySelector('[data-model-home-connection="apimart"]')))
+}
+
+// 用真实 bridge 把凭据写进某 profile（safeStorage 加密），返回后关闭。
+async function seedRealCredential(p) {
+  const { app, win } = await launch('seed', p)
+  await win.evaluate((k) => window.nomiDesktop.modelCatalog.upsertVendorApiKey('apimart', { apiKey: k, enabled: true }), API_KEY)
+  await app.close().catch(() => {})
+}
+// 磁盘微调终态（凭据密文保留，仅翻标志 + 认证 meta），聚焦 deepseek-v4-pro。
+function patchDisk(p, { vendorEnabled, credentialEnabled, modelEnabled, certified }) {
+  const cat = JSON.parse(fs.readFileSync(p.catFile, 'utf8'))
+  const v = cat.vendors.find((x) => x.key === 'apimart'); if (v) v.enabled = vendorEnabled
+  const cred = cat.apiKeysByVendor?.apimart; if (cred) cred.enabled = credentialEnabled
+  const m = (cat.models || []).find((x) => x.vendorKey === 'apimart' && x.modelKey === MODEL)
+  if (m) {
+    m.enabled = modelEnabled
+    m.meta = certified
+      ? { adapter: { state: 'verified', activeRevision: 'rev-1', modes: [{ taskKind: 'chat', state: 'verified' }], runId: 'run-cert', updatedAt: '2026-09-01T00:00:00.000Z' } }
+      : {}
+  }
+  for (const mm of cat.models || []) if (mm.vendorKey === 'apimart' && mm.kind === 'text' && mm.modelKey !== MODEL) mm.enabled = false
+  fs.writeFileSync(p.catFile, JSON.stringify(cat, null, 2))
+}
+
+try {
+  // ── 态① 裸凭据写入旁路：fix 后 vendor 必被 de-publish，名实一致 ──
+  {
+    const p = mkProfile('bare')
+    const { app, win } = await launch('bare', p)
+    // 复现旁路：只写凭据，不配对 upsertVendor({enabled:false})。fix 在共享边界补齐 de-publish。
+    await win.evaluate((k) => window.nomiDesktop.modelCatalog.upsertVendorApiKey('apimart', { apiKey: k, enabled: true }), API_KEY)
+    const r = await resolverUsable(win)
+    const dialog = await openModelSettings(win)
+    await win.waitForTimeout(500)
+    const inConnected = await apimartInConnectedSection(win)
+    await screenshotSettled(dialog, { path: path.join(shotsDir, '01-bare-credential-home.png') })
+    console.log(`  ① 裸凭据: vendor.enabled=${r.vendorEnabled} hasApiKey=${r.hasApiKey} resolver可用=${r.usable} UI已接入段=${inConnected}`)
+    // 硬断言：凭据写入后 vendor 被 de-publish；且「已接入」出现 ⟺ resolver 可用。
+    expect(r.vendorEnabled, '裸凭据写入后 vendor 仍 enabled=true：共享边界没把它 de-publish（会显示已接入但用不了）').toBe(false)
+    expect(inConnected, '裸凭据（resolver 不可用）时 apimart 仍列在「已接入」段：名实不符').toBe(false)
+    expect(inConnected, '态①名实不符：UI已接入 ≠ resolver可用').toBe(r.usable)
+    await app.close().catch(() => {})
+  }
+
+  // ── 态② 认证成功终态：apimart 应在已接入段，且 resolver 返回 brain ──
+  {
+    const p = mkProfile('certified')
+    await seedRealCredential(p)
+    patchDisk(p, { vendorEnabled: true, credentialEnabled: true, modelEnabled: true, certified: true })
+    const { app, win } = await launch('certified', p)
+    const r = await resolverUsable(win)
+    const dialog = await openModelSettings(win)
+    await win.waitForTimeout(500)
+    const inConnected = await apimartInConnectedSection(win)
+    await screenshotSettled(dialog, { path: path.join(shotsDir, '02-certified-home.png') })
+    console.log(`  ② 认证成功: vendor.enabled=${r.vendorEnabled} resolver可用=${r.usable} UI已接入段=${inConnected}`)
+    // 真 key 才可能真解出 brain；占位 key 会让 resolver 不可用（safeStorage 解不出）——两种都要求「名实一致」。
+    expect(inConnected, '态②名实不符：UI已接入 ≠ resolver可用').toBe(r.usable)
+    if (process.env.APIMART_API_KEY) {
+      expect(r.usable, '给了真 APIMART_API_KEY，认证成功终态却没解出可用文本大脑').toBe(true)
+      expect(inConnected, '认证成功且 resolver 可用，apimart 却没列进「已接入」段').toBe(true)
+    }
+    await app.close().catch(() => {})
+  }
+
+  console.log(`\n✅ 凭据连接名实一致走查通过。截图：${shotsDir}`)
+  process.exit(0)
+} catch (err) {
+  console.log(`\n✖ ${err?.stack || err?.message || err}`)
+  process.exit(1)
+}


### PR DESCRIPTION
REALTEST 复现的「粘 key 显示已接入实际不可用」定性：真实 UI 三路径本就诚实（认证 fail-closed 是获批设计），断点=裸凭据写入旁路不配对 vendor 停用、且不变量靠调用点自觉。根修在唯一共享边界：写 key 同一操作 de-publish 已启用 vendor；走查锁两态文案⟺真实可用性；UI 手动停用降为冗余防御。零额度；R21 契约；gates=0；D 路径修复后截图编排者亲验。

🤖 Generated with [Claude Code](https://claude.com/claude-code)