### PR TITLE
docs(research): 2026-09-02 dual radar — papers + model triage

### DIFF
--- a/docs/research/2026-09-02-model-radar.md
+++ b/docs/research/2026-09-02-model-radar.md
@@ -1,0 +1,39 @@
+# 2026-09-02 供应商模型雷达 · 分诊
+
+雷达轮次（`pnpm run radar:models`，今晨 09:57 实跑，`latest.json`；`failures: []` 两家都查成）：
+
+| 供应商 | 盯住 | 新增 | 下架 | 备注 |
+|---|---|---|---|---|
+| apimart | 128 | 1 | 0 | `minimax-h3/max`——**我们已有 `MINIMAX_H3_MAX_ARCHETYPE`**（源为一手 minimaxi），这是同一模型的 apimart 新渠道页，非新能力 |
+| kie | 142 | 1 | 0 | `google/gemini-omni-flash-1-1`——**我们已有 `GEMINI_OMNI_11_ARCHETYPE`**，identifierPatterns 精确命中；纯基线滞后，非缺口 |
+
+> **本轮核心结论：两条「新增」都不是新东西，是快照滞后。** 脚本报的 `added` 是「现网目录 vs 上次基线快照」的差；这两个模型我们**都已经建了档案**，只是快照没更新（按铁律 3，快照要等用户看过本轮差异才 `--update-baseline`，所以它们会持续显形直到用户点头更新）。逐个 grep 复核见下，均已交叉引用到具体文件。**本轮无 🟢（无需新接）。**
+
+---
+
+## 逐条分诊
+
+### ⚪ apimart · `minimax-h3/max` · video — 已有档案，仅新增渠道源
+- **文档页**（2026-09-02 实抓）：<https://docs.apimart.ai/en/api-reference/videos/minimax-h3/max.md>
+- **是什么**：apimart 为 **MiniMax-H3-Max** 单独开的视频生成页。页面明写 H3-Max 是**独立于 MiniMax-H3 的模型**（"Use MiniMax-H3-Max when speed matters and you only need text-to-video or first/last-frame control. For 2K, reference images/videos/audio, use MiniMax-H3."）——速度档，只做 T2V + 首/尾帧。
+- **实抓到的能力面**：`POST https://api.apimart.ai/v1/videos/generations`，Bearer 鉴权，**异步**（返回 `task_id`，轮询 `GET /v1/tasks/{task_id}`）。`model=MiniMax-H3-Max`（大小写不敏感）；`prompt` ≤7000 字符；`duration` 5–15s（默认 5）；`resolution` `768P`(默认)/`480P`；`aspect_ratio` 21:9/16:9/4:3/1:1/3:4/9:16（T2V 默认 16:9）；`first_frame_image`/`last_frame_image`（或 `image_with_roles` 数组）；`watermark`(默认 false)；`webhook`。**不支持**参考图/视频/音频、2K、中间帧。图片：≤2 张（首帧+尾帧），单文件 ≤30MB，尺寸 256–5760px。**定价（该中转页）**：768P **$0.075/秒**、480P **$0.0495/秒**、输入图免费。
+- **对 Nomi 哪个痛点**：T2V + 首尾帧转场镜，速度/成本档。
+- **覆盖现状**（grep 复核，铁律 7）：**已覆盖**。`electron/shared/videoCapabilities/minimaxH3Max.ts` 的 `MINIMAX_H3_MAX_ARCHETYPE` `identifierPatterns:["minimax/h3-max","MiniMax-H3-Max"]`，模式 t2v + i2v(首尾帧)、480P/768P、5–15s，与本页一致。其 `sources` 现指向**一手 `platform.minimaxi.com`**（checkedAt 2026-08-30），**未声明 apimart 这条渠道源**。另 `MINIMAX_H3_APIMART_ARCHETYPE`（`minimax-h3-apimart`）只覆盖非 Max 的 H3（源 `docs.apimart.ai/.../minimax-h3/generation`）。
+- **判断**：⚪ 忽略（无需新接）。**唯一可做的小事**（非本轮必做）：若将来要走 apimart 通道跑 H3-Max，可把本页作为**补充源**加进 `MINIMAX_H3_MAX_ARCHETYPE.sources`，并留意两处**差异待实测**——① 分辨率档：一手页写 480P/768P，apimart 页也写 768P/480P（一致）；但 `MINIMAX_H3_APIMART_ARCHETYPE`（非 Max）写到 2K，别混档；② **定价 $0.075/$0.0495/秒是 apimart 中转价**（铁律 5，一手 minimaxi 价可能不同，真接时交叉核）。这属档案维护、不属新接模型。
+
+### ⚪ kie · `google/gemini-omni-flash-1-1` · video — 已有档案，基线滞后显形
+- **文档页**（2026-09-02 实抓，08-31 亦抓过）：<https://docs.kie.ai/market/google/gemini-omni-flash-1-1.md>
+- **是什么**：Google Gemini Omni 1.1 Flash 多模态视频生成，走 kie `POST /api/v1/jobs/createTask` 异步（`taskId` 轮询或 `callBackUrl`）。
+- **实抓到的能力面**：`image_urls` **≤7 张**（单张 ≤20MB），**与 `first_frame_url` 互斥**；`first_frame_url`/`last_frame_url`（尾帧需伴随首帧）；用 `first_frame_url` 时 `image_urls`/`video_list`/`character_ids`/`audio_ids` 全禁；`duration` 4/6/8/10s（有视频输入时忽略）；`resolution` 360p/720p(默认)/1080p/4k；`aspect_ratio` 16:9/9:16。**配额系统**：共 7 units（图 1/张、视频 2/最多 1、character_ids 1/最多 3）。计费回调报 `creditsConsumed`（具体价文档未给）。
+- **对 Nomi 哪个痛点**：跨镜身份（7 张参考图上限高）+ 首尾帧转场。
+- **覆盖现状**（grep 复核，铁律 7）：**已覆盖**。`electron/shared/videoCapabilities/geminiOmni11.ts` 的 `GEMINI_OMNI_11_ARCHETYPE` `identifierPatterns:["google/gemini-omni-flash-1-1","gemini-omni-flash-1-1"]` 精确命中该 slug；三模式 t2v / firstlast / reference(≤7) 全在，4k、audio_ids≤3、video_list≤1 均已在 `sources.covers` 记录（同一 kie 页，checkedAt 2026-08-30）。
+- **判断**：⚪ 忽略。**并订正 08-31 radar**：`docs/research/2026-08-31-model-radar.md` 当天把此模型判为「🟢 真缺口，`gemini-omni` 全仓 grep 无命中」——**该结论现已不成立**（档案已建，很可能就是那次点头后接的，或另一路并行接入）。这正是铁律 7 的教训：断言缺口前先按归一 token grep，别只按报错串。今日 `added:1` 是**基线未更新**的显形，不是回归、不是缺口。
+
+---
+
+## 底部
+
+- **`uncovered` 抽样**：本轮不抽。理由——两条 `added` 已确认「已覆盖」，无新接需求；`uncovered`（apimart 89 / kie 76，共 ~165 条）是首次建基线的存量池（铁律 6），与今日痛点（Agent 界面实施准备、跨镜身份）无新增交集，逐条分诊只会把报告变收件箱。如需清存量另开专项，不塞进日课雷达。
+- **本轮忽略**：2 条（均因已覆盖）。**无 🟢 / 无 🟡。**
+- **快照纪律**：**未跑 `--update-baseline`**（铁律 3，等用户看过本轮差异）。用户看过后若认可「两条都已覆盖」，可更新快照，下轮这两条即不再显形。
+- **给用户的动作项**：无需接新模型。可选的档案维护（非阻塞）：给 `MINIMAX_H3_MAX_ARCHETYPE` 补 apimart 渠道源；确认 08-31 那条 gemini-omni「缺口」结论作废。这两件都是清理级，按 P0 卫生清理可直接做，但因涉及改档案文件、留给用户一并决定是否随快照更新一起处理。

--- a/docs/research/2026-09-02-radar.md
+++ b/docs/research/2026-09-02-radar.md
@@ -1,0 +1,80 @@
+# 2026-09-02 论文雷达 · 分诊
+
+**一句话**：本轮头条是 **GroundShot**（2026-06，训练无关 + 模型无关的 agentic 跨镜身份记忆 + 拍摄顺序调度）——它把 Nomi 的 decompose-stitch 直接当框架来做，且明说能包 Kling/Vidu/Wan 这类现成后端，是我们「一名角色跨多镜」最可直接照抄的算法。
+
+**本轮最该动的 1-2 件事**：
+1. **把 GroundShot 的三步管线（解析调度 → 生成入库 → 复位输出）当作 Nomi 跨镜身份的目标架构记下来**——它证实了「先生成参考质量最高的镜、再拿它喂后续镜」这个调度思路，正对我们拆镜头规划师 + character_ref 的命门。近期不必全上，但**「按参考有用度重排生成顺序」这一条**可以先在 arrange_storyboard 侧做轻量试验。
+2. **VQQA 的闭环（生成 → VLM 批评当语义梯度 → 改写 prompt → 重生成）可以增量落到 AI 优化节点**：training-free、黑盒 NL 接口、+11.57%/+8.43%，正好补我们「用户输入糙 → 生成差」的杠杆，且与已有 VLM 走查基建同源。
+
+今天正做 Agent 界面实施准备，HCI 档单列了「渐进披露 + 认知负荷」证据链（见 🟡），与记忆里「Beautiful UI 整件复用 + 认知负荷最低是最高原则」同向。
+
+---
+
+## 🟢 可落地（这周/这月能进 Nomi 的具体能力）
+
+### GroundShot — 实体锚定的跨镜一致长视频（训练无关 · 模型无关 · agentic）
+- arxiv **2606.20799**（2026-06） · <https://arxiv.org/abs/2606.20799>
+- 出处：浙大 CAD&CG 国重 + 复旦 + 百度（Yixuan Lai / Tianjia Shao / Kun Zhou）。**未见公开代码仓**（本轮实抓无 repo 链接，火度暂看 lab 分量，不看 star）。
+- **洞察**：这不是又一个身份一致 trick，是把**整个 decompose-stitch 当框架**：① 用 LLM 抽复现实体、对每个「镜×实体」预测「当参考源的有用度」，连成 DAG 拓扑排序 →**生成顺序与叙事顺序解耦**（先拍最适合当参考的镜）；② 每镜生成后做开放词表 grounding 抠出角色/物体 crop，过 type-aware 质检（正脸/清晰度/可复现），第一张够强的成「canonical reference」，后续只在既相似又非冗余时入库；③ 每镜生成前从记忆检索参考，有前景参考走 Ref2V、无则 T2V。实验包 **Vidu / Kling / Wan2.1+Phantom** 三种后端，全部即插即用。
+- **落到哪个文件 / 怎么改**：目标架构对齐 `拆镜头规划师` + `arrange_storyboard`（生成顺序调度）+ character_ref/设定卡（canonical reference 入库与检索）。**近期最小试验**：在 storyboard 编排层加「参考有用度排序」——先渲染角色正脸最清楚的镜，把它的产物作为后续同角色镜的参考锚。完整实体记忆库属中期，先记为目标态，别一次全上（P1 加新删旧、别开并行版）。
+- **判断**：🟢 头条。training-free + model-agnostic + 能包我们已接的 Kling 家族 = 与 P4 解耦哲学完全同构；算法每一步都能在现有 MCP 工具面复述。
+
+### VQQA — VLM 批评当语义梯度的闭环 prompt 优化（训练无关 · 黑盒）
+- arxiv **2603.12310**（2026-03） · <https://arxiv.org/abs/2603.12310>
+- **洞察**：把「被动评测指标」换成「可执行的 VLM 批评」，循环 = 生成 → VLM 指出瑕疵 → NL 接口改写 prompt → 重生成 → 迭代。不碰 backbone 内部，T2V-CompBench +11.57%、VBench2 +8.43%。
+- **落到哪个文件 / 怎么改**：AI 优化节点 / prompt 库。我们已有 VLM 走查基建（截图 + 人眼/模型判断），把它接成「生成后回灌一次批评 → 自动改写 prompt」的可选闭环即可，天然复用现有通道。
+- **判断**：🟢。贴「用户输入糙→生成差」痛点、增量、可复用；比重训类 prompt 方案（PhyPrompt RL / RAPO++ fine-tune）更符合我们「拿不到大算力」的约束。
+
+### SCMAPR — 自纠多 agent prompt 精修（欠说明输入时增益最大）
+- arxiv **2604.05489**（2026-04） · <https://arxiv.org/abs/2604.05489>
+- **洞察**：多 agent 自纠精修 prompt，**用户输入越简短/欠说明，增益越明显**——正中 Nomi「用户就写一句话」的常态。
+- **落到哪个文件 / 怎么改**：同上 prompt 库 / AI 优化节点，可与 VQQA 组合（SCMAPR 管冷启动扩写、VQQA 管生成后闭环回灌）。列为 🟢 但次于 VQQA（VQQA 有量化增益 + 与我们 VLM 基建同源，SCMAPR 先做 A/B 对照再定权重）。
+
+---
+
+## 🟡 架构教训（不直接落地，但影响设计决策）
+
+### DirectorBench — 长视频生成的多 agent 诊断基准（明写转场是全行业瓶颈）
+- arxiv **2605.30090**（2026-05） · <https://arxiv.org/abs/2605.30090>
+- **洞察**：评 4 条长视频工作流，**转场质量均值仅 0.256**（0-1 尺度）——全行业在镜间转场上集体拉胯；prompt 级用户需求满足均值 0.71。5 维（脚本/视觉/音频/跨模态/稳定）+ 40 checkpoint + 7 用户画像。
+- **影响 Nomi 哪个决策**：印证「镜间转场 + 拆镜规划」是我们该押的差异化，不是画质军备竞赛（与 D2 结构约束、招牌只给结构性差异化同向）。**也是 🔵 候选**（见下），此处先记教训：别把预算砸在单镜画质，砸在镜间。
+
+### ShotDirector / ShotVerse — 可控多镜 + 电影化转场 + 相机轨迹
+- ShotDirector arxiv **2512.10286**（2025-12，6-DoF 相机 + 编辑模式感知分层 prompt + ShotWeaver40K 数据集）· <https://arxiv.org/abs/2512.10286>
+- ShotVerse arxiv **2603.11421**（2026-03，「Plan-then-Control」：VLM Planner + Controller 相机 adapter 渲染轨迹）· <https://arxiv.org/abs/2603.11421>
+- **影响 Nomi 哪个决策**：文本→相机轨迹的**语义参数化**（6-DoF pose + 内参）可喂进我们 3D 站位参考 / 机位语义。当前都需相机 adapter/训练，Nomi 拿不到，故列教训——但**「机位用结构化参数而非自然语言描述」这个设计取向**值得在站位工具里对齐。CamTrol（arxiv 2406.10126，training-free 相机控制）是更轻的备选，若哪天要做机位控制先看它。
+
+### 认知负荷 + 渐进披露（Agent 界面实施的 HCI 支点，今天正相关）
+- 「Gaze-Informed AI Disclosure Interfaces」arxiv **2605.14999**（2026-05）：按注意/认知负荷**自适应触发渐进披露**（负荷高才展开细节）· <https://arxiv.org/abs/2605.14999>
+- 「Human-AI Agent Interaction in a Business Context」arxiv **2606.18716**（2026-06）：AI agent 的自主/自适应行为带来 trust/safety 设计挑战，给了正向 UX 的原则与度量。
+- **影响 Nomi 哪个决策**：直接支撑记忆里「认知负荷最低是最高原则 / 动效极简披露」——**默认收起、按需展开**有实证支点（设计系统 §1.5 控件层级 L1 常驻 vs L2/L3/L4 的分层正是渐进披露的实现）。做 Agent 样张 v2 时可引这条当「为什么默认不塞满」的依据。列 🟡（是设计决策依据，不是可落地代码）。
+
+### MCP 生态可靠性/安全基准群（工具协议侧的护栏教训）
+- MCPAgentBench arxiv **2512.24565**（真实任务 + 干扰项工具列表，测工具选择/辨别）
+- MCPEvol-Bench arxiv **2607.14642**（2026-07，MCP server **演化**时 agent 掉点：GPT-5.4 -13.7%、Claude-Sonnet-4-6 -14.4%，规划/推理错误激增）· <https://arxiv.org/html/2607.14642>
+- MCP Security Bench arxiv **2510.15994**（MCP 专属漏洞易被利用，10 个 backbone 实验）
+- **影响 Nomi 哪个决策**：我们自己就是 MCP host（nomi_* 工具面）。教训直接对应 2026-08-25 地基审计「手写 MCP 缺取消绑定/运行时校验/版本协商」那笔学费（R20）——**工具面演化会让 agent 掉点**，故工具 schema 变更要当破坏性变更管、加版本协商；干扰项实验提示**工具太多会拉低选择准确率**，与 Agent 界面「一功能一个家、别堆控件」同一根因。列 🟡：不是接哪个 benchmark，是「我们的工具面设计与演化纪律」的外部佐证。
+
+---
+
+## 🔵 对标基准（能拿来量化自评 Nomi）
+
+### DirectorBench（同时是 🟡 教训，见上）
+- **怎么接进 eval 体系**：它的**转场质量分（0-1）**与 **checkpoint 级瓶颈定位**是现成尺子；把我们导出的多镜成片按其 5 维 + 40 checkpoint 打分，能直接量化「Nomi vs SOTA 工作流」且定位是哪一环拉胯。接进 `evals/` 那条生成质量 lane（区别于 UX 冗余 lane）。**待核实**：benchmark 数据/代码是否公开（本轮实抓未见明确 release 链接，接入前先确认可获取性）。
+
+### 多镜评测基准群（选一条锚身份/转场，别全接）
+- MuSS arxiv **2604.23789**（多镜 subject-to-video，电影叙事基准 + 跨镜身份保持指标）
+- MSVBench arxiv **2602.23969** / MSAVBench arxiv **2605.20183**（后者含音视频同步，评 19 个模型，指出「导演级控制 + 细粒度音画同步」仍是难点）
+- EntityBench arxiv **2605.15199**（实体一致长程多镜，频域身份分解 + 训练无关跨镜特征共享）
+- **怎么接进 eval 体系**：这些都能量化「跨镜身份一致」这条 Nomi 命门。**建议先只接一条**（EntityBench 或 MuSS 的身份保持指标）作为身份 lane 的锚，别一次接四个把 eval 变成收件箱。接法：抽其身份保持/叙事连贯指标，接到 `evals/` 生成质量 lane，与 GroundShot 落地形成「同一把尺子量改进」。
+
+---
+
+## 底部
+
+**本轮 vs 上轮（2026-09-01）diff**：
+- 上轮 radar（`2026-09-01-radar.md`）主线是短视频数据 API 评测方向；本轮回到固定方向表的 8 个视频生成/agent 方向。
+- **新出现**：GroundShot（训练无关 agentic 身份记忆，本轮头条，上轮方向表未命中此具体工作）、VQQA/SCMAPR（闭环 prompt 优化落地档）、MCPEvol-Bench（2026-07，MCP 演化掉点，最新一条）。
+- **仍在场/复现**：DirectorBench（decompose-stitch 考卷，转场瓶颈数字更新为 0.256）、ViMax（decompose-stitch 参照）持续是架构对标锚，与 CLAUDE.md「有人在写我们的卷子」判断一致。
+
+**本轮筛掉的噪音（不进正文）**：Multi-Shot Character Consistency（2412，>6 月，过期）、VPO（2508，>6 月）、CameraCtrl/CamTrol（2404-2406，旧但 CamTrol 作为 training-free 备选在 🟡 提了一句）、AniME（2508，>6 月且需重训）、纯数据集/纯画质 SOTA 若与拆镜/身份/转场/评测无直接关联者。共约 6-8 篇。


### PR DESCRIPTION
双雷达日课（2026-09-02, opus）。两份文档，勿合并（供用户过目 + 快照更新决策）。

## 论文雷达 `docs/research/2026-09-02-radar.md`
- **🟢 可落地 3**：GroundShot（2606.20799，训练无关+模型无关的 agentic 跨镜身份记忆+拍摄顺序调度，包 Kling/Vidu/Wan——**本轮头条**，直接对齐拆镜头规划师+character_ref）；VQQA（2603.12310，VLM 批评当语义梯度的闭环 prompt 优化，+11.57%/+8.43%，落 AI 优化节点）；SCMAPR（2604.05489，欠说明输入增益最大）。
- **🟡 架构教训 4**：DirectorBench（转场质量均值仅 0.256=全行业瓶颈）；ShotDirector/ShotVerse（相机+转场控制取向）；HCI 认知负荷+渐进披露（2605.14999，支撑今日 Agent 界面「默认收起」）；MCP 基准群（MCPEvol-Bench 演化掉点 13.7%/14.4%，对应我们 MCP host 演化纪律）。
- **🔵 对标基准**：DirectorBench + 多镜身份/转场基准群（建议先接一条锚身份，别全接）。

## 模型雷达 `docs/research/2026-09-02-model-radar.md`
- **结论：本轮两条 `added` 都不是新东西，无需新接。** apimart `minimax-h3/max` 与 kie `gemini-omni-flash-1-1` **均已有档案**（`MINIMAX_H3_MAX_ARCHETYPE` / `GEMINI_OMNI_11_ARCHETYPE`，identifierPatterns 精确命中）——快照滞后显形。订正 08-31 把 gemini-omni 判为「真缺口」的结论（档案已存在，铁律 7 教训：grep 后再断言缺口）。
- 能力面已按 R5 实抓两家文档页记录（含 apimart H3-Max 定价 $0.075/$0.0495/秒——中转价待一手核）。
- **未跑 `--update-baseline`**（铁律 3，等用户看过本轮差异再更新快照）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)