### PR TITLE
fix(i18n): EN locale geometry overflow + vendor EN names (tour findings)

### DIFF
--- a/src/design/actions.tsx
+++ b/src/design/actions.tsx
@@ -184,7 +184,10 @@ export const ActionCard = forwardRef<HTMLButtonElement, ActionCardProps>(functio
         {icon}
       </span>
       <span className="flex-1 min-w-0">
-        <span className="block text-body font-semibold truncate">{title}</span>
+        {/* 标题允许 2 行（line-clamp-2），不按最长中文标题定死单行截断——EN 标题（如
+            "See how Nomi creates a video"）比中文长得多，单行 truncate 会截成「…a v…」。
+            2 行 clamp 各 locale 通吃：短标题仍单行，长标题换行不外溢，卡片高度 88px 兜得住。 */}
+        <span className="block text-body font-semibold line-clamp-2 leading-snug">{title}</span>
         <span
           className={cn(
             'block mt-0.5 text-caption truncate',

--- a/src/i18n/locales/modelDisplayText.ts
+++ b/src/i18n/locales/modelDisplayText.ts
@@ -121,6 +121,16 @@ export const enModelDisplayText: Readonly<Record<string, string>> = {
   魔搭图像: 'ModelScope Image',
   魔搭: 'ModelScope',
   魔搭社区: 'ModelScope',
+  // Vendor display names. The catalog seeds carry Chinese vendor names (electron/catalog/*Vendor.ts);
+  // the settings UI localizes them here via translateModelDisplayText, same as 魔搭社区→ModelScope.
+  // Any vendor whose seed `name` is Chinese needs an entry here, or it renders Chinese in the EN UI.
+  // 火山方舟 = Volcengine's Ark model-service platform. Official English brand "Volcengine Ark"
+  //   (console self-brands as "Volcano Engine Ark Console — Volcengine Console",
+  //    https://console.volcengine.com/ark ; matches existing 'Volcengine Seedream' labels below).
+  火山方舟: 'Volcengine Ark',
+  火山豆包语音: 'Volcengine Voice',
+  '即梦会员（本地 CLI）': 'Dreamina membership (local CLI)',
+  'Codex 本地生图（实验）': 'Codex local image (experimental)',
   即梦: 'Dreamina',
   本地: 'Local',
   '本地 ComfyUI': 'Local ComfyUI',

--- a/src/i18n/locales/timelineEditor.ts
+++ b/src/i18n/locales/timelineEditor.ts
@@ -87,6 +87,13 @@ export const zhTimelineEditor = {
     emptyAudio: '从素材库拖入音频当配乐',
     emptyVisual: '从生成区拖入素材',
     placeAt: '放到 {{timecode}}',
+    // rail*Label = 轨道左侧固定宽标签列（--workbench-timeline-label-width，112px，标尺/播放头都按它对齐）
+    //   里显示的短名，几何约束：必须塞得进这列，不能靠加宽列来容纳（那会牵动整条轴的内容起点与标尺对齐）。
+    // *Label（不带 rail 前缀）= 句子里用的描述名（如 wrongType「…需要放到{{track}}」），要读得通顺。
+    //   中文两者恰好同字；英文分开——rail 用 Images/Videos/Audio（进得了 112px 列），句子用 Image track/… 更自然。
+    railImageLabel: '图片轨',
+    railVideoLabel: '视频轨',
+    railAudioLabel: '音频轨',
     imageLabel: '图片轨',
     videoLabel: '视频轨',
     audioLabel: '音频轨',
@@ -247,6 +254,11 @@ export const enTimelineEditor = {
     emptyAudio: 'Drag audio from Assets to use as music',
     emptyVisual: 'Drag media from Generation',
     placeAt: 'Place at {{timecode}}',
+    // rail*Label: short names for the fixed-width rail column (112px); must fit without widening it.
+    // *Label (no rail prefix): descriptive names used inside sentences (e.g. wrongType), kept readable.
+    railImageLabel: 'Images',
+    railVideoLabel: 'Videos',
+    railAudioLabel: 'Audio',
     imageLabel: 'Image track',
     videoLabel: 'Video track',
     audioLabel: 'Audio track',

--- a/src/workbench/timeline/TimelineTrack.tsx
+++ b/src/workbench/timeline/TimelineTrack.tsx
@@ -28,12 +28,14 @@ type TimelineTrackProps = {
 
 function TimelineTrack({ track, transitionFeedback = [], variant = 'primary' }: TimelineTrackProps): JSX.Element {
   const { t } = useTranslation()
+  // 轨道标签列宽度固定（--workbench-timeline-label-width=112px，标尺/播放头都按它对齐），用短的 rail*Label，
+  // 别用描述名 *Label（英文 'Image track' 会被这列截成 'Image t…'）。句子里的轨道名仍用 *Label（见下 wrongType）。
   const displayTrackLabel =
     track.type === 'image'
-      ? t('timelineEditor.track.imageLabel')
+      ? t('timelineEditor.track.railImageLabel')
       : track.type === 'video'
-        ? t('timelineEditor.track.videoLabel')
-        : t('timelineEditor.track.audioLabel')
+        ? t('timelineEditor.track.railVideoLabel')
+        : t('timelineEditor.track.railAudioLabel')
   const secondary = variant === 'secondary'
   const transitionRowsAtBoundary = new Map<number, number>()
   const laidOutTransitionFeedback = transitionFeedback.map((feedback) => {


### PR DESCRIPTION
Orchestrator's personal bilingual tour (30 shots eyeballed) found 3 EN defects, one class: geometry/metadata sized for zh with no EN allowance.

- D1 library action-card title truncation → ActionCard truncate→line-clamp-2 (design-system shared)
- D2 timeline track-label truncation → split dual-duty key: short railLabels (Images/Videos) vs sentence labels; rail geometry anchor untouched
- D3 vendor EN names incomplete → enModelDisplayText seam: 火山方舟→Volcengine Ark (+3 more), source console.volcengine.com/ark

Verified: gates green, i18n-sweep 51/51, before/after shots eyeballed by orchestrator (en+zh 01/08/10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)