### PR TITLE
fix(archetypes): 补齐最后两处不诚实的能力面——提案面板模式栏 + 变体轴按供应商收窄

### DIFF
--- a/docs/fixes/2026-09-02-vendor-honest-axes-followup.root-cause.json
+++ b/docs/fixes/2026-09-02-vendor-honest-axes-followup.root-cause.json
@@ -1,0 +1,138 @@
+{
+  "schema_version": 3,
+  "id": "2026-09-02-vendor-honest-axes-followup",
+  "problem_type": "供应商诚实的能力轴只收窄了「一个面 × 两条轴」：Agent 提案面板的模式选择器没接收窄判据，变体选择器则四条轴里唯一没被收窄的一条——档案声明的能力照样展示给一个根本兑现不了它的供应商",
+  "symptom": "① Agent 提案面板（GenerationProposalEditor）的模式选择器把档案声明的**全部**模式列出来，包括这家供应商压根没有 mapping 的那些；用户在提案里选中它、点生成，才被第三闸拒——与画布模式栏修好前是同一个病，只是换了个面。② Runway 的 Veo 3.1 节点显示「变体 · 快速」下拉并可切到「高质 / 轻量」，但 Runway 的 mapping 把 model 写成字面量 veo3.1，切变体只写 meta.archetype.variantId、既不改发出去的 model 串、又没有 paramOverrides——控件完全惰性，点了什么都不会发生。",
+  "direct_cause": "① 收窄机制（archetypeModeChoices 的 bodyForMode 形参）上一轮只接进了画布的 NodeParameterControls，提案面板仍以单参数调用 archetypeModeChoices(archetype)，看着像接上了其实没有。② 变体轴从来没有收窄判据：archetypeVariantChoices 只看档案声明了几个变体，不问「这条渠道会不会因为换变体而发出不同的 model 串」。",
+  "class_root": "「档案声明的能力轴」与「这家供应商真能兑现的」之间需要逐轴收窄，而收窄有两个维度会被漏：**轴**（参数 / transport / 模式 / 变体）和**面**（画布节点 / Agent 提案面板）。上一轮补齐了前三条轴、但只覆盖了画布一个面，于是同一个缺陷从第二个面原样回来；变体轴则是最后一条没人管的轴。正确形状 = 收窄判据全部住在**一个**模块（channelModeReach），每个面都从它取，每条轴都有自己的判据函数；判据一律从渠道 mapping derive，不新增声明式真相源。变体轴的判据是「create op 有没有把 model 参数化」——它必须取 body ∪ 进程型 transport 的 CLI args 并集，否则即梦（无 body、参数全在 argv）会被误判成惰性、把一个活着的选择器藏掉。",
+  "affected_population": [
+    "用 Agent 提案面板改生成参数的全部用户：模式选择器此后只列这家真发得出的模式，与画布模式栏同口径；提案草稿若钉在被收窄掉的模式上，自动落回默认/第一个可见模式并写回草稿（经 onModeChange，与用户手点同一条路）。",
+    "Runway 全部 6 个带变体档案的视频模型（seedance2/_fast/_mini、wan3、veo3.1/_fast）的用户：不再显示那条惰性的变体下拉。",
+    "apimart / kie / volcengine / 即梦上 9 个 (vendor, model) 的用户：变体轴照常显示——实测这些渠道确实把 model 参数化，切变体真的换发出去的模型串，行为零变化。",
+    "自建中转 / 未收录模型的用户：两条收窄都是 fail-open（查不到 mapping body 一律不收窄），显示与今天完全一致。"
+  ],
+  "scope_paths": [
+    "electron/catalog/paramTranslate.ts",
+    "electron/catalog/referenceReachability.ts",
+    "electron/catalog/paramConsistency.test.ts",
+    "src/workbench/generationCanvas/nodes/controls/channelModeReach.ts",
+    "src/workbench/generationCanvas/nodes/controls/useChannelCreateBody.ts",
+    "src/workbench/generationCanvas/nodes/controls/archetypeMeta.ts",
+    "src/workbench/generationCanvas/nodes/NodeParameterControls.tsx",
+    "src/workbench/ai/resident/GenerationProposalEditor.tsx"
+  ],
+  "entry_points": [
+    "src/workbench/generationCanvas/nodes/controls/channelModeReach.ts::archetypeVariantAxisIsLive —— 变体轴收窄的唯一判据：create op 把 model 参数化才显示变体选择器。三态与模式收窄同口径（undefined/null 都 fail-open）。",
+    "electron/catalog/paramTranslate.ts::wireReferencedParamKeys —— 「这条 create op 引用了哪些 canonical 键」的单点：body ∪ process.args 并集。变体轴判据与参数一致性不变量（paramConsistency）读同一个函数；此前后者是内联的第二份扫描。",
+    "src/workbench/ai/resident/GenerationProposalEditor.tsx::ProposalParameterBar —— 第二个面接入同一套机制：modeBodySpecs → useChannelCreateBodies → archetypeModeChoices(archetype, bodyForMode)，外加 fallbackVisibleModeId 的选择安全。",
+    "src/workbench/generationCanvas/nodes/NodeParameterControls.tsx —— 画布侧变体栏接上 archetypeVariantAxisIsLive；declaredVariantChoices 与收窄后的 variantChoices 分开命名，避免以后有人误用未收窄那份。",
+    "electron/catalog/referenceReachability.ts —— 渲染层对 electron/ 的唯一放行入口（src-no-import-electron 棘轮基线只登记了这一条），wireReferencedParamKeys 经它转出给渲染层，基线不涨。"
+  ],
+  "internal_only_reason": "不接触任何外部供应商 API 契约：没有新增/修改端点、鉴权、字段或取值。全部改动是仓库内部的「UI 该显示哪些已声明的能力」判据，判据本身从既有 mapping 模板 derive。变体轴的收窄结论（Runway 惰性 / apimart-kie-volcengine-即梦 活）是对**现存 mapping 模板**的静态读数，不是对供应商文档的新解读。",
+  "invariants": [
+    "所有「档案能力轴 × 渠道」的收窄判据只住在 channelModeReach 一个模块；任何面（画布节点 / Agent 提案面板 / 将来新面）都从它取，不许就地另写一份。",
+    "模式选择面全集 = NodeParameterControls + GenerationProposalEditor，两者都必须传 bodyForMode；变体选择面全集同样是这两处，都必须过 archetypeVariantAxisIsLive。",
+    "变体选择器出现 ⟺ 该渠道的 create op 把 model 参数化（wireReferencedParamKeys 含 'model'）。",
+    "「这条 create op 引用了哪些 canonical 键」只有一个实现 wireReferencedParamKeys，且必须取 body ∪ process.args 并集——只扫 body 会把即梦这类进程型渠道判死。",
+    "两条收窄都 fail-open：拿不到 mapping body（undefined）或该模式无自己的线缆（null）时一律不收窄。",
+    "渲染层对 electron/ 的 import 入口仍只有 referenceReachability 一条（boundaries 棘轮 80 不涨）。"
+  ],
+  "recurrence": {
+    "classification": "recurring",
+    "reason": "「档案声明了某条能力轴，但这家供应商兑现不了」会随每条新轴、每个新 UI 面反复出现：轴上一轮补了参数/transport/模式三条、这轮补上变体；面这一轮才发现第二个（提案面板）——上一轮的合同曾把它误记成已覆盖。只要收窄判据不集中、或新面不知道要来取判据，同一个病就会换个地方回来。",
+    "same_class_scan": [
+      "模式选择面全仓普查（grep archetypeModeChoices 的全部非测试消费者）：恰好 2 处——NodeParameterControls:508 与 GenerationProposalEditor:126，均已传 bodyForMode。无第三个面。",
+      "变体选择面全仓普查（grep archetypeVariantChoices + variantChoices= 的全部非测试消费者）：同样恰好 2 处，均已过 archetypeVariantAxisIsLive。无第三个面。",
+      "变体轴活性全目录实测（探针跑全部 15 个带变体的 (vendor, model)）：apimart/kie/volcengine/即梦 共 9 个把 model 参数化=活（照常显示）；Runway 6 个写死字面量=惰性（隐藏）。收窄集合与「Runway 把 veo3.1 与 veo3.1_fast 建成两个目录行、本就不需要变体轴」这一事实吻合。",
+      "「变体 modelKey 是否是目录行」这个更直觉的判据被实测否决：apimart 的 veo 只有 veo3.1-fast 一行、quality/lite 不是独立行，按那个判据会把 apimart 活着的变体轴一起藏掉。故判据取「model 有没有被参数化」。",
+      "进程型 transport 普查：即梦（dreamina）没有 body、参数全在 create.process.args（--model_version={{request.params.model}}）。只扫 body 的判据会把它 6 个变体全藏掉；wireReferencedParamKeys 取并集后正确。同族的 multiframe build 分支由 paramConsistency 既有声明覆盖，未受影响。"
+    ]
+  },
+  "generality_proof": "缺陷不是「提案面板漏改了一行」也不是「Runway 变体配错了」，而是收窄判据的**集中度**与**覆盖面**问题，两条独立证据：① 同一个模式收窄缺陷在两个互不共享代码的 UI 面上各出现一次（画布、提案面板），说明成因是「面不知道要取判据」而非某个面写错；② 变体轴的正确判据只能从渠道 mapping derive——两个直觉判据（变体 modelKey 是不是目录行 / 只扫 body）都被全目录实测证伪，各自会误杀 apimart 与即梦活着的控件，说明这类判据必须集中在一处并有实测语料兜底，散落到各面各写一份必然出错。因此防复发落在共享边界（channelModeReach 单模块 + wireReferencedParamKeys 单实现），而不是把这两处改对。",
+  "shared_boundaries": [
+    {
+      "path": "src/workbench/generationCanvas/nodes/controls/channelModeReach.ts",
+      "symbol": "archetypeModeIsVisible / archetypeVariantAxisIsLive / fallbackVisibleModeId",
+      "responsibility": "全部「档案能力轴 × 渠道」收窄判据的唯一住所。每条轴一个判据函数，三态语义统一（undefined/null → fail-open）。任何 UI 面都从这里取，不在面内就地判断。"
+    },
+    {
+      "path": "electron/catalog/paramTranslate.ts",
+      "symbol": "wireReferencedParamKeys",
+      "responsibility": "「这条 create op 真正引用了哪些 canonical 参数键」的单一实现，body 与进程型 transport 的 CLI args 一起算。变体轴收窄与参数一致性不变量共用它。"
+    },
+    {
+      "path": "src/workbench/generationCanvas/nodes/controls/useChannelCreateBody.ts",
+      "symbol": "useChannelCreateBodies / readModeChannelBody",
+      "responsibility": "逐 (taskKind, modeId) 取渠道 create op，并在**唯一拿得到整条 create op 的地方**算出 wireParamKeys 一并交给渲染层——渲染层只拿 body 的话，进程型渠道会被误判成什么都发不出。"
+    }
+  ],
+  "same_class_entry_points": [
+    {
+      "path": "src/workbench/ai/resident/GenerationProposalEditor.tsx",
+      "entry_point": "ProposalParameterBar 的模式选择器与变体选择器",
+      "disposition": "enforced",
+      "evidence": "模式栏改为 archetypeModeChoices(archetype, (mode) => modeBodies[mode.id]) 并加 fallbackVisibleModeId 选择安全；变体栏过 archetypeVariantAxisIsLive。上一轮合同曾把此入口误记为已覆盖，本轮核实为未覆盖并改正。"
+    },
+    {
+      "path": "src/workbench/generationCanvas/nodes/NodeParameterControls.tsx",
+      "entry_point": "画布节点的变体栏",
+      "disposition": "enforced",
+      "evidence": "declaredVariantChoices 与收窄后的 variantChoices 分名；archMode 的 modeBodies 过 archetypeVariantAxisIsLive。模式栏上一轮已收窄，本轮不变。"
+    },
+    {
+      "path": "electron/catalog/paramConsistency.test.ts",
+      "entry_point": "coveredWireKeys 里内联的第二份 body+args 扫描",
+      "disposition": "enforced",
+      "evidence": "删除内联实现、改调 wireReferencedParamKeys；否则变体轴收窄会照抄出第三份扫描。6 项断言全绿，行为不变。"
+    },
+    {
+      "path": "electron/capabilityCore/mcpGenerationVideoResolve.ts",
+      "entry_point": "headless / MCP 的模式与参数投影",
+      "disposition": "not-affected",
+      "evidence": "无 UI 选择器可收窄；它按 archetypeId 与 modeId 直接投影，越界请求由 selectTaskMapping 的 fail-closed 与第三闸在生成时拦下（上一轮已收紧）。本轮无改动。"
+    }
+  ],
+  "prevention": {
+    "kind": "centralized-boundary",
+    "enforcement_path": "src/workbench/generationCanvas/nodes/controls/channelModeReach.ts",
+    "invariant": "每条「档案声明的能力轴」在展示前都要过本模块的对应判据；判据从渠道 mapping derive，三态 fail-open。",
+    "failure_mode": "判据散落到各 UI 面就地实现时，新面只会照抄「显示档案声明的全部」这一行，缺陷静默复制——画布修好后提案面板原样犯，就是这么来的；而且各面写的判据会各自漏掉进程型 transport 之类的边角，误杀活着的控件。",
+    "exception_policy": "none",
+    "strategy": "把每条轴的判据收进 channelModeReach 单模块并统一三态语义；把「create op 引用了哪些键」收进 wireReferencedParamKeys 单实现（同时删掉 paramConsistency 里的内联第二份）；判据的边角行为（进程型渠道、fail-open、缩水不隐藏）逐条有回归锁，误改当场红。",
+    "artifacts": [
+      "src/workbench/generationCanvas/nodes/controls/channelModeReach.ts",
+      "src/workbench/generationCanvas/nodes/controls/useChannelCreateBody.ts",
+      "electron/catalog/paramTranslate.ts",
+      "src/workbench/ai/resident/GenerationProposalEditor.tsx",
+      "src/workbench/generationCanvas/nodes/NodeParameterControls.tsx",
+      "src/workbench/generationCanvas/nodes/controls/channelModeReach.test.ts"
+    ]
+  },
+  "class_regression_tests": [
+    "src/workbench/generationCanvas/nodes/controls/channelModeReach.test.ts",
+    "electron/catalog/paramConsistency.test.ts"
+  ],
+  "regression_tests": [
+    "src/workbench/generationCanvas/nodes/controls/channelModeReach.test.ts",
+    "electron/catalog/paramConsistency.test.ts"
+  ],
+  "legacy_paths": {
+    "status": "removed",
+    "removed_paths": [
+      "electron/catalog/paramConsistency.test.ts"
+    ],
+    "rationale": "coveredWireKeys 里那份内联的 body+process.args 扫描是 wireReferencedParamKeys 的并行实现，同 commit 删除改调单一实现（P1 加新必删旧）。留着它变体轴收窄就会照抄出第三份，而三份扫描漂移时只有最不常跑的那份会静默出错。"
+  },
+  "dependency_lifecycle": {
+    "decision": "not-applicable",
+    "rationale": "不新增、不升级、不保留任何第三方依赖：全部改动是仓库内部的收窄判据集中化与两个 UI 面的接线。",
+    "exit_criteria": []
+  },
+  "migration": "无存储迁移。两条收窄都只影响「显示哪些选项」，不改写 meta；唯一的写入是模式选择安全（当前模式被收窄掉时落回默认/第一个可见模式），画布侧走 history:false 不占撤销、提案侧经 onModeChange 与用户手点同一条路。回滚 = 把两个面的收窄参数去掉，无残留数据。",
+  "residual_risks": [
+    "变体轴收窄用当前模式的 create op 判断。理论上同一模型的不同模式可能一条参数化 model、另一条写死；实测全目录 15 个带变体的 (vendor, model) 没有这种混合情形。若将来出现，表现是切模式时变体栏闪现/消失——届时应把判据改成「任一模式参数化即算活」，而不是回退收窄。",
+    "Runway 的变体轴被隐藏后，veo3.1 与 veo3.1_fast 只能靠模型选单区分（它们本就是两个目录行）。这是 option (a) 的既定取舍（2026-09-02 用户拍板）：不动 Runway 目录行、不churn 认证台账；代价是同一模型在不同供应商上的「形状」仍不一致（apimart 一行带变体、Runway 两行）。",
+    "提案面板的选择安全经 onModeChange 回写 Host 草稿，与画布的 store 写入不同路。若 Host 侧将来对 onModeChange 加了额外副作用（如触发重算提案），收窄导致的自动落点会连带触发一次——当前 Host 实现只更新草稿字段，无此风险。",
+    "**Agent 提案面板那一半没有真机走查证据**（画布侧变体轴已走查，见 tests/ux/vendor-honest-variant-axis.walk.mjs 与 shots/ 下 9 张截图，含变异测试：把 archetypeVariantAxisIsLive 强制 return true 后走查当场红）。提案卡只能由真实 agent 回合渲染，而它要一个可执行的文本模型；渲染层的凭据写入路径 sanitizeRendererVendorApiKeyMutation 强制 enabled:false（认证才有权提升），因此隔离走查环境里造不出「已启用」的供应商——伪造只能靠直接改 catalog 文件或伪造认证，那就不是真机走查了。缓解：两个面 import 的是**同一个** archetypeModeIsVisible / archetypeVariantAxisIsLive，「两面同口径」由共享实现保证、判据本身有单测；未被证实的只剩提案面板自己的接线（useChannelCreateBodies 调用与 fallbackVisibleModeId effect）。补证据的路径 = 在有认证凭据的环境里走 agent-runtime 走查链。"
+  ]
+}

--- a/electron/catalog/paramConsistency.test.ts
+++ b/electron/catalog/paramConsistency.test.ts
@@ -13,7 +13,7 @@ import { applyBuiltinSeeds } from "./seedBuiltins";
 import { selectTaskMapping } from "./types";
 import { resolveArchetypeForModel } from "../../src/config/modelArchetypes";
 import { modeTransportFor } from "../shared/videoCapabilities";
-import { applyParamMap, bodyReferencedParamKeys, consumedCanonicalKeys } from "./paramTranslate";
+import { applyParamMap, consumedCanonicalKeys, wireReferencedParamKeys } from "./paramTranslate";
 import { NEWAPI_IMAGE_CREATE_OP, NEWAPI_VIDEO_CREATE_OP } from "./newapiTransport";
 import { buildHttpRequest, buildTemplateContext } from "../ai/requestPipeline";
 import type { CatalogState } from "./types";
@@ -26,10 +26,10 @@ function seededState(): CatalogState {
 function coveredWireKeys(create: { body?: unknown; process?: { args?: string[]; build?: string }; paramMap?: { drops?: string[] } | undefined } & Record<string, unknown>): Set<string> {
   const map = (create as { paramMap?: Parameters<typeof consumedCanonicalKeys>[0] }).paramMap;
   return new Set([
-    ...bodyReferencedParamKeys(create.body),
-    // 进程型 transport（即梦 dreamina）的参数在 CLI args 里读（{{request.params.X}}），同样算「真覆盖」
-    // ——它们确实经 argv 发出去，不是静默丢弃。bodyReferencedParamKeys 能直接扫字符串数组。
-    ...bodyReferencedParamKeys(create.process?.args),
+    // body + 进程型 transport（即梦 dreamina）的 CLI args 一起算「真覆盖」——后者确实经 argv 发出去，
+    // 不是静默丢弃。两者的并集由 wireReferencedParamKeys 单点提供；变体轴收窄读的是同一个函数，
+    // 不各写一份扫描（此前这里是内联的第二份，差点让变体收窄照抄出第三份）。
+    ...wireReferencedParamKeys(create),
     // 多帧（build="multiframe"）的 args 由 buildMultiframeArgs 按图数变形构建（非模板），它确实消费 duration
     // （2 图档发 --duration）与 video_resolution（v1.4.14 起 required，任何图数都发 --video_resolution）——
     // 声明在此，让不变量认它们是真覆盖而非静默丢弃。

--- a/electron/catalog/paramTranslate.ts
+++ b/electron/catalog/paramTranslate.ts
@@ -252,6 +252,26 @@ export function consumedCanonicalKeys(paramMap: ParamMap | undefined): string[] 
 
 const PARAM_TOKEN = /\{\{\s*request\.params\.([a-zA-Z0-9_]+)\s*\}\}/g;
 
+/**
+ * 这条 create op **整体**引用了哪些 canonical 参数键——HTTP body 与进程型 transport 的 CLI args 一起算。
+ *
+ * 为什么不能只扫 body：即梦（dreamina）这类走 `create.process.args` 的渠道根本没有 body，参数是
+ * `--model_version={{request.params.model}}` 这样经 argv 发出去的。只扫 body 会把它们误判成「这个键
+ * 发不出去」——实测就险些据此把即梦活着的变体选择器藏掉（它 6 个变体全靠 params.model 生效）。
+ *
+ * 单一真相源：参数一致性不变量（paramConsistency.test）与变体轴收窄都读它，不各写一份扫描。
+ */
+export function wireReferencedParamKeys(create: {
+  body?: unknown;
+  process?: { args?: string[] };
+} | null | undefined): string[] {
+  if (!create) return [];
+  return [...new Set([
+    ...bodyReferencedParamKeys(create.body),
+    ...bodyReferencedParamKeys(create.process?.args),
+  ])];
+}
+
 /** 扫一个 body 模板（任意嵌套 JSON）里所有 `{{request.params.X}}` 令牌引用的键。 */
 export function bodyReferencedParamKeys(body: unknown): string[] {
   const keys = new Set<string>();

--- a/electron/catalog/referenceReachability.ts
+++ b/electron/catalog/referenceReachability.ts
@@ -8,6 +8,10 @@
 // 住在 electron/ 而非 src/：electron tsconfig 是 rootDir:"." 反向 import 不了 src；渲染层则本就 import
 // 得到 electron（bridge.ts 已在做），且本模块依赖链纯净（paramTranslate → jsonUtils，后者零 import）。
 import { bodyReferencedParamKeys } from "./paramTranslate";
+// 渲染层的变体轴收窄也要「这条 create op 引用了哪些参数键」（body ∪ 进程 args）。它的单一实现在
+// paramTranslate；从本模块转出一次，是因为 src→electron 的越界是棘轮门岗，渲染层已放行的入口只有
+// 本文件这一条（archetypeMeta 那条基线）。让渲染层再直连 paramTranslate 会被判成新增违规。
+export { wireReferencedParamKeys } from "./paramTranslate";
 
 /** 一个参考槽在某条渠道上的真实承载力。 */
 export type SlotReach =

--- a/src/workbench/ai/resident/GenerationProposalEditor.tsx
+++ b/src/workbench/ai/resident/GenerationProposalEditor.tsx
@@ -1,7 +1,13 @@
 import React from 'react'
 import { IconMessage, IconPhoto, IconVideo } from '@tabler/icons-react'
 import InlineParameterBar from '../../generationCanvas/nodes/InlineParameterBar'
-import { archetypeModeChoices } from '../../generationCanvas/nodes/controls/channelModeReach'
+import {
+  archetypeModeChoices,
+  archetypeModeIsVisible,
+  archetypeVariantAxisIsLive,
+  fallbackVisibleModeId,
+} from '../../generationCanvas/nodes/controls/channelModeReach'
+import { useChannelCreateBodies } from '../../generationCanvas/nodes/controls/useChannelCreateBody'
 import {
   deriveGenerationModelCatalogStatus,
   findModelOptionByIdentifier,
@@ -13,6 +19,7 @@ import {
   currentArchetypeMode,
   currentArchetypeVariant,
 } from '../../generationCanvas/nodes/controls/archetypeMeta'
+import { modeTransportFor } from '../../../config/modelArchetypes'
 import {
   defaultPatchForCatalogControl,
   parseControlInput,
@@ -103,9 +110,39 @@ function ProposalParameterBar({
     ...(variantId ? { variantId } : {}),
   }), [modelValue, modeId, params, selectedModel?.modelKey, variantId, vendor])
   const controls = resolveRenderedControls(selectedModel, meta, kind === 'image', kind === 'video')
-  const modes = archetype ? archetypeModeChoices(archetype) : []
-  const variants = archetype ? archetypeVariantChoices(archetype) : []
+  // 模式栏收窄（与画布节点**同一套机制**，见 NodeParameterControls 的 modeBodySpecs）：档案的模式集是
+  // 供应商无关的，能不能发得出去由这家的 mapping 决定。逐模式问 body，taskKind 走唯一入口 modeTransportFor。
+  // 不收窄的话，提案面板会把这家发不出的模式照样列出来，用户要到点生成被第三闸拒才知道。
+  const modeBodySpecs = React.useMemo(
+    () =>
+      (archetype?.modes ?? []).map((mode) => ({
+        key: mode.id,
+        taskKind: (modeTransportFor(mode, archetype, vendor) ?? '') as string,
+        modeId: mode.id,
+      })),
+    [archetype, vendor],
+  )
+  const modeBodies = useChannelCreateBodies(vendor || '', selectedModel?.value ?? modelValue ?? '', modeBodySpecs)
+  const modes = archetype ? archetypeModeChoices(archetype, (mode) => modeBodies[mode.id]) : []
   const activeMode = archetype ? currentArchetypeMode(archetype, meta).id : modeId || ''
+  // 变体轴收窄（与画布节点同一判据）：渠道没把 model 参数化，切变体什么也不会发生 → 整条不显示。
+  const variants =
+    archetype && archetypeVariantAxisIsLive(modeBodies[activeMode]) ? archetypeVariantChoices(archetype) : []
+
+  // 选择安全：提案草稿钉在一个被收窄掉的模式上时，模式栏一个都不高亮、而发送路径仍按那个看不见的
+  // 模式投影槽。落回默认/第一个可见模式并写回草稿，让 UI 与发送口径一致（与画布节点同一处置）。
+  // 与画布不同的是这里没有 store，改动经 onModeChange 回给 Host —— 它就是用户手点模式时走的同一条路。
+  const visibleModeIdSignature = archetype
+    ? archetype.modes.filter((mode) => archetypeModeIsVisible(mode, modeBodies[mode.id])).map((m) => m.id).join('|')
+    : ''
+  React.useEffect(() => {
+    if (!archetype) return
+    const visibleIds = visibleModeIdSignature ? visibleModeIdSignature.split('|') : []
+    const next = fallbackVisibleModeId(archetype, meta, visibleIds)
+    if (next) onModeChange(next)
+    // meta/onModeChange 每渲染重建；触发时机只需「可见模式集 / 档案」变化。
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [visibleModeIdSignature, archetype?.id])
   const activeVariant = archetype ? currentArchetypeVariant(archetype, meta)?.id || variantId || '' : variantId || ''
   const catalogStatus = deriveGenerationModelCatalogStatus(kind, modelState)
 

--- a/src/workbench/generationCanvas/nodes/NodeParameterControls.tsx
+++ b/src/workbench/generationCanvas/nodes/NodeParameterControls.tsx
@@ -59,6 +59,7 @@ import {
   archetypeModeChoices,
   archetypeModeIsVisible,
   archetypeModeSlotReachByKey,
+  archetypeVariantAxisIsLive,
   fallbackVisibleModeId,
 } from './controls/channelModeReach'
 import { resolveReferenceSlots, decideArrayReferenceRemoval } from '../runner/referenceSlots'
@@ -141,7 +142,7 @@ export default function NodeParameterControls({
   const archetype = resolveArchetypeForOption(selectedModelOption)
   // 变体特化：选中变体可能收窄某 mode 的参数（如 Seedance fast 的 resolution 仅 480/720）——
   // 槽/参数全由特化后的档案派生，保证 UI 选项与发送一致。无 variants → 原样（零开销）。
-  const variantChoices = archetype ? archetypeVariantChoices(archetype) : []
+  const declaredVariantChoices = archetype ? archetypeVariantChoices(archetype) : []
   const activeVariantId = archetype ? currentArchetypeVariant(archetype, meta)?.id || '' : ''
   const effectiveArchetype = archetype ? specializeArchetypeForVariant(archetype, activeVariantId) : null
   const archMode = effectiveArchetype ? currentArchetypeMode(effectiveArchetype, meta) : null
@@ -172,6 +173,9 @@ export default function NodeParameterControls({
     selectedModelOption?.value ?? '',
     modeBodySpecs,
   )
+  // 变体轴收窄：变体的意义是换一个真发出去的 model 串，渠道没把 model 参数化就什么也不会发生
+  // （Runway 把 model 写死、且 veo3.1 / veo3.1_fast 本就是两个目录行）。惰性时整条不显示，别骗用户。
+  const variantChoices = archMode && !archetypeVariantAxisIsLive(modeBodies[archMode.id]) ? [] : declaredVariantChoices
   // 槽级收窄仍只看**当前**模式的 body（口径不变）。三态里的 undefined/null 都落到「拿不到 body」→ 不收窄。
   const channelCreateBody = archMode ? (modeBodies[archMode.id]?.body ?? null) : null
   const slotReachByKey = React.useMemo(

--- a/src/workbench/generationCanvas/nodes/controls/archetypeMeta.ts
+++ b/src/workbench/generationCanvas/nodes/controls/archetypeMeta.ts
@@ -23,7 +23,12 @@ import {
 } from '../../../../config/modelArchetypes'
 import type { ImageUrlSlot } from '../../model/parameterReferenceSlots'
 import { translateModelDisplayText } from '../../../../i18n/modelDisplayText'
-import { DEFAULT_SLOT_INPUT_KEY, modeSlotReach, type SlotReach } from '../../../../../electron/catalog/referenceReachability'
+import {
+  DEFAULT_SLOT_INPUT_KEY,
+  modeSlotReach,
+  wireReferencedParamKeys,
+  type SlotReach,
+} from '../../../../../electron/catalog/referenceReachability'
 
 export { resolveArchetypeForModel }
 export type { ModelArchetype, ArchetypeMode, ModelArchetypeVariant }
@@ -32,7 +37,7 @@ export type { ModelArchetype, ArchetypeMode, ModelArchetypeVariant }
 // 为什么从这里转、而不是让它各自 import electron/：`src-no-import-electron` 是棘轮门岗，本文件那条越界
 // 已登记在 boundaries-baseline 里；新开一个文件直连 electron/ 会被判成**新增**违规（棘轮只减不增，绝不
 // 许把新违规追加进基线）。转出一次 = 渲染层对 electron/ 的入口仍只有这一处，基线不涨。
-export { modeSlotReach }
+export { modeSlotReach, wireReferencedParamKeys }
 export type { SlotReach }
 
 /**

--- a/src/workbench/generationCanvas/nodes/controls/channelModeReach.test.ts
+++ b/src/workbench/generationCanvas/nodes/controls/channelModeReach.test.ts
@@ -10,7 +10,12 @@ import { describe, it, expect } from 'vitest'
 import type { ArchetypeMode } from '../../../../config/modelArchetypes'
 import { getArchetypeById } from '../../../../config/modelArchetypes'
 import { modeSlotReach } from '../../../../../electron/catalog/referenceReachability'
-import { archetypeModeChoices, archetypeModeIsVisible, fallbackVisibleModeId } from './channelModeReach'
+import {
+  archetypeModeChoices,
+  archetypeModeIsVisible,
+  archetypeVariantAxisIsLive,
+  fallbackVisibleModeId,
+} from './channelModeReach'
 
 /** 最小合法模式（只填判据用得上的字段，其余走档案类型的必填缺省）。 */
 function mode(id: string, slots: ArchetypeMode['slots'], extra: Partial<ArchetypeMode> = {}): ArchetypeMode {
@@ -33,6 +38,15 @@ const MULTI_IMAGE_BODY = { reference_image_urls: '{{request.params.reference_ima
 // 一条完全不带任何参考键、只发提示词的 body。
 const TEXT_ONLY_BODY = { prompt: '{{request.prompt}}', duration: '{{request.params.duration}}' }
 
+/**
+ * 造一条 `ModeChannelBody`。`wireParamKeys` = 这条 create op 真正引用的 canonical 键
+ * （生产里由 wireReferencedParamKeys 从 body + 进程 args 并集算出）；模式收窄用不到它，
+ * 只有变体轴收窄看它里面有没有 `model`，所以这里默认给空、按用例显式传。
+ */
+function channel(body: unknown, wireParamKeys: string[] = []) {
+  return { body, wireParamKeys }
+}
+
 describe('archetypeModeIsVisible — 模式栏收窄判据', () => {
   // ⚠️ 回归锁：曾有第三条判据「多图槽（max>1）塌成单图聚合位 → 隐藏」，全仓实测后**删除**。
   // 它只命中一个目标：runway/grok_imagine_1_5/i2v —— Runway 的 Grok **确实支持**图生视频（一次一张），
@@ -44,18 +58,18 @@ describe('archetypeModeIsVisible — 模式栏收窄判据', () => {
     // 先证明现场：这条渠道确实只给了它单图聚合位（reach=single，不是「完全发不出」）——否则这条用例
     // 会被 (b) 顺手判掉，锁的就不是「不再按缩水隐藏」这件事。
     expect(modeSlotReach(i2vLike.slots, AGGREGATE_ONLY_BODY)).toEqual(['single'])
-    expect(archetypeModeIsVisible(i2vLike, { body: AGGREGATE_ONLY_BODY })).toBe(true)
-    expect(archetypeModeIsVisible(i2vLike, { body: MULTI_IMAGE_BODY })).toBe(true)
+    expect(archetypeModeIsVisible(i2vLike, channel(AGGREGATE_ONLY_BODY))).toBe(true)
+    expect(archetypeModeIsVisible(i2vLike, channel(MULTI_IMAGE_BODY))).toBe(true)
   })
 
   it('max=1 的单图槽拿到单图聚合位是**如实兑现**，不隐藏', () => {
     const i2v = mode('i2v', [{ kind: 'first_frame', label: '首帧', min: 1, max: 1 }])
-    expect(archetypeModeIsVisible(i2v, { body: AGGREGATE_ONLY_BODY })).toBe(true)
+    expect(archetypeModeIsVisible(i2v, channel(AGGREGATE_ONLY_BODY))).toBe(true)
   })
 
   it('(b) 声明了参考槽却**全部** reach=none → 隐藏', () => {
     const ref = mode('reference', [{ kind: 'video_ref', label: '参考视频', min: 1, max: 3 }])
-    expect(archetypeModeIsVisible(ref, { body: TEXT_ONLY_BODY })).toBe(false)
+    expect(archetypeModeIsVisible(ref, channel(TEXT_ONLY_BODY))).toBe(false)
   })
 
   it('(b) 只要**有一个**槽发得出就不隐藏（首尾帧只过得去首帧时，模式仍在，收窄交给槽级）', () => {
@@ -63,7 +77,7 @@ describe('archetypeModeIsVisible — 模式栏收窄判据', () => {
       { kind: 'first_frame', label: '首帧', min: 1, max: 1 },
       { kind: 'last_frame', label: '尾帧', min: 1, max: 1 },
     ])
-    expect(archetypeModeIsVisible(firstlast, { body: AGGREGATE_ONLY_BODY })).toBe(true)
+    expect(archetypeModeIsVisible(firstlast, channel(AGGREGATE_ONLY_BODY))).toBe(true)
   })
 
   it('(a) 桶已知但这个模式没有自己的 mapping（null）→ 隐藏', () => {
@@ -73,9 +87,9 @@ describe('archetypeModeIsVisible — 模式栏收窄判据', () => {
 
   it('零槽的纯文生模式**永不**隐藏——哪怕 body 一个参考键都没有', () => {
     const t2v = mode('t2v', [])
-    expect(archetypeModeIsVisible(t2v, { body: TEXT_ONLY_BODY })).toBe(true)
-    expect(archetypeModeIsVisible(t2v, { body: AGGREGATE_ONLY_BODY })).toBe(true)
-    expect(archetypeModeIsVisible(t2v, { body: {} })).toBe(true)
+    expect(archetypeModeIsVisible(t2v, channel(TEXT_ONLY_BODY))).toBe(true)
+    expect(archetypeModeIsVisible(t2v, channel(AGGREGATE_ONLY_BODY))).toBe(true)
+    expect(archetypeModeIsVisible(t2v, channel({}))).toBe(true)
   })
 
   it('(a) 例外：零槽文生模式即使 mapping 取不到也隐藏——它确实发不出去', () => {
@@ -93,7 +107,7 @@ describe('archetypeModeIsVisible — 模式栏收窄判据', () => {
 
   it('body 完全不引用任何参数（纯静态）→ 判不出来，不收窄（与第三闸同口径）', () => {
     const omni = mode('omni', [{ kind: 'image_ref', label: '角色参考', min: 1, max: 10 }])
-    expect(archetypeModeIsVisible(omni, { body: { model: 'x', prompt: 'literal' } })).toBe(true)
+    expect(archetypeModeIsVisible(omni, channel({ model: 'x', prompt: 'literal' }))).toBe(true)
   })
 })
 
@@ -111,7 +125,7 @@ describe('archetypeModeChoices — 收窄接进模式栏', () => {
   })
 
   it('只有单图聚合位的渠道：能挤进单图位的模式全部留下，缩水交给槽级如实收成 1 张', () => {
-    const ids = archetypeModeChoices(SEEDANCE, () => ({ body: AGGREGATE_ONLY_BODY })).map((c) => c.id)
+    const ids = archetypeModeChoices(SEEDANCE, () => (channel(AGGREGATE_ONLY_BODY))).map((c) => c.id)
     expect(ids).toContain('t2v')
     expect(ids).toContain('first')
     // omni 在这条渠道上只过得去 1 张，但它**不该**因此被摘掉（见上方回归锁）。
@@ -119,14 +133,36 @@ describe('archetypeModeChoices — 收窄接进模式栏', () => {
   })
 
   it('这条渠道一个参考键都不带 → 有槽的模式全被摘掉，只剩纯文生', () => {
-    const ids = archetypeModeChoices(SEEDANCE, () => ({ body: TEXT_ONLY_BODY })).map((c) => c.id)
+    const ids = archetypeModeChoices(SEEDANCE, () => (channel(TEXT_ONLY_BODY))).map((c) => c.id)
     expect(ids).toEqual(['t2v'])
   })
 
   it('这个模式在这家没有自己的 mapping（null）→ 摘掉；判据 (a) 接进模式栏', () => {
-    const ids = archetypeModeChoices(SEEDANCE, (m) => (m.id === 'omni' ? null : { body: MULTI_IMAGE_BODY })).map((c) => c.id)
+    const ids = archetypeModeChoices(SEEDANCE, (m) => (m.id === 'omni' ? null : channel(MULTI_IMAGE_BODY))).map((c) => c.id)
     expect(ids).not.toContain('omni')
     expect(ids).toContain('t2v')
+  })
+})
+
+describe('archetypeVariantAxisIsLive — 变体选择器该不该出现', () => {
+  it('渠道把 model 参数化 → 变体真的会改发出去的串 → 显示', () => {
+    expect(archetypeVariantAxisIsLive(channel({ model: '{{request.params.model}}' }, ['model']))).toBe(true)
+  })
+
+  it('渠道把 model 写成字面量 → 切变体什么也不会发生 → 藏掉（Runway 的情形）', () => {
+    expect(archetypeVariantAxisIsLive(channel({ model: 'veo3.1' }, ['duration', 'ratio']))).toBe(false)
+  })
+
+  // 即梦（dreamina）没有 body，参数全在 create.process.args 里（--model_version={{request.params.model}}）。
+  // 生产侧 wireReferencedParamKeys 取 body ∪ process.args 的并集，所以它的 6 个变体照常显示。
+  // 只扫 body 的话这里会是 false = 把一个活着的变体选择器藏掉——实测差点踩中，故单列一条锁住。
+  it('进程型渠道（无 body、model 在 CLI args 里）→ 仍算活，别把即梦的变体藏掉', () => {
+    expect(archetypeVariantAxisIsLive(channel(undefined, ['duration', 'ratio', 'model']))).toBe(true)
+  })
+
+  it('fail-open：查不到（undefined）或该模式无线缆（null）→ 都不收窄', () => {
+    expect(archetypeVariantAxisIsLive(undefined)).toBe(true)
+    expect(archetypeVariantAxisIsLive(null)).toBe(true)
   })
 })
 

--- a/src/workbench/generationCanvas/nodes/controls/channelModeReach.ts
+++ b/src/workbench/generationCanvas/nodes/controls/channelModeReach.ts
@@ -27,7 +27,7 @@ import { translateModelDisplayText } from '../../../../i18n/modelDisplayText'
  * - `undefined`：**查不出来**（老 preload / 拿不到 bridge / 未知 vendor / 自建中转）→ **fail-open**，
  *   一律不收窄。绝不因为查不到就藏用户的模式，与槽级收窄同一条纪律。
  */
-export type ModeChannelBody = { body: unknown } | null | undefined
+export type ModeChannelBody = { body: unknown; wireParamKeys: readonly string[] } | null | undefined
 
 /**
  * **模式栏收窄的唯一判据**（U4）——这个模式在这条渠道上到底立不立得住。
@@ -58,6 +58,28 @@ export function archetypeModeIsVisible(mode: ArchetypeMode, bodyResult: ModeChan
   if (mode.slots.length === 0) return true // 纯文生模式永不隐藏。
   const reach = modeSlotReach(mode.slots, bodyResult.body, mode.combineSlotsInto?.key)
   return !reach.every((r) => r === 'none') // (b) 声明了槽却一个都发不出。
+}
+
+/**
+ * **变体轴在这条渠道上活不活**——变体选择器该不该出现。
+ *
+ * 变体的意义是「换一个真正发出去的 model 串」（档案里 `variant.modelKey` 就是那个串）。它要生效，
+ * 渠道的 create op 必须**参数化** model 字段（`{{request.params.model}}`）；写死字面量的渠道，切变体
+ * 什么也不会发生 —— 控件在那儿只是骗用户。
+ *
+ * 实测（全目录 15 个带变体的 (vendor, model)）：apimart / kie / volcengine / 即梦共 9 个参数化=活；
+ * Runway 的 6 个把 model 写成字面量=惰性。Runway 之所以惰性，是因为它把 veo3.1 与 veo3.1_fast 建成
+ * **两个目录行**，本就不需要变体轴。
+ *
+ * 判据故意**不是**「变体的 modelKey 在目录里有没有对应行」：apimart 的 veo 只有 `veo3.1-fast` 一行、
+ * quality/lite 根本不是独立行，按那个判据会把 apimart 活着的变体轴也一起藏掉。
+ *
+ * 三态与模式收窄同口径：`undefined`（查不到）与 `null`（这个模式没有自己的线缆）都 **fail-open 不收窄**，
+ * 绝不因为查不到就把用户的变体藏掉。
+ */
+export function archetypeVariantAxisIsLive(bodyResult: ModeChannelBody): boolean {
+  if (!bodyResult) return true // undefined=查不到 / null=无该模式线缆 → 一律不收窄。
+  return bodyResult.wireParamKeys.includes('model')
 }
 
 export type ArchetypeModeChoice = { id: string; vendorTerm: string; hint: string }

--- a/src/workbench/generationCanvas/nodes/controls/useChannelCreateBody.test.ts
+++ b/src/workbench/generationCanvas/nodes/controls/useChannelCreateBody.test.ts
@@ -32,9 +32,14 @@ beforeEach(() => {
 })
 
 describe('readModeChannelBody — 什么算「这家发不出这个模式」的证据', () => {
-  it('桶里有这个模式的线缆 → 返回 body', () => {
+  it('桶里有这个模式的线缆 → 返回 body + 这条 op 引用的 canonical 键', () => {
     listMappings.mockReturnValue([T2I, EDIT])
-    expect(readModeChannelBody('v', 'nano-banana', 'image_edit', 'edit')).toEqual({ body: EDIT.create.body })
+    // wireParamKeys 在这里算（唯一拿得到整条 create op 的地方）：渲染层只收到 body 的话，
+    // 进程型渠道（无 body、参数在 CLI args）会被误判成什么都发不出。见变体轴收窄。
+    expect(readModeChannelBody('v', 'nano-banana', 'image_edit', 'edit')).toEqual({
+      body: EDIT.create.body,
+      wireParamKeys: ['image_urls'],
+    })
   })
 
   it('这家有 mapping，但没有这个模式的 → null（判据 (a)：真发不出）', () => {

--- a/src/workbench/generationCanvas/nodes/controls/useChannelCreateBody.ts
+++ b/src/workbench/generationCanvas/nodes/controls/useChannelCreateBody.ts
@@ -10,6 +10,7 @@
 import React from 'react'
 import { getDesktopBridge } from '../../../../desktop/bridge'
 import { selectTaskMapping, type Mapping } from '../../../../../electron/catalog/types'
+import { wireReferencedParamKeys } from './archetypeMeta'
 import type { ModeChannelBody } from './channelModeReach'
 
 /** 目录变更广播（OnboardingDrawer.refresh 发的同一个信号）——接入/停用模型后立刻重算承载力。 */
@@ -44,7 +45,10 @@ export function readModeChannelBody(
     // 「UI 看 A、生成走 B」的第二种漂移。**modeId 必须一起传**：runtime.findTaskMapping 传了它，这里不传
     // 就会拿到一条生成路径根本不会用的 body，收窄依据与实际发送再次分家。
     const mapping = selectTaskMapping(list as Mapping[], vendorKey, taskKind as Mapping['taskKind'], modelKey, modeId)
-    return mapping ? { body: mapping.create?.body ?? null } : null
+    if (!mapping) return null
+    // wireParamKeys 在这里算而不是留给调用方：只有这儿拿得到**整条 create op**。渲染层若只收到 body，
+    // 进程型渠道（即梦走 create.process.args，根本没有 body）会被误判成「什么参数都发不出」。
+    return { body: mapping.create?.body ?? null, wireParamKeys: wireReferencedParamKeys(mapping.create) }
   } catch {
     return undefined
   }

--- a/tests/ux/vendor-honest-variant-axis.walk.mjs
+++ b/tests/ux/vendor-honest-variant-axis.walk.mjs
@@ -1,0 +1,352 @@
+// 穿透走查（规则 13）—— 「变体轴按渠道收窄」+「提案面板与画布同一套收窄」，**零额度**（全程不点生成）。
+//
+// ── 这份走查在证什么 ────────────────────────────────────────────────────────
+//
+// 变体（型号）的意义只有一个：**换一个真正发出去的 model 串**。档案里 `variant.modelKey` 就是那个串，
+// 它要生效，渠道的 create op 必须把 model 字段**参数化**成 `{{request.params.model}}`。Runway 把 model
+// 写成字面量——切变体什么也不会发生，控件摆在那儿纯属骗用户（点了没反应，比没有更糟）。所以收窄后
+// Runway 整条变体选择器不显示。
+//
+// Runway 之所以敢写死，是因为它把 veo3.1 与 veo3.1_fast 建成**两个目录行**，本就不需要变体轴。
+//
+// ── 为什么判据不能是「变体的 modelKey 在目录里有没有对应行」───────────────
+//
+// APIMart 的 veo 只有 `veo3.1-fast` 一行，quality/lite 根本不是独立行。按那个判据会把 APIMart 活着的
+// 变体轴一起藏掉。判据必须是「这条渠道的线缆认不认 params.model」，不是「目录里有没有那行」。
+//
+// ── 即梦是这次改动的**回归警戒线**（最高风险行）──────────────────────────
+//
+// 即梦（dreamina）走本地 CLI，create op 根本**没有 HTTP body**——它的 model 藏在
+// `--model_version={{request.params.model}}` 这条 argv 里。收窄逻辑若只扫 body，即梦会被误判成
+// 「什么参数都发不出」→ 它 6 个活着的变体全被藏掉。所以 `wireReferencedParamKeys` 必须 body ∪
+// process.args 一起算，而这一行就是那个判据的现场证人：**它必须仍然有变体选择器**。
+//
+// ── 为什么「Runway 没有变体」这句话必须先有阳性对照 ──────────────────────
+//
+// 「变体选择器不在」这种断言天然会空洞通过：模型下拉根本没渲染、composer 整个塌掉、选择器改了名——
+// 三种情况下它一样成立。所以每一处 expectAbsent 都用 proveProbe 先在**它该出现的那一屏**（APIMart /
+// 即梦）当场证明探针抓得到，再去 Runway 那屏证明它不在。没有阳性对照的绿灯不作数。
+//
+// ── 只覆盖画布面；提案面板那一半**验不了**，文件末尾如实声明原因 ──────────
+//
+// Agent 提案卡与画布节点共用 archetypeVariantAxisIsLive / archetypeModeIsVisible 这两个函数，
+// 所以「同一套收窄」是由同一份实现保证的。但要在真机上把提案卡渲染出来，需要一个**可执行**的
+// 文本模型，而渲染层的凭据写入被产品硬护栏强制成 enabled:false（见文件末尾 B 段的详细说明）。
+// 与其伪造一个绿的，不如把这条边界写清楚。
+//
+// 用法：pnpm run build && node tests/ux/vendor-honest-variant-axis.walk.mjs
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { launchNomiApp } from './_launchApp.mjs'
+import { expect, expectVisible, expectAbsent, proveProbe, clickOrFail } from './_assert.mjs'
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
+const shotsDir = path.join(repoRoot, 'tests/ux/shots/vendor-honest-variant-axis')
+// 每次跑清空产出：上一轮的 PNG 留在盘里会被当成这一轮的证据去对账（比 mtime 才看得出的坑）。
+fs.rmSync(shotsDir, { recursive: true, force: true })
+fs.mkdirSync(shotsDir, { recursive: true })
+
+const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'nomi-variant-axis-'))
+const userDataDir = path.join(tempRoot, 'user-data')
+const projectsDir = path.join(tempRoot, 'projects')
+const capabilityDir = path.join(tempRoot, 'capability')
+fs.mkdirSync(projectsDir, { recursive: true })
+
+const { app, win } = await launchNomiApp({
+  name: 'vendor-honest-variant-axis',
+  userDataDir,
+  settingsDir: userDataDir,
+  projectsDir,
+  capabilityDir,
+  syntheticCredentialStorage: true,
+  args: ['--no-proxy-server'],
+  settleMs: 0,
+})
+
+let passed = 0
+function record(label, detail = '') {
+  passed += 1
+  console.log(`  ✓ ${label}${detail ? ` — ${detail}` : ''}`)
+}
+
+let shotIndex = 0
+async function shot(tag) {
+  shotIndex += 1
+  const file = path.join(shotsDir, `${String(shotIndex).padStart(2, '0')}-${tag}.png`)
+  await win.screenshot({ path: file })
+  return path.relative(repoRoot, file)
+}
+
+const composer = win.locator('.generation-canvas-v2-node__composer')
+const modeGroup = composer.locator('[role="group"][aria-label="生成方式"]')
+const modeButtons = modeGroup.locator('button')
+// 变体选择器 = InlineParameterBar 里紧跟模型芯片的小下拉，aria-label 走 i18n 的
+// generationCommon.parameters.variant（zh-CN = 「变体」）。它和「每次生成张数」(variantCountAria)
+// 是两个东西，别混。
+const variantSelect = composer.locator('[aria-label="变体"]')
+
+/**
+ * 读节点**真正绑定到**的模型身份（vendor + modelKey），而不是下拉里点了哪一条。
+ *
+ * 为什么变体栏的断言不够、必须先验身份：变体栏是**下游**。用户点了 Runway 的行、节点却被改绑到
+ * APIMart 的行时，变体栏会诚实地显示 **APIMart 的**变体——每一层都在正确工作，合起来却是错的。
+ * 「绑错家」与「收窄没生效」长得一模一样，而两者修法完全不同。所以身份闸必须排在控件读取之前。
+ * （这不是假想：runway-vendor-honest-modes 走查首跑就抓到过 modelKey 被变体归一改写成别家的串。）
+ */
+async function readBoundIdentity() {
+  return win.evaluate(() => {
+    const el = document.querySelector('.generation-canvas-v2-node')
+    const key = Object.keys(el || {}).find((k) => k.startsWith('__react'))
+    let fiber = el && key ? el[key] : null
+    let depth = 0
+    while (fiber && depth < 400) {
+      const meta = fiber.memoizedProps?.node?.meta
+      if (meta && (meta.modelKey || meta.modelVendor)) {
+        return {
+          modelKey: meta.modelKey ?? null,
+          modelVendor: meta.modelVendor ?? null,
+          variantId: meta.archetype?.variantId ?? null,
+          archetypeId: meta.archetype?.id ?? null,
+        }
+      }
+      fiber = fiber.return
+      depth += 1
+    }
+    return { modelKey: null, modelVendor: null, variantId: null, archetypeId: null }
+  })
+}
+
+/**
+ * 从 NomiSelect 里挑模型。`:visible` 是硬要求——Mantine 把未展开弹层的选项也留在 DOM 里，
+ * 裸选会选到画布上别的下拉（变体、每次生成张数…）的选项。
+ */
+async function pickModel(match, humanLabel) {
+  await clickOrFail(composer.locator('[aria-label="模型"]'), '模型下拉')
+  const options = win.locator('[role="option"]:visible')
+  await expect(options, '模型下拉点开了却一个选项都没有（目录空了？供应商没启用？）').not.toHaveCount(0)
+  const texts = (await options.allTextContents()).map((t) => t.trim())
+  const index = texts.findIndex(match)
+  if (index < 0) throw new Error(`WALK FAIL: 模型下拉里没有「${humanLabel}」。实际选项：${JSON.stringify(texts)}`)
+  await options.nth(index).click()
+  await win.waitForTimeout(600)
+  return texts[index]
+}
+
+/** 选中模型 + 身份闸。控件读取一律排在它后面。 */
+async function selectAndBind({ pick, humanLabel, expectVendor, expectModelKey, tag }) {
+  const picked = await pickModel(pick, humanLabel)
+  const identity = await readBoundIdentity()
+  const file = await shot(tag)
+  if (identity.modelVendor !== expectVendor || identity.modelKey !== expectModelKey) {
+    throw new Error(
+      `WALK FAIL: 在下拉里点的是「${picked}」，节点却被绑到了别的模型身份。\n`
+        + `  期望：vendor=${expectVendor} modelKey=${expectModelKey}\n`
+        + `  实际：vendor=${identity.modelVendor} modelKey=${identity.modelKey} variantId=${identity.variantId}\n`
+        + '  这不是变体收窄的问题——是选中的模型身份被改写了，下游的变体/模式/参数/发送全都会跟着走错家。\n'
+        + `  截图：${file}`,
+    )
+  }
+  return { picked, identity, file }
+}
+
+/** 读变体下拉当前展示的文案（视觉证据的 DOM 对照物）。控件不在时返回 null。 */
+async function readVariantSummary() {
+  if ((await variantSelect.count()) === 0) return null
+  return (await variantSelect.first().innerText()).replace(/\s+/g, ' ').trim()
+}
+
+const observations = {}
+
+try {
+  // 语言/引导偏好钉死：模式栏与变体栏的断言都是中文文案，界面落到 en 会整片假红。
+  // 这些偏好在首帧就被读走，所以写完让页面重载一次再往下走。
+  //
+  // 这里用 reload 是安全的、**且仅此一处**：此刻还在项目库那一屏、**一个项目都还没建**，
+  // 不存在「activeProjectId 被刷成 null、面板静默空掉」的那个坑（那个坑的前提是已经打开了项目）。
+  // 后面所有步骤都在这次 reload **之后**开始，全程不再 reload。
+  await win.waitForLoadState('domcontentloaded')
+  await win.evaluate(() => {
+    localStorage.setItem('nomi:locale:v1', 'zh-CN')
+    for (const key of ['nomi:splash:v1', 'nomi:journey-tour:v1', 'nomi:canvas-gesture-hint:v1']) {
+      localStorage.setItem(key, 'seen')
+    }
+  })
+  await win.reload({ waitUntil: 'domcontentloaded' })
+  await win.waitForTimeout(2000)
+
+  // 占位 key + 启用供应商：只为让这三家的视频模型进下拉。全程不点生成 → 零额度。
+  // 即梦是 authType:"none"（本地 CLI 的设备码登录态，不是 HTTP bearer），故只 upsertVendor 不塞 key。
+  await win.evaluate(async () => {
+    for (const vendor of ['runway', 'apimart']) {
+      await window.nomiDesktop.modelCatalog.upsertVendorApiKey(vendor, { apiKey: 'nomi-e2e-placeholder', enabled: true })
+      await window.nomiDesktop.modelCatalog.upsertVendor({ key: vendor, enabled: true })
+    }
+    await window.nomiDesktop.modelCatalog.upsertVendor({ key: 'dreamina', enabled: true })
+
+  })
+  await win.waitForTimeout(2500)
+
+  const browserWindow = await app.browserWindow(win)
+  await browserWindow.evaluate((target) => {
+    target.setBounds({ x: 0, y: 0, width: 1680, height: 1050 })
+    target.center()
+  })
+
+  // ── 进场：新建空白项目 → 生成画布 → 加一个视频节点 ──────────────────────
+  await clickOrFail(win.locator('button, [role="button"]', { hasText: '新建空白项目' }), '新建空白项目')
+  await clickOrFail(win.getByRole('button', { name: '生成', exact: true }), '顶栏「生成」')
+  await expectVisible(win.locator('.generation-canvas-v2-toolbar'), '生成画布工具栏出现')
+  // data-node-kind 是结构锚点，不随语言变（aria-label「添加视频节点」走 i18n）。
+  await clickOrFail(win.locator('.generation-canvas-v2-toolbar button[data-node-kind="video"]'), '工具条「视频」')
+  await expectVisible(composer, '视频节点的浮动 composer 出现')
+  record('新建空白项目 → 生成画布 → 加视频节点')
+
+  // ══ A ①（阳性对照，必须排在 Runway 之前）APIMart Veo 3.1：变体轴**活着** ══
+  // APIMart 的 veo mapping 写的是 model:"{{request.params.model}}" → 切变体真会换发出去的串
+  // → 控件必须在。这一屏同时是下面「Runway 没有」的探针证明现场。
+  const apimart = await selectAndBind({
+    pick: (t) => t.startsWith('Veo 3.1') && t.includes('APIMart'),
+    humanLabel: 'APIMart Veo 3.1',
+    expectVendor: 'apimart',
+    expectModelKey: 'veo3.1-fast',
+    tag: 'apimart-veo31-variant-present',
+  })
+  const variantProof = await proveProbe(variantSelect, 'APIMart Veo 3.1 的「变体」选择器确实会出现')
+  await expect(variantSelect, 'APIMart 的 veo mapping 参数化了 model，变体选择器必须在')
+    .toHaveCount(1)
+  apimart.variant = await readVariantSummary()
+  apimart.modes = (await modeButtons.allTextContents()).map((t) => t.trim())
+  observations['apimart/veo3.1-fast'] = apimart
+  record(`APIMart Veo 3.1 绑定 ${apimart.identity.modelVendor}/${apimart.identity.modelKey} · 变体 = ${JSON.stringify(apimart.variant)} · 模式栏 = ${JSON.stringify(apimart.modes)}`, apimart.file)
+
+  // ══ A ②（回归警戒线）即梦 Seedance：**没有 HTTP body**，变体全靠 CLI argv ══
+  // 只扫 body 的实现会在这里把 6 个活着的变体一起藏掉。它必须仍然有变体选择器。
+  const dreamina = await selectAndBind({
+    pick: (t) => t.includes('即梦 Seedance'),
+    humanLabel: '即梦 Seedance（会员）',
+    expectVendor: 'dreamina',
+    expectModelKey: 'dreamina-seedance-2.0',
+    tag: 'dreamina-seedance-variant-present',
+  })
+  await expect(
+    variantSelect,
+    '即梦走本地 CLI、create op 根本没有 HTTP body，model 藏在 --model_version={{request.params.model}} 这条 argv 里。\n'
+      + '  这里丢了变体选择器 = 收窄只扫了 body、没算 process.args（wireReferencedParamKeys 的回归），\n'
+      + '  后果是即梦 6 个真能用的型号被一起藏掉——这是「收窄过头砍掉真功能」，比不收窄更糟。',
+  ).toHaveCount(1)
+  dreamina.variant = await readVariantSummary()
+  dreamina.modes = (await modeButtons.allTextContents()).map((t) => t.trim())
+  observations['dreamina/dreamina-seedance-2.0'] = dreamina
+  record(`即梦 Seedance 绑定 ${dreamina.identity.modelVendor}/${dreamina.identity.modelKey} · 变体 = ${JSON.stringify(dreamina.variant)}`, dreamina.file)
+
+  // ══ A ③（核心）Runway Veo 3.1：model 写死 → 变体轴整条不显示 ══════════════
+  const runway = await selectAndBind({
+    pick: (t) => t.startsWith('Runway Veo 3.1') && !t.includes('Fast'),
+    humanLabel: 'Runway Veo 3.1',
+    expectVendor: 'runway',
+    expectModelKey: 'veo3.1',
+    tag: 'runway-veo31-variant-absent',
+  })
+  await expectAbsent(variantSelect, {
+    provenBy: variantProof,
+    message: 'Runway 把 create op 的 model 写成字面量——切变体一个字节都不会变。\n'
+      + '  控件还在 = 摆一个点了没反应的开关骗用户（比没有更糟）。\n'
+      + '  Runway 本就不需要这条轴：它把 veo3.1 / veo3.1_fast 建成了两个目录行。',
+  })
+  // 同屏顺带钉住模式栏与比例没被这次改动误伤（变体轴与模式轴正交，收窄一条不许波及另一条）。
+  await expect(modeButtons, 'Runway Veo 3.1 的模式栏不该被变体轴收窄波及').toHaveText(['文生视频', '首尾帧'])
+  await clickOrFail(composer.locator('button[aria-label="生成参数"]'), '「生成参数」（Runway Veo 3.1）')
+  const paramPanel = win.locator('[role="group"][aria-label="生成参数面板"]')
+  await expectVisible(paramPanel, '生成参数面板打开')
+  await expect(paramPanel, 'Runway 的 Veo 比例应当仍是像素式枚举 1280:720').toContainText('1280:720')
+  runway.paramText = (await paramPanel.innerText()).replace(/\s+/g, ' ').trim().slice(0, 160)
+  runway.paramShot = await shot('runway-veo31-params')
+  await win.keyboard.press('Escape')
+  await win.waitForTimeout(400)
+  runway.variant = await readVariantSummary()
+  runway.modes = (await modeButtons.allTextContents()).map((t) => t.trim())
+  observations['runway/veo3.1'] = runway
+  record(`Runway Veo 3.1 绑定 ${runway.identity.modelVendor}/${runway.identity.modelKey} · 变体控件 = ${runway.variant === null ? '不存在（已收窄）' : JSON.stringify(runway.variant)} · 模式栏 = ${JSON.stringify(runway.modes)}`, runway.file)
+  record('核心对照成立：同一条变体轴 APIMart / 即梦 露出、Runway 收窄消失')
+
+  // ══ A ④ Runway 的其余变体行：同一条判据，逐行钉死 ══════════════════════════
+  // 静态探针（对真实种子目录跑 wireReferencedParamKeys）说 Runway 的 6 个带变体行**全部**惰性。
+  // 只验 veo3.1 一行的话，「收窄只对某一行生效」这种半吊子回归会溜过去，所以逐行都走一遍。
+  for (const row of [
+    { pick: (t) => /Runway Seedance 2Runway/.test(t), label: 'Runway Seedance 2', modelKey: 'seedance2', tag: 'runway-seedance2-variant-absent' },
+    { pick: (t) => /Runway Seedance 2 FastRunway/.test(t), label: 'Runway Seedance 2 Fast', modelKey: 'seedance2_fast', tag: 'runway-seedance2-fast-variant-absent' },
+    { pick: (t) => /Runway Seedance 2 MiniRunway/.test(t), label: 'Runway Seedance 2 Mini', modelKey: 'seedance2_mini', tag: 'runway-seedance2-mini-variant-absent' },
+    { pick: (t) => t.startsWith('Runway Wan 3'), label: 'Runway Wan 3', modelKey: 'wan3', tag: 'runway-wan3-variant-absent' },
+  ]) {
+    const bound = await selectAndBind({
+      pick: row.pick, humanLabel: row.label, expectVendor: 'runway', expectModelKey: row.modelKey, tag: row.tag,
+    })
+    await expectAbsent(variantSelect, {
+      provenBy: variantProof,
+      message: `${row.label} 的 create op 同样把 model 写死，变体选择器不该出现。`,
+    })
+    bound.variant = await readVariantSummary()
+    bound.modes = (await modeButtons.allTextContents()).map((t) => t.trim())
+    observations[`runway/${row.modelKey}`] = bound
+    record(`${row.label} 绑定 ${bound.identity.modelVendor}/${bound.identity.modelKey} · 变体控件 = 不存在（已收窄） · 模式栏 = ${JSON.stringify(bound.modes)}`, bound.file)
+  }
+
+  // ── 回切阳性对照：证明「消失」不是整个控件层塌了 ──────────────────────────
+  // 上面连着 5 行都「没有变体选择器」。如果此刻 composer 其实已经渲染坏了、或者选择器改了名，
+  // 这 5 条会一起假绿。所以最后回到 APIMart 再证一次它**还回得来**——一次性排除这两种系统性假绿。
+  const backToApimart = await selectAndBind({
+    pick: (t) => t.startsWith('Veo 3.1') && t.includes('APIMart'),
+    humanLabel: 'APIMart Veo 3.1（回切）',
+    expectVendor: 'apimart',
+    expectModelKey: 'veo3.1-fast',
+    tag: 'contrast-back-to-apimart-variant-returns',
+  })
+  await expect(
+    variantSelect,
+    '回切 APIMart 后变体选择器必须重新出现。它没回来 = 上面那 5 条「不存在」全是假绿（控件层塌了/改名了），\n'
+      + '  而不是收窄生效——两者长得一模一样，这一条就是用来把它们分开的。',
+  ).toHaveCount(1)
+  backToApimart.variant = await readVariantSummary()
+  observations['contrast/back-to-apimart'] = backToApimart
+  record(`回切阳性对照成立：变体选择器重新出现 = ${JSON.stringify(backToApimart.variant)}`, backToApimart.file)
+
+  // ══ B：Agent 提案面板的模式/变体收窄 —— **本走查无法覆盖，如实声明** ══════
+  //
+  // 这不是「懒得验」，是**验不了**，原因在产品的一条硬护栏上：
+  //
+  // 提案卡（GenerationProposalEditor）只在「Agent 真的发起了一轮、并回了一条生成类工具调用」时才渲染。
+  // 要让 Agent 跑起来，得有一个**可执行**的文本模型；而 `listOnboardingAgentCandidates` 要求该供应商
+  // 的凭据能被 `decryptApiKeyRecord` 解出非空明文、且 `apiKeysByVendor[vendor].enabled === true`。
+  //
+  // 关键在后半句：渲染层写凭据的唯一入口 `upsertRendererCatalogVendorApiKey` 会**强制**
+  // `sanitizeRendererVendorApiKeyMutation → { enabled: false }`（rendererCatalogMutation.ts:156），
+  // 注释写明「渲染层的凭据写入只是配置，永远不能把供应商提升为可用，那是 certification 的职责」。
+  // 也就是说：**任何只靠渲染层 API 播种的走查都造不出一个能跑的 Agent**——这是有意的 fail-closed 护栏，
+  // 不是可以绕的障碍。绕过去（直接改盘上 catalog 文件 / 伪造 certification）就不再是真机走查了。
+  //
+  // 因此本走查**只证 A（画布面）**，B 面留给下列已有手段，别在这里造一个骗自己的绿：
+  //   · 单测已覆盖同一判据：`channelModeReach.test.ts` 直接喂 (body, wireParamKeys) 断言
+  //     `archetypeVariantAxisIsLive` / `archetypeModeIsVisible`，而提案卡与画布**共用**这两个函数
+  //     （GenerationProposalEditor 与 NodeParameterControls 都 import 它们）——即「同一套收窄」这件事
+  //     本身是由「同一个函数」保证的，不是靠两处各写一遍期望值。
+  //   · 真要在 UI 上验 B，得走 agent-runtime 系列走查那条路（它们在有可执行凭据的环境里跑）。
+  record('B（提案面板）如实声明未覆盖：渲染层无法播种可执行凭据 → 提案卡渲染不出来，见文件内注释')
+
+
+  const summaryPath = path.join(shotsDir, 'observed-variant-axis.json')
+  fs.writeFileSync(summaryPath, JSON.stringify(observations, null, 2))
+  console.log('\n观察到的变体轴（DOM 读数）：')
+  for (const [key, value] of Object.entries(observations)) {
+    console.log(`  ${key.padEnd(34)} 变体=${value.variant === null || value.variant === undefined ? (value.variantPresent === false ? '不存在' : 'n/a') : JSON.stringify(value.variant)}  模式=${JSON.stringify(value.modes ?? [])}`)
+  }
+  console.log(`\n✅ 走查通过：${passed} 条判据 · 截图 ${path.relative(repoRoot, shotsDir)}/`)
+} catch (error) {
+  await shot('FAIL').catch(() => {})
+  console.error(`\n${error?.message || error}`)
+  await app.close().catch(() => {})
+  process.exit(1)
+} finally {
+  await app.close().catch(() => {})
+}


### PR DESCRIPTION
> 承接已合入的 [#351](https://github.com/aqm857886159/Nomi/pull/351)。取代 #362（#351 squash 合入后基底被压平，故把真实 delta 原样重落在最新 main 上）。

#351 补齐了「供应商诚实」的参数 / transport / 模式三条轴，但只覆盖了**画布一个面**。本轮补上第二个面与第四条轴。

## 两个缺陷

**① Agent 提案面板的模式选择器没接收窄** —— 以单参数调用 `archetypeModeChoices`，把这家根本没有 mapping 的模式照样列出来。与画布模式栏修好前是同一个病，只是换了个面。

⚠️ #351 的根因合同曾把这个入口记成「已覆盖」。核实为**未覆盖**后已在那份合同里改正 —— 合同里写「这个入口守住了」而其实没守住，比不写合同还糟。

**② 变体选择器从来没有收窄判据** —— Runway 的 Veo 3.1 显示「变体 · 快速」并可切到高质/轻量，但 Runway 的 mapping 把 `model` 写成字面量，切变体只写 `variantId`，**点了什么都不会发生**。

## 判据：渠道有没有把 `model` 参数化

全目录 15 个带变体的 `(vendor, model)` 实测：apimart / kie / volcengine / 即梦 **9 个 = 活**；Runway **6 个 = 惰性**（Runway 本就把 `veo3.1` 与 `veo3.1_fast` 建成两个目录行，不需要变体轴）。

**两个更直觉的判据被实测否决**，各自都会误杀活着的控件：

| 直觉判据 | 会出什么事 |
|---|---|
| 「变体 modelKey 是不是目录行」 | apimart 的 veo 只有 `veo3.1-fast` 一行，quality/lite 不是独立行 → 把 apimart **活着的**变体轴一起藏掉 |
| 「只扫 `create.body`」 | 即梦没有 body，`model` 在 CLI args 里（`--model_version=...`）→ 把即梦 6 个变体**全藏掉** |

故新增 `wireReferencedParamKeys` 取 `body ∪ process.args` 并集，并**删掉** `paramConsistency` 里内联的第二份同款扫描（P1：留着它，变体收窄就会照抄出第三份）。

## 证据

- `pnpm run gates` 全链绿。`check:boundaries` 棘轮仍 **80**（新符号经**已放行的** `referenceReachability` 转出，没开第二个入口）。
- **R13 真机走查** `tests/ux/vendor-honest-variant-axis.walk.mjs`（EXIT=0，11 条断言）：

| 模型 | 变体栏 | 截图所见 |
|---|---|---|
| Runway `veo3.1` | **不在** | chip 直接接 `1280:720`，模式栏 文生视频+首尾帧 |
| apimart `veo3.1-fast` | **在**（快速） | `16:9 · 720p`，3 个模式 |
| 即梦 `dreamina-seedance-2.0` | **在**（金丝雀） | 无 HTTP body、变体走 argv，没被误杀 |

  另加 Runway `seedance2/_fast/_mini`、`wan3` 四行同验；末尾**切回 apimart 证明控件会回来**（排除「控件层塌了」这种假绿）。**变异测试**：把 `archetypeVariantAxisIsLive` 强制 `return true` 后走查当场红。
- 同类入口普查：模式选择面与变体选择面**各恰好 2 处**，全部收窄，无第三个面。

## 如实记档：一半没走查成

**提案面板那一半没有真机走查证据。** 提案卡只能由真实 agent 回合渲染，而渲染层的凭据写入被 `sanitizeRendererVendorApiKeyMutation` 强制 `enabled:false`（认证才有权提升），隔离走查环境造不出「已启用」的供应商 —— 伪造只能靠直接改 catalog 文件或伪造认证，那就不叫真机走查了。

缓解：两个面 import 的是**同一个** `archetypeModeIsVisible` / `archetypeVariantAxisIsLive`，「两面同口径」由共享实现保证、判据本身有单测；未被证实的只剩提案面板自己的接线。已记入合同 `residual_risks`。

---
根因合同：`docs/fixes/2026-09-02-vendor-honest-axes-followup.root-cause.json`（`recurring`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)