### PR TITLE
fix(mcp): 技能资源 e2e 接进执行链并改为 derive——它此前从没跑过

### DIFF
--- a/docs/fixes/2026-09-02-unwired-stale-skill-resource-test.root-cause.json
+++ b/docs/fixes/2026-09-02-unwired-stale-skill-resource-test.root-cause.json
@@ -1,0 +1,103 @@
+{
+  "schema_version": 3,
+  "id": "2026-09-02-unwired-stale-skill-resource-test",
+  "problem_type": "A test that no runner executes claims coverage it never provided, and its hand-copied floor assertion hides that it never ran",
+  "symptom": "tests/ux/mcp-skills-integration.e2e.mjs 里写着 `assert(list.resources.length >= 20)`，被登记为「技能资源面的手抄下限，技能目录一收束就会重演落后」。实查后发现更根本的问题：**它根本没在跑**——全仓对该文件的引用只有它自己的头注释（「用法：pnpm run build && node tests/ux/...」），不在 package.json、不在 tests/system/profiles.mjs、不在任何 workflow、也不被任何 glob 拉起。同时它的断言已按面收敛前的形态过期：期望裸 uri `nomi-skill://director-cinematography`（现已内容寻址为 `nomi-skill://<dir>/<packageVersion>/<contentHash>`），文件头还写着「23 个技能」而仓内实际捆绑 33 个。",
+  "direct_cause": "该文件被当作「手动跑的集成测试」写下并留在 tests/ux 下，从未接进任何套件；此后 MCP 面收敛（#359）与技能资源内容寻址 cutover 都没有触及它，因为没有任何门岗会执行它。",
+  "class_root": "验证资产的存在不等于验证在发生。一份从不执行的测试是**负资产**：它在目录里、在代码搜索里、在 review 时都表现得像覆盖，于是抑制了别人补真覆盖的动机，而它自身对任何回归的检出力是零。这与 2026-09-02 的另外两次是同一族——门岗与它要守的真相源脱钩：那两次是「断言手抄了派生值」和「守它的 job 不由真相源触发」，这次是更极端的一档：**根本没有任何 job 会触发它**。`>= 20` 这类手抄下限进一步掩盖了这一点——它永远不会红，所以「一直绿」和「从来没跑」在观感上无法区分。",
+  "generality_proof": "判据可机械化：tests/ 下的可执行 e2e 入口（有 main/顶层执行且带 .e2e.mjs 后缀）必须被至少一个 package.json script 或 profile 引用，否则它提供的是覆盖的外观而非覆盖本身。本次实查发现该目录下同族文件 mcp-l1-handshake.e2e.mjs 被 package.json 的 test:mcp-journey 引用并因此在面收敛时被正确更新——同一目录、同一形态、同一次收敛，一个跟上一个没跟上，差别只在是否被某个 script 引用。",
+  "affected_population": [
+    "依赖 MCP resources/prompts 面（技能库对外暴露）的用户：该面的 list/read/渐进披露/未知资源报错在收敛后从未被真实验证过",
+    "读代码判断覆盖度的人：该文件的存在让「技能资源面有集成测试」看起来成立，实际为零检出力，抑制了补真覆盖的动机",
+    "后续任何修改技能可见性或资源 uri 形态的贡献者：没有任何门岗会因他们的改动而红"
+  ],
+  "scope_paths": [
+    "tests/ux/mcp-skills-integration.e2e.mjs",
+    "package.json"
+  ],
+  "entry_points": [
+    "pnpm run test:mcp-journey（本次把该 e2e 接入的入口，与 MCP 面同触发面）",
+    "MCP stdio 服务的 resources/list、resources/read、prompts/list 三个方法",
+    "electron/skills/skillStore.ts 的 listSkillSummariesForMcp（技能可见集合的产品侧真相）"
+  ],
+  "invariants": [
+    "签名客户端下，resources/list 暴露的 nomi-skill:// 资源集合，必须与仓内 skills/ 下带 SKILL.md 的目录集合完全相等——期望值从目录 derive，不是手抄的数量下限。",
+    "resources/list 里的非技能资源必须恰为 live-draft widget 一条，使「资源总数」不再是一个没人能解释的数字。",
+    "技能正文必须按 resources/list 返回的内容寻址 uri 读取，不得依赖收敛前的裸 uri。",
+    "该 e2e 必须被 package.json 的 test:mcp-journey 引用，与 MCP 面同触发面执行；未被任何 script 引用的 e2e 等于不存在。"
+  ],
+  "regression_tests": [
+    "tests/ux/mcp-skills-integration.e2e.mjs"
+  ],
+  "class_regression_tests": [
+    "tests/ux/mcp-skills-integration.e2e.mjs"
+  ],
+  "shared_boundaries": [
+    {
+      "path": "package.json",
+      "symbol": "test:mcp-journey",
+      "responsibility": "MCP 面 e2e 的唯一执行入口。技能资源面与协议握手面都挂在这里，从而与 MCP 源码改动同触发面；新增 MCP 面 e2e 必须从这里接入，否则不会被执行。"
+    }
+  ],
+  "same_class_entry_points": [
+    {
+      "path": "tests/ux/mcp-skills-integration.e2e.mjs",
+      "entry_point": "技能资源面 e2e（本次修复对象）",
+      "disposition": "enforced",
+      "evidence": "已接入 test:mcp-journey 并对真 stdio 服务实跑通过：10 条断言全绿，`resources/list 恰好暴露仓内全部 33 个技能（集合相等，非手抄下限）`。R17 反向对照已实跑：往期望集合里塞一个不存在的技能名，断言立刻红并精确输出「缺少 [zzz-skill-that-should-not-exist]」，还原后转绿——证明该断言非空转。"
+    },
+    {
+      "path": "tests/ux/mcp-l1-handshake.e2e.mjs",
+      "entry_point": "同目录同形态的 MCP 协议握手 e2e",
+      "disposition": "not-affected",
+      "evidence": "实查 package.json：它已被 test:mcp-journey 引用，因此在 #359 面收敛时被正确更新（文件内可见 `面收敛：nomi_add_nodes → nomi_canvas_edit` 等迁移注释）。它构成本次类根因判断的对照组——同一目录、同一形态、同一次收敛，被引用的跟上了，没被引用的落后了。"
+    },
+    {
+      "path": "tests/ux/packaged-mcp-smoke.e2e.mjs",
+      "entry_point": "打包后 MCP smoke（技能资源面的另一处覆盖）",
+      "disposition": "not-affected",
+      "evidence": "已由 dist:mac:dir 引用并在 2026-09-02-stale-hand-copied-surface-baseline 一轮中迁移到收敛后的面并实跑通过。它覆盖签名/未签名两支的技能可见性，与本文件覆盖的 prompts/list 命名、渐进披露、未知资源报错互补而不重复，故两者都保留。"
+    }
+  ],
+  "prevention": {
+    "kind": "centralized-boundary",
+    "enforcement_path": "package.json",
+    "invariant": "MCP 面的 e2e 全部经 test:mcp-journey 执行；该 script 是 MCP 面 e2e 的唯一入口，因此「写了但没接」在这里可见。",
+    "failure_mode": "违反时，e2e 文件留在 tests/ux 下但没有任何 runner 执行它：它看起来像覆盖、搜索得到、review 时被当作已有保障，实际检出力为零；配上 `>= N` 这类永不变红的手抄下限，「一直绿」与「从来没跑」在观感上无法区分，回归可以无限期潜伏。",
+    "strategy": "把该 e2e 接入 test:mcp-journey，使其与 MCP 面同触发面执行；同时把它的期望集合从仓内 skills/ 目录 derive、把资源读取改为按返回的内容寻址 uri，使它在被执行之后确实具备检出力，而不是被接进来之后变成一个恒绿的摆设。",
+    "exception_policy": "none",
+    "artifacts": [
+      "package.json",
+      "tests/ux/mcp-skills-integration.e2e.mjs"
+    ]
+  },
+  "residual_risks": [
+    "本轮把「未被引用的 e2e」这一类的防护落在 test:mcp-journey 这个集中入口上，而不是新增一个「扫 tests/ 下所有 e2e 是否被引用」的静态门岗。后者能覆盖全仓，但需要先判定哪些文件是可执行入口、哪些是被 import 的 helper 或 fixture，误判成本高；本轮刻意不造这个轮子（R20），代价是其它目录若再出现未接线的 e2e 仍需人工发现。",
+    "期望集合按「skills/ 下带 SKILL.md 的目录」derive。若将来技能来源扩展（例如从远端拉取或用户安装目录参与 MCP 暴露），该 derive 会与实际不符而误红。当前 spawnMcpStdioClient 使用隔离的 settings/capability 目录，用户技能不参与，故成立；来源扩展时需同步改这里的真相源。",
+    "该 e2e 需要 dist-electron 构建产物（assertBuilt），因此只能在 journey 触发面执行，无法下沉到 contracts 阶段。这意味着纯 MCP 源码改动仍要等 journey 面才会红，而不是 contracts 面——本轮不改这一层，因为它需要 Electron 真进程，无法在不构建的前提下跑。"
+  ],
+  "recurrence": {
+    "classification": "recurring",
+    "reason": "同族在 2026-09-02 一天内出现第三次：交付账本的全局聚合计数、quality-gate 的并发分组键、packaged smoke 的手抄工具面下限，本次是同族里最极端的一档——门岗与真相源不只是触发面错位，而是根本没有任何 job 会触发它。且它具备结构性防护（把 MCP 面 e2e 收敛到 test:mcp-journey 这个唯一入口），故按 recurring 提交。",
+    "same_class_scan": [
+      "对 tests/ux/mcp-skills-integration.e2e.mjs 做全仓引用反查（grep 全树，排除 node_modules/.git）：命中仅为它自己的头注释与本轮之前写下的根因合同引用，无任何 script/profile/workflow 引用；对照 mcp-l1-handshake.e2e.mjs 则命中 package.json:104 的 test:mcp-journey。据此确认「未接线」而非「接线了但没触发」。",
+      "排除 glob 拉起的可能：检查 package.json、tests/system/profiles.mjs、scripts/*.mjs 与 quality-gate.yml 中所有涉及 tests/ux 的写法，e2e 均为逐文件显式调用，无通配批量执行；check-walkthroughs.mjs 虽扫 189 份走查，但它是静态质量检查、不执行测试。",
+      "实测该文件除了手抄下限外还有两处按收敛前形态写的断言（裸 uri 读取、未签名身份却期望内部创作技能），进一步证明它长期未被执行——若跑过，这两处会立刻红。",
+      "R17 反向对照已实跑：往期望集合塞入不存在的技能名 → 断言红并精确指名；还原 → 10 条全绿。另对身份校验做过一次对照，发现伪造 proof 时服务直接拒绝启动（'A verified MCP client connection is required'），说明该 stdio 入口强制要求已验证客户端，故未签名分支不由本测试覆盖，而由 packaged smoke 的 external 分支覆盖。"
+    ]
+  },
+  "internal_only_reason": "本修复完全位于仓库内部的测试接线与断言，不涉及外部 API 或第三方文档契约。所依据的事实（引用关系、技能目录内容、资源 uri 形态、身份校验行为）均直接在本仓实测取得，并以真 Electron stdio 进程实跑验证。",
+  "legacy_paths": {
+    "status": "removed",
+    "removed_paths": [
+      "tests/ux/mcp-skills-integration.e2e.mjs"
+    ],
+    "rationale": "旧路径即该文件中手抄的 `resources.length >= 20` 下限、按收敛前形态写的裸 uri 读取、以及自建的一套 spawn/rpc 管道。三者在同一 commit 内被删除：下限由与 skills/ 目录集合相等的断言取代，裸 uri 由按 resources/list 返回的内容寻址 uri 读取取代，自建管道由共享的 _mcpJourney.mjs helper 取代（该 helper 的基础 env 已自带已验证客户端身份，故不再自行 seed 一遍，避免并行版）。文件本身保留并接入执行链。"
+    },
+  "dependency_lifecycle": {
+    "decision": "not-applicable",
+    "rationale": "本修复不涉及任何依赖版本或运行时生命周期变更，只改动一份 e2e 的断言与其在 package.json 中的接线。",
+    "exit_criteria": []
+  },
+  "migration": "无数据迁移。test:mcp-journey 现在依次执行协议握手与技能资源两份 e2e，两者共用同一份隔离目录与已验证客户端身份 helper，运行时间增加约一次 Electron 冷启动。该 script 属 journey 触发面，按 scripts/validation-policy.mjs 在 MCP 与 Electron 相关改动时被选中，因此技能资源面的回归此后会与 MCP 改动同批次暴露，不再等到无关 PR。"
+}

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "postinstall": "node ./scripts/install-electron-runtime.mjs && node ./scripts/install-git-hooks.cjs && node ./scripts/install-claude-hooks.cjs",
     "test:e2e": "pnpm run check:electron-install && node tests/ux/smoke.e2e.mjs",
     "test:mcp": "pnpm run check:electron-install && node tests/ux/mcp-journey.e2e.mjs",
-    "test:mcp-journey": "pnpm run check:electron-install && node tests/ux/mcp-l1-handshake.e2e.mjs",
+    "test:mcp-journey": "pnpm run check:electron-install && node tests/ux/mcp-l1-handshake.e2e.mjs && node tests/ux/mcp-skills-integration.e2e.mjs",
     "test:model-integration:no-repo": "node tests/ux/model-integration-no-repo.mjs",
     "test:model-integration:packaged": "node tests/ux/model-integration-packaged.e2e.mjs",
     "test:model-integration:trusted-audio": "node tests/ux/model-integration-trusted-audio.e2e.mjs",

--- a/tests/ux/mcp-skills-integration.e2e.mjs
+++ b/tests/ux/mcp-skills-integration.e2e.mjs
@@ -1,99 +1,123 @@
-// P3#1 真集成测试（闭之前只有 mock 单测的缺口）：起真 MCP stdio 服务（app 自身二进制 + NOMI_MCP_STDIO=1，
-// = Claude Code/Codex/WorkBuddy 拉起它的真路径），像外部 agent 那样发 JSON-RPC，验真 skillStore 把 23 个
-// 导演/编剧技能经 resources + prompts 真的 list/read 出来。零生成额度（只读技能，不碰模型/项目）。
-// 用法：pnpm run build && node tests/ux/mcp-skills-integration.e2e.mjs
-import { spawn } from "node:child_process";
-import { mkdtempSync } from "node:fs";
-import os from "node:os";
-import readline from "node:readline";
-import path from "node:path";
-import { fileURLToPath } from "node:url";
-import { createRequire } from "node:module";
-import { withLinuxNoSandbox } from "./_launchApp.mjs";
+// 真集成测试：起真 MCP stdio 服务（app 自身二进制 + NOMI_MCP_STDIO=1，= Claude Code / Codex 拉起它的
+// 真路径），像外部 agent 那样发 JSON-RPC，验真 skillStore 把仓内技能经 resources + prompts 真的
+// list/read 出来。零生成额度（只读技能，不碰模型/项目）。
+//
+// 2026-09-02 重写（docs/fixes/2026-09-02-unwired-stale-skill-resource-test.root-cause.json）。修之前它有两个毛病：
+//
+// 1. **从没跑过。** 全仓只有它自己的头注释引用它——不在 package.json、不在 tests/system/profiles.mjs、
+//    不在任何 workflow。于是它一边在文件里写着「验真 skillStore」，一边对任何回归零检出力；
+//    而 `resources.length >= 20` 这种手抄下限连「有没有在跑」都掩盖了。现已挂进 test:mcp-journey，
+//    与 MCP 面同触发面。
+// 2. **断言已过期。** 它按面收敛前的形态写：期望裸 uri `nomi-skill://director-cinematography`
+//    （现已内容寻址成 `nomi-skill://<dir>/<packageVersion>/<contentHash>`），且以未签名身份却期望拿到
+//    内部创作技能（未签名 host 只能看 audience:"mcp" 的公开子集）。
+//
+// 现在：签名身份（local-authenticated → 全量目录），期望集合从**仓内 skills/ 目录 derive**，
+// 不再手抄数量。签名客户端没有 audience 过滤，所以这里不存在「在测试里重抄一份可见性规则」的风险。
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import {
+  assertBuilt,
+  makeIsolatedDirs,
+  repoRoot,
+  spawnMcpStdioClient,
+} from './_mcpJourney.mjs'
 
-const require = createRequire(import.meta.url);
-const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
-// 隔离 settings 目录 → stdio 服务读不到用户真 app 的 lockfile → 走 headless dispatch（本仓新代码），
-// 而不是把 skills.list 转发给用户正在运行的旧构建（那会报「未知方法」）。技能仍从仓内 skills/ 加载。
-const tempSettings = mkdtempSync(path.join(os.tmpdir(), "nomi-mcp-it-"));
+const SKILL_URI_PREFIX = 'nomi-skill://'
+const UI_RESOURCE_URI = 'ui://nomi/live-draft.html'
 
-let passed = 0;
-function assert(cond, label) {
-  if (!cond) { console.log(`  ✗ ${label}`); throw new Error(`FAIL: ${label}`); }
-  passed += 1;
-  console.log(`  ✓ ${label}`);
+/** 真相源：仓内 skills/ 下每个带 SKILL.md 的目录。签名客户端应当一个不少地拿到它们。 */
+function bundledSkillDirectories() {
+  const skillsDir = path.join(repoRoot, 'skills')
+  return fs.readdirSync(skillsDir, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory() && fs.existsSync(path.join(skillsDir, entry.name, 'SKILL.md')))
+    .map((entry) => entry.name)
+    .sort()
 }
 
-// 起真 MCP stdio 服务（dev：electron 二进制 + args=[repoRoot] + NOMI_MCP_STDIO=1，见 mcpConfig.ts）。
-const child = spawn(require("electron"), withLinuxNoSandbox([repoRoot, "--disable-gpu"]), {
-  cwd: repoRoot,
-  // NOMI_CAPABILITY_DIR 隔离能力核 lockfile（否则探到用户运行中的真 app → 把 skills.list 转发给旧构建报错）。
-  env: { ...process.env, NOMI_MCP_STDIO: "1", NOMI_SETTINGS_DIR: tempSettings, NOMI_ELECTRON_USER_DATA_DIR: tempSettings, NOMI_CAPABILITY_DIR: path.join(tempSettings, "capability-core") },
-  stdio: ["pipe", "pipe", "inherit"],
-});
+let passed = 0
+function check(condition, label) {
+  if (!condition) throw new Error(`MCP-SKILLS FAIL: ${label}`)
+  passed += 1
+  console.log(`  ✓ ${label}`)
+}
 
-const pending = new Map();
-let seq = 0;
-const rl = readline.createInterface({ input: child.stdout });
-rl.on("line", (line) => {
-  const t = line.trim();
-  if (!t.startsWith("{")) return; // 非 JSON 行（启动杂质）忽略
-  let msg;
-  try { msg = JSON.parse(t); } catch { return; }
-  if (msg.id != null && pending.has(msg.id)) {
-    const { resolve, timer } = pending.get(msg.id);
-    clearTimeout(timer);
-    pending.delete(msg.id);
-    resolve(msg);
+async function main() {
+  assertBuilt()
+  const dirs = makeIsolatedDirs('nomi-mcp-skills-')
+  // spawnMcpStdioClient 的基础 env 本身就带一份已验证的客户端身份（见 _mcpJourney.mjs 的
+  // seedMcpClientIdentityEnv，默认 'claude'），因此这里**不再自己 seed 一遍**——重复注入等于并行版。
+  // 签名身份 → mcpSkillAccess() 判为 local-authenticated → 拿到全量创作技能目录（无 audience 过滤，
+  // 所以本测试不需要、也不应该在测试里重抄一份可见性规则）。
+  const mcp = spawnMcpStdioClient({
+    ...dirs,
+    clientInfo: { name: 'Nomi MCP skills integration', version: '1.0.0' },
+    capabilities: {},
+  })
+
+  try {
+    const init = await mcp.rpc('initialize', {
+      protocolVersion: '2025-11-25',
+      capabilities: {},
+      clientInfo: { name: 'Nomi MCP skills integration', version: '1.0.0' },
+    }, 30_000)
+    check(Boolean(init.result), 'initialize 有响应（MCP stdio 服务起来了）')
+    const caps = init.result.capabilities || {}
+    check(Boolean(caps.tools && caps.resources && caps.prompts), '广告 tools + resources + prompts 能力')
+
+    const resources = (await mcp.rpc('resources/list', {}, 30_000)).result?.resources || []
+    const skillResources = resources.filter((resource) => String(resource.uri).startsWith(SKILL_URI_PREFIX))
+
+    // 内容寻址后 uri 形如 nomi-skill://<dir>/<packageVersion>/<contentHash>，取首段即目录名。
+    const listedDirectories = [...new Set(
+      skillResources.map((resource) => String(resource.uri).slice(SKILL_URI_PREFIX.length).split('/')[0]),
+    )].sort()
+    const expectedDirectories = bundledSkillDirectories()
+    assert.deepEqual(
+      listedDirectories,
+      expectedDirectories,
+      `resources/list 的技能集合与仓内 skills/ 不一致：`
+        + `多出 [${listedDirectories.filter((name) => !expectedDirectories.includes(name)).join(', ')}]，`
+        + `缺少 [${expectedDirectories.filter((name) => !listedDirectories.includes(name)).join(', ')}]`,
+    )
+    check(true, `resources/list 恰好暴露仓内全部 ${expectedDirectories.length} 个技能（集合相等，非手抄下限）`)
+
+    // 非技能资源只有 MCP Apps 的 widget 一条——显式钉住，免得「资源总数」将来又变成一个没人解释的数字。
+    const otherResources = resources.filter((resource) => !String(resource.uri).startsWith(SKILL_URI_PREFIX))
+    assert.deepEqual(otherResources.map((resource) => resource.uri), [UI_RESOURCE_URI],
+      'resources/list 的非技能资源应当只有 live-draft widget')
+    check(true, '非技能资源恰为 live-draft widget 一条')
+
+    const cinematography = skillResources.find(
+      (resource) => String(resource.uri).startsWith(`${SKILL_URI_PREFIX}director-cinematography/`),
+    )
+    check(Boolean(cinematography), '含 director-cinematography 资源（内容寻址 uri）')
+    check(
+      cinematography.name === 'director.cinematography' && (cinematography.description || '').length > 5,
+      '资源带 name + 非空 description',
+    )
+    // 渐进披露：list 只给索引，正文要另外 read。
+    check(cinematography.text === undefined && cinematography.body === undefined, 'resources/list 不含正文（渐进披露）')
+
+    const read = (await mcp.rpc('resources/read', { uri: cinematography.uri }, 30_000)).result
+    const text = read?.contents?.[0]?.text || ''
+    check(text.length > 1_000 && text.includes('镜头'), 'resources/read 按返回的 uri 载入真实技能正文')
+
+    const prompts = (await mcp.rpc('prompts/list', {}, 30_000)).result
+    const promptNames = (prompts?.prompts || []).map((prompt) => prompt.name)
+    check(promptNames.includes('director-cinematography'), 'prompts/list 用 directoryName 当命令名（斜杠友好）')
+
+    const badRead = await mcp.rpc('resources/read', { uri: `${SKILL_URI_PREFIX}nope-nonexistent` }, 30_000)
+    check(Boolean(badRead.error), '未知技能资源回 error')
+
+    console.log(`\nMCP-SKILLS-INTEGRATION PASS: ${passed} assertions（真 stdio 服务 · 真 skillStore · 零生成额度）`)
+  } finally {
+    await mcp.terminate()
   }
-});
-
-function rpc(method, params, timeoutMs = 30000) {
-  const id = (seq += 1);
-  return new Promise((resolve, reject) => {
-    const timer = setTimeout(() => { pending.delete(id); reject(new Error(`RPC 超时: ${method}`)); }, timeoutMs);
-    pending.set(id, { resolve, timer });
-    child.stdin.write(JSON.stringify({ jsonrpc: "2.0", id, method, params }) + "\n");
-  });
 }
 
-try {
-  // 起服务要点时间（app.whenReady → startMcpStdioServer）。initialize 自带重试等它就绪。
-  let init = null;
-  for (let i = 0; i < 20 && !init; i++) {
-    try { init = await rpc("initialize", { protocolVersion: "2025-11-25", capabilities: {} }, 4000); }
-    catch { await new Promise((r) => setTimeout(r, 1000)); }
-  }
-  assert(init && init.result, "initialize 有响应（MCP stdio 服务起来了）");
-  const caps = init.result.capabilities || {};
-  assert(caps.tools && caps.resources && caps.prompts, "广告 tools + resources + prompts 能力");
-
-  const list = (await rpc("resources/list", {})).result;
-  const uris = (list.resources || []).map((r) => r.uri);
-  assert(list.resources.length >= 20, `resources/list 返回 ≥20 技能（实=${list.resources.length}）`);
-  assert(uris.includes("nomi-skill://director-cinematography"), "含 director-cinematography 资源");
-  assert(uris.includes("nomi-skill://writer-dialogue"), "含 writer-dialogue 资源");
-  const cin = list.resources.find((r) => r.uri === "nomi-skill://director-cinematography");
-  assert(cin && cin.name === "director.cinematography" && (cin.description || "").length > 5, "资源带 name + 非空 description");
-  // 渐进披露：list 不含正文
-  assert(cin && cin.text === undefined && cin.body === undefined, "resources/list 不含正文（渐进披露）");
-
-  const read = (await rpc("resources/read", { uri: "nomi-skill://director-shot-translation" })).result;
-  const text = read.contents?.[0]?.text || "";
-  assert(text.includes("运镜") || text.includes("翻译") || text.length > 200, "resources/read 载入真实技能正文");
-
-  const prompts = (await rpc("prompts/list", {})).result;
-  const pnames = (prompts.prompts || []).map((p) => p.name);
-  assert(pnames.includes("director-cinematography"), "prompts/list 用 directoryName 当命令名（斜杠友好）");
-
-  const badRead = await rpc("resources/read", { uri: "nomi-skill://nope-nonexistent" });
-  assert(badRead.error, "未知技能资源回 error");
-
-  console.log(`\nMCP-SKILLS-INTEGRATION PASS: ${passed} assertions（真 stdio 服务 · 真 skillStore · 零生成额度）`);
-  child.kill("SIGTERM");
-  setTimeout(() => process.exit(0), 300);
-} catch (err) {
-  console.log(`✗ ${err?.message || err}`);
-  child.kill("SIGTERM");
-  setTimeout(() => process.exit(1), 300);
-}
+main().catch((error) => {
+  console.error(error instanceof Error ? error.stack || error.message : String(error))
+  process.exitCode = 1
+})


### PR DESCRIPTION
## 本来要修的，和实际发现的

上一轮把 `tests/ux/mcp-skills-integration.e2e.mjs` 的 `resources.length >= 20` 登记为「手抄下限，技能面一收束就会重演落后」。

实查后发现更根本的问题：**这个测试根本没在跑。**

全仓对它的引用只有它自己的头注释（「用法：手动跑」）——不在 `package.json`、不在 `tests/system/profiles.mjs`、不在任何 workflow、也不被 glob 拉起。它一边在文件里写着「验真 skillStore」，一边对任何回归**零检出力**。

## 类根因

> **验证资产的存在 ≠ 验证在发生。**

一份从不执行的测试是**负资产**：它在目录里、在代码搜索里、在 review 时都表现得像覆盖，于是**抑制了别人补真覆盖的动机**，而它自身检出力为零。

`>= 20` 这种永不变红的手抄下限进一步掩盖了它——**「一直绿」和「从来没跑」在观感上无法区分。**

这是 09-02 同族的第三次，也是最极端的一档：前两次是「断言手抄派生值」和「守它的 job 不由真相源触发」，这次是**根本没有任何 job 会触发它**。

### 对照组

同目录、同形态的 `mcp-l1-handshake.e2e.mjs` 被 `test:mcp-journey` 引用，因此在 [#359](https://github.com/aqm857886159/Nomi/pull/359) 面收敛时**被正确更新**（文件里能看到迁移注释）。

**同一次收敛，被引用的跟上了，没被引用的落后了。**

它确实已过期两处（真跑过就会立刻红）：期望裸 uri `nomi-skill://director-cinematography`（现已内容寻址成 `<dir>/<packageVersion>/<contentHash>`），以及以未签名身份却期望拿到内部创作技能。头注释还写着「23 个技能」，仓内实际捆绑 33 个。

## 改动

| | |
|---|---|
| **接进 `test:mcp-journey`** | 与 MCP 面同触发面，不再是孤儿 |
| 期望集合 | `>= 20` → **从仓内 `skills/` 目录 derive**，集合相等（实测恰好 33 个）|
| 非技能资源 | 显式钉为 `ui://nomi/live-draft.html` 一条，让「资源总数 34」不再是个没人解释的数字 |
| 技能正文 | 按 `resources/list` 返回的内容寻址 uri 读取 |
| 管道 | 自建 spawn/rpc → 共享 `_mcpJourney.mjs` helper；该 helper 基础 env **已自带**已验证身份，故不再自己 seed 一遍（去并行版）|

签名客户端**没有 audience 过滤**，所以这里不需要、也不该在测试里重抄一份可见性规则——那正是上一轮合同要治的病。

## 验证

- **真 Electron stdio 实跑**：10 条断言全绿
  ```
  ✓ resources/list 恰好暴露仓内全部 33 个技能（集合相等，非手抄下限）
  ✓ 非技能资源恰为 live-draft widget 一条
  ✓ resources/read 按返回的 uri 载入真实技能正文
  MCP-SKILLS-INTEGRATION PASS: 10 assertions
  ```
- **R17 反向对照**：往期望集合塞一个不存在的技能名 → 断言红并精确输出 `缺少 [zzz-skill-that-should-not-exist]`；还原后转绿 → 证明非空转
- 另一次对照顺带查明：伪造 proof 时服务**直接拒绝启动**（`A verified MCP client connection is required`），说明该 stdio 入口强制要求已验证客户端；未签名分支由 packaged smoke 的 external 支覆盖，两者互补不重复
- `pnpm run gates` 全门通过；根因合同经完整 recurring 规则强制校验 `ok: true`

## 保留的判断

没有新造「扫全仓 e2e 是否被引用」的静态门岗（R20）：要先判定哪些文件是可执行入口、哪些是被 import 的 helper/fixture，误判成本高。本轮把防护落在 `test:mcp-journey` 这个集中入口上，代价与理由已写进合同 `residual_risks`。

根因合同：`docs/fixes/2026-09-02-unwired-stale-skill-resource-test.root-cause.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)