### PR TITLE
fix(tests): 补掉 #410 漏扫的第二处恒真探针，并把同类扫描升级成门岗

### DIFF
--- a/docs/fixes/2026-09-03-vacuous-fs-read-spy-probe.root-cause.json
+++ b/docs/fixes/2026-09-03-vacuous-fs-read-spy-probe.root-cause.json
@@ -1,0 +1,102 @@
+{
+  "schema_version": 3,
+  "id": "2026-09-03-vacuous-fs-read-spy-probe",
+  "problem_type": "同类扫描按测试名做、漏掉同构造的第二处；恒真探针因此留在仓里",
+  "symptom": "PR #410 修掉了「按路径过滤 fs 读 spy」的恒真断言，但同一个构造在 projectAgentRepository.test.ts:622 原样留存，继续以恒真的 toHaveLength(0) 冒充「稳态不重扫账本」的覆盖。",
+  "direct_cause": "#410 的同类扫描用测试名/描述文字做 grep（'1,000-command\\|steady-state'），而第二处所在的用例叫「marks a post-publish directory failure as committed and non-retryable」，名字里没有这两个词，于是不在命中集里——尽管它的断言与被修那条逐字同构。",
+  "class_root": "同类扫描按「症状的名字」检索，而不是按「缺陷的构造」检索。名字是作者当时怎么描述它，构造才是缺陷本身；只要第二处换个说法命名，按名字扫的同类检查就必然漏掉它，而且漏得毫无征兆。",
+  "migration": "第二处改用 #410 引入的生产侧计数器 __projectAgentCommandLedgerScanCountForTests()，与第一处同一套写法；恒真的 readSpy 与其断言在同一 commit 删除，不留并行探针。",
+  "affected_population": [
+    "任何断言「稳态不重扫账本」「某 fs 读不发生」的测试",
+    "任何以测试名/描述文字作为同类扫描检索式的根因修复",
+    "未来新写的、按路径过滤 fs 读 spy 调用记录的测试"
+  ],
+  "scope_paths": [
+    "electron/projectAgentHost/projectAgentRepository.test.ts",
+    "scripts/check-test-waits.mjs",
+    "docs/lessons/vacuous-probe-passes-forever.md"
+  ],
+  "entry_points": [
+    "electron/projectAgentHost/projectAgentRepository.test.ts:622 的 expect(readSpy.mock.calls.filter(...)).toHaveLength(0)",
+    "pnpm run test / test:system:focused（该文件在两者的收集范围内）",
+    "pnpm run check:test-waits（本次新增规则的执行入口）"
+  ],
+  "invariants": [
+    "全仓不存在「按路径过滤 fs 读 spy 的 mock.calls」这一构造，且由门岗硬零守住、无棘轮基线。",
+    "「稳态不重扫账本」一律用生产侧计数器观测，不经过 fs 间接层。",
+    "该断言在被测不变量被破坏时必须变红（变异测试证实：expected 3 to be +0）。"
+  ],
+  "regression_tests": [
+    "electron/projectAgentHost/projectAgentRepository.test.ts"
+  ],
+  "residual_risks": [
+    "门岗按行匹配 .mock.calls + .filter( + ===，若同一表达式被拆成多行则漏检。取舍是宁可漏检也不误报——本仓 2 处历史实例均为单行，且真正的兜底是「永不发生的断言必配阳性对照」这条纪律，不是正则。",
+    "规则只在文件同时 spy 了 fs 读接口时才触发，因此不拦非 fs 的 mock.calls 路径过滤（如 agentChatV2Ipc.test.ts:345 的 trace spy，实测不误报）。那类探针不存在 fd/路径错位，不属本类。"
+  ],
+  "external_sources": [],
+  "internal_only_reason": "缺陷完全发生在本仓测试写法与自有门岗之间，没有第三方 API 契约参与判定。",
+  "recurrence": {
+    "classification": "recurring",
+    "reason": "同一构造在本仓已出现 2 次（#410 修 1 处、本次修第 2 处），且第 2 处正是被上一轮同类扫描漏掉的——说明靠人写检索式复发概率高。",
+    "same_class_scan": [
+      "按构造全仓实扫 git grep -nE '\\.mock\\.calls' -- '*.test.ts' '*.test.mjs' | grep '\\.filter(' | grep '===' ：当前 main 得 2 命中——projectAgentRepository.test.ts:622（本次修）与 electron/ai/agentChatV2Ipc.test.ts:345。后者是 trace spy、非 fs，不存在 fd/路径错位，判 not-affected，门岗实测不误报。",
+      "对照 #410 的同类扫描检索式（grep -rn '1,000-command\\|steady-state' electron/）：它按测试名检索，得 2 命中且不含 projectAgentRepository.test.ts——这次漏检的直接机制，已由本次门岗按构造检索补上。",
+      "全仓实扫 fs 读 spy：spyOn(fs, 'readFileSync'|'readFile'|'readSync'|'read') 得 3 个文件（runtime.assets.test.ts、projectAgentRepository.test.ts、projectAgentCommandLedger.test.ts）。后者的 expect(readSpy).not.toHaveBeenCalled() 无路径过滤、能看见 fd 形态的读，是活信号（#410 已判 not-affected，本次复核维持）。"
+    ]
+  },
+  "generality_proof": "门岗按**构造**检索而非按名字：只要出现「文件里 spy 了 fs 读接口」且「拿 mock.calls 按值过滤」这对组合就报红，与用例叫什么、断言写在哪条测试里无关。这正好补上 #410 按名字扫描的漏点——同一次检索若按构造做，两处会一起命中。",
+  "shared_boundaries": [
+    {
+      "path": "scripts/check-test-waits.mjs",
+      "symbol": "RULES 里的 'fs-read-spy-path-filter' 规则 + context.spiesOnFsRead",
+      "responsibility": "以硬零、按构造的方式在全仓测试文件上拦截「按路径过滤 fs 读 spy」这一恒真探针写法，取代靠人写 grep 的同类扫描。"
+    }
+  ],
+  "same_class_entry_points": [
+    {
+      "path": "electron/projectAgentHost/projectAgentRepository.test.ts",
+      "entry_point": "marks a post-publish directory failure as committed and non-retryable",
+      "disposition": "enforced",
+      "evidence": "改用生产侧计数器后做变异测试（关掉 validate() 缓存强制每命令全量重扫）：新断言红在 'expected 3 to be +0'；同一变异体下旧写法此前实测为绿。"
+    },
+    {
+      "path": "electron/ai/agentChatV2Ipc.test.ts",
+      "entry_point": "state.trace.mock.calls.filter(...) 按 requestId 过滤",
+      "disposition": "not-affected",
+      "evidence": "是自建 trace spy 而非 fs 读 spy，第一个参数就是 requestId 本身，不存在 fd/路径错位；门岗对该文件实测不报红（规则要求文件同时 spy 了 fs 读接口）。"
+    },
+    {
+      "path": "electron/projectAgentHost/projectAgentCommandLedger.test.ts",
+      "entry_point": "expect(readSpy).not.toHaveBeenCalled()",
+      "disposition": "not-affected",
+      "evidence": "未按路径过滤，任何形态（含 fd）的读都会被它看见，是活信号；#410 已判定 not-affected，本次按构造复扫维持该结论。"
+    }
+  ],
+  "prevention": {
+    "kind": "static-gate",
+    "enforcement_path": "scripts/check-test-waits.mjs",
+    "invariant": "任何测试文件只要同时出现「spy 了 fs 读接口」与「按值过滤 mock.calls」，门岗即报红并给出文件、行号与替代写法；硬零，无棘轮基线。",
+    "failure_mode": "重新引入该构造 → check:test-waits 退出码 1，gates 链在 push 前拦下；实测在未修的 main 文件上确实报红、修好后转绿。",
+    "exception_policy": "none",
+    "strategy": "把同类扫描从「人写的、按名字的一次性 grep」升级为「按构造的常驻门岗」——名字会变、构造不会，这样第二处不必等下一个人想起来去找。",
+    "artifacts": [
+      "scripts/check-test-waits.mjs",
+      "electron/projectAgentHost/projectAgentRepository.test.ts"
+    ]
+  },
+  "class_regression_tests": [
+    "electron/projectAgentHost/projectAgentRepository.test.ts"
+  ],
+  "legacy_paths": {
+    "status": "removed",
+    "removed_paths": [
+      "electron/projectAgentHost/projectAgentRepository.test.ts"
+    ],
+    "rationale": "恒真的 readSpy 及其 toHaveLength(0) 断言在同一 commit 删除，替换为生产侧计数器；不保留并行探针，且门岗使该构造不可再被写出来。"
+  },
+  "dependency_lifecycle": {
+    "decision": "not-applicable",
+    "rationale": "只用到 vitest 既有 spy API 与仓内既有生产计数器，无第三方依赖参与判定。",
+    "exit_criteria": []
+  }
+}

--- a/docs/lessons/INDEX.md
+++ b/docs/lessons/INDEX.md
@@ -60,6 +60,7 @@
 - [性能预算在 macOS 校准却在 Linux CI 执行 → 假回归](canvas-perf-budget-calibrated-on-macos-fails-on-linux.md) — 别改预算挤 PR，那是治症状
 - [harness 的 catch 会把自己的 bug 洗成产品结论](harness-catch-launders-bugs-into-verdicts.md) — 报某腿失败前先分清是断言红的还是 catch 编的
 - [A/B 两版提示词：确认关卡会污染两臂](prompt-ab-gating-question-confounds-arms.md) — 量到的是服从度不是质量
+- [探针测不到它命名的那件事，断言就永远绿](vacuous-probe-passes-forever.md) — 按路径过滤 fs 读 spy 恒空；四个会话判成「负载 flake」的那条其实恒真。变异测试是唯一判据，「永不发生」必配阳性对照
 - [门岗断言不许手抄真相源的派生值，且必须与真相源同触发面](gate-assertions-must-not-copy-derived-values.md) — 看到 `>= N` 先问「N 是抄谁的」；决定落后与否的是触发面不是细心；死名字既造假红也造假绿
 
 ## C. Git 交付、分支与文档改动

--- a/docs/lessons/vacuous-probe-passes-forever.md
+++ b/docs/lessons/vacuous-probe-passes-forever.md
@@ -1,0 +1,37 @@
+# 探针测不到它命名的那件事：断言恒真，而你为这个零付了全额代价
+
+> 📎 教训 · 首次记录 2026-09-03 · 状态：✅ 已固化（`check:test-waits` 的 `fs-read-spy-path-filter` 规则接管）
+> **触发场景**：你正要写「这事永远不发生」的计数断言（`toHaveLength(0)` / `toBe(0)`）；或你 spy 住 `fs` 的读接口再按路径过滤 `mock.calls`；或某条测试反复超时、你正准备判它「并行负载 flake」。
+
+**结论**：`toBe(0)` 只有在**同一个 run 里证明过这个计数器会涨**之后才有意义。没有阳性对照的零，和仪器坏掉长得一模一样——而且它永远不会自己暴露。
+
+## 为什么会踩
+
+`projectAgentHost.test.ts` 那条招牌断言这么写：
+
+```ts
+const ledgerReadSpy = vi.spyOn(fs, "readFileSync");
+const ledgerReads = ledgerReadSpy.mock.calls.filter(([filePath]) => String(filePath) === paths.ledger);
+expect(ledgerReads).toHaveLength(0);   // 「稳态不许重扫账本」
+```
+
+可生产读账本走的是 `readRegular()`：**按路径 `open`、按 fd `read`**（`projectAgentCommandLedger.ts` 里 `fs.readFileSync(fd)`）。所以 `readFileSync` 的第一个参数永远是数字 fd，永远不等于路径串——**过滤器恒空，断言恒真**。
+
+实测（变异测试）：把 `validate()` 的缓存关掉、让它每条命令都全量重扫账本，那条断言照样绿，2045 次 `readFileSync` 调用里它「看到」0 次。它保护的东西，一次都没保护过。
+
+**代价却是真的**：它挂在 1000 条命令的真实落盘循环上，无外部负载就已吃掉 30s `testTimeout` 的 85%（实测 25,446ms @ load 36），于是在四个分支上超时——被四个会话分别判成「并行负载 flake」。**花全款买了个空盒子，还因为盒子太重反复翻车。**
+
+同一天在 `projectAgentRepository.test.ts:622` 扫出**第二份一模一样的写法**。第一份由 PR #410 修掉时没连带扫同类，第二份留到 #411 才补——所以这条的重点不只是「别这么写」，还有「扫出一处就 grep 全仓同形状」。
+
+## 怎么用
+
+- **别用 fs spy 的调用记录当行为探针**。生产「按路径 open、按 fd 读」是常态，按路径过滤必然落空。要么用**生产侧计数器**（`__projectAgentCommandLedgerScanCountForTests` / `__projectAgentFullValidationCountForTests` 这一套，不经过 fs 间接层），要么按 **open 意图**数（读打开 vs 写打开用 flag 区分）。
+- **每条「永远不发生」的断言配一条阳性对照**：同一个 run 里让它发生一次，断言计数器确实变成 1。`projectAgentHost.test.ts` 的「counts a real cold-cache ledger rescan」就是这个用途——它存在的唯一理由是让上一条不能悄悄变死。
+- **同一条测试超时 ≥ 2 次就别再判负载**，去做变异测试：手动破坏被测的不变量，**不红 = 断言是死的**。这个判据跟机器快慢无关，是这类问题唯一可靠的分辨法。
+- **扫出一处就 grep 全仓同形状**（`.mock.calls` + `.filter(` + `===`），别只修报到你面前的那一处。
+
+## 出处
+
+- PR #410（修第一处 + 换成生产侧计数器 + 加阳性对照用例）、PR #411（修第二处 + 立本门岗）
+- 变异测试：关掉 `validate()` 缓存 → 旧断言绿、新断言红
+- 相关：[[dead-selector-lies-both-ways]]、[[race-repro-needs-positive-control]]、[[assert-you-are-in-the-situation-you-claim]]、[[flaky-test-check-other-worktrees-first]]

--- a/electron/projectAgentHost/projectAgentRepository.test.ts
+++ b/electron/projectAgentHost/projectAgentRepository.test.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { __projectAgentCommandLedgerScanCountForTests } from "./projectAgentCommandLedger";
 import {
   PROJECT_AGENT_STORE_SCHEMA_VERSION,
   ProjectAgentRepositoryCommittedDurabilityError,
@@ -577,7 +578,7 @@ describe("ProjectAgentRepository", () => {
     const realRename = fs.renameSync.bind(fs);
     const directoryFds = new Set<number>();
     let mainPublished = false;
-    const readSpy = vi.spyOn(fs, "readFileSync");
+    const scansBefore = __projectAgentCommandLedgerScanCountForTests();
     setDurabilityMode("durable");
     vi.spyOn(fs, "openSync").mockImplementation((filePath, flags, mode) => {
       const fd = realOpen(filePath, flags, mode);
@@ -619,7 +620,11 @@ describe("ProjectAgentRepository", () => {
     expect(repository.lookupCommittedCommand(state(BINDING_A, 1), "repository-fixture-command-1")).toMatchObject({
       appliedRevision: 1,
     });
-    expect(readSpy.mock.calls.filter(([filePath]) => String(filePath) === paths.ledger)).toHaveLength(0);
+    // 提交后仍走内存索引答题，一次账本全量重扫都没有。上一版这里过滤 `fs.readFileSync` 的
+    // 路径参数，而重扫走 readRegular() → fs.readFileSync(fd)，第一个参数是 fd 数字不是路径，
+    // 过滤器**永远匹配不到**——那条断言恒真。计数器不经过 fs 间接层，`projectAgentHost.test.ts`
+    // 里的阳性对照用例钉住「它真的会涨」。
+    expect(__projectAgentCommandLedgerScanCountForTests() - scansBefore).toBe(0);
     expect(fs.existsSync(paths.backup)).toBe(false);
   });
 

--- a/scripts/check-test-waits.mjs
+++ b/scripts/check-test-waits.mjs
@@ -89,7 +89,31 @@ const RULES = [
       return Boolean(expected && context.clockDeltaNames.has(expected[1]))
     },
   },
+  {
+    // 2026-09-03 加。上面三条抓的是「墙钟当判据」，这条抓的是**探针根本测不到它命名的那件事**
+    // ——同一族假绿的另一种成因，而且更隐蔽：它不是偶尔红，是永远绿。
+    //
+    // 形状：spy 住 fs 的读接口，再拿 `mock.calls` 按**路径**过滤。可生产读文件的惯用写法是
+    // 「按路径 open、按 fd 读」（`projectAgentCommandLedger.ts` 的 readRegular() 就是），
+    // 于是 `readFileSync` 的第一个参数永远是数字 fd、永远不等于路径串，过滤器恒空、断言恒真。
+    //
+    // 实证：`projectAgentHost.test.ts` 那条「不许稳态重扫账本」的招牌断言就是这么写的。
+    // 强制让它每条命令都全量重扫（关掉 validate() 的缓存）后，它数出的仍然是 0 条、照样绿——
+    // 它为这个恒真的零付了 1000 次真实落盘往返的代价，然后在四个分支上超时，被判成「负载 flake」。
+    // 同一天在 `projectAgentRepository.test.ts` 扫出第二份一模一样的写法（#410 只修了第一份）。
+    //
+    // 正解：改用**生产侧计数器**（`__projectAgentCommandLedgerScanCountForTests` /
+    // `__projectAgentFullValidationCountForTests` 那一套），不经过 fs 间接层，不会悄悄失效；
+    // 并配一条阳性对照用例钉住「这个计数器真的会涨」。
+    id: 'fs-read-spy-path-filter',
+    label: '按路径过滤 fs 读 spy 的 mock.calls——生产按 fd 读，过滤器恒空、断言恒真（造的是假绿，不是假红）',
+    test: (line, context) =>
+      context.spiesOnFsRead && /\.mock\.calls\b/.test(line) && /\.filter\(/.test(line) && /===/.test(line),
+  },
 ]
+
+// 生产读文件常见「按路径 open、按 fd 读」，所以按路径过滤读 spy 的调用记录必然落空。
+const FS_READ_SPY = /spyOn\(\s*fs\s*,\s*['"](readFileSync|readFile|readSync|read)['"]/
 
 // `wallclock-budget-assertion` 的棘轮基线（只减不增）。
 //
@@ -110,7 +134,7 @@ const WALLCLOCK_BUDGET_BASELINE = new Map([
 const hits = []
 for (const file of collectTestFiles()) {
   const source = stripComments(fs.readFileSync(file, 'utf8'))
-  const context = { clockDeltaNames: collectClockDeltaNames(source) }
+  const context = { clockDeltaNames: collectClockDeltaNames(source), spiesOnFsRead: FS_READ_SPY.test(source) }
   source.split('\n').forEach((line, i) => {
     for (const rule of RULES) {
       if (rule.test(line, context)) hits.push({ rule, file, line: i + 1, text: line.trim().slice(0, 120) })
@@ -149,9 +173,14 @@ if (hardHits.length > 0 || budgetViolations.length > 0 || staleBaseline.length >
     console.log(`    ${relative}  [wallclock-budget-assertion]  基线陈旧：登记 ${allowed} 处、实际 ${actual} 处`)
     console.log('        → 好事，把 WALLCLOCK_BUDGET_BASELINE 里的数字降到实际值（棘轮只减不增）')
   }
-  if (hardHits.length > 0) {
+  if (hardHits.some((hit) => hit.rule.id !== 'fs-read-spy-path-filter')) {
     console.log('  → 等后台编排链请 import electron/productionRun/productionRunTestHelpers 的 waitForProduction')
     console.log('    （60s 安全网只拦真死锁/真回归，不给磁盘排队计时；来龙去脉见 docs/plan/2026-08-25-fix-flaky-production-run-tests.md）')
+  }
+  if (hardHits.some((hit) => hit.rule.id === 'fs-read-spy-path-filter')) {
+    console.log('  → fs-read-spy-path-filter：生产按 fd 读，按路径过滤读 spy 恒空、断言恒真（假绿）。')
+    console.log('    改用生产侧计数器（__projectAgentCommandLedgerScanCountForTests 那一套），')
+    console.log('    并配一条阳性对照用例钉住「它真的会涨」——见 docs/lessons/vacuous-probe-passes-forever.md')
   }
   if (budgetViolations.length > 0) {
     console.log('  → 新增的耗时断言：若它量的是「这段计算够不够快」，删掉换与机器速度无关的判据')


### PR DESCRIPTION
补 [#410](https://github.com/aqm857886159/Nomi/pull/410) 的一处漏网，外加把它的同类扫描方式固化成门岗。

## #410 漏了什么

#410 修掉了「按路径过滤 fs 读 spy」这个恒真断言，做得很彻底（换成生产侧计数器 `__projectAgentCommandLedgerScanCountForTests`、另立一条阳性对照用例、两窗等长的工作量不变量）。但**同一个构造在仓里还有第二处**，原样留着：

`electron/projectAgentHost/projectAgentRepository.test.ts:622`
```ts
expect(readSpy.mock.calls.filter(([filePath]) => String(filePath) === paths.ledger)).toHaveLength(0);
```

和被修的那条逐字同构，因此同样恒真——生产走 `readRegular()` 按 fd 读，`readFileSync` 的第一个参数永远是数字，按路径过滤永远匹配不到。

## 为什么会漏

不是粗心，是**检索式的选法**。#410 的同类扫描按测试名做：

```
grep -rn '1,000-command\|steady-state' electron/   → 2 命中，不含 repository.test.ts
```

而第二处所在的用例叫 `marks a post-publish directory failure as committed and non-retryable`——名字里没有那两个词。**名字是作者当时怎么描述它，构造才是缺陷本身**；只要第二处换个说法命名，按名字扫就必然漏，而且漏得毫无征兆。

按构造扫就一起命中了：
```
git grep -nE '\.mock\.calls' -- '*.test.ts' '*.test.mjs' | grep '\.filter(' | grep '==='
```

## 改了什么

1. **第二处改用生产侧计数器**，与 #410 第一处同一套写法；恒真的 `readSpy` 与其断言同 commit 删除，不留并行探针。

2. **新增门岗规则 `fs-read-spy-path-filter`**（`check:test-waits`，硬零无基线）：文件同时出现「spy 了 fs 读接口」+「按值过滤 `mock.calls`」即报红。这是把 #410 那次人工同类扫描**按构造重做一遍并常驻化**——名字会变，构造不会。

## 验证

- **变异测试**（关掉 `validate()` 缓存，强制每条命令全量重扫账本）：新断言红在 `expected 3 to be +0`。同一变异体下旧写法此前实测为**绿**——这就是它恒真的直接证据。
- **门岗红/绿双验**：在未修的 main 版本文件上报红并给出 `:622` 与行文；修好后转绿。
- **误报面实扫**：全仓按构造另 1 命中 `electron/ai/agentChatV2Ipc.test.ts:345`，是自建 trace spy 而非 fs（第一个参数就是 requestId，不存在 fd/路径错位），门岗对该文件实测不报红。
- `pnpm run gates` **exit 0**：1121 个测试文件通过、1 skipped、0 failed，五门戳已盖。

根因合同：`docs/fixes/2026-09-03-vacuous-fs-read-spy-probe.root-cause.json`（v3，recurring，prevention = 该门岗）
教训：`docs/lessons/vacuous-probe-passes-forever.md`（B 区已挂索引）

---

附带说明：我在不知道 #410 在途的情况下并行做了同一件事（[#409](https://github.com/aqm857886159/Nomi/pull/409)），独立得出同样的根因。#410 的实现更好（生产侧计数器优于我的 fs open-intent 计数，两窗等长的工作量不变量我没做到），所以 #409 已关闭，只把它真正独有的这两项提出来做成本 PR。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
