### PR TITLE
fix(vocab-gate): let the ratchet record a genuine convergence instead of reading it as a relabel

### DIFF
--- a/docs/engineering-rules.md
+++ b/docs/engineering-rules.md
@@ -293,6 +293,7 @@ CSS 文件分工与「只可减不可增」规则详见 R1 最后一节。
 
 - `registered`：确实是独立领域合同，reason 必须说明为什么不能复用。
 - `debt`：已知重复/待收敛 owner；`debtCap` 只减不增，等量换一个 owner 也不算减少。
+- `converged`：收敛 provenance；每条记录用 `retiredOwners` 明列已退役 owner、用 `survivingOwner` 明列 surviving owner。门岗会对 live scan 验证前者全部消失、后者仍存在且有 substantive `registered` entry，并对 reference baseline 验证每个 retired owner 确实在册且成员集与 surviving owner 一致；只有这样的记录能解释历史 `historical-debt-promoted`，不能绕过 `debtCap` 或 `historical-cap-not-tight`。
 
 `--update-baseline` 只生成带 `TODO` 的待解释条目，写完仍然红；它是检索助手，不是自动放行按钮。
 

--- a/docs/fixes/2026-09-03-vocabulary-convergence-record.root-cause.json
+++ b/docs/fixes/2026-09-03-vocabulary-convergence-record.root-cause.json
@@ -1,0 +1,107 @@
+{
+  "schema_version": 3,
+  "id": "2026-09-03-vocabulary-convergence-record",
+  "problem_type": "semantic vocabulary ratchet cannot distinguish a real multi-owner convergence from debt relabelling",
+  "symptom": "A branch that deleted two src/ generation-node-status owners and retained one neutral electron/shared owner was rejected as historical-debt-promoted, even though the live scan proved the old definitions were gone and the new owner was the only definition.",
+  "direct_cause": "evaluateHistoricalRatchet only sees a removed reference debt identity and a same-member registered identity at a new site. It had no checkable provenance record connecting the retired owners to the surviving owner, so the genuine merge and a forged reclassification had the same observable shape.",
+  "class_root": "The ratchet lacked a source-verified convergence contract: a reduction must name every retired owner and the surviving registered owner, prove the retired sites are absent and the survivor is present, and prove the retired sites existed in the reference baseline with the same member set.",
+  "affected_population": [
+    "Any baseline reduction that merges two or more vocabulary owners into one registered owner.",
+    "Historical checks comparing a current baseline with a reference snapshot after a source-level vocabulary convergence.",
+    "The generation-node-status convergence from src/workbench/generationCanvas/model/* into electron/shared/canvas/generationNodeStatus.ts."
+  ],
+  "scope_paths": [
+    "scripts/check-vocabularies.mjs",
+    "scripts/check-vocabularies-history.node-test.mjs",
+    "docs/engineering-rules.md"
+  ],
+  "entry_points": [
+    "scripts/check-vocabularies.mjs:validateBaseline and evaluate — current baseline shape, live source presence, and surviving registered owner.",
+    "scripts/check-vocabularies.mjs:evaluateHistoricalRatchet — reference existence, member-set matching, and the narrowly scoped promotion bypass.",
+    "scripts/check-vocabularies-history.node-test.mjs — the six requested convergence and ratchet regression cases."
+  ],
+  "external_sources": [],
+  "internal_only_reason": "This is an internal baseline and source-scan invariant; no third-party contract or external documentation determines whether a repository owner was genuinely retired or survived.",
+  "invariants": [
+    "Every convergence record explicitly names one or more retiredOwners and exactly one survivingOwner.",
+    "Every retired owner in a current convergence record is absent from the live scan, and the surviving owner is present.",
+    "The surviving owner is a current registered baseline entry with a substantive reason.",
+    "Every retired owner exists in the historical reference baseline in either registered or debt, and its normalized members equal the surviving registered owner's members.",
+    "Only retired debt entries and member sets matched by a valid convergence record bypass historical-debt-promoted; all other promotion paths retain their prior behavior.",
+    "debtCap remains non-increasing and exactly equals current debt length; convergence cannot bypass historical-cap-increased or historical-cap-not-tight."
+  ],
+  "generality_proof": "The record is evaluated at the shared baseline and historical-ratchet boundary rather than in a generation-specific fixture. Its retired-owner list is checked against every scanned site and every reference entry, while the bypass is keyed by the exact retired site and the surviving registered site/member set. Therefore any future multi-owner convergence must satisfy the same live, historical, and cap checks; a rename, missing source owner, mismatched member set, unregistered survivor, new debt, cap increase, or loose cap still fails.",
+  "shared_boundaries": [
+    {
+      "path": "scripts/check-vocabularies.mjs",
+      "symbol": "evaluate",
+      "responsibility": "Fail closed on malformed convergence records, retired owners still present in the live scan, missing surviving owners, and survivors that are not registered."
+    },
+    {
+      "path": "scripts/check-vocabularies.mjs",
+      "symbol": "evaluateHistoricalRatchet",
+      "responsibility": "Verify reference-baseline provenance and member identity, then permit only the exact recorded convergence to explain a retired debt promotion while preserving all cap checks."
+    }
+  ],
+  "same_class_entry_points": [
+    {
+      "path": "scripts/check-vocabularies-history.node-test.mjs",
+      "entry_point": "multi-owner convergence fixture",
+      "disposition": "enforced",
+      "evidence": "The valid case merges two reference debt owners and one reference registered owner into one current registered owner; without the record the old historical promotion guard rejects the reduction, and with the record the exact source and reference checks pass."
+    },
+    {
+      "path": "scripts/check-vocabularies-history.node-test.mjs",
+      "entry_point": "existing renamed debt promotion regression",
+      "disposition": "enforced",
+      "evidence": "The pre-existing case has no convergence record and continues to fail as historical debt reclassified as registered, proving the new bypass is not a general same-member rename exception."
+    },
+    {
+      "path": "scripts/check-vocabularies.mjs",
+      "entry_point": "current debt and historical cap checks",
+      "disposition": "enforced",
+      "evidence": "The convergence-specific tests keep cap growth and untightened reductions red; those checks remain outside the convergence bypass and are still rendered as historical-cap-increased or historical-cap-not-tight."
+    }
+  ],
+  "recurrence": {
+    "classification": "recurring",
+    "reason": "Owner convergence is a recurring repository refactor pattern, and the failure is structural: any future deletion of a debt owner into a newly named registered owner is indistinguishable from gaming unless provenance and source presence are checked at the shared ratchet boundary.",
+    "same_class_scan": [
+      "Searched scripts/check-vocabularies.mjs and all scripts/check-vocabularies*.node-test.mjs for historical-debt-promoted, reference debt, registered promotion, debtCap, and existing convergence-like canonical move handling.",
+      "Live AST scan confirmed the generation-node-status survivor at electron/shared/canvas/generationNodeStatus.ts::variable:GENERATION_NODE_STATUSES/as-const and no former src owner sites.",
+      "Reference history inspection found the former generation-node-status owners in d270d34e (the pre-convergence baseline), while origin/main is already post-convergence."
+    ]
+  },
+  "prevention": {
+    "kind": "static-gate",
+    "enforcement_path": "scripts/check-vocabularies.mjs",
+    "invariant": "A convergence record can affect historical-debt-promoted only after explicit owner naming, current source presence/absence checks, reference-baseline membership checks, surviving registered reason checks, and exact normalized-member matching; cap ratchets remain unconditional.",
+    "failure_mode": "The gate exits non-zero with a specific convergence failure for malformed or unproven provenance, or with the existing historical promotion/cap failure for any unrecorded or cap-violating path.",
+    "exception_policy": "none",
+    "strategy": "Centralize provenance validation before the historical promotion guard and keep the bypass keyed to validated owner identity instead of member-set similarity alone.",
+    "artifacts": [
+      "scripts/check-vocabularies.mjs"
+    ]
+  },
+  "regression_tests": [
+    "scripts/check-vocabularies-history.node-test.mjs"
+  ],
+  "class_regression_tests": [
+    "scripts/check-vocabularies-history.node-test.mjs"
+  ],
+  "legacy_paths": {
+    "status": "not-applicable",
+    "removed_paths": [],
+    "rationale": "No legacy runtime path is retained or removed; this change adds a checked baseline provenance capability and does not create a fallback implementation."
+  },
+  "dependency_lifecycle": {
+    "decision": "not-applicable",
+    "rationale": "The gate uses existing Node built-ins and repository AST scan output; no third-party dependency controls this invariant.",
+    "exit_criteria": []
+  },
+  "migration": "Existing baselines remain valid because converged is optional. A future convergence records the retired site strings and surviving site in the current baseline after the source change; the record is not a substitute for the surviving registered entry or for tightening debtCap. The already-merged generation-node-status convergence cannot be added to the current baseline as a live historical record because origin/main is already post-convergence and therefore no default reference baseline still contains both retired owners.",
+  "residual_risks": [
+    "The real generation-node-status convergence is confirmed in the live tree and in pre-convergence commit history, but no real record is committed in the current baseline: origin/main's reference baseline is already post-convergence, so adding the record now would correctly fail the new reference-presence check. The capability is proven with explicit historical fixtures instead.",
+    "The gate verifies the declared owner sites and normalized member sets, not semantic equivalence of implementation behavior beyond the AST scan contract; a malicious author who changes the scan itself remains outside this specific invariant's scope."
+  ]
+}

--- a/scripts/check-vocabularies-history.node-test.mjs
+++ b/scripts/check-vocabularies-history.node-test.mjs
@@ -168,6 +168,133 @@ test('reference baseline prevents cap growth, new debt, reclassification, and un
   })
 })
 
+test('convergence records are explicit, live-verified, and scoped to historical owners', async (t) => {
+  const sites = {
+    retiredDebt: 'src/old-status.ts::type:OldStatus/type-union',
+    retiredRegistered: 'src/old-schema.ts::variable:oldStatusSchema/z.enum',
+    retiredDebtTwo: 'src/older-status.ts::type:OlderStatus/type-union',
+    surviving: 'electron/shared/status.ts::variable:STATUS_VALUES/as-const',
+  }
+  const members = ['queued', 'running']
+  const entries = {
+    retiredDebt: vocabularyEntry(sites.retiredDebt, members),
+    retiredRegistered: vocabularyEntry(sites.retiredRegistered, members),
+    retiredDebtTwo: vocabularyEntry(sites.retiredDebtTwo, members),
+    surviving: vocabularyEntry(sites.surviving, members, 'The shared status tuple is the single runtime and type owner.'),
+  }
+  const reference = {
+    debtCap: 2,
+    registered: [entries.retiredRegistered],
+    debt: [entries.retiredDebt, entries.retiredDebtTwo],
+  }
+  const convergence = {
+    retiredOwners: [sites.retiredDebt, sites.retiredRegistered, sites.retiredDebtTwo],
+    survivingOwner: sites.surviving,
+  }
+
+  await t.test('a genuine merge passes when the record explains the retired debt owner', () => {
+    const fixture = makeFixture(
+      { 'electron/shared/status.ts': `const STATUS_VALUES = ['queued', 'running'] as const` },
+      { debtCap: 0, registered: [entries.surviving], debt: [], converged: [convergence] },
+    )
+    const referencePath = path.join(fixture.root, 'reference-baseline.json')
+    writeJson(referencePath, reference)
+    try {
+      const result = runChecker(fixture, '--reference-baseline', referencePath)
+      assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`)
+    } finally {
+      cleanup(fixture)
+    }
+  })
+
+  await t.test('a retired owner still in the live scan invalidates the record', () => {
+    const fixture = makeFixture(
+      {
+        'src/old-status.ts': `type OldStatus = 'queued' | 'running'`,
+        'electron/shared/status.ts': `const STATUS_VALUES = ['queued', 'running'] as const`,
+      },
+      { debtCap: 0, registered: [entries.surviving], debt: [], converged: [convergence] },
+    )
+    const referencePath = path.join(fixture.root, 'reference-baseline.json')
+    writeJson(referencePath, reference)
+    try {
+      const result = runChecker(fixture, '--reference-baseline', referencePath)
+      assert.equal(result.status, 1, `${result.stdout}\n${result.stderr}`)
+      assert.match(result.stderr, /convergence retired owner is still present.*src\/old-status\.ts/s)
+    } finally {
+      cleanup(fixture)
+    }
+  })
+
+  await t.test('a surviving owner absent from the live scan invalidates the record', () => {
+    const fixture = makeFixture(
+      {},
+      { debtCap: 0, registered: [entries.surviving], debt: [], converged: [convergence] },
+    )
+    const referencePath = path.join(fixture.root, 'reference-baseline.json')
+    writeJson(referencePath, reference)
+    try {
+      const result = runChecker(fixture, '--reference-baseline', referencePath)
+      assert.equal(result.status, 1, `${result.stdout}\n${result.stderr}`)
+      assert.match(result.stderr, /convergence surviving owner is absent.*electron\/shared\/status\.ts/s)
+    } finally {
+      cleanup(fixture)
+    }
+  })
+
+  await t.test('a retired owner absent from the reference baseline invalidates the record', () => {
+    const fixture = makeFixture(
+      { 'electron/shared/status.ts': `const STATUS_VALUES = ['queued', 'running'] as const` },
+      { debtCap: 0, registered: [entries.surviving], debt: [], converged: [convergence] },
+    )
+    const referencePath = path.join(fixture.root, 'reference-baseline.json')
+    writeJson(referencePath, {
+      debtCap: 1,
+      registered: [entries.retiredRegistered],
+      debt: [entries.retiredDebtTwo],
+    })
+    try {
+      const result = runChecker(fixture, '--reference-baseline', referencePath)
+      assert.equal(result.status, 1, `${result.stdout}\n${result.stderr}`)
+      assert.match(result.stderr, /convergence retired owner is absent from reference baseline.*src\/old-status\.ts/s)
+    } finally {
+      cleanup(fixture)
+    }
+  })
+
+  await t.test('a convergence record cannot grow the historical debt cap', () => {
+    const fixture = makeFixture(
+      { 'electron/shared/status.ts': `const STATUS_VALUES = ['queued', 'running'] as const` },
+      { debtCap: 3, registered: [entries.surviving], debt: [], converged: [convergence] },
+    )
+    const referencePath = path.join(fixture.root, 'reference-baseline.json')
+    writeJson(referencePath, reference)
+    try {
+      const result = runChecker(fixture, '--reference-baseline', referencePath)
+      assert.equal(result.status, 1, `${result.stdout}\n${result.stderr}`)
+      assert.match(result.stderr, /historical debt cap increased/)
+    } finally {
+      cleanup(fixture)
+    }
+  })
+
+  await t.test('a convergence record cannot leave a reduced historical cap untightened', () => {
+    const fixture = makeFixture(
+      { 'electron/shared/status.ts': `const STATUS_VALUES = ['queued', 'running'] as const` },
+      { debtCap: 1, registered: [entries.surviving], debt: [], converged: [convergence] },
+    )
+    const referencePath = path.join(fixture.root, 'reference-baseline.json')
+    writeJson(referencePath, reference)
+    try {
+      const result = runChecker(fixture, '--reference-baseline', referencePath)
+      assert.equal(result.status, 1, `${result.stdout}\n${result.stderr}`)
+      assert.match(result.stderr, /historical debt reduction must tighten cap/)
+    } finally {
+      cleanup(fixture)
+    }
+  })
+})
+
 test('default reference resolution reads the uncommitted baseline from HEAD', () => {
   const siteA = 'src/a.ts::type:AStatus/type-union'
   const siteB = 'src/b.ts::type:BStatus/type-union'

--- a/scripts/check-vocabularies.mjs
+++ b/scripts/check-vocabularies.mjs
@@ -155,6 +155,7 @@ function writePendingEntries(baselinePath, baseline, vocabularies) {
     registered: [...(baseline.registered ?? [])],
     debt: [...(baseline.debt ?? [])],
   }
+  if (baseline.converged !== undefined) next.converged = [...baseline.converged]
   const knownSites = new Set(baselineEntries(next).map((entry) => entry.site))
   for (const vocabulary of vocabularies) {
     if (knownSites.has(vocabulary.site)) continue
@@ -218,6 +219,53 @@ function validateBaseline(baseline) {
     }
     seen.add(entry.site)
   }
+  if (baseline.converged !== undefined) {
+    if (!Array.isArray(baseline.converged)) {
+      failures.push({ kind: 'invalid-baseline', message: 'converged must be an array' })
+    } else {
+      const retiredOwners = new Set()
+      for (const [index, record] of baseline.converged.entries()) {
+        const label = `converged[${index}]`
+        if (!record || typeof record !== 'object' || Array.isArray(record)) {
+          failures.push({ kind: 'invalid-baseline', message: `${label} must be an object` })
+          continue
+        }
+        if (!Array.isArray(record.retiredOwners) || record.retiredOwners.length === 0) {
+          failures.push({ kind: 'invalid-baseline', message: `${label}.retiredOwners must be a non-empty array` })
+        } else {
+          const recordRetiredOwners = new Set()
+          for (const [ownerIndex, site] of record.retiredOwners.entries()) {
+            if (typeof site !== 'string' || !site.trim()) {
+              failures.push({
+                kind: 'invalid-baseline',
+                message: `${label}.retiredOwners[${ownerIndex}] must be a non-empty string`,
+              })
+              continue
+            }
+            if (recordRetiredOwners.has(site)) {
+              failures.push({ kind: 'invalid-baseline', message: `${label} repeats retired owner：${site}` })
+            }
+            recordRetiredOwners.add(site)
+            if (retiredOwners.has(site)) {
+              failures.push({
+                kind: 'invalid-baseline',
+                message: `retired owner appears in multiple convergences：${site}`,
+              })
+            }
+            retiredOwners.add(site)
+          }
+        }
+        if (typeof record.survivingOwner !== 'string' || !record.survivingOwner.trim()) {
+          failures.push({ kind: 'invalid-baseline', message: `${label}.survivingOwner must be a non-empty string` })
+        } else if (record.retiredOwners?.includes(record.survivingOwner)) {
+          failures.push({
+            kind: 'invalid-baseline',
+            message: `${label}.survivingOwner must not also be retired：${record.survivingOwner}`,
+          })
+        }
+      }
+    }
+  }
   return failures
 }
 
@@ -267,6 +315,31 @@ export function evaluate(vocabularies, baseline) {
   const currentBySite = new Map(vocabularies.map((vocabulary) => [vocabulary.site, vocabulary]))
   const entryBySite = new Map(entries.map((entry) => [entry.site, entry]))
   const failures = []
+
+  for (const record of baseline.converged ?? []) {
+    // Retired sites must be gone from the live scan; otherwise this is a claim
+    // about a rename or duplicate, not evidence of a completed convergence.
+    for (const retiredOwner of record.retiredOwners) {
+      if (currentBySite.has(retiredOwner)) {
+        failures.push({
+          kind: 'convergence-retired-present',
+          retiredOwner,
+          survivingOwner: record.survivingOwner,
+        })
+      }
+    }
+    // The survivor must still be discoverable, or the record would explain a
+    // reduction with no live owner receiving the vocabulary.
+    if (!currentBySite.has(record.survivingOwner)) {
+      failures.push({ kind: 'convergence-surviving-absent', survivingOwner: record.survivingOwner })
+    }
+    // A convergence record explains provenance only; ownership still requires
+    // the normal registered bucket and its substantive reason check below.
+    const survivingEntry = baseline.registered.find((entry) => entry.site === record.survivingOwner)
+    if (!survivingEntry) {
+      failures.push({ kind: 'convergence-surviving-not-registered', survivingOwner: record.survivingOwner })
+    }
+  }
 
   const unregistered = vocabularies.filter((vocabulary) => !entryBySite.has(vocabulary.site))
   const stale = entries.filter((entry) => !currentBySite.has(entry.site))
@@ -334,6 +407,48 @@ export function evaluateHistoricalRatchet(vocabularies, baseline, referenceBasel
   const consumedRetiredCanonicalSites = new Set()
   const consumedReplacementCanonicalSites = new Set()
 
+  const validConvergenceByRetiredSite = new Map()
+  const referenceEntriesBySite = new Map(baselineEntries(referenceBaseline).map((entry) => [entry.site, entry]))
+  for (const record of baseline.converged ?? []) {
+    if (
+      record.retiredOwners.some((site) => currentVocabularySites.has(site)) ||
+      !currentVocabularySites.has(record.survivingOwner)
+    ) {
+      continue
+    }
+    const surviving = currentRegistered.find((candidate) => candidate.site === record.survivingOwner)
+    // A retired site must be present in the old ledger; otherwise the record
+    // could invent history for an owner that was never part of the ratchet.
+    const missingReferenceOwner = record.retiredOwners.find((site) => !referenceEntriesBySite.has(site))
+    if (missingReferenceOwner) {
+      failures.push({
+        kind: 'convergence-retired-unreferenced',
+        retiredOwner: missingReferenceOwner,
+        survivingOwner: record.survivingOwner,
+        referenceLabel,
+      })
+      continue
+    }
+    if (!surviving || !isSubstantiveReason(surviving.reason)) continue
+    // Matching normalized members proves this record explains this vocabulary,
+    // rather than granting a same-site/name-independent promotion exception.
+    const mismatchedReferenceOwner = record.retiredOwners.find(
+      (site) => !sameMembers(referenceEntriesBySite.get(site).members, surviving.members),
+    )
+    if (mismatchedReferenceOwner) {
+      failures.push({
+        kind: 'convergence-members-mismatch',
+        retiredOwner: mismatchedReferenceOwner,
+        survivingOwner: record.survivingOwner,
+        referenceLabel,
+      })
+      continue
+    }
+    for (const retiredOwner of record.retiredOwners) {
+      validConvergenceByRetiredSite.set(retiredOwner, record.survivingOwner)
+    }
+  }
+
   if (baseline.debtCap > referenceBaseline.debtCap) {
     failures.push({
       kind: 'historical-cap-increased',
@@ -362,6 +477,15 @@ export function evaluateHistoricalRatchet(vocabularies, baseline, referenceBasel
       continue
     }
     if (currentDebtIdentities.has(identity)) continue
+    const convergenceSurvivor = validConvergenceByRetiredSite.get(entry.site)
+    const convergedPromotion = convergenceSurvivor
+      ? currentRegistered.find(
+          (candidate) => candidate.site === convergenceSurvivor && sameMembers(candidate.members, entry.members),
+        )
+      : undefined
+    // Only an independently validated record can explain a debt reduction. The
+    // regular promotion guard below remains unchanged for every other rename.
+    if (convergedPromotion) continue
     const renamedPromotions = currentRegistered.filter(
       (candidate) =>
         sameMembers(candidate.members, entry.members) &&
@@ -433,6 +557,24 @@ function renderFailures(failures) {
         }
       }
       console.error('    → 先复用现有 owner；确需独立时登记并写明 reason。\n')
+    } else if (failure.kind === 'convergence-retired-present') {
+      console.error(`  convergence retired owner is still present：${failure.retiredOwner}`)
+      console.error(`    surviving owner：${failure.survivingOwner}`)
+      console.error('    → retired owners must be absent from the live source scan.\n')
+    } else if (failure.kind === 'convergence-surviving-absent') {
+      console.error(`  convergence surviving owner is absent：${failure.survivingOwner}`)
+      console.error('    → the surviving owner must be present in the live source scan.\n')
+    } else if (failure.kind === 'convergence-surviving-not-registered') {
+      console.error(`  convergence surviving owner is not registered：${failure.survivingOwner}`)
+      console.error('    → the surviving owner still needs a substantive registered entry.\n')
+    } else if (failure.kind === 'convergence-retired-unreferenced') {
+      console.error(`  convergence retired owner is absent from reference baseline：${failure.retiredOwner}`)
+      console.error(`    surviving owner：${failure.survivingOwner}`)
+      console.error(`    reference：${failure.referenceLabel}\n`)
+    } else if (failure.kind === 'convergence-members-mismatch') {
+      console.error(`  convergence members do not match the surviving owner：${failure.retiredOwner}`)
+      console.error(`    surviving owner：${failure.survivingOwner}`)
+      console.error(`    reference：${failure.referenceLabel}\n`)
     } else if (failure.kind === 'owner-moved') {
       console.error(`  owner moved：${failure.entry.site} → ${failure.vocabulary.site}`)
       console.error(`    members：[${failure.vocabulary.members.join(' | ')}]`)


### PR DESCRIPTION
## 门岗认不出「真收敛」

`historical-debt-promoted` 的存在是对的：它防的是「把欠债 owner 改个名挪进 registered，账面上债就凭空少一条」。但它**分不出改名洗白和真收敛** —— 两个 owner 被真正合并成一个时，账面形状完全一样：一条欠债身份消失、一条同成员的 registered 条目出现。而那正是棘轮想要的减债，却被判红。

触发这条的真实案例：`src/` 里两份「生成节点状态」owner（`generationCanvasTypes.ts::GenerationNodeStatus` 在 debt、`generationCanvasSchema.ts::generationNodeStatusSchema` 在 registered）被合并成 `electron/shared/canvas/generationNodeStatus.ts` 一份。四条替代路径逐条堵死：

| 做法 | 结果 |
|---|---|
| 保留旧欠债条目 | `stale`（源码里已经没有了） |
| 登记新 site | `historical-debt-promoted`（**已实测**，每个参照基线各报一次） |
| 新 site 放进 debt | `historical-new-debt`（site+members 是新身份） |
| 在 `src/` 再留一份字面量 | 违反 P1，且 `electron/` 不能 import `src/`（R26） |

## 加了什么

baseline 根部一个可选 `converged` 数组：`{ "retiredOwners": ["<site>", ...], "survivingOwner": "<site>" }`

**不是让门岗信这份声明。** 它逐条对着实时 AST 扫描和参照基线核验：每个退役 site 必须真的从源码消失、幸存者必须真的在、幸存者必须持有自己那条带实质理由的 registered 条目、每个退役 site 必须真的在参照基线上存在过、所有归一化成员集必须与幸存者一致。

只有这份**经过校验的确切映射**才会抑制 `historical-debt-promoted`。`debtCap` 与 `historical-cap-not-tight` 保持无条件 —— 收敛记录既撑不大上限，也不能让缩小后的上限松着。

## 测试先行

改之前红的：退役 owner 仍在源码中、幸存者不在扫描里、两个 cap 用例。

两个 fixture 在过程中被加强过，值得记录：第一版「有效用例」结果**已被既有的 canonical-move 特例接受**，等于没测到新能力，换成了真正的多欠债合并；第一版「参照里不存在」的 fixture 太弱，旧门岗根本不会拒它。无记录的回归护栏仍然照旧拒掉改名 fixture。

## 已知边界（明写，不糊弄）

**记录只在「所选参照快照里还留着退役 owner」时可验。** 所以真实的 generation-node-status 记录**没有**加进来 —— `origin/main` 的 baseline 已是收敛后状态，参照里看不到退役 owner，加了反而会红。能力本身用显式历史 fixture 覆盖。

## 验证

`check-vocabularies-baseline.node-test.mjs` 9/9；`check-vocabularies-history` 27/27；`pnpm run check:vocabularies` EXIT=0（实时扫描 198 个 owner）；`pnpm run gates` 全过，戳绑定 sha `f3e2899d`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)