### PR TITLE
docs(m5): record packaged graduation checklist

### DIFF
--- a/docs/plan/2026-09-03-m5-packaged-graduation.md
+++ b/docs/plan/2026-09-03-m5-packaged-graduation.md
@@ -9,8 +9,8 @@
 - Slice B: record packaged evidence for M0-M4 commitments, including explicit
   gaps where `agentHostEnabled=false` or an audited boundary is not present.
 - Slice C: add a release runbook for real Claude/Codex hosts and paid vendor
-  generation, and wire the zero-quota packaged journey into the Mac Package CI
-  job.
+  generation. The existing Mac Package CI smoke remains the blocking packaged
+  check; full L2 is not wired while its real parity failure is open.
 
 ## Non-goals
 

--- a/docs/plan/INDEX.md
+++ b/docs/plan/INDEX.md
@@ -190,7 +190,6 @@
 
 | 文件 | 一句话 | 状态 |
 |---|---|---|
-| [2026-09-03-m5-packaged-graduation.md](2026-09-03-m5-packaged-graduation.md) | M5 打包真机毕业：零额度 MCP 全链、M0-M4 不变量复验与发版边界 | 🚧 |
 | [v0.7.1-execution.md](v0.7.1-execution.md) | v0.7.1 卡片可用性修复+媒体轨道抽象+性能 | 📎 |
 | [v0.8-execution-token-opt-and-phase-b.md](v0.8-execution-token-opt-and-phase-b.md) | v0.8 Token 优化 + Phase B 接入 | 📎 |
 | [v0.8-handoff-2026-05-30.md](v0.8-handoff-2026-05-30.md) | v0.8 用户旅程交接 | 📎 |

--- a/docs/plan/INDEX.md
+++ b/docs/plan/INDEX.md
@@ -159,6 +159,7 @@
 | [2026-09-01-feedback-share-center.md](2026-09-01-feedback-share-center.md) | v0.21 低摩擦反馈与分享中心：私密 Tally 表单、公开 GitHub、自动带入安全运行时上下文 | 🚧 |
 | [2026-09-01-storyboard-table-genre-profile.md](2026-09-01-storyboard-table-genre-profile.md) | **分镜表 v5**：场分组+图优先行+结构化提示词（@/骨架段）+行内执行；A 段已合（#330），B-D 分阶段交付；样张 docs/design/mockups/2026-09-01-storyboard-table-image-first.html | 🚧 |
 | [2026-09-02-walkthrough-catalog-seed-version.md](2026-09-02-walkthrough-catalog-seed-version.md) | 隔离走查 catalog 种子按被测 app 版本校验：future seed quarantine + 版本真源单一化，终结「切模型静默失效」假绿 | ✅ |
+| [2026-09-03-m5-packaged-graduation.md](2026-09-03-m5-packaged-graduation.md) | M5 打包真机毕业：零额度 MCP 全链、M0-M4 证据清单与发版前人工 runbook | 🚧 |
 
 ## 性能 / 技术地基 / 巨壳拆分 / 管线
 

--- a/docs/qa/2026-09-03-m5-graduation-checklist.md
+++ b/docs/qa/2026-09-03-m5-graduation-checklist.md
@@ -11,7 +11,7 @@
 | M3：七层上下文在真实 Host 运行 | 需要真实 Agent Host/外部 AI session 的上下文 receipt | 未覆盖：本分支保持 Host 关闭 |
 | M3：技能 F-A5 三层载入：目录元数据→正文→证据 | packaged smoke 的 `resources/list` / content-addressed `resources/read`，核对 `director.cinematography` 正文 | PASS：34 resources；director body 7885 chars；unsigned 不泄露内部技能 |
 | M4：签名/未签名客户端边界 | packaged smoke 同时跑 3 signed client + generic unsigned，后者调用写工具 | PASS：unsigned generic writes rejected |
-| M4：污染标记驱动 spend 的危险动作拦截 | 依据 K-01..K-08 对当前 MCP skill/read→effect 链做打包态探针 | FAIL/未覆盖：当前实现没有可断言的 structured taint/effect gate；不能把文案当拦截证据 |
+| M4：污染标记驱动 spend 的危险动作拦截 | `electron/harness/context/promptPipe.test.ts` + `provenanceActionGuard.test.ts` 验证实现；打包态需 Agent Host 真旅程 | 未覆盖：最新 main 已有 structured provenance/action guard 且单测通过，但 `agentHostEnabled=false`，本次真实打包 MCP 不能到达该 Host 边界；不能把 unsigned write rejection 当成 taint spend 证据 |
 
 ## 开发态与打包态差异
 

--- a/docs/qa/2026-09-03-m5-graduation-checklist.md
+++ b/docs/qa/2026-09-03-m5-graduation-checklist.md
@@ -1,0 +1,24 @@
+# M5 打包真机毕业清单
+
+日期：2026-09-03  ·  构建：`release/mac-arm64/Nomi.app`  ·  `agentHostEnabled=false`
+
+| M0-M4 承诺 | 打包态验证方式 | 结果 |
+|---|---|---|
+| M0：MCP 外部连接、签名客户端身份、工具面和未知调用拒绝 | `node tests/ux/packaged-mcp-smoke.e2e.mjs release/mac-arm64/Nomi.app`；工具名从 `dist-electron` 声明派生 | PASS：23 tools；claude/codex/cursor signed；generic unsigned 写入拒绝 |
+| M1：集成草稿持久化、重启后读取、凭据不落盘 | `node tests/ux/model-integration-packaged.e2e.mjs --packaged release/mac-arm64/Nomi.app` | PASS：restart readback；`createRequests=0`；`credentialBytes=0` |
+| M1：Host 账本全量持久化/恢复 | 同上仅覆盖 integration draft，不启用 Agent Host | 未覆盖：`agentHostEnabled=false` |
+| M2：项目→节点→生成计划→供应商假调用→产物→时间轴→导出 | 开发态与打包态运行同一 `mcp-l2-journeys.e2e.mjs`、同一 fake APIMart loopback | 开发态 PASS 43/43；打包态 FAIL 15/43，停在 generation confirmation |
+| M3：七层上下文在真实 Host 运行 | 需要真实 Agent Host/外部 AI session 的上下文 receipt | 未覆盖：本分支保持 Host 关闭 |
+| M3：技能 F-A5 三层载入：目录元数据→正文→证据 | packaged smoke 的 `resources/list` / content-addressed `resources/read`，核对 `director.cinematography` 正文 | PASS：34 resources；director body 7885 chars；unsigned 不泄露内部技能 |
+| M4：签名/未签名客户端边界 | packaged smoke 同时跑 3 signed client + generic unsigned，后者调用写工具 | PASS：unsigned generic writes rejected |
+| M4：污染标记驱动 spend 的危险动作拦截 | 依据 K-01..K-08 对当前 MCP skill/read→effect 链做打包态探针 | FAIL/未覆盖：当前实现没有可断言的 structured taint/effect gate；不能把文案当拦截证据 |
+
+## 开发态与打包态差异
+
+开发态在 `nomi_operation_gate` 请求后弹出 Nomi 确认卡并完成 43/43；同一 commit 生成的打包 app 在前 15 条通过后返回 `human_approval_required`，没有完成确认卡，未进入 provider、timeline 或 MP4 export。这是打包毕业阻断项，不能通过放宽断言或 `continue-on-error` 处理。
+
+## 执行与 CI 边界
+
+- 开发态：`node tests/ux/mcp-l2-journeys.e2e.mjs` → `MCP-L2 PASS: 43 assertions`。
+- 打包态：`pnpm run test:mcp-l2:packaged` → 当前保持红，直到确认桥 parity 修复并重新验证。
+- Mac Package CI 已保留真实通过的 packaged smoke；完整 L2 暂不接成阻断 CI，避免把真实 FAIL 伪装成绿灯。


### PR DESCRIPTION
## Scope
- Record every M0-M4 promise with packaged verification, explicit PASS/FAIL/未覆盖, and the development/package parity result.
- Record the M4 structured provenance guard boundary honestly: implementation/unit tests pass, packaged Agent Host is not reachable while `agentHostEnabled=false`.

## Evidence
- Local `pnpm run gates` passed at `9f912147`; focused M4 provenance tests: 3 files / 16 tests passed.
- R-M-3 self-check: multimodal turns remain separate; stage transitions re-check prior beliefs; IDs/receipts/budget remain preserved over parallelism.

## Review
- Clean replacement for superseded #418; stacked on clean PR #420; do not merge yet.