### PR TITLE
test(ux): fix download write-race in walk/e2e byte assertions

### DIFF
--- a/tests/ux/canvas-card-stack.walk.mjs
+++ b/tests/ux/canvas-card-stack.walk.mjs
@@ -192,7 +192,7 @@ try {
   const imageDownloadButton = tray.locator('[data-result-stack-item="image-v1"] button[aria-label="下载这一版"]')
   check('历史图片提供下载入口', await imageDownloadButton.isEnabled())
   await clickOrFail(imageDownloadButton, '下载历史图片')
-  await expect.poll(() => fs.existsSync(downloadPath), { message: '下载桥接应写出历史图片文件', timeout: 10_000 }).toBe(true)
+  await expect.poll(() => fs.existsSync(downloadPath) && fs.statSync(downloadPath).size > 0, { message: '下载桥接应写出非空历史图片文件', timeout: 10_000 }).toBe(true)
   check('历史图片下载文件非空', fs.statSync(downloadPath).size > 0)
 
   const deleteRow = tray.locator('[data-result-stack-item="image-v2"]')

--- a/tests/ux/model3d-asset-library.e2e.mjs
+++ b/tests/ux/model3d-asset-library.e2e.mjs
@@ -4,6 +4,8 @@ import os from 'node:os'
 import path from 'node:path'
 import { createRequire } from 'node:module'
 
+import { expect } from '@playwright/test'
+
 import { launchNomiApp, repoRoot } from './_launchApp.mjs'
 import { seedFinishedJourneyProject } from './fixtures/journey-project-fixture.mjs'
 
@@ -179,6 +181,16 @@ try {
       .find((item) => /下载 GLB|Download GLB/.test(item.getAttribute('aria-label') || ''))
     return Boolean(button && !button.disabled)
   })
+  // The desktop bridge streams the GLB to disk: the file appears (0 bytes) before its bytes finish
+  // flushing, so gate the byte checks on the download having fully landed — size matches the managed
+  // source asset — otherwise readFileSync races a half-written file on slow CI (same write race as
+  // canvas-card-stack's history-image download).
+  await expect
+    .poll(() => (fs.existsSync(downloadPath) ? fs.statSync(downloadPath).size : -1), {
+      message: 'GLB 下载桥接应写出与受管资产等长的完整文件',
+      timeout: 10_000,
+    })
+    .toBe(fs.statSync(storedModel).size)
   check(fs.existsSync(downloadPath), 'download button saves a GLB through the desktop bridge')
   check(sha256(fs.readFileSync(downloadPath)) === sha256(fs.readFileSync(storedModel)), 'downloaded GLB bytes match the managed asset')
 


### PR DESCRIPTION
## 竞态机制（一句）

桌面「另存」桥接把字节**流式**写盘：目标文件先以 0 字节出现，内容随后落盘。两处下载断言只 poll「文件存在」，下一行立刻断言 size>0 / 读全量字节做 SHA 比对——本机瞬时永远绿，CI 慢机器撞上「已创建、未写完」窗口 → 间歇红（今天 canvas 分片(2) 连红，堵 main 解冻钥匙 PR #364）。

## 根因

poll 的就绪判据（exists）与其后断言真正需要的条件（字节已写完）脱钩。把「非空/等长」这个就绪条件移进 poll 本身，其后的最终断言此时必稳。

## 全仓同类清单（P2 通用性）

`grep -rn existsSync tests/ux/*.walk.mjs tests/ux/*.e2e.mjs` 逐个看后随断言；只有两处 `showSaveDialog` 下载桥接把「等待」和「立即读字节」配对，即本族：

| file:line | 原写法 | 修法 |
|---|---|---|
| `tests/ux/canvas-card-stack.walk.mjs:195` | `expect.poll(exists)` → 下一行 `statSync().size>0` | poll 改成 `exists && size>0` |
| `tests/ux/model3d-asset-library.e2e.mjs:182` | 等待只 gate 在「下载按钮重新可用」，随后 `readFileSync` 做 SHA 比对 | 在字节断言前加 `expect.poll(size === 受管资产 size)` |

其余 `existsSync` 命中均为守卫（`if !existsSync`）或读一个**阻塞式工具调用已持久化**的文件（如 `mcp-journey.e2e.mjs:307` step h 重读一个已 `succeeded` 的 generate 结果）——不在流式写窗口内，跳过。

## 为何只 CI 红

字节 flush 与文件创建之间的窗口在快盘/静态机上是微秒级，本机单跑必落在窗口后；CI 慢机（xvfb 软渲染 + 并行负载）把这个窗口放大到 >poll 首次采样，于是「文件在、size=0」被采到 → 断言红。属「单跑绿、CI 偶发红」一族。

## 验证

- 两处均用 Playwright `expect.poll`（无手写墙钟 `Date.now()` 截止轮询），`check:test-waits` 保持硬零。
- `pnpm run gates` 全过（exit 0）：gates:contracts 全绿 + 完整 vitest（1107 文件 / 10343 tests 通过）+ build。
- `canvas-card-stack` 走查在安静时段完整跑通、所有 check 全绿（含被改的下载断言）；后续复跑在本机 100% 磁盘 + load 30 下于**其它无关步骤**间歇失败（166 截图 ENOSPC / 204 删除托盘 / 326 展开组），均在下载断言 195 之后，为环境负载放大所致，非本改动。

改的是走查/e2e 测试代码，非产品代码。