### PR TITLE
ci: 拆分 22 分钟串行 E2E 大 job，PR 必查轮关键路径砍半

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -109,14 +109,17 @@ jobs:
           NOMI_CHANGED_HEAD: ${{ github.sha }}
         run: pnpm run test:system:focused
 
+  # 2026-09-02 拆班：此前 smoke/journeys/canvas-full/perf 全串在这一个 job 里（实测 ~22.5 分钟，
+  # 整条 PR 轮的关键路径）。现在按风险面拆成三个并行 job：本 job 只留 smoke + journeys + canvas
+  # critical（~5 分钟），canvas full 走 canvas-acceptance 两片 matrix，perf 走 canvas-performance。
+  # 覆盖一条不少：canvas=='full' 时 full 套件本就是 critical 的超集，由 canvas-acceptance 全量跑。
   desktop-linux:
     name: E2E Walkthroughs (Linux)
     needs: scope
     if: >-
       needs.scope.outputs.desktop == 'true' ||
       needs.scope.outputs.journeys == 'true' ||
-      needs.scope.outputs.canvas != 'none' ||
-      needs.scope.outputs.performance == 'true'
+      needs.scope.outputs.canvas == 'critical'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -145,12 +148,6 @@ jobs:
       - name: Critical canvas acceptance
         if: needs.scope.outputs.canvas == 'critical'
         run: xvfb-run -a pnpm run test:canvas:critical
-      - name: Full functional canvas acceptance
-        if: needs.scope.outputs.canvas == 'full'
-        run: xvfb-run -a pnpm run test:canvas:acceptance
-      - name: Canvas performance budget
-        if: needs.scope.outputs.performance == 'true'
-        run: xvfb-run -a pnpm run test:canvas:performance
 
       # 走查证据（截图 + output.jsonl）。win-gate.yml 一直有这步，本 job 却没有——
       # 结果是 ubuntu 这边走查一红就只剩一行「✗ 某某检查」，几何类失败隔着 CI 根本判不了因
@@ -160,6 +157,98 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: linux-walkthrough-evidence
+          path: |
+            evals/runs/**/screenshots/**
+            evals/runs/**/output.jsonl
+            outputs/canvas-acceptance/**
+            outputs/canvas-smoke/**
+            outputs/canvas-card-stack-20260827/**
+            tests/system/runs/**/report.md
+            tests/system/runs/**/summary.json
+            tests/ux/shots/canvas-drag-pan-gestures/**
+            tests/ux/shots/group-ports/**
+            tests/ux/shots/react-flow-read-only/**
+            tests/ux/perf-results/canvas-*.json
+          if-no-files-found: warn
+          retention-days: 7
+
+  # full 功能走查 13 个场景按实测耗时装箱成两片并行跑（分桶清单在 tests/ux/canvas-real-suite.mjs
+  # 的 FULL_CANVAS_SHARDS，漏分/重分/幽灵场景会让两片当场 fail-closed 抛错，场景不可能被静默漏跑）。
+  canvas-acceptance:
+    name: Canvas Acceptance (Linux)
+    needs: scope
+    if: needs.scope.outputs.canvas == 'full'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2]
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - uses: pnpm/action-setup@v6
+        with:
+          version: 10.8.1
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: pnpm
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Build selected desktop surfaces once
+        run: pnpm run build
+      - name: Full functional canvas acceptance
+        run: xvfb-run -a pnpm run test:canvas:acceptance -- --shard ${{ matrix.shard }}/2
+      - name: Upload walkthrough evidence
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: canvas-acceptance-evidence-${{ matrix.shard }}
+          path: |
+            evals/runs/**/screenshots/**
+            evals/runs/**/output.jsonl
+            outputs/canvas-acceptance/**
+            outputs/canvas-smoke/**
+            outputs/canvas-card-stack-20260827/**
+            tests/system/runs/**/report.md
+            tests/system/runs/**/summary.json
+            tests/ux/shots/canvas-drag-pan-gestures/**
+            tests/ux/shots/group-ports/**
+            tests/ux/shots/react-flow-read-only/**
+            tests/ux/perf-results/canvas-*.json
+          if-no-files-found: warn
+          retention-days: 7
+
+  # perf 预算单场景实测 ~763s，是全流水线最长的一根；独立成 job 后它只拖自己，
+  # 不再把 smoke/journeys/canvas 走查压在同一根串行棒上。预算与校准（仪器）一字未动。
+  canvas-performance:
+    name: Canvas Performance (Linux)
+    needs: scope
+    if: needs.scope.outputs.performance == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - uses: pnpm/action-setup@v6
+        with:
+          version: 10.8.1
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: pnpm
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Build selected desktop surfaces once
+        run: pnpm run build
+      - name: Canvas performance budget
+        run: xvfb-run -a pnpm run test:canvas:performance
+      - name: Upload walkthrough evidence
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: canvas-performance-evidence
           path: |
             evals/runs/**/screenshots/**
             evals/runs/**/output.jsonl
@@ -199,7 +288,7 @@ jobs:
 
   quality:
     name: Quality Gate
-    needs: [scope, contracts, unit, desktop-linux, mac-package]
+    needs: [scope, contracts, unit, desktop-linux, canvas-acceptance, canvas-performance, mac-package]
     if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:
@@ -230,9 +319,14 @@ jobs:
           test "${{ needs.unit.result }}" = "success"
           if [ "${{ needs.scope.outputs.desktop }}" = "true" ] || \
              [ "${{ needs.scope.outputs.journeys }}" = "true" ] || \
-             [ "${{ needs.scope.outputs.canvas }}" != "none" ] || \
-             [ "${{ needs.scope.outputs.performance }}" = "true" ]; then
+             [ "${{ needs.scope.outputs.canvas }}" = "critical" ]; then
             test "${{ needs['desktop-linux'].result }}" = "success"
+          fi
+          if [ "${{ needs.scope.outputs.canvas }}" = "full" ]; then
+            test "${{ needs['canvas-acceptance'].result }}" = "success"
+          fi
+          if [ "${{ needs.scope.outputs.performance }}" = "true" ]; then
+            test "${{ needs['canvas-performance'].result }}" = "success"
           fi
           if [ "${{ needs.scope.outputs.package }}" = "true" ]; then
             test "${{ needs['mac-package'].result }}" = "success"

--- a/docs/fixes/2026-09-02-quality-gate-e2e-walkthrough-sharding.root-cause.json
+++ b/docs/fixes/2026-09-02-quality-gate-e2e-walkthrough-sharding.root-cause.json
@@ -1,0 +1,115 @@
+{
+  "schema_version": 3,
+  "id": "2026-09-02-quality-gate-e2e-walkthrough-sharding",
+  "problem_type": "CI wall-clock regression by serial accretion",
+  "symptom": "Every PR round that selects desktop/journey/canvas/performance surfaces takes 22-25 minutes end to end, and on a 16-merge day the serial wall clock plus runner queueing became the largest loss in the whole delivery flow. Job timing over the last full-lane runs shows E2E Walkthroughs (Linux) at 1333-1370s while every other job finishes under 300s.",
+  "direct_cause": "quality-gate.yml ran five independent test surfaces (Electron smoke ~32s, CI journeys ~158s + MCP handshake ~7s, full canvas acceptance ~325s, canvas performance budget ~763s) serially inside the single desktop-linux job, so the job's duration was the sum, not the max, of its surfaces.",
+  "class_root": "The workflow had exactly one Linux walkthrough job, so every new heavyweight surface added over time was appended as another serial step in that job - the path of least resistance. Nothing structurally forced independent risk surfaces into parallel jobs, and nothing made a scenario-to-shard partition verifiable, so splitting was never safe to attempt and the critical path only ever grew.",
+  "affected_population": [
+    "every pull request, main push, and merge-group build whose scope selects desktop, journeys, canvas, or performance surfaces (the 22-25 minute rounds observed on 2026-09-02)",
+    "every future author adding a walkthrough surface, who would otherwise append it serially to the same job and grow the critical path again"
+  ],
+  "scope_paths": [
+    ".github/workflows/quality-gate.yml",
+    "scripts/check-quality-gate-workflow.node-test.mjs",
+    "tests/ux/canvas-real-suite.mjs",
+    "tests/ux/canvas-real-suite.test.mjs"
+  ],
+  "entry_points": [
+    "pull request rounds and main pushes selecting desktop/journey/canvas/performance surfaces",
+    "merge_group builds and workflow_dispatch full-validation runs (same job graph)"
+  ],
+  "internal_only_reason": "CI topology change fully determined by the workflow file, its shape-guard test, and the canvas suite runner; no external API or vendor behaviour is involved.",
+  "structural_guarantee": "scripts/check-quality-gate-workflow.node-test.mjs pins the parallel topology byte-for-byte: desktop-linux may only run smoke/journeys/critical-canvas (full acceptance and performance steps are asserted absent), canvas-acceptance must be a fail-fast:false [1,2] shard matrix with the exact shard command, canvas-performance must run the untouched instrument command in its own job, and the Quality Gate aggregation must require each selected surface's job result individually. tests/ux/canvas-real-suite.mjs assertFullCanvasShardPartition makes every CI shard throw before running anything if a full-profile scenario is missing from, duplicated in, or unknown to the shard partition, so a scenario can never be silently dropped by the split.",
+  "verification": [
+    "pnpm run check:quality-gate-workflow passes 34/34 with the new topology pinned",
+    "npx vitest run tests/ux/canvas-real-suite.test.mjs passes 10/10 including partition-drift fail-closed cases",
+    "PR round on this branch shows desktop-linux and both canvas-acceptance shards running in parallel with end-to-end wall time recorded in the PR body before/after table",
+    "workflow_dispatch full-validation run on this branch exercises canvas-performance and mac-package on the new graph"
+  ],
+  "regression_tests": [
+    "scripts/check-quality-gate-workflow.node-test.mjs",
+    "tests/ux/canvas-real-suite.test.mjs"
+  ],
+  "residual_risks": [
+    "The canvas performance budget remains a single ~763s scenario and is now the longest lane (~14.5 min end to end) on performance-selected rounds; splitting the benchmark itself means touching the calibrated instrument (PERFORMANCE_BUDGETS) and is deliberately out of scope here.",
+    "Three extra runner slots per full round (two acceptance shards + performance job setup, ~78s each) add mild queue pressure at peak; per-run wall time drops far more than the added slot time, so runs vacate slots sooner overall.",
+    "Shard balance (162.5s vs 162.9s, measured from run 33609025386) will drift as scenarios change; drift degrades balance only, never coverage, because the partition assertion is about membership, not timing."
+  ],
+  "recurrence": {
+    "classification": "recurring",
+    "reason": "Serial accretion is the default failure mode of a single walkthrough job: the next heavyweight surface would again be appended as one more step unless the guard pins which surfaces each job may run and the shard partition fails closed on unassigned scenarios.",
+    "same_class_scan": [
+      "quality-gate.yml job audit (2026-09-02): desktop-linux was the only multi-surface serial job (5 surfaces, 1285s of serial test time); contracts/unit/mac-package each run one surface family and finish under 300s, no further split has payoff.",
+      "win-gate.yml runs walkthroughs serially too, but it is an optional non-required surface off the merge critical path; not converted, revisit only if it joins the required set.",
+      "tests/ux/canvas-real-suite.mjs full profile (13 scenarios, 325s serial) was the largest intra-step serial block; it now carries the shard partition with a runtime fail-closed completeness assertion."
+    ]
+  },
+  "legacy_paths": {
+    "status": "not-applicable",
+    "removed_paths": [],
+    "rationale": "The serial full-acceptance and performance steps were deleted from desktop-linux in the same commit that adds the parallel jobs (no parallel-version survives; the guard test asserts the old steps are absent), and no file path was removed."
+  },
+  "dependency_lifecycle": {
+    "decision": "not-applicable",
+    "rationale": "No dependency added, upgraded, or removed; the change is confined to workflow YAML, its shape-guard test, and the canvas suite runner's shard selection.",
+    "exit_criteria": []
+  },
+  "same_class_entry_points": [
+    {
+      "path": ".github/workflows/quality-gate.yml",
+      "entry_point": "desktop-linux serial accretion of walkthrough surfaces",
+      "disposition": "enforced",
+      "evidence": "Guard test asserts 'Full functional canvas acceptance' and 'Canvas performance budget' steps are absent from desktop-linux and pins the canvas-acceptance shard matrix and canvas-performance job with their exact commands."
+    },
+    {
+      "path": "tests/ux/canvas-real-suite.mjs",
+      "entry_point": "full-profile scenario list growth without shard assignment",
+      "disposition": "enforced",
+      "evidence": "assertFullCanvasShardPartition throws on missing/unknown/duplicated ids before any scenario runs, and tests/ux/canvas-real-suite.test.mjs proves the drift case fails closed."
+    },
+    {
+      "path": ".github/workflows/win-gate.yml",
+      "entry_point": "windows walkthrough lane",
+      "disposition": "not-affected",
+      "evidence": "Optional surface outside the required-check set (Quality Gate, Mac Package); it never gates merges, so its serial layout is off the critical path by construction."
+    }
+  ],
+  "prevention": {
+    "kind": "static-gate",
+    "enforcement_path": "scripts/check-quality-gate-workflow.node-test.mjs",
+    "invariant": "Independent walkthrough risk surfaces (smoke+journeys+critical canvas, full canvas shards, performance budget) run in parallel jobs whose exact commands, selection conditions, and per-surface Quality Gate aggregation are pinned; the full-canvas shard partition must cover every scenario exactly once or every shard fails closed.",
+    "failure_mode": "Re-appending a heavyweight surface to desktop-linux, dropping a shard, changing shard counts without the partition, or un-anchoring a surface from the Quality Gate aggregation fails the Contracts job until the guard is consciously co-updated; an unassigned new scenario turns both CI shards red at startup.",
+    "exception_policy": "none",
+    "strategy": "Keep one job per independent risk surface; when a new walkthrough surface lands, give it its own conditional job (or shard bucket) plus a pinned aggregation clause in the same commit, and rebalance shard buckets from measured summary.json durations.",
+    "artifacts": [
+      ".github/workflows/quality-gate.yml",
+      "scripts/check-quality-gate-workflow.node-test.mjs",
+      "tests/ux/canvas-real-suite.mjs"
+    ]
+  },
+  "class_regression_tests": [
+    "scripts/check-quality-gate-workflow.node-test.mjs",
+    "tests/ux/canvas-real-suite.test.mjs"
+  ],
+  "generality_proof": "Class = 'required-check wall time grows because independent surfaces accrete serially inside one CI job'. Scanned every job in quality-gate.yml with per-step timings from runs 33609025386/33595409350/33595402457/33608529936: desktop-linux was the only multi-surface serial job (sum 1285s vs max-surface 763s); contracts (~200s), unit (~260s), and mac-package (~260s) are single-surface and cannot pay for a split. After the change each surface family owns one parallel job, the aggregation requires each selected surface individually, and the guard test plus the fail-closed shard partition prevent both re-accretion and silent coverage loss - so the class, not just today's instance, is closed on the required path.",
+  "shared_boundaries": [
+    {
+      "path": "scripts/check-quality-gate-workflow.node-test.mjs",
+      "symbol": "quality gate workflow shape guard (node --test)",
+      "responsibility": "Pins the parallel job topology, per-job commands, shard matrix, and per-surface Quality Gate aggregation; the Contracts job fails on any unconscious edit."
+    },
+    {
+      "path": "tests/ux/canvas-real-suite.mjs",
+      "symbol": "assertFullCanvasShardPartition / FULL_CANVAS_SHARDS",
+      "responsibility": "Single source of truth for the full-profile shard partition; throws before running anything when a scenario is unassigned, duplicated, or unknown, so CI shards fail closed instead of under-covering."
+    }
+  ],
+  "migration": "No persisted data or consumer migration. Required check names (Quality Gate, Mac Package) and their semantics are unchanged; branch protection needs no edit. Evidence artifacts split by job (linux-walkthrough-evidence keeps its name; canvas-acceptance-evidence-1/2 and canvas-performance-evidence are new), and full-profile shard runs write summary.json under outputs/canvas-acceptance/full-<i>of<n>/ while unsharded local runs keep outputs/canvas-acceptance/full/.",
+  "invariants": [
+    "Every scenario in FULL_CANVAS_SCENARIOS runs in exactly one CI shard, or every shard fails closed before running anything.",
+    "The exact test commands for every surface (smoke, journeys, MCP handshake, critical canvas, full canvas, performance, package) are preserved; no test was removed or weakened by the split.",
+    "Required checks remain exactly 'Quality Gate' and 'Mac Package', and Quality Gate turns green only when every risk-selected surface job succeeded.",
+    "The workflow file and its shape guard change together or the Contracts job fails."
+  ]
+}

--- a/scripts/check-quality-gate-workflow.node-test.mjs
+++ b/scripts/check-quality-gate-workflow.node-test.mjs
@@ -6,6 +6,7 @@ import { fileURLToPath } from 'node:url'
 import { load } from 'js-yaml'
 
 import { PROFILES, STAGES } from '../tests/system/profiles.mjs'
+import { assertFullCanvasShardPartition, FULL_CANVAS_SHARDS } from '../tests/ux/canvas-real-suite.mjs'
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
 const workflow = load(fs.readFileSync(path.join(repoRoot, '.github/workflows/quality-gate.yml'), 'utf8'))
@@ -67,9 +68,9 @@ test('quality gate uses Node 24-native actions without a forced runtime shim', (
     (job) => job.steps?.flatMap((step) => (typeof step.uses === 'string' ? [step.uses] : [])) ?? [],
   )
 
-  assert.equal(actionUses.filter((uses) => uses === 'actions/checkout@v7').length, 6)
-  assert.equal(actionUses.filter((uses) => uses === 'pnpm/action-setup@v6').length, 4)
-  assert.equal(actionUses.filter((uses) => uses === 'actions/setup-node@v7').length, 5)
+  assert.equal(actionUses.filter((uses) => uses === 'actions/checkout@v7').length, 8)
+  assert.equal(actionUses.filter((uses) => uses === 'pnpm/action-setup@v6').length, 6)
+  assert.equal(actionUses.filter((uses) => uses === 'actions/setup-node@v7').length, 7)
   assert.ok(actionUses.includes('actions/upload-artifact@v7'))
   assert.ok(actionUses.every((uses) => !/@v4$/.test(uses)))
   for (const job of Object.values(workflow.jobs)) {
@@ -97,10 +98,13 @@ test('contracts always run and unit alone chooses focused or full coverage', () 
   assert.equal(focused.run, 'pnpm run test:system:focused')
 })
 
-test('Linux builds once and runs only selected desktop, journey, canvas, and performance surfaces', () => {
+test('Linux walkthrough job builds once and keeps only smoke, journey, and critical canvas surfaces', () => {
   const desktop = workflow.jobs['desktop-linux']
   assert.equal(desktop.needs, 'scope')
-  for (const output of ['desktop', 'journeys', 'canvas', 'performance']) assert.match(desktop.if, new RegExp(output))
+  assert.equal(
+    desktop.if,
+    "needs.scope.outputs.desktop == 'true' || needs.scope.outputs.journeys == 'true' || needs.scope.outputs.canvas == 'critical'",
+  )
 
   const selectedSteps = Object.fromEntries(
     desktop.steps.filter((step) => step.name && step.run).map((step) => [step.name, step]),
@@ -112,23 +116,60 @@ test('Linux builds once and runs only selected desktop, journey, canvas, and per
       selectedSteps['CI-safe user journeys'].run,
       selectedSteps['MCP L1 handshake journey'].run,
       selectedSteps['Critical canvas acceptance'].run,
-      selectedSteps['Full functional canvas acceptance'].run,
-      selectedSteps['Canvas performance budget'].run,
     ],
     [
       'xvfb-run -a pnpm run test:e2e',
       'xvfb-run -a pnpm run test:journeys',
       'xvfb-run -a pnpm run test:mcp-journey',
       'xvfb-run -a pnpm run test:canvas:critical',
-      'xvfb-run -a pnpm run test:canvas:acceptance',
-      'xvfb-run -a pnpm run test:canvas:performance',
     ],
   )
+  assert.equal(selectedSteps['Electron smoke'].if, "needs.scope.outputs.desktop == 'true'")
+  assert.equal(selectedSteps['CI-safe user journeys'].if, "needs.scope.outputs.journeys == 'true'")
+  assert.equal(selectedSteps['MCP L1 handshake journey'].if, "needs.scope.outputs.journeys == 'true'")
+  assert.equal(selectedSteps['Critical canvas acceptance'].if, "needs.scope.outputs.canvas == 'critical'")
   assert.equal(runCommands(desktop).filter((command) => command === 'pnpm run build').length, 1)
+  // full/performance 面已拆到并行 job；本 job 不得再串行执行它们（那是 22 分钟关键路径的根因）。
+  assert.equal(selectedSteps['Full functional canvas acceptance'], undefined)
+  assert.equal(selectedSteps['Canvas performance budget'], undefined)
 
   const evidence = desktop.steps.find((step) => step.uses === 'actions/upload-artifact@v7')
   assert.equal(evidence.if, 'always()')
+  assert.equal(evidence.with.name, 'linux-walkthrough-evidence')
   assert.match(evidence.with.path, /outputs\/canvas-acceptance\/\*\*/)
+})
+
+test('full canvas acceptance runs as a fail-closed two-shard matrix that partitions every scenario', () => {
+  const acceptance = workflow.jobs['canvas-acceptance']
+  assert.equal(acceptance.needs, 'scope')
+  assert.equal(acceptance.if, "needs.scope.outputs.canvas == 'full'")
+  assert.deepEqual(acceptance.strategy, { 'fail-fast': false, matrix: { shard: [1, 2] } })
+  assert.equal(FULL_CANVAS_SHARDS.length, 2)
+  assert.doesNotThrow(() => assertFullCanvasShardPartition())
+
+  const commands = runCommands(acceptance)
+  assert.ok(commands.includes('xvfb-run -a pnpm run test:canvas:acceptance -- --shard ${{ matrix.shard }}/2'))
+  assert.equal(commands.filter((command) => command === 'pnpm run build').length, 1)
+
+  const evidence = acceptance.steps.find((step) => step.uses === 'actions/upload-artifact@v7')
+  assert.equal(evidence.if, 'always()')
+  assert.equal(evidence.with.name, 'canvas-acceptance-evidence-${{ matrix.shard }}')
+  assert.match(evidence.with.path, /outputs\/canvas-acceptance\/\*\*/)
+})
+
+test('canvas performance budget runs as its own parallel job with an untouched instrument command', () => {
+  const performance = workflow.jobs['canvas-performance']
+  assert.equal(performance.needs, 'scope')
+  assert.equal(performance.if, "needs.scope.outputs.performance == 'true'")
+  assert.equal(performance.strategy, undefined)
+
+  const commands = runCommands(performance)
+  assert.ok(commands.includes('xvfb-run -a pnpm run test:canvas:performance'))
+  assert.equal(commands.filter((command) => command === 'pnpm run build').length, 1)
+
+  const evidence = performance.steps.find((step) => step.uses === 'actions/upload-artifact@v7')
+  assert.equal(evidence.if, 'always()')
+  assert.equal(evidence.with.name, 'canvas-performance-evidence')
   assert.match(evidence.with.path, /tests\/ux\/perf-results\/canvas-\*\.json/)
 })
 
@@ -177,7 +218,15 @@ test('package scripts expose canonical separated profiles and classifier contrac
 
 test('Quality Gate requires mandatory jobs and every risk-selected optional surface', () => {
   const quality = workflow.jobs.quality
-  assert.deepEqual(quality.needs, ['scope', 'contracts', 'unit', 'desktop-linux', 'mac-package'])
+  assert.deepEqual(quality.needs, [
+    'scope',
+    'contracts',
+    'unit',
+    'desktop-linux',
+    'canvas-acceptance',
+    'canvas-performance',
+    'mac-package',
+  ])
   assert.equal(quality.if, '${{ always() }}')
   assert.equal(quality.name, 'Quality Gate')
 
@@ -198,6 +247,12 @@ test('Quality Gate requires mandatory jobs and every risk-selected optional surf
   for (const output of ['desktop', 'journeys', 'canvas', 'performance', 'package']) {
     assert.match(command, new RegExp(`needs\\.scope\\.outputs\\.${output}`))
   }
+  // 每个风险面独立聚合：full 走查、perf 预算拆成并行 job 后仍必须逐面要求 success，
+  // 不允许出现「面被选中但结果没人验」的缺口（canvas 的 critical/full 两档分别锚到两个 job）。
+  assert.match(command, /"\$\{\{ needs\.scope\.outputs\.canvas \}\}" = "critical"/)
+  assert.match(command, /"\$\{\{ needs\.scope\.outputs\.canvas \}\}" = "full"/)
   assert.match(command, /needs\['desktop-linux'\]\.result/)
+  assert.match(command, /needs\['canvas-acceptance'\]\.result/)
+  assert.match(command, /needs\['canvas-performance'\]\.result/)
   assert.match(command, /needs\['mac-package'\]\.result/)
 })

--- a/tests/ux/canvas-real-suite.mjs
+++ b/tests/ux/canvas-real-suite.mjs
@@ -198,6 +198,10 @@ export function parseCanvasSuiteArgv(argv) {
   const [profile = 'critical', ...rest] = argv
   let shard = null
   for (let index = 0; index < rest.length; index += 1) {
+    // npm 吃掉 `--` 分隔符，pnpm 会原样转发（CI 实测：`pnpm run … -- --shard 1/2`
+    // 到达脚本时是 `full -- --shard 1/2`）。按 CLI 惯例把独立的 `--` 当作
+    // 选项结束符跳过；其余未知参数照旧 fail-closed。
+    if (rest[index] === '--') continue
     if (rest[index] === '--shard') {
       shard = parseCanvasShard(rest[index + 1])
       index += 1

--- a/tests/ux/canvas-real-suite.mjs
+++ b/tests/ux/canvas-real-suite.mjs
@@ -37,9 +37,55 @@ export const PERFORMANCE_CANVAS_SCENARIOS = [
   },
 ]
 
-export function scenariosForProfile(profile) {
+// CI 把 full 档拆成两个并行 runner 跑（quality-gate.yml 的 canvas-acceptance matrix）。
+// 分桶按 2026-09-02 run 33609025386 实测耗时做 LPT 装箱：shard1≈162.5s、shard2≈162.9s。
+// 桶是显式清单而不是 index 取模：新场景加进 FULL_CANVAS_SCENARIOS 却没分桶时，
+// 每个 shard 启动即 fail-closed 抛错（见 assertFullCanvasShardPartition），场景不可能被静默漏跑。
+export const FULL_CANVAS_SHARDS = Object.freeze([
+  Object.freeze(['gestures', 'read-only-reload', 'blank-context-menu', 'group-baseline', 'group-reference-direction', 'canvas-reconcile']),
+  Object.freeze(['group-ports', 'card-stack-persistence', 'shortcuts', 'node-context-menu', 'batch-production', 'selection-toolbar', 'canvas-landing']),
+])
+
+export function assertFullCanvasShardPartition(scenarios = FULL_CANVAS_SCENARIOS, shards = FULL_CANVAS_SHARDS) {
+  const assigned = shards.flat()
+  const assignedSet = new Set(assigned)
+  const scenarioIds = scenarios.map((scenario) => scenario.id)
+  const scenarioIdSet = new Set(scenarioIds)
+  const duplicated = assigned.filter((id, index) => assigned.indexOf(id) !== index)
+  const unknown = assigned.filter((id) => !scenarioIdSet.has(id))
+  const missing = scenarioIds.filter((id) => !assignedSet.has(id))
+  if (duplicated.length || unknown.length || missing.length) {
+    throw new Error(
+      `full canvas shard partition is broken: `
+        + `missing=[${missing.join(', ')}] unknown=[${unknown.join(', ')}] duplicated=[${duplicated.join(', ')}]. `
+        + `Every FULL_CANVAS_SCENARIOS id must appear in exactly one FULL_CANVAS_SHARDS bucket.`,
+    )
+  }
+}
+
+export function parseCanvasShard(spec) {
+  const match = /^([0-9]+)\/([0-9]+)$/.exec(String(spec ?? ''))
+  if (!match) throw new Error(`invalid canvas shard spec: ${JSON.stringify(spec)} (expected <index>/<total>, e.g. 1/2)`)
+  const index = Number(match[1])
+  const total = Number(match[2])
+  if (total !== FULL_CANVAS_SHARDS.length) {
+    throw new Error(`canvas shard total ${total} does not match FULL_CANVAS_SHARDS (${FULL_CANVAS_SHARDS.length})`)
+  }
+  if (index < 1 || index > total) throw new Error(`canvas shard index ${index} out of range 1..${total}`)
+  return { index, total }
+}
+
+export function scenariosForProfile(profile, { shard } = {}) {
+  if (shard && profile !== 'full') {
+    throw new Error(`canvas shard is only supported for the full profile, not: ${profile}`)
+  }
   if (profile === 'critical') return CRITICAL_CANVAS_SCENARIOS
-  if (profile === 'full') return FULL_CANVAS_SCENARIOS
+  if (profile === 'full') {
+    if (!shard) return FULL_CANVAS_SCENARIOS
+    assertFullCanvasShardPartition()
+    const bucket = new Set(FULL_CANVAS_SHARDS[shard.index - 1])
+    return FULL_CANVAS_SCENARIOS.filter((scenario) => bucket.has(scenario.id))
+  }
   if (profile === 'performance') return PERFORMANCE_CANVAS_SCENARIOS
   throw new Error(`unknown canvas suite profile: ${profile}`)
 }
@@ -124,31 +170,49 @@ export function runCanvasScenario(scenario, {
   }
 }
 
-export function runCanvasSuite(profile, { cwd = repoRoot, env = process.env } = {}) {
-  const outputDir = path.join(cwd, 'outputs', 'canvas-acceptance', profile)
+export function runCanvasSuite(profile, { cwd = repoRoot, env = process.env, shard = null } = {}) {
+  const suiteLabel = shard ? `${profile} ${shard.index}/${shard.total}` : profile
+  const outputName = shard ? `${profile}-${shard.index}of${shard.total}` : profile
+  const outputDir = path.join(cwd, 'outputs', 'canvas-acceptance', outputName)
   fs.rmSync(outputDir, { recursive: true, force: true })
   fs.mkdirSync(outputDir, { recursive: true })
   const results = []
 
-  for (const scenario of scenariosForProfile(profile)) {
-    console.log(`\n[canvas:${profile}] ${scenario.id}`)
+  for (const scenario of scenariosForProfile(profile, { shard })) {
+    console.log(`\n[canvas:${suiteLabel}] ${scenario.id}`)
     results.push(runCanvasScenario(scenario, { cwd, env, outputDir }))
   }
 
   const summary = {
     profile,
+    shard: shard ? `${shard.index}/${shard.total}` : null,
     passed: results.filter((result) => result.exitCode === 0).length,
     failed: results.filter((result) => result.exitCode !== 0).length,
     results,
   }
   fs.writeFileSync(path.join(outputDir, 'summary.json'), JSON.stringify(summary, null, 2))
-  return summary
+  return { ...summary, suiteLabel }
+}
+
+export function parseCanvasSuiteArgv(argv) {
+  const [profile = 'critical', ...rest] = argv
+  let shard = null
+  for (let index = 0; index < rest.length; index += 1) {
+    if (rest[index] === '--shard') {
+      shard = parseCanvasShard(rest[index + 1])
+      index += 1
+      continue
+    }
+    throw new Error(`unknown canvas suite argument: ${rest[index]}`)
+  }
+  return { profile, shard }
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {
   try {
-    const summary = runCanvasSuite(process.argv[2] || 'critical')
-    console.log(`\ncanvas-${summary.profile}: ${summary.failed === 0 ? 'PASS' : 'FAIL'} (${summary.passed}/${summary.results.length})`)
+    const { profile, shard } = parseCanvasSuiteArgv(process.argv.slice(2))
+    const summary = runCanvasSuite(profile, { shard })
+    console.log(`\ncanvas-${summary.suiteLabel}: ${summary.failed === 0 ? 'PASS' : 'FAIL'} (${summary.passed}/${summary.results.length})`)
     process.exit(summary.failed === 0 ? 0 : 1)
   } catch (error) {
     console.error(error instanceof Error ? error.message : String(error))

--- a/tests/ux/canvas-real-suite.test.mjs
+++ b/tests/ux/canvas-real-suite.test.mjs
@@ -73,6 +73,8 @@ describe('real canvas acceptance suite', () => {
     expect(() => scenariosForProfile('critical', { shard: { index: 1, total: 2 } })).toThrow('only supported for the full profile')
     expect(() => scenariosForProfile('performance', { shard: { index: 1, total: 2 } })).toThrow('only supported for the full profile')
     expect(parseCanvasSuiteArgv(['full', '--shard', '1/2'])).toEqual({ profile: 'full', shard: { index: 1, total: 2 } })
+    // pnpm 会把 `--` 分隔符原样转发给脚本（CI 实际到达的 argv 形状），npm 则吃掉它；两种都必须可解析。
+    expect(parseCanvasSuiteArgv(['full', '--', '--shard', '2/2'])).toEqual({ profile: 'full', shard: { index: 2, total: 2 } })
     expect(parseCanvasSuiteArgv(['critical'])).toEqual({ profile: 'critical', shard: null })
     expect(() => parseCanvasSuiteArgv(['full', '--shards', '1/2'])).toThrow('unknown canvas suite argument')
   })

--- a/tests/ux/canvas-real-suite.test.mjs
+++ b/tests/ux/canvas-real-suite.test.mjs
@@ -3,9 +3,13 @@ import os from 'node:os'
 import path from 'node:path'
 import { describe, expect, it } from 'vitest'
 import {
+  assertFullCanvasShardPartition,
   CRITICAL_CANVAS_SCENARIOS,
   DEFAULT_CANVAS_SCENARIO_TIMEOUT_MS,
   FULL_CANVAS_SCENARIOS,
+  FULL_CANVAS_SHARDS,
+  parseCanvasShard,
+  parseCanvasSuiteArgv,
   PERFORMANCE_CANVAS_SCENARIOS,
   PERFORMANCE_CANVAS_SCENARIO_TIMEOUT_MS,
   runCanvasScenario,
@@ -30,6 +34,47 @@ describe('real canvas acceptance suite', () => {
 
   it('fails closed for unknown profiles', () => {
     expect(() => scenariosForProfile('typo')).toThrow('unknown canvas suite profile')
+  })
+
+  it('partitions every full scenario into exactly one CI shard, in canonical order', () => {
+    expect(() => assertFullCanvasShardPartition()).not.toThrow()
+
+    const fullIds = FULL_CANVAS_SCENARIOS.map((scenario) => scenario.id)
+    const shardedIds = FULL_CANVAS_SHARDS.map((_, index) =>
+      scenariosForProfile('full', { shard: { index: index + 1, total: FULL_CANVAS_SHARDS.length } })
+        .map((scenario) => scenario.id),
+    )
+
+    expect(shardedIds.flat().toSorted()).toEqual(fullIds.toSorted())
+    for (const ids of shardedIds) {
+      expect(ids.length).toBeGreaterThan(0)
+      expect(fullIds.filter((id) => ids.includes(id))).toEqual(ids)
+    }
+  })
+
+  it('fails closed when a full scenario is left out of the shard partition', () => {
+    const drifted = [...FULL_CANVAS_SCENARIOS, { id: 'brand-new-walkthrough', script: 'tests/ux/new.walk.mjs' }]
+    expect(() => assertFullCanvasShardPartition(drifted)).toThrow(/missing=\[brand-new-walkthrough\]/)
+    expect(() => assertFullCanvasShardPartition(FULL_CANVAS_SCENARIOS, [['gestures'], ['gestures']])).toThrow(/duplicated=\[gestures\]/)
+    expect(() => assertFullCanvasShardPartition(FULL_CANVAS_SCENARIOS, FULL_CANVAS_SHARDS.map((ids) => [...ids, 'ghost']))).toThrow(/unknown=\[ghost/)
+  })
+
+  it('parses only well-formed shard specs matching the declared shard count', () => {
+    expect(parseCanvasShard('1/2')).toEqual({ index: 1, total: 2 })
+    expect(parseCanvasShard('2/2')).toEqual({ index: 2, total: 2 })
+    expect(() => parseCanvasShard('0/2')).toThrow('out of range')
+    expect(() => parseCanvasShard('3/2')).toThrow('out of range')
+    expect(() => parseCanvasShard('1/3')).toThrow('does not match FULL_CANVAS_SHARDS')
+    expect(() => parseCanvasShard('half')).toThrow('invalid canvas shard spec')
+    expect(() => parseCanvasShard(undefined)).toThrow('invalid canvas shard spec')
+  })
+
+  it('rejects sharding for non-full profiles and unknown CLI arguments', () => {
+    expect(() => scenariosForProfile('critical', { shard: { index: 1, total: 2 } })).toThrow('only supported for the full profile')
+    expect(() => scenariosForProfile('performance', { shard: { index: 1, total: 2 } })).toThrow('only supported for the full profile')
+    expect(parseCanvasSuiteArgv(['full', '--shard', '1/2'])).toEqual({ profile: 'full', shard: { index: 1, total: 2 } })
+    expect(parseCanvasSuiteArgv(['critical'])).toEqual({ profile: 'critical', shard: null })
+    expect(() => parseCanvasSuiteArgv(['full', '--shards', '1/2'])).toThrow('unknown canvas suite argument')
   })
 
   it('keeps performance separate from functional full acceptance with its own bounded budget', () => {


### PR DESCRIPTION
## CI 提速：把 22 分钟的串行 E2E 大 job 拆成三班并行

今天 16 次合并、每轮 20-25 分钟、高峰排队 40+ 分钟——剖析最近 4 个 full-lane 运行（33609025386 / 33595409350 / 33595402457 / 33608529936），关键路径不是缓存也不是排队，是 **desktop-linux 一个 job 把五个独立测试面串行跑成 22.5 分钟**。

### 剖析：before（4 个 full-lane run 的中位数）

| Job | 中位耗时 | 排队 |
|---|---|---|
| Validation Scope | 18s | 1-3s |
| Contracts | 200s | 1-3s |
| Unit | 235s | 1-3s |
| **E2E Walkthroughs (Linux)** | **1353s（22.5 min）← 关键路径** | 1-3s |
| Mac Package | 258s | 2-3s |
| Quality Gate（汇总） | 14s | 1-3s |
| **端到端墙钟** | **23.1–24.3 min** | |

E2E job 内部（串行的和 = 关键路径）：setup+install ~33s · build 40s · smoke 32s · journeys 158s · MCP 握手 7s · **canvas full 走查 325s（13 场景）** · **canvas perf 预算 764s（单场景）**。

缓存审计结论：pnpm store 已热（install 6-8s）、无 Playwright 浏览器下载、build 仅 40s——**没有可砍的缓存刀**，唯一的刀是拆并行。

### 施工：三刀

1. **desktop-linux 只留 smoke + journeys + MCP + canvas critical**（~4.5 min）——不再串 full/perf。
2. **canvas full 13 场景按实测耗时 LPT 装箱成 2 片 matrix 并行**（shard1 162.5s / shard2 162.9s，各 ~4 min）。分桶是显式清单（`FULL_CANVAS_SHARDS`），新场景漏分桶时**两片启动即 fail-closed 抛错**——场景不可能被静默漏跑（附 vitest 漂移用例证明）。
3. **canvas perf 预算独立成 job**（~14 min）——它只拖自己，不再压着其它走查。预算/校准（仪器）一字未动。

### 覆盖红线（一条没删）

- 每个面的测试命令逐字保留；full ⊇ critical，canvas=full 时由 shard 全量跑。
- required checks 名字不变：`Quality Gate` + `Mac Package`；汇总 job 逐面要求被选中面 success（canvas critical/full 两档分别锚到两个 job）。
- 守卫测试同 commit 共改：`check-quality-gate-workflow.node-test.mjs` 34/34，锚死并行拓扑 + 禁止串行回潮（断言 full/perf 步骤不得再出现在 desktop-linux）。
- 高风险 workflow 改动配完整 v3 根因契约：`docs/fixes/2026-09-02-quality-gate-e2e-walkthrough-sharding.root-cause.json`。

### 预测 after（本 PR 实测数字见下方更新）

| 车道 | before | after |
|---|---|---|
| full lane（perf+package，今天的 23 分钟轮） | 23.1–24.3 min | ~14.5 min（封顶 = perf 单场景 764s，仪器不动砍不动） |
| validation-infra / 非 perf full 轮 | ~10.5 min | ~5 min |
| journeys/desktop 轮 | ~5.5 min | ~5.5 min（不变） |
| docs-only 轮 | ~3.5 min | ~3.5 min（不变） |

### 没动的刀 + 理由

- **perf benchmark 内部拆分**：单场景 764s 是新封顶，但它是校准过的仪器（PERFORMANCE_BUDGETS，darwin 校准 / xvfb 1.3-2x 教训，#243/#239 假回归），拆它=另立校准工程，不属于本刀。
- **缓存**：已热，无可省。
- **Mac Package 条件化**：已按 PACKAGE_PATTERNS 条件化，docs-only 本就跳过。
- **win-gate.yml 串行走查**：非 required、不在合并关键路径。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## 实测 after（commit d232cc15，两轮真跑）

**PR 必查轮**（[run 33620501155](https://github.com/aqm857886159/Nomi/actions/runs/33620501155)，validation-infra 档：unit full + smoke/journeys/MCP + canvas full 双片）：**端到端 5m23s，全绿**。
Scope 15s · Contracts 203s · Unit 283s · E2E 282s · Shard1 246s · Shard2 243s（LPT 装箱兑现：两片差 3s）· Quality 16s。同档 before 按实测步长合成 ≈10.5 min → **-49%**。

**Full lane**（[dispatch 33620505937](https://github.com/aqm857886159/Nomi/actions/runs/33620505937)，全面开：perf+package）：**墙钟 14m43s**，全部测试面绿：Perf 842s（长杆，符合预测）· Mac Package 231s · E2E 285s · Shard 266s/244s · Unit 281s。对比今天 4 个 full-lane run 的 23.1–24.3 min → **-37%**。
（该 dispatch 轮 Contracts 红是 dispatch 车道固有旧性质、与本改动无关：`base_ref=origin/main` 解析到 runner 上**当前** main 尖，16 连并日里分支落后于 main，反向 diff 把别人 PR 的高风险文件（`scripts/root-cause-contracts.mjs`，本 diff 未碰）卷进了根因合同门。PR 车道用 PR base sha，不受影响、已全绿。）

**首轮 fail-closed 实弹验证**（run 33619208510）：pnpm 10 原样转发 `--` 分隔符，两片启动 1s 内响亮报红而不是静默错跑——分片防线按设计工作；根修在参数解析层（d232cc15），npm/pnpm/直接 node 三种入口统一。
