### PR TITLE
test(mcp): harness 种 verified-client 凭据——恢复 MCP 旅程运输层（审计 E-02）

### DIFF
--- a/tests/ux/_mcpJourney.mjs
+++ b/tests/ux/_mcpJourney.mjs
@@ -19,6 +19,7 @@
 // the renderer confirm card (createHybridGateway) and cannot complete without a human click, whereas the
 // headless stdio server routes spend through elicitation → makeConfirmedGateway (mcpStdioServer.ts:99).
 import { spawn } from 'node:child_process'
+import crypto from 'node:crypto'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
@@ -236,6 +237,29 @@ export function writeIsolatedCatalog(settingsDir, mockOrigin) {
 export const BAD_SHOT_MARKER = '#BADSHOT'
 
 /**
+ * Seed a verified MCP client identity for an isolated capability dir: ensure the capability-core
+ * bearer token exists (the headless stdio server never mints one — only the GUI app's ensureToken
+ * does), then derive the same HMAC proof `signMcpClient` computes (security.ts:139-146,
+ * context `nomi-mcp-client:v1:<client>`). Returns the env pair the startup gate
+ * (mcpStdioProjectSessionBinding.ts:21-24, since M1 round-2 0b6441c6) requires — without it every
+ * journey dies at initialize with "A verified MCP client connection is required" (audit E-02,
+ * docs/research/2026-09-02-mcp-editing-chain-audit.md). Never overwrites an existing token, so
+ * journeys sharing the capability dir with a live GUI instance keep the GUI-minted token.
+ */
+export function seedMcpClientIdentityEnv(capabilityDir, client = 'claude') {
+  const tokenPath = path.join(capabilityDir, 'token')
+  let token = ''
+  try { token = fs.readFileSync(tokenPath, 'utf8').trim() } catch { /* not seeded yet */ }
+  if (!token) {
+    token = crypto.randomBytes(24).toString('hex')
+    fs.mkdirSync(capabilityDir, { recursive: true })
+    fs.writeFileSync(tokenPath, token, { encoding: 'utf8', mode: 0o600 })
+  }
+  const proof = crypto.createHmac('sha256', token).update(`nomi-mcp-client:v1:${client}`).digest('base64url')
+  return { NOMI_MCP_CLIENT: client, NOMI_MCP_CLIENT_PROOF: proof }
+}
+
+/**
  * Spawn the real in-Electron MCP stdio server (headless) and return a JSON-RPC client.
  * The client:
  *   · declares the given `capabilities` at initialize (default: elicitation, so plan/spend confirmations
@@ -246,6 +270,9 @@ export const BAD_SHOT_MARKER = '#BADSHOT'
  *
  * env is fully isolated: caller passes settingsDir / userDataDir / projectsDir / capabilityDir, plus an
  * optional `env` bag merged over the base isolation env (the sibling adds NOMI_E2E_PRODUCTION_FIXTURE).
+ * The base env always carries a verified client identity (seedMcpClientIdentityEnv, default 'claude') —
+ * the production binding refuses to start without one — and the `env` bag can override the pair for
+ * journeys that pin a different registered client (both mcp-generation journeys pin 'codex').
  * NOMI_LOOP_SPEND_OK is intentionally NOT set — spend must flow through elicitation → makeConfirmedGateway,
  * proving the headless zero-dialog spend path (mcpStdioServer.ts:99), not an env escape hatch.
  */
@@ -263,6 +290,7 @@ export function spawnMcpStdioClient({
       NOMI_ELECTRON_USER_DATA_DIR: userDataDir,
       NOMI_PROJECTS_DIR: projectsDir,
       NOMI_CAPABILITY_DIR: capabilityDir,
+      ...seedMcpClientIdentityEnv(capabilityDir),
       ...(env || {}),
     },
     stdio: ['pipe', 'pipe', 'inherit'],


### PR DESCRIPTION
## 背景（审计 E-02，PR #321）

`docs/research/2026-09-02-mcp-editing-chain-audit.md` E-02（P0 网破）实证：`pnpm run test:mcp`（J-MCP1 旗舰旅程）在 main 上是红的。根因 = M1 round-2 commit `0b6441c6`（经 #301 合入）让 `createProductionMcpStdioProjectSessionBinding`（`electron/capabilityCore/mcpStdioProjectSessionBinding.ts:21-24`）启动时无条件要求已验证 MCP 客户端（capability token + HMAC proof），而旅程 harness spawn 不带 `NOMI_MCP_CLIENT/NOMI_MCP_CLIENT_PROOF` → stdio server 秒退 exit 1，stderr 才有原因。

## 修法（harness 公共层，P2 一处修齐全族）

`tests/ux/_mcpJourney.mjs` 新增 `seedMcpClientIdentityEnv(capabilityDir, client='claude')`：
- capability token 缺则种（0600；**不覆盖已存在的**——与 GUI 共用 capabilityDir 的旅程保住 GUI 铸的 token）；
- proof 按 `security.ts:139-146` 同款 `HMAC-SHA256(token, "nomi-mcp-client:v1:<client>")` base64url 派生；
- 挂进 `spawnMcpStdioClient` 基础 env（`env` 包仍可覆盖——`mcp-generation-elicitation-first` / `mcp-generation-single-shot-gui-fallback` 钉 `codex` 身份的写法不受影响）。

全族对账（grep `spawnMcpStdioClient` 全部消费者）：`mcp-journey`（test:mcp）/ `production-mcp-journey` / `draft-journey` 三条此前全死于同一堵墙，公共层一次修齐；`packaged-mcp-smoke` 走打包 launcher 签名路（自带 proof，刻意不共 harness）、`_modelIntegrationHarness` 自带 signed/unsigned 矩阵，均不动。

## 红→绿证据（本机 darwin，哨兵文件真退出码）

**修前（origin/main@349529e6 + 本机 build）**：exit **1**
```
[nomi:mcp-stdio] 启动失败: A verified MCP client connection is required
✗ Error: J-MCP1 FAIL: initialize failed — process exited code=1 signal=null
```
**修后**：运输层复活——initialize → create_project → add_nodes(14) → connect_nodes → list_models 共 **15 条断言通过**（修前 0 条）。

## 诚实边界：test:mcp 尚未全绿——撞出第二处独立回归

Step f 起 J-MCP1 调 `nomi_generate`，而 M1 已**无条件退役**该路（`5df73eff`；`nomiGenerateRetirement.test.ts` 断言目录/协议双面不可见不可调）→ `未知工具: nomi_generate`，exit 1。审计 R2「3 行可翻绿」只在审计班自己的 8 步走查上成立（它不调生成），对完整 J-MCP1 不成立。生成幕（f/g/h）改写要落到语义 single-shot 面（`nomi_operation_create` 候选流），该面正在 #318（M2 slice-1）在途重塑——归 slice-2 施工班，不该在本急修班里抢跑移靶。本 PR 把「网」的运输层修回，与审计「先修网再施工」的次序一致。

## Gates（全跑，哨兵退出码全 0）

`check:filesize` ✓ `check:tokens` ✓ `check:i18n` ✓ `check:heavy-path` ✓ `lint:ci` ✓ `typecheck` ✓ `test`（vitest 1092 文件 / 10082 用例全过）✓ `build` ✓（本树 build 于改动前跑绿；delta 仅 `tests/ux/_mcpJourney.mjs` +28 行，非 build 输入）

delta vs origin/main：**1 个文件**（`tests/ux/_mcpJourney.mjs`），只增不删。

🤖 Generated with [Claude Code](https://claude.com/claude-code)