### PR TITLE
docs(m5): add agent graduation release runbook

### DIFF
--- a/docs/qa/2026-09-03-m5-graduation-checklist.md
+++ b/docs/qa/2026-09-03-m5-graduation-checklist.md
@@ -7,7 +7,7 @@
 | M0：MCP 外部连接、签名客户端身份、工具面和未知调用拒绝 | `node tests/ux/packaged-mcp-smoke.e2e.mjs release/mac-arm64/Nomi.app`；工具名从 `dist-electron` 声明派生 | PASS：23 tools；claude/codex/cursor signed；generic unsigned 写入拒绝 |
 | M1：集成草稿持久化、重启后读取、凭据不落盘 | `node tests/ux/model-integration-packaged.e2e.mjs --packaged release/mac-arm64/Nomi.app` | PASS：restart readback；`createRequests=0`；`credentialBytes=0` |
 | M1：Host 账本全量持久化/恢复 | 同上仅覆盖 integration draft，不启用 Agent Host | 未覆盖：`agentHostEnabled=false` |
-| M2：项目→节点→生成计划→供应商假调用→产物→时间轴→导出 | 开发态与打包态运行同一 `mcp-l2-journeys.e2e.mjs`、同一 fake APIMart loopback | 开发态 PASS 43/43；打包态 FAIL 15/43，停在 generation confirmation |
+| M2：项目→节点→生成计划→供应商假调用→产物→时间轴→导出 | 开发态与打包态运行同一 `mcp-l2-journeys.e2e.mjs`、同一 fake APIMart loopback | 开发态 PASS 50/50；打包态 FAIL 15/50，停在 generation confirmation |
 | M3：七层上下文在真实 Host 运行 | 需要真实 Agent Host/外部 AI session 的上下文 receipt | 未覆盖：本分支保持 Host 关闭 |
 | M3：技能 F-A5 三层载入：目录元数据→正文→证据 | packaged smoke 的 `resources/list` / content-addressed `resources/read`，核对 `director.cinematography` 正文 | PASS：34 resources；director body 7885 chars；unsigned 不泄露内部技能 |
 | M4：签名/未签名客户端边界 | packaged smoke 同时跑 3 signed client + generic unsigned，后者调用写工具 | PASS：unsigned generic writes rejected |
@@ -15,10 +15,10 @@
 
 ## 开发态与打包态差异
 
-开发态在 `nomi_operation_gate` 请求后弹出 Nomi 确认卡并完成 43/43；同一 commit 生成的打包 app 在前 15 条通过后返回 `human_approval_required`，没有完成确认卡，未进入 provider、timeline 或 MP4 export。这是打包毕业阻断项，不能通过放宽断言或 `continue-on-error` 处理。
+开发态在 `nomi_operation_gate` 请求后弹出 Nomi 确认卡并完成 50/50；同一最新 main 基线生成的打包 app 在前 15 条通过后返回 `human_approval_required`，没有完成确认卡，未进入 provider、timeline 或 MP4 export。这是打包毕业阻断项，不能通过放宽断言或 `continue-on-error` 处理。
 
 ## 执行与 CI 边界
 
-- 开发态：`node tests/ux/mcp-l2-journeys.e2e.mjs` → `MCP-L2 PASS: 43 assertions`。
+- 开发态：`node tests/ux/mcp-l2-journeys.e2e.mjs` → `MCP-L2 PASS: 50 assertions`。
 - 打包态：`pnpm run test:mcp-l2:packaged` → 当前保持红，直到确认桥 parity 修复并重新验证。
 - Mac Package CI 已保留真实通过的 packaged smoke；完整 L2 暂不接成阻断 CI，避免把真实 FAIL 伪装成绿灯。

--- a/docs/release/agent-graduation-runbook.md
+++ b/docs/release/agent-graduation-runbook.md
@@ -1,0 +1,19 @@
+# Agent 发版前毕业检查单
+
+以下检查需要真实宿主或真实额度，不进 CI；每项都必须保留对应 MCP trace、Run ledger 和供应商账单/响应证据。
+
+1. **真实 Claude Code MCP 连接**
+   - 成本：现有 Claude 账号/套餐与其模型额度；不使用 Nomi 的零额度 fixture。
+   - 判据：签名握手、项目选择、技能三层按需读取、真人确认卡完成；断开后无孤儿 Run，重连能读回同一 project/lease/receipt。
+2. **真实 Codex MCP 连接**
+   - 成本：现有 Codex 账号/套餐与其模型额度；不使用 Nomi 的零额度 fixture。
+   - 判据：与 Claude 相同，并额外核对 origin、client proof、project lease、receipt 全部来自同一客户端，未签名客户端不能写入或触发 effect。
+3. **真实付费生成与导出**
+   - 成本：所选供应商显示的实际单价 × 镜头数，以供应商最终账单/扣费记录为准；执行前人工批准预算。
+   - 判据：冻结合同、预算上限、receipt、供应商 task、到账 artifact、timeline 与导出 MP4 一一对应；失败、重启、重试均不重复扣费或重复提交。
+
+## 进入条件
+
+- 先通过 `pnpm run dist:mac:dir` 的 packaged smoke 和 `node tests/ux/model-integration-packaged.e2e.mjs --packaged release/mac-arm64/Nomi.app`。
+- 先修复并重跑 `pnpm run test:mcp-l2:packaged` 的 generation confirmation parity FAIL。
+- 真实 Host 与付费检查只能在维护者明确批准账号/额度后执行；CI 保持 `agentHostEnabled=false`、零额度。


### PR DESCRIPTION
## Scope
- Add the pre-release checklist for real Claude Code, real Codex, and paid generation/export.
- Record cost ownership and pass/fail evidence required before release.
- Keep these checks out of CI; `agentHostEnabled=false` and zero-cost fixtures remain the CI boundary.

## Evidence
- Local `pnpm run gates` passed at `926801b6`.
- Latest packaged dir build and packaged smoke pass: 24 tools, 34 resources, signed/unsigned boundary verified.
- Full packaged L2 remains an honest FAIL at 15/50 generation confirmation while development L2 passes 50/50; the full journey is not wired as blocking CI.
- R-M-3 self-check: multimodal turns remain separate; stage transitions must re-check prior beliefs; IDs/receipts/budget remain preserved over parallelism.

## Review
- Clean replacement for superseded #419; stacked on clean PR #421; do not merge yet.