### PR TITLE
fix(catalog): 全目录 93 模型真测矩阵——修 4 类线上必炸 wire 漂移+矩阵存档（用户点名）

### DIFF
--- a/docs/fixes/2026-09-01-vendor-wire-drift-live-matrix.root-cause.json
+++ b/docs/fixes/2026-09-01-vendor-wire-drift-live-matrix.root-cause.json
@@ -1,0 +1,160 @@
+{
+  "schema_version": 3,
+  "id": "2026-09-01-vendor-wire-drift-live-matrix",
+  "problem_type": "HTTP 供应商（fal/Runway/KIE）的 wire 契约悄然漂移：本地测试全绿、真实 API 必 4xx（「本地绿线上炸」族）",
+  "symptom": "2026-09-01 全目录 93 模型真测矩阵（¥20.29）暴露 4 类线上必炸：(1) fal openai/gpt-image-2 的 image_size 发 \"1024x1024\" 字符串 → 422（fal 只认枚举名或 {width,height} 对象）；(2) fal 队列轮询用完整子路径端点，但网关只在 owner/app 根挂 status/result → 深路径恒 405，连坐 Seedance 2.5/Kling V3 Pro/Gemini Omni/H3-Max/Seedream 5 Pro/ElevenLabs SFX 六个模型；(3) Runway 文生图 ratio 未按模型判别：muse_image/gpt_image_2 的枚举不含共享默认 1024:1024、seedream5_lite 的合法值是独立枚举 → 三个 t2i 恒 400；(4) KIE kling-3.0/video 新要求显式布尔 multi_shots（缺省 422/数组 500/false 通过）。",
+  "direct_cause": "wire 参数值与端点路径由经验/旧探测写成，未逐字段对账官方现役文档；本地 loopback 假服务器不校验字段格式与路径形态，宽松断言（如 includes(\"/requests/\")）把错误路径也放行；Runway 的 per-model ratio 差异未建模（纯 t2i mapping 没挂归一化）。",
+  "class_root": "在「档案声明」与「供应商接受」之间缺一层零成本 wire 一致性验证：loopback fixture 什么都收，唯一能暴露格式漂移的是付费真调用，而真调用此前从未全目录跑过；同时出处门岗只查「有没有挂 SOURCE URL」不查「参数内容与文档一致且 checkedAt 未过期」，供应商演进（kling 新增必填、fal 网关路径收敛）即静默脱钩。",
+  "affected_population": [
+    "选 fal openai/gpt-image-2 生图的用户：每次提交 422（修复前现役）",
+    "选 fal 队列族六模型（seedance-2.5/kling-video-v3-pro/gemini-omni/minimax-h3-max/seedream-5-pro/elevenlabs-sfx）的用户：提交后轮询恒 405 拿不到结果（修复前现役）",
+    "选 Runway muse_image/gpt_image_2/seedream5_lite 文生图的用户：每次提交 400（修复前现役）",
+    "选 KIE kling-3.0 视频的用户：每次提交 422（修复前现役）",
+    "未来任何一家供应商演进 wire 契约（新增必填/收敛路径/改枚举）后的同类静默脱钩"
+  ],
+  "scope_paths": [
+    "electron/catalog/paramTranslate.ts",
+    "electron/catalog/falOfficial.ts",
+    "electron/catalog/runwayOfficial.ts",
+    "electron/catalog/kieKling.ts",
+    "electron/catalog/vendorWireDriftFixes.test.ts",
+    "docs/research/2026-09-02-model-acceptance-matrix.md"
+  ],
+  "external_sources": [
+    {
+      "kind": "official-doc",
+      "url": "https://fal.ai/models/openai/gpt-image-2/api",
+      "checked_at": "2026-09-01",
+      "purpose": "fal image_size 合法形态裁决：枚举名（square_hd/square/portrait_4_3/portrait_16_9/landscape_4_3/landscape_16_9/auto）或 {width,height} 对象；WxH 字符串非法。"
+    },
+    {
+      "kind": "official-doc",
+      "url": "https://docs.fal.ai/model-endpoints/queue",
+      "checked_at": "2026-09-01",
+      "purpose": "fal 队列 status/result 端点形态对账——文档印全路径但真实网关只认 owner/app 根（2026-09-01 三端点实测 405/202 对照），代码注释以实测为准并记录差异。"
+    },
+    {
+      "kind": "source-code",
+      "url": "https://raw.githubusercontent.com/runwayml/openapi/main/openapi.json",
+      "checked_at": "2026-09-01",
+      "purpose": "Runway 官方机读 spec：逐模型 text_to_image ratio.enum 裁决（含纠正 seedream5_lite 用了 pro 枚举的错修——正确值 2848:1600/1600:2848）。"
+    },
+    {
+      "kind": "official-doc",
+      "url": "https://docs.kie.ai/market/kling",
+      "checked_at": "2026-09-01",
+      "purpose": "KIE kling-3.0 新必填 multi_shots 为布尔的官方依据（缺省 422/数组 500/false 通过的实测与文档一致）。"
+    }
+  ],
+  "entry_points": [
+    "生成画布 → fal 图片模型 composer（gpt-image-2 等）→ createTask wire 构造",
+    "生成画布 → fal 队列族视频/音频模型 → 提交后 status/result 轮询",
+    "生成画布 → Runway 文生图（muse_image/gpt_image_2/seedream5_lite）→ text_to_image wire 构造",
+    "生成画布 → KIE kling-3.0 视频 → jobs/createTask wire 构造"
+  ],
+  "invariants": [
+    "fal 图片请求的 image_size 只以官方枚举名或 {width,height} 对象出线，绝不以 WxH 字符串出线（官方 fal.ai/models/openai/gpt-image-2/api，checkedAt 2026-09-01）。",
+    "fal 队列 status/result 请求只打 queue.fal.run/{owner}/{app} 根路径（falAppRoot 收敛前两段）；此点官方 docs.fal.ai/model-endpoints/queue 印全路径但真实网关拒收（3 端点实测 405，根路径 202）——以实测为准并在代码注释诚实标注差异与日期。",
+    "Runway 每条图像 mapping 出线前必经 normalizeRunwayImageReferences 按模型 ratio 重映射：muse_image/gpt_image_2 落各自枚举、seedream5_lite 落官方 openapi.json 列出的 2848:1600/1600:2848（此前探测值 2720:1530 实为 seedream5_pro 的枚举——探测能过≠用对了，文档对账才裁决）。",
+    "KIE kling-3.0 create 请求恒携带布尔 multi_shots（官方 docs.kie.ai/market/kling，checkedAt 2026-09-01）。"
+  ],
+  "generality_proof": "四类修复各收敛在单一共享边界：fal 尺寸映射只有 ratioResToFalImageSize 一个出口（newapi 方言保留独立的 ratioResToOpenAiSize——两方言两映射是按供应商方言分治，不是并行版）；fal 队列路径只有 falAppRoot 一个构造点；Runway 图像 ratio 只有 normalizeRunwayImageReferences 一个归一化点且挂满每条图像 mapping（此前纯 t2i 不挂正是根因）；kling 只有 KLING_3_CREATE_OP 一个 create 模板。vendorWireDriftFixes.test.ts 16 例逐边界锁死合法/非法形态。DOCCHECK 复审把三处出处补齐并纠正 seedream5_lite 枚举（真 API 复测 SUCCEEDED）。",
+  "shared_boundaries": [
+    {
+      "path": "electron/catalog/falOfficial.ts",
+      "symbol": "falAppRoot / queueOperations",
+      "responsibility": "fal 队列 status/result 端点的唯一构造点：把任意模型子路径收敛到 owner/app 前两段，使六个队列族模型的轮询不可能再打出被网关 405 的深路径。"
+    },
+    {
+      "path": "electron/catalog/paramTranslate.ts",
+      "symbol": "ratioResToFalImageSize",
+      "responsibility": "fal 方言 image_size 的唯一映射出口：比例×分辨率 → 官方枚举名，WxH 字符串形态在构造层即不可产生。"
+    },
+    {
+      "path": "electron/catalog/runwayOfficial.ts",
+      "symbol": "normalizeRunwayImageReferences",
+      "responsibility": "Runway 图像请求 ratio 的唯一按模型归一化点，挂在每条图像 mapping 上；模型专属枚举/约束集中在此，一处更新全线生效。"
+    },
+    {
+      "path": "electron/catalog/kieKling.ts",
+      "symbol": "KLING_3_CREATE_OP",
+      "responsibility": "kling-3.0 create 请求体的唯一模板：显式携带官方新必填 multi_shots:false，缺省形态不可再出线。"
+    }
+  ],
+  "same_class_entry_points": [
+    {
+      "path": "electron/catalog/falOfficial.ts",
+      "entry_point": "全部 fal 队列族模型的提交/轮询 mapping",
+      "disposition": "enforced",
+      "evidence": "queueOperations 统一改走 falAppRoot；矩阵真测 fal 10 模型全通过；vendorWireDriftFixes.test.ts 断言深路径不再产生。"
+    },
+    {
+      "path": "electron/catalog/runwayOfficial.ts",
+      "entry_point": "Runway 全部图像 mapping（含此前未挂归一化的纯 t2i）",
+      "disposition": "enforced",
+      "evidence": "normalizeRunwayImageReferences 挂满每条图像 mapping；seedream5_lite 按官方 openapi.json 枚举改正后真 API 复测出图。"
+    },
+    {
+      "path": "electron/catalog/paramTranslate.ts",
+      "entry_point": "newapi 方言的 ratioResToOpenAiSize 调用方",
+      "disposition": "not-affected",
+      "evidence": "newapi 方言接受 WxH 字符串（其官方形态），保留独立映射；两方言各自对账各自文档，互不复用错误形态。"
+    },
+    {
+      "path": "electron/catalog/kieKling.ts",
+      "entry_point": "kling-3.0 之外的 KIE 模型 create 模板",
+      "disposition": "not-affected",
+      "evidence": "矩阵真测 KIE 18 模型：仅 kling-3.0 要求 multi_shots（官方文档仅该模型列此字段）；其余模型 create 真测通过无此必填。"
+    }
+  ],
+  "recurrence": {
+    "classification": "recurring",
+    "reason": "供应商按自己的节奏演进 wire 契约（kling 新增必填、fal 网关收敛路径、Runway 按模型分化枚举），每次演进都可能让任意 mapping 静默脱钩；且本地 loopback 层结构上无法暴露此类漂移，必须由「文档对账+零额度干跑+付费封印」三段流程与周期性真测矩阵托底。",
+    "same_class_scan": [
+      "全目录 93 模型真实 API 矩阵（¥20.29，docs/research/2026-09-02-model-acceptance-matrix.md）：45 真跑通/30 同族契约在架/0 下线/11 账户额度受限——除本契约四类外无其他线上炸点。",
+      "DOCCHECK 复审三处无出处修复：fal image_size 官方文档证实、fal 队列路径官方文档与实测不符（以实测为准并注明日期证据）、seedream5_lite 枚举经官方 openapi.json 纠正并真 API 复测。",
+      "同日姊妹契约 2026-09-01-dreamina-cli-v1417-alignment 覆盖本地 CLI 传输的同类漂移（v1.4.14 必填参数族）；HTTP 与 CLI 两条传输线的同类病一并入册。",
+      "全目录 230 mapping 的逐条文档大对账（DOCAUDIT 双班）已排定为后续批，按三段核心流程作业并为每条 mapping 补构造干跑测试。"
+    ]
+  },
+  "prevention": {
+    "kind": "centralized-boundary",
+    "enforcement_path": "electron/catalog/falOfficial.ts",
+    "invariant": "fal 队列 status/result 只能经 falAppRoot 产生 owner/app 根路径；image_size 只能经 ratioResToFalImageSize 产生枚举/对象形态；Runway 图像 ratio 只能经 normalizeRunwayImageReferences 按模型落枚举；kling-3.0 create 只能经 KLING_3_CREATE_OP 携带 multi_shots——四个唯一出口使已知非法形态在构造层不可达。",
+    "failure_mode": "任何调用方绕不开这四个出口：深路径轮询、WxH 字符串、跨模型 ratio、缺 multi_shots 的请求在单元层即被 vendorWireDriftFixes.test.ts 拦截，无法到达供应商。",
+    "exception_policy": "none",
+    "strategy": "每供应商每形态只留一个 wire 构造出口，合法性集中于出口并以官方现役文档为据（出处+checkedAt 注释）；文档与实测冲突时以实测为准并在代码注明日期与证据；周期性真测矩阵作为付费封印层兜底。",
+    "artifacts": [
+      "electron/catalog/falOfficial.ts",
+      "electron/catalog/paramTranslate.ts",
+      "electron/catalog/runwayOfficial.ts",
+      "electron/catalog/kieKling.ts",
+      "electron/catalog/vendorWireDriftFixes.test.ts"
+    ]
+  },
+  "regression_tests": [
+    "electron/catalog/vendorWireDriftFixes.test.ts"
+  ],
+  "class_regression_tests": [
+    "electron/catalog/vendorWireDriftFixes.test.ts"
+  ],
+  "legacy_paths": {
+    "status": "removed",
+    "removed_paths": [
+      "electron/catalog/falOfficial.ts"
+    ],
+    "rationale": "falOfficial.ts 内旧的深路径 status/result 构造逻辑与 runwayOfficial.ts 内共享默认 ratio 直传路径已在本 diff 中被唯一出口替换（P1 同 diff 删旧，无 fallback 保留）；文件本体保留并在本 diff 修改。paramTranslate.ts 的 ratioResToOpenAiSize 非旧路径而是 newapi 方言的正确映射，保留。",
+    "removal_evidence": "vendorWireDriftFixes.test.ts 断言深路径与 WxH 字符串形态不再可产生；git diff 中旧构造分支已删除。"
+  },
+  "dependency_lifecycle": {
+    "decision": "not-applicable",
+    "rationale": "未引入新依赖；仅修正既有供应商 HTTP wire 构造与其官方现役契约的对账。",
+    "exit_criteria": []
+  },
+  "migration": "无用户数据迁移。既有节点选中的模型不变；修复后同一操作路径直接产出合法请求。",
+  "residual_risks": [
+    "fal 队列路径以实测为准（官方文档印全路径但网关拒收）——若 fal 未来把网关行为改回文档形态，vendorWireDriftFixes.test.ts 会因真实调用失败在矩阵复跑中暴露，届时以当日实测重裁；已在代码注释记录 2026-09-01 三端点证据。",
+    "11 个模型因账户额度（APIMart 高价视频、KIE seedance-2.5、Runway seedance/veo 系）未做付费封印，标注于矩阵文档；充值后按三段流程第三段补封印。",
+    "全目录 230 mapping 的逐字段文档对账与构造干跑测试尚未铺满（DOCAUDIT 双班排定）；铺满前，本契约四出口之外的 mapping 仍依赖既有出处注释与周期矩阵兜底。"
+  ]
+}

--- a/docs/research/2026-09-02-model-acceptance-matrix.md
+++ b/docs/research/2026-09-02-model-acceptance-matrix.md
@@ -62,8 +62,8 @@ APIMart 视频：**全 15 模型识别探测确认在架，0 下线**。族代�
 | 模型 | 模式 | 结果 | 证据 |
 |---|---|---|---|
 | nano-banana-2 | t2i·edit | ✅ | 1.1MB PNG |
-| **gpt-image-2** | t2i·edit | 🔧 **BUG-1 已修** | `image_size` 须 fal 枚举（`square`…），非 `"1024x1024"` 串（422）。修后 ✅ 804KB |
-| **seedream-5-pro** | t2i·edit | 🔧 **BUG-2 已修** | 轮询路径须收敛到 app 根（`bytedance/seedream`）；旧路径 405。修后 ✅ 1.67MB |
+| **gpt-image-2** | t2i·edit | 🔧 **BUG-1 已修** | `image_size` 须 fal 枚举（`square`…），非 `"1024x1024"` 串（422）。修后 ✅ 804KB。[DOCCHECK ✓ `fal.ai/models/openai/gpt-image-2/api`：`ImageSize\|Enum`，枚举名/`{w,h}`对象皆可、WxH串非法 — 与修法一致] |
+| **seedream-5-pro** | t2i·edit | 🔧 **BUG-2 已修** | 轮询路径须收敛到 app 根（`bytedance/seedream`）；旧路径 405。修后 ✅ 1.67MB。[DOCCHECK ⚠️→✓ `docs.fal.ai/model-endpoints/queue` 印全路径但**实测网关收敛前两段**（含文档自身 flux/schnell 例），以实测为准 — 修法证实] |
 | **eleven-sfx-v2** | sfx | 🔧 **BUG-2 已修** | 同上（`fal-ai/elevenlabs` 根）。修后 ✅ 49KB |
 | minimax-music-3 | music | ✅ | 5.3MB mp3 |
 | **seedance-2.5** | t2v·i2v | 🔧 **BUG-2 已修** | 深端点轮询 405→修后 ✅ 真出 mp4（202KB，dur 须 ≥4）|
@@ -74,7 +74,7 @@ APIMart 视频：**全 15 模型识别探测确认在架，0 下线**。族代�
 | 模型 | 模式 | 结果 | 证据 |
 |---|---|---|---|
 | grok_imagine_image_2 / seedream5_pro / gen4_image / gemini_image3_pro / gemini_image3.1_flash / gemini_2.5_flash | t2i | ✅×6 | 全下载亲验 |
-| **muse_image / gpt_image_2 / seedream5_lite** | t2i | 🔧 **BUG-3 已修** | 这三个的 ratio 枚举**不含**共享默认 `1024:1024`（muse 最小 1600 系、gpt 最小 2048 系、seedream5_lite freeform ≥3.68M px）→ 用默认恒 400。修后 ✅（muse 2.6MB / seedream5_lite 3.6MB / gpt 4.2MB，亲验红苹果）|
+| **muse_image / gpt_image_2 / seedream5_lite** | t2i | 🔧 **BUG-3 已修** | 这三个的 ratio 枚举**不含**共享默认 `1024:1024`（muse 最小 1600 系、gpt 最小 2048 系、seedream5_lite ≥3.68M px）→ 用默认恒 400。修后 ✅（muse 2.6MB / seedream5_lite 3.6MB / gpt 4.2MB，亲验红苹果）。[DOCCHECK ✓/改 一手 spec `runwayml/openapi` 逐模型 `ratio.enum`：muse/gpt 映射值全在 enum — 一致；**seedream5_lite 横/竖原 `2720:1530` 不在 enum → 改正为 spec 值 `2848:1600`/`1600:2848`**（真发均 ACCEPTED）] |
 | gen4_image_turbo | i2i | 🟡 | 强制要参考图（i2i-only），契约在架 |
 | gen4.5 / seedance2_5 / seedance2 / seedance2_fast / seedance2_mini / wan3 / grok_imagine_1_5 / hailuo3 / veo3.1 / veo3.1_fast / happyhorse_1_0 / gemini_omni_flash | t2v | 🟡×12（wan3 代表 ✅ 真出 mp4）| 12 全探测确认在架（8 提交带估价即取消，4 返"credits 不足"=在架）；wan3 480p·5s 真出 mp4 帧亲验 |
 | gen4_turbo | i2v | 🟡 | i2v-only（gen4_turbo 无 t2v）|
@@ -86,10 +86,13 @@ APIMart 视频：**全 15 模型识别探测确认在架，0 下线**。族代�
 
 1. **BUG-1 · fal `openai/gpt-image-2` 的 `image_size` 发错类型** —— 我们 `ratioResToOpenAiSize` 产出 `"1024x1024"` WxH 串，但 fal 的 `ImageSize` 只认枚举（`square`/`portrait_16_9`…）或 `{width,height}` 对象，发串直接 422 `model_attributes_type`。该转换器对 newapi/OpenAI 的 `size` 字段是对的（那个要 WxH），所以修法是**新增 fal 专用转换器**，不改共享的。
    - 修：`electron/catalog/paramTranslate.ts` 加 `ratioResToFalImageSize`（按朝向出 fal 枚举）；`electron/catalog/falOfficial.ts:65-66` 两处 gpt-image-2 mapping 改用它。
+   - **官方出处**（DOCCHECK 2026-09-01 核实 → 与原修法**一致**）：`https://fal.ai/models/openai/gpt-image-2/api`（目录实发端点）原文 `image_size` 类型 = `ImageSize | Enum`，「one of the presets, `{width, height}`, or 'auto' … **Possible enum values: square_hd, square, portrait_4_3, portrait_16_9, landscape_4_3, landscape_16_9, auto**. Default value: landscape_4_3. Note: For custom image sizes, you can pass the width and height as an object.」→ 枚举名/对象皆可、WxH 串非法，原修法（走枚举名）正确。
 2. **BUG-2 · fal 队列轮询路径没收敛到 app 根** —— fal 提交用完整子路径端点，但 status/result 只挂在 `owner/app`（前两段）上；深子路径端点轮询完整路径恒 **405**。影响 **fal Seedance 2.5 / Kling V3 Pro / Gemini Omni / MiniMax H3-Max / Seedream 5 Pro / ElevenLabs SFX**（凡端点 > 2 段）。loopback 测试用 `pathname.includes("/requests/")` 宽松匹配，遮住了这个漂移。
    - 修：`electron/catalog/falOfficial.ts` `queueOperations` 加 `falAppRoot()`，query/result 用收敛根；create 仍用完整端点。
-3. **BUG-3 · Runway 图像 ratio 未按模型判别** —— `runway-image` archetype 用一份 ratio 列表喂全部 10 个 Runway 图像模型，但 Runway 是**按模型判别的 union**：`muse_image`/`gpt_image_2` 的枚举不含共享默认 `1024:1024`（含 `auto` + 更大档），`seedream5_lite` 是 freeform 要 ≥3.68M px。用默认发这三个 → 恒 400 `Validation of body failed`。视频侧早有 `normalizeRunwayVideoContract` 的 ratioFamilies 解此类，图像侧一直漏了。
+   - **官方出处 ⚠️ 文档与实际不符，以实测为准**（DOCCHECK 2026-09-01 核实 → 原修法**一致/已证实**）：官方 `https://docs.fal.ai/model-endpoints/queue` 示例用 `fal-ai/flux/schnell`，写 `status_url` **保留完整端点**（`…/fal-ai/flux/schnell/requests/{id}/status`），与本修法相反。但真发实测（3 端点提交即取消）证伪——fal 网关自己就收敛到前两段：`fal-ai/flux/schnell`（**即文档那例**）读回 `…/fal-ai/flux/…`(202)，而文档写的全路径反而 **405**；`bytedance/seedance-2.5/text-to-video`、`fal-ai/kling-video/v3/pro/text-to-video` 同样收敛到前两段。故文档此点已陈旧，`slice(0,2)` 修法与现役网关一致（result 端点回**裸** `.../requests/{id}` 无 `/response`，未完成时返 400=未就绪、非 405，证明端点对）。
+3. **BUG-3 · Runway 图像 ratio 未按模型判别** —— `runway-image` archetype 用一份 ratio 列表喂全部 10 个 Runway 图像模型，但 Runway 是**按模型判别的 union**：`muse_image`/`gpt_image_2` 的枚举不含共享默认 `1024:1024`（含 `auto` + 更大档），`seedream5_lite` 要 ≥3.68M px。用默认发这三个 → 恒 400 `Validation of body failed`。视频侧早有 `normalizeRunwayVideoContract` 的 ratioFamilies 解此类，图像侧一直漏了。
    - 修：`electron/catalog/runwayOfficial.ts` `normalizeRunwayImageReferences` 加按模型判别的 ratio 重映射（视频 ratioFamilies 的图像对偶）；并让**每条**图像 mapping 都挂这个 transform（纯 t2i 过去不挂它，正是这三个模型文生图挂掉的根因）。
+   - **官方出处**（DOCCHECK 2026-09-01 核实 → muse/gpt **一致**；seedream5_lite **已改正**）：一手机读 spec `https://raw.githubusercontent.com/runwayml/openapi/main/openapi.json` 的 `/v1/text_to_image` oneOf 逐模型 `ratio.enum` 确认——muse_image/gpt_image_2 均**不含 1024:1024**，原映射值（1600:1600·2016:1152·1152:2016 / 1920:1920·2560:1440·1440:2560）**全在各自 enum 内**，一致。**seedream5_lite 原修法用 `2720:1530`/`1530:2720` 不在 spec enum**（那是 seedream5_**pro** 的值）→ 已改正为 spec 列出的 `2848:1600`/`1600:2848`（横/竖，方仍 2048:2048）。真发实测：三模型发 1024:1024 全 400、发各自映射值全 ACCEPTED（seedream5_lite 亦容忍 enum 外自由值如 2720:1530，但仍取 spec 值 fail-safe）。
 4. **BUG-4 · KIE `kling-3.0/video` 缺 `multi_shots` 布尔** —— KIE 现在**要求显式传** `multi_shots`（不传 → 422 `multi_shots cannot be empty`；传数组 → 500 `must be a boolean`；传 `false` → 通过）。官方文档（docs.kie.ai/market/kling）：`multi_shots` 是布尔开关，true 切到 `multi_prompt[]` 多镜头，false=单镜头走 prompt。我们目录只发 prompt、漏了这个字段 → KIE kling t2v/i2v 全 422。
    - 修：`electron/catalog/kieKling.ts` `KLING_3_CREATE_OP` input 加 `multi_shots: false`（单镜头默认；多镜头作后续增强）。
 

--- a/docs/research/2026-09-02-model-acceptance-matrix.md
+++ b/docs/research/2026-09-02-model-acceptance-matrix.md
@@ -1,0 +1,121 @@
+# 模型验收矩阵（2026-09-02）
+
+> 目标：目录里**每个模型 × 每个模式**，用真 key 打真实 API 尽量测通，产出「模型 × 模式 → 真实可用性」矩阵，并把我们侧坏掉的当场修掉。
+> 方法：以 `electron/catalog` 的 archetype 注册 + `applyBuiltinSeeds()` 种子为准盘点（**代码为准，不凭记忆**）；按成本分层真测（文本/图片/音频全跑；视频按「同端点同 wire 模板」分族——族代表最便宜变体最短时长真跑一发，其余做**不计费的模型识别探测**）。
+> 预算：**¥60 硬顶**，逐笔记账。**实际花销 ¥20.29**。
+> 分支：`test/model-acceptance-matrix-20260901`（含 4 处 catalog 修复 + 回归测试）。
+> Key：`~/.nomi-test-keys.env`（KIE 新 key、其余六家已验活；ElevenLabs 零 scope 跳过）。报告已打码。
+
+## 摘要
+
+- **盘点结果**：18 vendor / 144 model / 230 mapping（`applyBuiltinSeeds` 空目录种子）。本轮用现有 7 个可用 key **真测 5 家 = 93 model**（KIE 18 / APIMart 34 / MiniMax 4 / fal 10 / Runway 27）；其余 11 家因无 key / 本地会员前置跳过（见文末「未测清单」）。
+- **可用性（按 mapping-mode 计，93 model 覆盖的可测模式）**：**✅ 真跑通 45 · 🟡 族代表跑通·本变体契约在架 30 · ❌ 我们侧坏（已全部修复）4 类 · ⛔ 账户额度限制 11**。**0 个模型判定为"下线/不存在"**——所有探到的模型都活着。
+- **我们侧修了 4 处真 bug**（全是"本地绿、线上 4xx"一族，mock/loopback 恰好没打到真实契约）：见「修复记录」。全部**真 API 复测通过 + 加了结构回归测试（16 例）**。
+- **全绿**：typecheck ×2 / lint(0 err) / catalog 1251 tests / tokens / heavy-path / vocabularies / archetype-sources 全过。
+
+## 逐笔账（花销 ¥20.29 / 上限 ¥60）
+
+| vendor | 花销 | 说明 |
+|---|---|---|
+| KIE | ¥6.80 | 8 图 + 2 suno + 4 视频真跑（seedance-2/happyhorse/wan-3.0/minimax-h3）+ gemini-omni 视频复测 |
+| Runway | ¥5.20 | 9 图（含 3 修复复测）+ 5 音频 + wan3 视频代表；12 视频探测（提交即取消）|
+| APIMart | ¥3.37 | 8 图 + 4 音频 + grok 视频代表 + Context-IR；15 视频全探测（校验错=不计费）|
+| fal | ¥3.30 | 3 图 + 2 音频 + 3 修复复测 + seedance-2.5 视频代表；3 视频探测 |
+| MiniMax | ¥1.62 | M3 文本 + 2 TTS + H3 视频代表 |
+
+**最贵三笔**：runway/wan3 t2v(¥1.5) · minimax/MiniMax-H3 t2v(¥1.5) · apimart/grok t2v(¥1.0)。
+
+## 矩阵（按 vendor）
+
+图例：✅=真跑通并下载产物亲验 · 🟡=同 wire 族代表已真跑通、本变体经真实 API 识别探测确认在架 · ⛔=模型在架但本账户额度不足（非我们 bug）· 🔧=曾坏、本轮已修并复测通过。
+
+### APIMart（34，base `https://api.apimart.ai`）
+| 模型 | 模式 | 结果 | 证据 |
+|---|---|---|---|
+| deepseek-v4-pro / -flash / v3.2 / v3.2-think / v3.1-terminus / gemini-3.5-flash | chat | ✅×6 | `/v1/chat/completions` 各返 "4"（reasoning 模型需足够 max_tokens）|
+| MiniMax-H3-Context-IR | prompt_refine | ✅ | `/v1/videos/generations` → 增强 prompt（非 chat 端点）|
+| doubao-seedream-5-0-pro / 4.5 | t2i·edit | ✅ | 4.5 须 2K（我们默认已是 2K；1K 会 `invalid_resolution`）|
+| gemini-2.5-flash-image(nano-banana) / gemini-3.1-flash(nano-banana-2) | t2i·edit | ✅ | 亲验红苹果 |
+| gpt-image-2 / qwen-image-2.0 / qwen-image-3.0 / z-image-turbo | t2i·(edit) | ✅ | 亲验内容对提示词 |
+| sora-2 / veo3.1-fast / kling-v3 / kling-3.0-turbo / happyhorse-1.1 / grok-imagine-1.5 / seedance-2.0 / seedance-2.5 / MiniMax-H3 / wan2.7 / wan3.0 / MiniMax-Hailuo-2.3 / Omni-Flash-Ext / MiniMax-H3-Regeneration / viduq3 | t2v·i2v | 🟡×15（grok 代表 ✅ 真出 mp4）| 全 15 探测：8 参数校验/余额（=在架），5 返 402 余额（=在架），grok 480p·6s 真跑出 mp4 亲验 |
+
+APIMart 视频：**全 15 模型识别探测确认在架，0 下线**。族代表 grok 真出 mp4（红苹果，帧亲验）。注：本账户余额有限（vidu/kling 单发需数十亿单位），多数视频只能探测不能真跑到底——**账户侧**，非目录 bug。
+
+### KIE（18，base `https://api.kie.ai`）
+| 模型 | 模式 | 结果 | 证据 |
+|---|---|---|---|
+| gpt-image-2 / seedream(4.5) / nano-banana / nano-banana-2 / nano-banana-2-lite / seedream-5-pro / seedream-5-lite / flux-2-pro | t2i | ✅×8 | 全下载亲验（460KB–1.66MB PNG）|
+| seedance-2 / happyhorse / minimax-h3 / wan-3.0 | t2v | ✅×4 | 真出 mp4（2.2–20.6MB），帧亲验（睡猫等）|
+| **kling-3.0** | t2v·i2v | 🔧 **BUG-4 已修** | KIE 现要求显式 `multi_shots:false`；不传恒 422。修后 402（=校验通过）|
+| gemini-omni-1.1 | t2v·i2v | ✅ | duration 须为字符串（我们 `toString` 已处理）；真出 mp4 |
+| seedance-2.5 | t2v·i2v | ⛔ | 402 Credits insufficient（在架，余额不足）|
+| suno-v5.5 / suno-sounds-v5.5 | music·sfx | ✅×2 | suno 音乐 5.4MB / sfx 216KB（callBackUrl 已内置，record-info 轮询通）|
+
+### MiniMax（4，base `https://api.minimaxi.com`）
+| 模型 | 模式 | 结果 | 证据 |
+|---|---|---|---|
+| MiniMax-M3 | chat | ✅ | `/v1/text/chatcompletion_v2` 返 "4"（reasoning 模型）|
+| MiniMax-H3 | t2v | ✅ | `/v2/video_generation` content-array；须显式 ratio（t2v 模式默认 16:9，正确）；真出 mp4 亲验 |
+| speech-2.8-hd / -turbo | tts | ✅×2 | `/v1/t2a_v2` 同步 hex→mp3（~50KB）|
+
+### fal（10，base `https://queue.fal.run`）
+| 模型 | 模式 | 结果 | 证据 |
+|---|---|---|---|
+| nano-banana-2 | t2i·edit | ✅ | 1.1MB PNG |
+| **gpt-image-2** | t2i·edit | 🔧 **BUG-1 已修** | `image_size` 须 fal 枚举（`square`…），非 `"1024x1024"` 串（422）。修后 ✅ 804KB |
+| **seedream-5-pro** | t2i·edit | 🔧 **BUG-2 已修** | 轮询路径须收敛到 app 根（`bytedance/seedream`）；旧路径 405。修后 ✅ 1.67MB |
+| **eleven-sfx-v2** | sfx | 🔧 **BUG-2 已修** | 同上（`fal-ai/elevenlabs` 根）。修后 ✅ 49KB |
+| minimax-music-3 | music | ✅ | 5.3MB mp3 |
+| **seedance-2.5** | t2v·i2v | 🔧 **BUG-2 已修** | 深端点轮询 405→修后 ✅ 真出 mp4（202KB，dur 须 ≥4）|
+| minimax-h3-max / kling-3.0 / gemini-omni-1.1 | t2v | 🟡×3 | 修后轮询路径通（app 根 status 真返 IN_QUEUE/COMPLETED），提交即取消省费 |
+| hitem3d(3D) | image_to_3d | 🟡 | 需输入图（图生 3D），本轮未备图；契约在架 |
+
+### Runway（27，base `https://api.dev.runwayml.com`，`X-Runway-Version: 2024-11-06`）
+| 模型 | 模式 | 结果 | 证据 |
+|---|---|---|---|
+| grok_imagine_image_2 / seedream5_pro / gen4_image / gemini_image3_pro / gemini_image3.1_flash / gemini_2.5_flash | t2i | ✅×6 | 全下载亲验 |
+| **muse_image / gpt_image_2 / seedream5_lite** | t2i | 🔧 **BUG-3 已修** | 这三个的 ratio 枚举**不含**共享默认 `1024:1024`（muse 最小 1600 系、gpt 最小 2048 系、seedream5_lite freeform ≥3.68M px）→ 用默认恒 400。修后 ✅（muse 2.6MB / seedream5_lite 3.6MB / gpt 4.2MB，亲验红苹果）|
+| gen4_image_turbo | i2i | 🟡 | 强制要参考图（i2i-only），契约在架 |
+| gen4.5 / seedance2_5 / seedance2 / seedance2_fast / seedance2_mini / wan3 / grok_imagine_1_5 / hailuo3 / veo3.1 / veo3.1_fast / happyhorse_1_0 / gemini_omni_flash | t2v | 🟡×12（wan3 代表 ✅ 真出 mp4）| 12 全探测确认在架（8 提交带估价即取消，4 返"credits 不足"=在架）；wan3 480p·5s 真出 mp4 帧亲验 |
+| gen4_turbo | i2v | 🟡 | i2v-only（gen4_turbo 无 t2v）|
+| seed_audio(sfx·speech) / eleven_text_to_sound_v2 / eleven_multilingual_v2 / eleven_v3 | audio | ✅×5 | `/v1/sound_effect`·`/v1/text_to_speech` 全下载（eleven 系须 `voice:{type:runway-preset,presetId:Maya}`）|
+
+## ❌ 归因（4 类，全部我们侧、全部已修）
+
+所有失败都归入「我们侧 wire 漂移」——**0 个供应商下线、0 个账户永久失效**（账户余额不足的模型仍在架、属账户侧）。
+
+1. **BUG-1 · fal `openai/gpt-image-2` 的 `image_size` 发错类型** —— 我们 `ratioResToOpenAiSize` 产出 `"1024x1024"` WxH 串，但 fal 的 `ImageSize` 只认枚举（`square`/`portrait_16_9`…）或 `{width,height}` 对象，发串直接 422 `model_attributes_type`。该转换器对 newapi/OpenAI 的 `size` 字段是对的（那个要 WxH），所以修法是**新增 fal 专用转换器**，不改共享的。
+   - 修：`electron/catalog/paramTranslate.ts` 加 `ratioResToFalImageSize`（按朝向出 fal 枚举）；`electron/catalog/falOfficial.ts:65-66` 两处 gpt-image-2 mapping 改用它。
+2. **BUG-2 · fal 队列轮询路径没收敛到 app 根** —— fal 提交用完整子路径端点，但 status/result 只挂在 `owner/app`（前两段）上；深子路径端点轮询完整路径恒 **405**。影响 **fal Seedance 2.5 / Kling V3 Pro / Gemini Omni / MiniMax H3-Max / Seedream 5 Pro / ElevenLabs SFX**（凡端点 > 2 段）。loopback 测试用 `pathname.includes("/requests/")` 宽松匹配，遮住了这个漂移。
+   - 修：`electron/catalog/falOfficial.ts` `queueOperations` 加 `falAppRoot()`，query/result 用收敛根；create 仍用完整端点。
+3. **BUG-3 · Runway 图像 ratio 未按模型判别** —— `runway-image` archetype 用一份 ratio 列表喂全部 10 个 Runway 图像模型，但 Runway 是**按模型判别的 union**：`muse_image`/`gpt_image_2` 的枚举不含共享默认 `1024:1024`（含 `auto` + 更大档），`seedream5_lite` 是 freeform 要 ≥3.68M px。用默认发这三个 → 恒 400 `Validation of body failed`。视频侧早有 `normalizeRunwayVideoContract` 的 ratioFamilies 解此类，图像侧一直漏了。
+   - 修：`electron/catalog/runwayOfficial.ts` `normalizeRunwayImageReferences` 加按模型判别的 ratio 重映射（视频 ratioFamilies 的图像对偶）；并让**每条**图像 mapping 都挂这个 transform（纯 t2i 过去不挂它，正是这三个模型文生图挂掉的根因）。
+4. **BUG-4 · KIE `kling-3.0/video` 缺 `multi_shots` 布尔** —— KIE 现在**要求显式传** `multi_shots`（不传 → 422 `multi_shots cannot be empty`；传数组 → 500 `must be a boolean`；传 `false` → 通过）。官方文档（docs.kie.ai/market/kling）：`multi_shots` 是布尔开关，true 切到 `multi_prompt[]` 多镜头，false=单镜头走 prompt。我们目录只发 prompt、漏了这个字段 → KIE kling t2v/i2v 全 422。
+   - 修：`electron/catalog/kieKling.ts` `KLING_3_CREATE_OP` input 加 `multi_shots: false`（单镜头默认；多镜头作后续增强）。
+
+## 建议下架/更新清单（交编排者，别擅删）
+
+- **无「建议下架」项**：本轮探到的 93 个模型**全部在架**（含探测确认的视频族）。
+- **账户额度提示（非 bug，供运营参考）**：
+  - APIMart 余额约 1860 万单位，而 vidu-q3 单发需 ~40 亿、kling 系需 ~30+ 亿 → 这些高价视频当前**跑不到底**（能识别、能校验，扣费才拦）。若要真产片需充值。
+  - KIE `seedance-2.5`、Runway `seedance2/2_5/2_fast/veo3.1` 均 402/credits 不足 → 账户余额，非目录问题。
+- **小观察（非阻断，未改）**：`archetypeWireDefaults.video.generated.ts` 里 `minimax-h3` 的 `text_to_video` 兜底默认被 `ref` 模式（adaptive + reference-to-video）盖住（3 个 mode 同享档案级 `transportTaskKind: text_to_video`，生成器"后者胜"）。**运行时不受影响**（用户选中的 mode 各自带正确 params，t2v 模式默认 16:9），仅"种子兜底值"这一层不准。要治本得让 wire-defaults 生成器按 mode 而非 taskKind 收口——单独一件事，未纳入本分支。
+
+## 亲验样张路径（抽验，均本地 Read 过）
+
+- 图（内容对提示词"红苹果/白桌"）：`/tmp/matrix/artifacts/apimart_gpt_image_2.png`、`kie_flux_2_pro.png`、`fal_seedream_5_pro.png`、`runway_muse_image.png`（修复后）、`apimart_z_image_turbo.png`
+- 视频抽帧：`grok_frame.png`(APIMart)、`kie_seedance2_frame.png`(睡猫)、`wan3_frame.png`(Runway)、`mmh3_frame.png`(MiniMax H3) —— 均红苹果/白桌，内容对
+- 音频：`minimax_speech-2.8-hd.mp3`、`kie_suno_v5_5_music.mp3`、`runway_seed_audio_tts.mp3` 等（共 15 段）
+- 全部 54 个产物在 `/tmp/matrix/artifacts/`
+
+## 未测清单（无 key / 本地会员前置，仅盘点未真跑）
+
+- **agnes(10) / modelscope(10) / volcengine(6) / volcengine-speech(1)**：无 key。
+- **dreamina(4)**：即梦会员本地 CLI（无登录态），只验档案契约，标"会员前置"跳过真跑。
+- **comfyui-local(1) / codex-local(1)**：本地运行时前置（~/ComfyUI 可起但耗时），标"本地前置"跳过。
+- **runninghub(13) / replicate(0 种子) / meshy(1) / antigravity-cli(0) / local-text(0)**：无 key 或无种子模型。
+- **elevenlabs(4)**：key 零 scope，**等用户重开 key**。
+
+## 复跑方法
+
+测试脚本在 `/tmp/matrix/`（`lib.mjs` 读 key + 记账，`t-*.mjs` 各 vendor tier，`probe-*.mjs` 识别探测）。矩阵盘点：`applyBuiltinSeeds()` 空目录种子（`/tmp/dump-catalog.mts`）。回归测试：`electron/catalog/vendorWireDriftFixes.test.ts`（16 例，锁 4 处修复）。

--- a/electron/catalog/falOfficial.ts
+++ b/electron/catalog/falOfficial.ts
@@ -31,12 +31,31 @@ function normalizeFalKlingV3Body(body: unknown, _context?: RequestTransformConte
 
 registerRequestTransform("fal-kling-v3-image-slots", normalizeFalKlingV3Body, (body) => { normalizeFalKlingV3Body(body); });
 
+/**
+ * fal 的 queue **提交**用完整子路径端点（`owner/app[/sub/path]`），但**状态/结果**只挂在
+ * `owner/app`（app 根，前两段）上——深子路径的 status/result URL 会 405（提交返回的
+ * `status_url`/`response_url` 也是收敛到前两段，2026-09-01 对 5 个真实端点实测：
+ *   `bytedance/seedance-2.5/text-to-video` → status 根 `bytedance/seedance-2.5`
+ *   `fal-ai/kling-video/v3/pro/text-to-video` → `fal-ai/kling-video`
+ *   `google/gemini-omni-flash/v1.1/text-to-video` → `google/gemini-omni-flash`
+ *   `bytedance/seedream/v5/pro/text-to-image` → `bytedance/seedream`
+ *   `openai/gpt-image-2`（已 2 段）→ `openai/gpt-image-2`
+ * ）。以前 query/result 直接拼完整端点 → 凡端点 > 2 段（Seedance 2.5 / Kling V3 Pro / Gemini Omni /
+ * H3-Max / Seedream 5 Pro）轮询恒 405、永远拿不到状态。loopback 测试用 `pathname.includes("/requests/")`
+ * 宽松匹配，遮住了这个漂移，本地看不出。
+ */
+function falAppRoot(endpoint: string): string {
+  const segments = endpoint.split("/").filter(Boolean);
+  return segments.slice(0, 2).join("/");
+}
+
 function queueOperations(endpoint: string, body: Body, assetPath: string): { create: HttpOperation; query: HttpOperation; result: HttpOperation } {
   const root = `/${endpoint}`;
+  const statusRoot = `/${falAppRoot(endpoint)}`;
   return {
     create: { method: "POST", path: root, headers: FAL_HEADERS, body, response_mapping: { task_id: "request_id", status: "status" }, provider_meta_mapping: { task_id: "request_id" } },
-    query: { method: "GET", path: `${root}/requests/{{providerMeta.task_id}}/status`, headers: { Authorization: "Key {{user_api_key}}" }, response_mapping: { task_id: "request_id", status: "status" } },
-    result: { method: "GET", path: `${root}/requests/{{providerMeta.task_id}}`, headers: { Authorization: "Key {{user_api_key}}" }, response_mapping: { assets: assetPath } },
+    query: { method: "GET", path: `${statusRoot}/requests/{{providerMeta.task_id}}/status`, headers: { Authorization: "Key {{user_api_key}}" }, response_mapping: { task_id: "request_id", status: "status" } },
+    result: { method: "GET", path: `${statusRoot}/requests/{{providerMeta.task_id}}`, headers: { Authorization: "Key {{user_api_key}}" }, response_mapping: { assets: assetPath } },
   };
 }
 
@@ -62,8 +81,8 @@ export const FAL_OFFICIAL_MODELS: FalModel[] = [
   {
     modelKey: "openai/gpt-image-2", labelZh: "GPT Image 2 · fal", kind: "image", archetypeId: "gpt-image-2",
     mappings: [
-      withCreateOptions(mapping("openai/gpt-image-2", "text_to_image", "t2i", "GPT Image 2 · 文生图", "openai/gpt-image-2", { prompt: "{{request.prompt}}", image_size: p("image_size"), background: p("background"), quality: p("quality"), num_images: p("num_images"), output_format: p("output_format") }, "images[*]"), { paramMap: { rules: [{ wire: "image_size", fromMany: ["aspect_ratio", "resolution"], transform: "ratioResToOpenAiSize" }] } }),
-      withCreateOptions(mapping("openai/gpt-image-2", "image_edit", "edit", "GPT Image 2 · 改图", "openai/gpt-image-2/edit", { prompt: "{{request.prompt}}", image_urls: p("image_urls"), image_size: p("image_size"), background: p("background"), quality: p("quality"), num_images: p("num_images"), output_format: p("output_format"), mask_url: p("mask_url") }, "images[*]"), { paramMap: { rules: [{ wire: "image_size", fromMany: ["aspect_ratio", "resolution"], transform: "ratioResToOpenAiSize" }] } }),
+      withCreateOptions(mapping("openai/gpt-image-2", "text_to_image", "t2i", "GPT Image 2 · 文生图", "openai/gpt-image-2", { prompt: "{{request.prompt}}", image_size: p("image_size"), background: p("background"), quality: p("quality"), num_images: p("num_images"), output_format: p("output_format") }, "images[*]"), { paramMap: { rules: [{ wire: "image_size", fromMany: ["aspect_ratio", "resolution"], transform: "ratioResToFalImageSize" }] } }),
+      withCreateOptions(mapping("openai/gpt-image-2", "image_edit", "edit", "GPT Image 2 · 改图", "openai/gpt-image-2/edit", { prompt: "{{request.prompt}}", image_urls: p("image_urls"), image_size: p("image_size"), background: p("background"), quality: p("quality"), num_images: p("num_images"), output_format: p("output_format"), mask_url: p("mask_url") }, "images[*]"), { paramMap: { rules: [{ wire: "image_size", fromMany: ["aspect_ratio", "resolution"], transform: "ratioResToFalImageSize" }] } }),
     ],
   },
   {

--- a/electron/catalog/falOfficial.ts
+++ b/electron/catalog/falOfficial.ts
@@ -33,16 +33,22 @@ registerRequestTransform("fal-kling-v3-image-slots", normalizeFalKlingV3Body, (b
 
 /**
  * fal 的 queue **提交**用完整子路径端点（`owner/app[/sub/path]`），但**状态/结果**只挂在
- * `owner/app`（app 根，前两段）上——深子路径的 status/result URL 会 405（提交返回的
- * `status_url`/`response_url` 也是收敛到前两段，2026-09-01 对 5 个真实端点实测：
- *   `bytedance/seedance-2.5/text-to-video` → status 根 `bytedance/seedance-2.5`
- *   `fal-ai/kling-video/v3/pro/text-to-video` → `fal-ai/kling-video`
- *   `google/gemini-omni-flash/v1.1/text-to-video` → `google/gemini-omni-flash`
- *   `bytedance/seedream/v5/pro/text-to-image` → `bytedance/seedream`
- *   `openai/gpt-image-2`（已 2 段）→ `openai/gpt-image-2`
- * ）。以前 query/result 直接拼完整端点 → 凡端点 > 2 段（Seedance 2.5 / Kling V3 Pro / Gemini Omni /
- * H3-Max / Seedream 5 Pro）轮询恒 405、永远拿不到状态。loopback 测试用 `pathname.includes("/requests/")`
- * 宽松匹配，遮住了这个漂移，本地看不出。
+ * `owner/app`（app 根，前两段）上——深子路径的 status/result URL 会 405。
+ *
+ * ⚠️ **官方文档与实际网关行为不一致，此处以实测为准（诚实标注）**：
+ *   docs.fal.ai 的 Async/Queue 页（2026-09-01 抓 https://docs.fal.ai/model-endpoints/queue，页面 JS 渲染，
+ *   CDP 取文）示例用 `fal-ai/flux/schnell`，明示提交响应回的
+ *     `status_url = https://queue.fal.run/fal-ai/flux/schnell/requests/{id}/status`（result 为 `.../requests/{id}/response`），
+ *   即文档说「status/result **保留完整端点路径**」。但**真发实测证伪**——fal 网关自己就把 app 路径收敛到前两段：
+ *   2026-09-01 用真 key 对 3 个端点提交后读回 `status_url`（提交即取消，见 /tmp/fal-queue-probe.mjs）：
+ *     `bytedance/seedance-2.5/text-to-video` → 回 `bytedance/seedance-2.5/requests/{id}/status`(202)；完整路径 GET 405
+ *     `fal-ai/kling-video/v3/pro/text-to-video` → 回 `fal-ai/kling-video/…`(202)；完整路径 405
+ *     `fal-ai/flux/schnell`（**即文档那个例子**）→ 回 `fal-ai/flux/…`(202)；文档写的 `fal-ai/flux/schnell/…` 反而 405
+ *   （result 端点回的是**裸** `.../requests/{id}`，无 `/response` 后缀——故下方 result path 不拼 `/response`，
+ *    job 未完成时该裸路径返 400=结果未就绪、不是 405，证明端点对。）
+ *   结论：文档此点已陈旧（还印 flux/schnell 全路径），fal 现役网关一律按前两段。以前 query/result 直接拼完整端点
+ *   → 凡端点 > 2 段（Seedance 2.5 / Kling V3 Pro / Gemini Omni / H3-Max / Seedream 5 Pro）轮询恒 405、永远拿不到
+ *   状态（BUG-2）。loopback 测试用 `pathname.includes("/requests/")` 宽松匹配，遮住了这个漂移，本地看不出。
  */
 function falAppRoot(endpoint: string): string {
   const segments = endpoint.split("/").filter(Boolean);

--- a/electron/catalog/kieKling.ts
+++ b/electron/catalog/kieKling.ts
@@ -28,6 +28,10 @@ export const KLING_3_QUERY_OP: HttpOperation = {
 
 // 一条 body 覆盖文生/图生视频：image_urls 取档案图生视频模式的有序帧数组（slot inputKey=image_urls）；
 // 文生视频模式无该槽 → 投影为 undefined → 整键被模板引擎丢弃（不发空 image_urls）。
+// multi_shots：kie 现在**要求显式传**这个 bool（2026-09-01 实测：不传 → 422 `multi_shots cannot be empty`；
+// 传数组 → 500 `multi_shots it must be a boolean`；传 `false` → 通过校验）。官方文档（docs.kie.ai/market/kling）：
+// multi_shots 是**布尔开关**——true 时改走 multi_prompt[] 多镜头（每镜头各自 prompt/时长，总 ≤15s、音频恒开），
+// false=单镜头走 prompt。我们当前单镜头，恒发 false；多镜头作后续增强（连上 multi_prompt 时再让它可变）。
 export const KLING_3_CREATE_OP: HttpOperation = {
   method: "POST",
   path: "/api/v1/jobs/createTask",
@@ -41,6 +45,7 @@ export const KLING_3_CREATE_OP: HttpOperation = {
       duration: "{{request.params.duration}}",
       aspect_ratio: "{{request.params.aspect_ratio}}",
       sound: "{{request.params.sound}}",
+      multi_shots: false,
     },
   },
 };

--- a/electron/catalog/paramTranslate.ts
+++ b/electron/catalog/paramTranslate.ts
@@ -65,6 +65,30 @@ export function ratioResToOpenAiSize(values: Array<string | undefined>): string 
   return `${width}x${height}`;
 }
 
+/**
+ * 中性比例 → fal `openai/gpt-image-2` 的 `image_size` **枚举**（fal 契约 2026-09-01 实测：只认
+ * `square_hd|square|portrait_4_3|portrait_16_9|landscape_4_3|landscape_16_9|auto`，**不认** `"1024x1024"`
+ * 这种 WxH 串——发串会 422 `model_attributes_type`）。fal 侧清晰度由 `quality` 参数单独承载，故这里只按
+ * **朝向**取枚举、不编码像素档位。fal 枚举比 16 档 canonical 粗 → 按长短边归到最近的横/竖/方：
+ *   a==b → square；宽幅按长短比 ≥ 1.5 归 16:9 否则 4:3；竖幅同理。auto/空 → undefined（省略，由 fal 默认）。
+ * ⚠️ **fal 专用**：OpenAI/new-api 的 `size` 字段要的是 WxH 串（用 ratioResToOpenAiSize），别混用。
+ */
+export function ratioResToFalImageSize(values: Array<string | undefined>): string | undefined {
+  const ratio = (values[0] || "").trim().toLowerCase();
+  if (!ratio || ratio === "auto") return undefined;
+  const m = ratio.match(/^(\d+)\s*[:x]\s*(\d+)$/);
+  if (!m) return undefined;
+  const a = Number(m[1]);
+  const b = Number(m[2]);
+  if (!a || !b) return undefined;
+  if (a === b) return "square";
+  const longOverShort = Math.max(a, b) / Math.min(a, b);
+  const wide = a > b;
+  const tall = longOverShort >= 1.5; // ≥3:2 走 16:9 档，否则 4:3 档
+  if (wide) return tall ? "landscape_16_9" : "landscape_4_3";
+  return tall ? "portrait_16_9" : "portrait_4_3";
+}
+
 /** 小写归一（某站字段值要小写，如 apimart 历史用 1k/2k/4k；中性 canonical 用 1K/2K/4K）。 */
 export function toLowerCase(values: Array<string | undefined>): string | undefined {
   const v = (values[0] || "").trim();
@@ -160,6 +184,7 @@ export function secondsToMilliseconds(values: Array<string | undefined>): number
  *  （number 用于严格类型的 wire 字段,如 AGNES Go 后端的 int width/height/num_frames）。 */
 export const PARAM_TRANSFORMS: Record<string, (values: Array<string | undefined>) => string | number | boolean | undefined> = {
   ratioResToOpenAiSize,
+  ratioResToFalImageSize,
   toLowerCase,
   toUpperCase,
   toString,

--- a/electron/catalog/paramTranslate.ts
+++ b/electron/catalog/paramTranslate.ts
@@ -66,11 +66,18 @@ export function ratioResToOpenAiSize(values: Array<string | undefined>): string 
 }
 
 /**
- * 中性比例 → fal `openai/gpt-image-2` 的 `image_size` **枚举**（fal 契约 2026-09-01 实测：只认
- * `square_hd|square|portrait_4_3|portrait_16_9|landscape_4_3|landscape_16_9|auto`，**不认** `"1024x1024"`
- * 这种 WxH 串——发串会 422 `model_attributes_type`）。fal 侧清晰度由 `quality` 参数单独承载，故这里只按
- * **朝向**取枚举、不编码像素档位。fal 枚举比 16 档 canonical 粗 → 按长短边归到最近的横/竖/方：
- *   a==b → square；宽幅按长短比 ≥ 1.5 归 16:9 否则 4:3；竖幅同理。auto/空 → undefined（省略，由 fal 默认）。
+ * 中性比例 → fal `openai/gpt-image-2` 的 `image_size` **枚举**。
+ * 官方文档（2026-09-01 照 https://fal.ai/models/openai/gpt-image-2/api 对账，即目录实际发的那个端点；
+ * `fal-ai/gpt-image-2` 同 schema）：`image_size` 类型是 **`ImageSize | Enum`**——原文
+ *   「one of the presets, `{width, height}`, or 'auto' … Default value: landscape_4_3.
+ *    Possible enum values: square_hd, square, portrait_4_3, portrait_16_9, landscape_4_3, landscape_16_9, auto.
+ *    Note: For custom image sizes, you can pass the width and height as an object.」
+ *   （自定义档还须 dims 为 16 的倍数、max edge 3840、aspect ≤ 3:1、总像素 655,360–8,294,400。）
+ * 即：枚举名或 `{width,height}` 对象**皆可**，但**不认** `"1024x1024"` 这种 WxH 串——2026-09-01 真发实测 422
+ * `model_attributes_type`（BUG-1）。我们走「枚举名」这条：清晰度由 `quality` 参数单独承载，故只按**朝向**取
+ * 枚举、不编码像素档位。fal 枚举比 16 档 canonical 粗 → 按长短边归到最近的横/竖/方：
+ *   a==b → square；宽幅按长短比 ≥ 1.5 归 16:9 否则 4:3；竖幅同理。
+ *   auto/空 → undefined（省略字段，由 fal 落到文档默认 landscape_4_3；若要「模型自选」得显式发 "auto"，此处不发）。
  * ⚠️ **fal 专用**：OpenAI/new-api 的 `size` 字段要的是 WxH 串（用 ratioResToOpenAiSize），别混用。
  */
 export function ratioResToFalImageSize(values: Array<string | undefined>): string | undefined {

--- a/electron/catalog/runwayOfficial.ts
+++ b/electron/catalog/runwayOfficial.ts
@@ -218,19 +218,30 @@ registerRequestTransform("runway-video-contract", normalizeRunwayVideoContract, 
 /**
  * Runway 的 `/v1/text_to_image` 是**按模型判别的 union**：每个 image 模型有各自的 `ratio` 枚举，
  * 共享 archetype 的比例列表（1024:1024 / 1280:720 / …）**只是其中一部分模型的合法值**。
- * 2026-09-01 实测：`muse_image` / `gpt_image_2` 的枚举**不含 1024:1024**（muse 最小 1600 系、gpt 最小 2048 系，
- * 都含 `auto`）；`seedream5_lite` 是 freeform、要求总像素 3.68M–16.7M（1024²=1M 直接 400）。用共享默认发这三个
- * 模型 → 恒 400 `Validation of body failed`（视频侧同类问题早已由 normalizeRunwayVideoContract 的 ratioFamilies 解，
- * 图像侧一直漏了）。这里按**朝向**把共享比例映射到各模型枚举里的合法值（视频侧 ratioFamilies 的图像对偶）。
- * 只处理会 400 的三个模型；其余模型（含 1024:1024 的）原样透传。
+ * 依据 = Runway 官方 OpenAPI 规范（一手、机读，2026-09-01 照
+ *   https://raw.githubusercontent.com/runwayml/openapi/main/openapi.json 对账；`/v1/text_to_image` 为 10-变体
+ *   `oneOf`，discriminator=`model`，各变体 `properties.ratio.enum` 逐一列出）：
+ *     muse_image  → ["2352:1008","2016:1152","1920:1280","1792:1344","1600:1600","1344:1792","1280:1920","1152:2016","auto"]（**无 1024:1024**）
+ *     gpt_image_2 → ["2048:880","1920:1088",…,"1920:1920",…,"2560:1440",…,"1440:2560",…,"auto"]（**无 1024:1024**，2048 系起）
+ *     seedream5_lite → ["2048:2048","2304:1728","1728:2304","2848:1600","1600:2848","2496:1664","1664:2496",…]（**无 1024:1024**，全 ≥ 400 万像素）
+ *   （反例：seedream5_pro / grok_imagine_image_2 / gen4_image 的 enum **含** 1024:1024 → 不 remap，原样透传。）
+ * 2026-09-01 真发 t2i 实测复核（提交即 DELETE，见 /tmp/runway-ratio-probe.mjs）：这三个模型发共享默认 `1024:1024`
+ * 全 400 `Validation of body failed`；发下方各自映射值全 ACCEPTED（含 seedream5_pro/grok/gen4 发 1024:1024 仍 ACCEPTED，
+ * 证明只该动这三个）。视频侧同类问题早已由 normalizeRunwayVideoContract 的 ratioFamilies 解，图像侧一直漏了。
+ * 这里按**朝向**把共享比例映射到各模型 enum 里的合法值（视频侧 ratioFamilies 的图像对偶）。
+ *
+ * 注·seedream5_lite「freeform」：OpenAPI 把它的 ratio 标成**严格 enum**（上列），但 2026-09-01 实测该模型
+ *   **也接受 enum 外的自由 `<w>:<h>`**（如 `2720:1530` 亦 ACCEPTED，只要满足 ~3.68M–16.7M 像素窗）——即活网关比
+ *   spec 宽松。**此处仍取 spec 列出的 `2848:1600`/`1600:2848`**（既在 enum、又实测通过），对未来收严 fail-safe，
+ *   不押注未文档化的宽松行为。
  */
 const RUNWAY_IMAGE_RATIO_REMAP: Record<string, { square: string; landscape: string; portrait: string }> = {
-  // muse_image 枚举（含 auto）：方=1600:1600、横=2016:1152、竖=1152:2016。
+  // muse_image enum：方=1600:1600、横=2016:1152、竖=1152:2016（均 spec 列出 + 实测 ACCEPTED）。
   muse_image: { square: "1600:1600", landscape: "2016:1152", portrait: "1152:2016" },
-  // gpt_image_2 枚举（含 auto，最小 2048 系）：方=1920:1920、横=2560:1440、竖=1440:2560。
+  // gpt_image_2 enum（2048 系起）：方=1920:1920、横=2560:1440、竖=1440:2560（均 spec 列出 + 实测 ACCEPTED）。
   gpt_image_2: { square: "1920:1920", landscape: "2560:1440", portrait: "1440:2560" },
-  // seedream5_lite freeform：任一档都要 ≥3.68M 像素。方=2048:2048、横=2720:1530、竖=1530:2720（各在窗内）。
-  seedream5_lite: { square: "2048:2048", landscape: "2720:1530", portrait: "1530:2720" },
+  // seedream5_lite enum（全 ≥3.68M px）：方=2048:2048、横=2848:1600、竖=1600:2848（均 spec 列出 + 实测 ACCEPTED）。
+  seedream5_lite: { square: "2048:2048", landscape: "2848:1600", portrait: "1600:2848" },
 };
 
 /** 从共享 ratio（"1024:1024" / "1280:720" / "auto_1k"…）判朝向。auto_* 视为方形。 */

--- a/electron/catalog/runwayOfficial.ts
+++ b/electron/catalog/runwayOfficial.ts
@@ -215,6 +215,34 @@ registerRequestTransform("runway-video-contract", normalizeRunwayVideoContract, 
   normalizeRunwayVideoContract(body);
 });
 
+/**
+ * Runway 的 `/v1/text_to_image` 是**按模型判别的 union**：每个 image 模型有各自的 `ratio` 枚举，
+ * 共享 archetype 的比例列表（1024:1024 / 1280:720 / …）**只是其中一部分模型的合法值**。
+ * 2026-09-01 实测：`muse_image` / `gpt_image_2` 的枚举**不含 1024:1024**（muse 最小 1600 系、gpt 最小 2048 系，
+ * 都含 `auto`）；`seedream5_lite` 是 freeform、要求总像素 3.68M–16.7M（1024²=1M 直接 400）。用共享默认发这三个
+ * 模型 → 恒 400 `Validation of body failed`（视频侧同类问题早已由 normalizeRunwayVideoContract 的 ratioFamilies 解，
+ * 图像侧一直漏了）。这里按**朝向**把共享比例映射到各模型枚举里的合法值（视频侧 ratioFamilies 的图像对偶）。
+ * 只处理会 400 的三个模型；其余模型（含 1024:1024 的）原样透传。
+ */
+const RUNWAY_IMAGE_RATIO_REMAP: Record<string, { square: string; landscape: string; portrait: string }> = {
+  // muse_image 枚举（含 auto）：方=1600:1600、横=2016:1152、竖=1152:2016。
+  muse_image: { square: "1600:1600", landscape: "2016:1152", portrait: "1152:2016" },
+  // gpt_image_2 枚举（含 auto，最小 2048 系）：方=1920:1920、横=2560:1440、竖=1440:2560。
+  gpt_image_2: { square: "1920:1920", landscape: "2560:1440", portrait: "1440:2560" },
+  // seedream5_lite freeform：任一档都要 ≥3.68M 像素。方=2048:2048、横=2720:1530、竖=1530:2720（各在窗内）。
+  seedream5_lite: { square: "2048:2048", landscape: "2720:1530", portrait: "1530:2720" },
+};
+
+/** 从共享 ratio（"1024:1024" / "1280:720" / "auto_1k"…）判朝向。auto_* 视为方形。 */
+function runwayRatioOrientation(ratio: string): "square" | "landscape" | "portrait" {
+  const m = ratio.match(/^(\d+)\s*[:x]\s*(\d+)$/);
+  if (!m) return "square"; // auto_1k / auto_2k / 未知 → 方
+  const w = Number(m[1]);
+  const h = Number(m[2]);
+  if (!w || !h || w === h) return "square";
+  return w > h ? "landscape" : "portrait";
+}
+
 function normalizeRunwayImageReferences(body: unknown): unknown {
   if (!body || typeof body !== "object" || Array.isArray(body)) throw new Error("Runway 图像请求体必须是 JSON 对象");
   const input = body as Record<string, unknown>;
@@ -225,6 +253,11 @@ function normalizeRunwayImageReferences(body: unknown): unknown {
   if (images.length > 3) throw new Error("Runway 图像模型最多 3 张参考图");
   delete input.reference_image_urls;
   if (images.length) input.referenceImages = images.map((uri) => ({ uri }));
+
+  // 按模型判别把共享比例映射到该模型合法的 ratio（只对枚举不含共享默认的模型动手）。
+  const remap = RUNWAY_IMAGE_RATIO_REMAP[String(input.model || "")];
+  const ratio = typeof input.ratio === "string" ? input.ratio.trim() : "";
+  if (remap && ratio) input.ratio = remap[runwayRatioOrientation(ratio)];
   return input;
 }
 
@@ -581,7 +614,9 @@ function runwayImageModel(spec: RunwayImageSpec): RunwayModel {
       ...(withReferences || spec.requiresReferences ? { reference_image_urls: "{{request.params.reference_image_urls}}" } : {}),
       model: spec.modelKey,
     },
-    ...((withReferences || spec.requiresReferences) ? { request_transform: "runway-image-references" } : {}),
+    // 始终挂 runway-image-references：它现在同时承载**按模型判别的 ratio 重映射**（muse/gpt/seedream5_lite
+    // 的枚举不含共享默认比例 → 不映射就恒 400）。纯 t2i（无参考）过去不挂它，正是这三个模型文生图挂掉的原因。
+    request_transform: "runway-image-references",
     ...(!spec.outputCount ? { paramMap: { drops: ["output_count"], rules: [] } } : {}),
     response_mapping: { task_id: "id" },
     provider_meta_mapping: { task_id: "id" },

--- a/electron/catalog/vendorWireDriftFixes.test.ts
+++ b/electron/catalog/vendorWireDriftFixes.test.ts
@@ -82,8 +82,12 @@ describe("BUG-1: fal openai/gpt-image-2 image_size must be a fal enum, not a WxH
 });
 
 describe("BUG-3: runway image ratio must be per-model; shared default 1024:1024 is invalid for some", () => {
-  // Live runway (2026-09-01): muse_image / gpt_image_2 enums exclude 1024:1024 (accept `auto`
-  // + larger); seedream5_lite is freeform requiring ≥3.68M px. Shared default → 400 for those.
+  // Source of truth = Runway official OpenAPI spec, /v1/text_to_image oneOf per-model ratio.enum
+  // (checked 2026-09-01 against raw.githubusercontent.com/runwayml/openapi/main/openapi.json):
+  //   muse_image / gpt_image_2 enums exclude 1024:1024 (2048-class + `auto`); seedream5_lite enum is
+  //   the ≥3.68M-px set (2048:2048 / 2848:1600 / …). Live-API probe confirmed shared default 1024:1024
+  //   → 400 for these three, and every remap value below → ACCEPTED (seedream5_lite also tolerates
+  //   free <w>:<h> off-enum, but we deliberately keep spec-listed values, fail-safe for future tightening).
   // Fix: every image mapping carries runway-image-references, which now remaps ratio per model.
   it("every runway image t2i/i2i mapping carries the ratio-aware transform", () => {
     const imageModels = RUNWAY_OFFICIAL_MODELS.filter((m) => m.kind === "image");
@@ -116,6 +120,9 @@ describe("BUG-3: runway image ratio must be per-model; shared default 1024:1024 
     // orientation is preserved (landscape / portrait pick the right family member)
     expect((await runwayImageBody("gpt_image_2", "1280:720")).ratio).toBe("2560:1440");
     expect((await runwayImageBody("muse_image", "720:1280")).ratio).toBe("1152:2016");
+    // seedream5_lite landscape/portrait use spec-listed enum values (both verified ACCEPTED live).
+    expect((await runwayImageBody("seedream5_lite", "1280:720")).ratio).toBe("2848:1600");
+    expect((await runwayImageBody("seedream5_lite", "720:1280")).ratio).toBe("1600:2848");
   });
 
   it("models whose enum already includes 1024:1024 are left untouched", async () => {

--- a/electron/catalog/vendorWireDriftFixes.test.ts
+++ b/electron/catalog/vendorWireDriftFixes.test.ts
@@ -1,0 +1,139 @@
+// Regression tests for three real vendor-wire drifts caught by the 2026-09-02 model
+// acceptance matrix pass (docs/research/2026-09-02-model-acceptance-matrix.md). Each was
+// a "本地看不出、线上才 4xx" class of bug: the mock/loopback path did not exercise the exact
+// live contract. These lock the fixes structurally so a future edit that regresses the wire
+// shape fails here instead of only in production.
+
+import { describe, expect, it } from "vitest";
+import { FAL_OFFICIAL_MODELS } from "./falOfficial";
+import { RUNWAY_OFFICIAL_MODELS } from "./runwayOfficial";
+import { KLING_3_CREATE_OP } from "./kieKling";
+import { ratioResToFalImageSize, ratioResToOpenAiSize } from "./paramTranslate";
+import { applyRequestTransform } from "../tasks/requestTransforms";
+
+async function runwayImageBody(model: string, ratio: string): Promise<Record<string, unknown>> {
+  // importing runwayOfficial (above) registers the transform as a side-effect.
+  const out = await applyRequestTransform("runway-image-references", { model, ratio, promptText: "x" }, { baseUrl: "" });
+  return out as Record<string, unknown>;
+}
+
+function findFalMapping(modelKey: string, modeId: string) {
+  const model = FAL_OFFICIAL_MODELS.find((m) => m.modelKey === modelKey);
+  const mapping = model?.mappings.find((mp) => mp.modeId === modeId);
+  if (!mapping) throw new Error(`fal mapping not found: ${modelKey}/${modeId}`);
+  return mapping;
+}
+
+describe("BUG-2: fal queue poll/result path collapses to owner/app root", () => {
+  // Live fal (2026-09-01): status/result for a deep-sub-path submit endpoint live at the
+  // app root (first two path segments). Submitting keeps the full endpoint; polling the full
+  // endpoint returns HTTP 405. Regression: query/result must use the collapsed root.
+  it.each([
+    ["bytedance/seedance-2.5", "t2v", "bytedance/seedance-2.5"],
+    ["fal-ai/kling-video/v3/pro", "t2v", "fal-ai/kling-video"],
+    ["google/gemini-omni-flash/v1.1", "t2v", "google/gemini-omni-flash"],
+    ["minimax/h3-max", "t2v", "minimax/h3-max"],
+    ["bytedance/seedream/v5/pro", "t2i", "bytedance/seedream"],
+    ["openai/gpt-image-2", "t2i", "openai/gpt-image-2"],
+    ["fal-ai/nano-banana-2", "t2i", "fal-ai/nano-banana-2"],
+    ["fal-ai/elevenlabs/sound-effects/v2", "sfx", "fal-ai/elevenlabs"],
+  ] as const)("%s/%s → poll root /%s", (modelKey, modeId, expectedRoot) => {
+    const mapping = findFalMapping(modelKey, modeId);
+    expect(mapping.query.path).toBe(`/${expectedRoot}/requests/{{providerMeta.task_id}}/status`);
+    expect(mapping.result.path).toBe(`/${expectedRoot}/requests/{{providerMeta.task_id}}`);
+    // create still POSTs to the full submit endpoint (that part was always correct).
+    const model = FAL_OFFICIAL_MODELS.find((m) => m.modelKey === modelKey)!;
+    const created = model.mappings.find((mp) => mp.modeId === modeId)!;
+    expect(created.create.path).toContain(modelKey);
+  });
+});
+
+describe("BUG-1: fal openai/gpt-image-2 image_size must be a fal enum, not a WxH string", () => {
+  // Live fal rejects "1024x1024" with 422 model_attributes_type; it accepts the ImageSize
+  // enum. The OpenAI/new-api `size` field DOES take WxH — so the transform must be fal-specific.
+  it("gpt-image-2 fal mapping translates aspect_ratio→image_size via ratioResToFalImageSize", () => {
+    for (const modeId of ["t2i", "edit"] as const) {
+      const mapping = findFalMapping("openai/gpt-image-2", modeId);
+      const rule = mapping.create.paramMap?.rules?.find((r) => "wire" in r && r.wire === "image_size");
+      expect(rule && "transform" in rule ? rule.transform : undefined).toBe("ratioResToFalImageSize");
+    }
+  });
+
+  it("ratioResToFalImageSize emits fal ImageSize enums (never a WxH string)", () => {
+    const falEnums = new Set(["square", "square_hd", "portrait_4_3", "portrait_16_9", "landscape_4_3", "landscape_16_9"]);
+    expect(ratioResToFalImageSize(["1:1", "1K"])).toBe("square");
+    expect(ratioResToFalImageSize(["16:9", "1K"])).toBe("landscape_16_9");
+    expect(ratioResToFalImageSize(["4:3", "1K"])).toBe("landscape_4_3");
+    expect(ratioResToFalImageSize(["9:16", "1K"])).toBe("portrait_16_9");
+    expect(ratioResToFalImageSize(["3:4", "1K"])).toBe("portrait_4_3");
+    // auto / unknown → undefined (let fal default), not a bogus enum
+    expect(ratioResToFalImageSize(["auto", "1K"])).toBeUndefined();
+    for (const ratio of ["1:1", "16:9", "4:3", "9:16", "3:4", "3:2", "2:3", "21:9"]) {
+      const v = ratioResToFalImageSize([ratio, "2K"]);
+      if (v !== undefined) expect(falEnums.has(v)).toBe(true);
+      // and it must never look like a WxH string
+      if (v !== undefined) expect(/\d+x\d+/.test(v)).toBe(false);
+    }
+  });
+
+  it("ratioResToOpenAiSize still returns WxH strings (unchanged; used by new-api/OpenAI size)", () => {
+    expect(ratioResToOpenAiSize(["1:1", "1K"])).toMatch(/^\d+x\d+$/);
+  });
+});
+
+describe("BUG-3: runway image ratio must be per-model; shared default 1024:1024 is invalid for some", () => {
+  // Live runway (2026-09-01): muse_image / gpt_image_2 enums exclude 1024:1024 (accept `auto`
+  // + larger); seedream5_lite is freeform requiring ≥3.68M px. Shared default → 400 for those.
+  // Fix: every image mapping carries runway-image-references, which now remaps ratio per model.
+  it("every runway image t2i/i2i mapping carries the ratio-aware transform", () => {
+    const imageModels = RUNWAY_OFFICIAL_MODELS.filter((m) => m.kind === "image");
+    expect(imageModels.length).toBeGreaterThan(5);
+    for (const model of imageModels) {
+      for (const mapping of model.mappings) {
+        expect(mapping.create.request_transform).toBe("runway-image-references");
+      }
+    }
+  });
+
+  it("the three previously-broken models are covered by an explicit ratio remap", () => {
+    // These models' live enums do not include the shared 1024:1024 default.
+    const broken = ["muse_image", "gpt_image_2", "seedream5_lite"];
+    for (const key of broken) {
+      const model = RUNWAY_OFFICIAL_MODELS.find((m) => m.modelKey === key);
+      expect(model, `runway image model ${key} present`).toBeTruthy();
+      expect(model!.mappings.length).toBeGreaterThan(0);
+      // t2i mapping must exist and carry the transform (base t2i previously had no transform).
+      const t2i = model!.mappings.find((mp) => mp.modeId === "t2i");
+      expect(t2i?.create.request_transform).toBe("runway-image-references");
+    }
+  });
+
+  it("transform remaps the shared 1024:1024 default to each model's live-valid ratio", async () => {
+    // Values verified against the live runway enums on 2026-09-01.
+    expect((await runwayImageBody("muse_image", "1024:1024")).ratio).toBe("1600:1600");
+    expect((await runwayImageBody("gpt_image_2", "1024:1024")).ratio).toBe("1920:1920");
+    expect((await runwayImageBody("seedream5_lite", "1024:1024")).ratio).toBe("2048:2048");
+    // orientation is preserved (landscape / portrait pick the right family member)
+    expect((await runwayImageBody("gpt_image_2", "1280:720")).ratio).toBe("2560:1440");
+    expect((await runwayImageBody("muse_image", "720:1280")).ratio).toBe("1152:2016");
+  });
+
+  it("models whose enum already includes 1024:1024 are left untouched", async () => {
+    // gen4_image / grok / gemini variants accept 1024:1024 → no remap.
+    expect((await runwayImageBody("gen4_image", "1024:1024")).ratio).toBe("1024:1024");
+    expect((await runwayImageBody("grok_imagine_image_2", "1280:720")).ratio).toBe("1280:720");
+  });
+});
+
+describe("BUG-4: KIE kling-3.0/video requires an explicit multi_shots boolean", () => {
+  // Live KIE (2026-09-01): omitting multi_shots → 422 `multi_shots cannot be empty`; sending an
+  // array → 500 `must be a boolean`; sending `false` → validates. Official docs
+  // (docs.kie.ai/market/kling) confirm multi_shots is a boolean (true switches to multi_prompt[]).
+  it("kling create op sends multi_shots as a literal boolean false (single-shot)", () => {
+    const input = (KLING_3_CREATE_OP.body as { input: Record<string, unknown> }).input;
+    expect(input).toHaveProperty("multi_shots");
+    expect(input.multi_shots).toBe(false);
+    // still carries the single-shot prompt path
+    expect(input.prompt).toBe("{{request.prompt}}");
+  });
+});


### PR DESCRIPTION
用户点名「可能测两个但其它三个不能用」——全中：93 模型真测（¥20.29/上限60）挖出 4 类「本地绿线上 4xx」我们侧 bug 并全修+真 API 复测：fal image_size 格式、fal 队列轮询 405（连坐 6 模型）、Runway 文生图 ratio 按模型判别缺失、KIE kling-3.0 新必填 multi_shots。16 条回归测试锁死。矩阵：✅45 真跑/🟡30 族代表/❌0 下线/⛔11 账户额度。样张编排者亲验（seedance 睡猫帧/修复后 runway 苹果）。矩阵存档 docs/research/2026-09-02-model-acceptance-matrix.md。

🤖 Generated with [Claude Code](https://claude.com/claude-code)