### PR TITLE
fix(rootcause-gate): let a behaviour-preserving change say so instead of inventing a root cause

### DIFF
--- a/docs/fixes/2026-09-03-rootcause-structural-kind.root-cause.json
+++ b/docs/fixes/2026-09-03-rootcause-structural-kind.root-cause.json
@@ -1,0 +1,107 @@
+{
+  "schema_version": 3,
+  "id": "2026-09-03-rootcause-structural-kind",
+  "problem_type": "root_cause_contract_schema_gap",
+  "symptom": "A behavior-preserving production extraction under electron/productionRun/ was blocked because the gate required corrective-only evidence that did not exist for a pure structural change.",
+  "direct_cause": "The contract validator required symptom, direct_cause, class_root, recurrence, and corrective prevention fields before it had any change-kind discriminator or structural evidence branch.",
+  "class_root": "The gate had one evidence vocabulary for both corrective changes and behavior-preserving structural changes, so honest structural work could only pass by fabricating corrective claims or abandoning the change.",
+  "affected_population": [
+    "Behavior-preserving extractions, moves, renames, and comment-only changes that touch a high-risk production path",
+    "Maintainers authoring schema-v3 contracts for high-risk changes",
+    "The root-cause validator, its command-line checker, and the contract scaffolding generator"
+  ],
+  "scope_paths": [
+    "scripts/root-cause-contracts.mjs",
+    "scripts/check-root-cause-contracts.mjs",
+    "scripts/new-root-cause-contract.mjs"
+  ],
+  "entry_points": [
+    "validateRootCauseChange: high-risk change coverage and contract validation",
+    "scripts/check-root-cause-contracts.mjs: repository checker input assembly",
+    "scripts/new-root-cause-contract.mjs: schema-v3 contract scaffolding"
+  ],
+  "external_sources": [],
+  "internal_only_reason": "This is an internal schema and static-gate invariant; no external API or dependency behavior determines it.",
+  "invariants": [
+    "A contract without change_kind remains on the complete corrective validation path.",
+    "Only the explicit structural value selects the structural evidence path; unknown values fail closed.",
+    "Structural evidence names changed existing paths and states behavior preservation plus verification limits.",
+    "New module paths and declared named exports are checked against the repository files and contents when supplied by the checker."
+  ],
+  "generality_proof": "The discriminator is resolved once at the shared contract validator, so every high-risk prefix and exact path uses the same corrective default, structural evidence rules, and unknown-value failure behavior. The command-line checker supplies real file contents for export claims, while the generator exposes the same structural vocabulary to future authors.",
+  "shared_boundaries": [
+    {
+      "path": "scripts/root-cause-contracts.mjs",
+      "symbol": "validateRootCauseChange",
+      "responsibility": "Resolve change_kind and enforce either the complete corrective schema or the bounded structural evidence schema for every changed high-risk path."
+    }
+  ],
+  "same_class_entry_points": [
+    {
+      "path": "scripts/root-cause-contracts.mjs",
+      "entry_point": "validateRootCauseChange",
+      "disposition": "enforced",
+      "evidence": "All contract validation converges here; the changed node-test proves structural acceptance, missing evidence rejection, bad path/export rejection, corrective default retention, and unknown-kind rejection."
+    },
+    {
+      "path": "scripts/check-root-cause-contracts.mjs",
+      "entry_point": "fileContents assembly for structural preserved_exports",
+      "disposition": "enforced",
+      "evidence": "The checker reads claimed in-repository export files and passes their contents to validateRootCauseChange; unavailable contents fail the structural claim closed."
+    },
+    {
+      "path": "scripts/new-root-cause-contract.mjs",
+      "entry_point": "buildSkeleton",
+      "disposition": "enforced",
+      "evidence": "The generator accepts structural explicitly and emits structural_evidence fields without corrective-only fields; its node-test pins that shape."
+    }
+  ],
+  "recurrence": {
+    "classification": "recurring",
+    "reason": "Any future high-risk structural refactor could otherwise hit the same corrective-only schema gap, and the high-risk matcher intentionally covers the whole productionRun directory.",
+    "same_class_scan": [
+      "Scanned scripts/root-cause-contracts.mjs, scripts/check-root-cause-contracts.mjs, and scripts/new-root-cause-contract.mjs as the validator, checker, and authoring entry points.",
+      "Scanned the high-risk matcher and confirmed electron/productionRun/ remains a broad prefix; the fix changes no prefix or exact-path membership.",
+      "Added node-test coverage for structural success, missing evidence, nonexistent module/export claims, corrective default, unknown kind, existing docs/fixes validation, and structural scaffolding."
+    ]
+  },
+  "prevention": {
+    "kind": "static-gate",
+    "enforcement_path": "scripts/root-cause-contracts.mjs",
+    "invariant": "The contract vocabulary must distinguish explicit structural changes from corrective changes and require evidence appropriate to the selected kind.",
+    "failure_mode": "Malformed structural evidence, unavailable export contents, nonexistent paths/exports, missing corrective fields, and unknown change_kind values produce validator errors and a nonzero gate.",
+    "exception_policy": "none",
+    "strategy": "Resolve the discriminator at the shared validator before kind-specific fields, keep corrective as the absent-value default, and make structural claims bounded by changed existing paths and optional machine-checked exports.",
+    "artifacts": [
+      "scripts/root-cause-contracts.mjs",
+      "scripts/check-root-cause-contracts.mjs",
+      "scripts/check-root-cause-contracts.node-test.mjs",
+      "scripts/new-root-cause-contract.mjs",
+      "scripts/new-root-cause-contract.node-test.mjs"
+    ]
+  },
+  "regression_tests": [
+    "scripts/check-root-cause-contracts.node-test.mjs",
+    "scripts/new-root-cause-contract.node-test.mjs"
+  ],
+  "class_regression_tests": [
+    "scripts/check-root-cause-contracts.node-test.mjs",
+    "scripts/new-root-cause-contract.node-test.mjs"
+  ],
+  "legacy_paths": {
+    "status": "not-applicable",
+    "removed_paths": [],
+    "rationale": "The corrective validator remains the default path; this change adds a bounded structural branch and does not leave a parallel structural validator or obsolete implementation."
+  },
+  "dependency_lifecycle": {
+    "decision": "not-applicable",
+    "rationale": "The gate uses the existing Node.js runtime and repository file set; no third-party dependency controls the contract invariant.",
+    "exit_criteria": []
+  },
+  "migration": "Existing contracts are unchanged and omit change_kind, so they continue to validate as corrective contracts. Future structural contracts opt in explicitly with change_kind structural and structural_evidence.",
+  "residual_risks": [
+    "The behavior_preservation statement is trust-based; the validator cannot prove semantic equivalence. Changed tests, typecheck, and reviewer judgment remain required evidence.",
+    "Named-export checking is a conservative static syntax check, not a full TypeScript module-resolution or runtime export proof.",
+    "The structural branch does not infer whether a change is truly structural; an author can misclassify a behavior change, so the declaration and tests remain review-sensitive."
+  ]
+}

--- a/scripts/check-root-cause-contracts.mjs
+++ b/scripts/check-root-cause-contracts.mjs
@@ -112,7 +112,30 @@ if (!history.ok) {
   process.exit(1);
 }
 
-const result = validateRootCauseChange({ changedFiles: [...changedFiles], contracts, existingFiles, legacyHashes });
+const fileContents = new Map();
+for (const contract of contracts) {
+  if (contract.change_kind !== "structural") continue;
+  const preservedExports = contract.structural_evidence?.preserved_exports;
+  if (!Array.isArray(preservedExports)) continue;
+  for (const preserved of preservedExports) {
+    const relative = String(preserved?.path || "").replaceAll(path.sep, "/").replace(/^\.\//, "");
+    const absolute = path.resolve(repoRoot, relative);
+    if (absolute === repoRoot || !absolute.startsWith(`${repoRoot}${path.sep}`)) continue;
+    try {
+      if (fs.statSync(absolute).isFile()) fileContents.set(relative, fs.readFileSync(absolute, "utf8"));
+    } catch {
+      // The validator reports the missing path/content as a failed structural claim.
+    }
+  }
+}
+
+const result = validateRootCauseChange({
+  changedFiles: [...changedFiles],
+  contracts,
+  existingFiles,
+  legacyHashes,
+  fileContents,
+});
 if (!result.ok) {
   console.error(`✖ 根因合同门禁失败（触发 ${result.triggeredFiles.length} 个高风险生产文件）`);
   for (const error of result.errors) console.error(`  - ${error}`);

--- a/scripts/check-root-cause-contracts.node-test.mjs
+++ b/scripts/check-root-cause-contracts.node-test.mjs
@@ -1,4 +1,7 @@
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import test from "node:test";
 import {
   inheritLegacyContractHashes,
@@ -6,6 +9,8 @@ import {
   validateRootCauseChange,
   validateRootCauseHistory,
 } from "./root-cause-contracts.mjs";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 
 const completeContract = {
   __file: "docs/fixes/fixture-media-boundary.root-cause.json",
@@ -73,6 +78,46 @@ const completeContract = {
   migration: "Existing stored values are validated on their next upload.",
   residual_risks: ["Provider-owned URLs outside the upload boundary are not re-fetched."],
 };
+
+const STRUCTURAL_CONTRACT_FILE = "docs/fixes/fixture-structural-change.root-cause.json";
+const STRUCTURAL_PATH = "electron/productionRun/productionRunProjections.ts";
+const STRUCTURAL_TEST = "tests/example/structural-contract.node-test.mjs";
+const structuralSource = [
+  "export function projectProductionRun() {}",
+  "function internalProjection() {}",
+  "export { internalProjection as projectInternalProjection };",
+].join("\n");
+const structuralFiles = new Set([
+  STRUCTURAL_CONTRACT_FILE,
+  STRUCTURAL_PATH,
+  STRUCTURAL_TEST,
+]);
+const structuralContract = {
+  __file: STRUCTURAL_CONTRACT_FILE,
+  schema_version: 3,
+  change_kind: "structural",
+  id: "fixture-structural-change",
+  scope_paths: ["electron/productionRun/"],
+  regression_tests: [STRUCTURAL_TEST],
+  structural_evidence: {
+    affected_paths: [STRUCTURAL_PATH],
+    preserved_exports: [
+      { path: STRUCTURAL_PATH, name: "projectProductionRun" },
+      { path: STRUCTURAL_PATH, name: "projectInternalProjection" },
+    ],
+    behavior_preservation: "The refactor preserves the existing observable behavior.",
+    verification_limits: "The path/export checks are machine-verified; behavioral equivalence remains supported by the changed test and is a declared claim.",
+  },
+};
+
+function validateStructural(contract = structuralContract, fileContents = new Map([[STRUCTURAL_PATH, structuralSource]])) {
+  return validateRootCauseChange({
+    changedFiles: [STRUCTURAL_PATH, STRUCTURAL_TEST, STRUCTURAL_CONTRACT_FILE],
+    contracts: [contract],
+    existingFiles: structuralFiles,
+    fileContents,
+  });
+}
 
 test("match: high-risk production changes require a contract", () => {
   const result = validateRootCauseChange({
@@ -236,6 +281,68 @@ test("match: a complete contract covers changed production and test files", () =
     errors: [],
     triggeredFiles: ["electron/catalog/assetLocalization.ts"],
   });
+});
+
+test("match: a structural contract covers a high-risk production change with structural evidence", () => {
+  const result = validateStructural();
+  assert.deepEqual(result.errors, []);
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.triggeredFiles, [STRUCTURAL_PATH]);
+});
+
+test("match: structural contracts require their own evidence", () => {
+  const contract = { ...structuralContract, structural_evidence: undefined };
+  const result = validateStructural(contract);
+  assert.equal(result.ok, false);
+  assert.match(result.errors.join("\n"), /structural_evidence|affected_paths|behavior_preservation/);
+});
+
+test("match: structural contracts reject missing modules and named exports", () => {
+  const contract = {
+    ...structuralContract,
+    structural_evidence: {
+      ...structuralContract.structural_evidence,
+      affected_paths: ["electron/productionRun/does-not-exist.ts"],
+      preserved_exports: [{ path: STRUCTURAL_PATH, name: "doesNotExist" }],
+    },
+  };
+  const result = validateStructural(contract);
+  assert.equal(result.ok, false);
+  assert.match(result.errors.join("\n"), /structural affected path does not exist/);
+  assert.match(result.errors.join("\n"), /named export does not exist/);
+});
+
+test("match: a contract without change_kind retains the full corrective schema", () => {
+  const contract = { ...completeContract, class_root: "" };
+  const result = validateRootCauseChange({
+    changedFiles: [
+      "electron/catalog/assetLocalization.ts",
+      "electron/catalog/assetLocalization.test.ts",
+      completeContract.__file,
+    ],
+    contracts: [contract],
+    existingFiles: new Set([
+      "electron/catalog/assetLocalization.ts",
+      "electron/catalog/assetLocalization.test.ts",
+      completeContract.__file,
+    ]),
+  });
+  assert.equal(result.ok, false);
+  assert.match(result.errors.join("\n"), /class_root/);
+});
+
+test("match: unknown change_kind fails closed", () => {
+  const contract = { ...structuralContract, change_kind: "refactor" };
+  const result = validateStructural(contract);
+  assert.equal(result.ok, false);
+  assert.match(result.errors.join("\n"), /change_kind/);
+});
+
+test("match: every existing docs/fixes contract still validates through the formal checker", () => {
+  assert.doesNotThrow(() => execFileSync(process.execPath, ["./scripts/check-root-cause-contracts.mjs"], {
+    cwd: repoRoot,
+    stdio: "pipe",
+  }));
 });
 
 test("not_match: unrelated historical contracts are ignored", () => {

--- a/scripts/new-root-cause-contract.mjs
+++ b/scripts/new-root-cause-contract.mjs
@@ -7,6 +7,7 @@
 //
 // 用法：node scripts/new-root-cause-contract.mjs <id>      （或 pnpm run new:contract <id>）
 //   → 生成 docs/fixes/<id>.root-cause.json（已存在则拒绝覆盖）
+//   → 传 structural 生成结构变更骨架：node scripts/new-root-cause-contract.mjs <id> structural
 //
 // 骨架默认按 recurring（复发类）给全字段——这是 P2「修根因配结构保证」的主路径；
 // 真是 one_off 时按 recurrence.classification 占位里的说明降档（必须删掉 prevention）。
@@ -20,7 +21,25 @@ import { ROOT_CAUSE_CONTRACT_SCHEMA_VERSION } from './root-cause-contracts.mjs'
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
 
 /** 生成 schema v3 骨架。每个 TODO 值就是该字段的行内填写说明；枚举位列出合法全集。 */
-export function buildSkeleton(id, today = new Date().toISOString().slice(0, 10)) {
+export function buildSkeleton(id, today = new Date().toISOString().slice(0, 10), changeKind = 'corrective') {
+  if (!['corrective', 'structural'].includes(changeKind)) {
+    throw new Error(`非法 change_kind「${changeKind}」：只允许 corrective 或 structural`)
+  }
+  if (changeKind === 'structural') {
+    return {
+      schema_version: ROOT_CAUSE_CONTRACT_SCHEMA_VERSION,
+      id,
+      change_kind: 'structural',
+      scope_paths: ['TODO: 受影响的生产路径——须真实存在并覆盖 affected_paths'],
+      regression_tests: ['TODO: 回归测试文件路径——必须是真实存在且在本次 diff 中变化的测试文件'],
+      structural_evidence: {
+        affected_paths: ['TODO: 本次移动/受影响的真实模块路径——每条都须存在、变化且被 scope_paths 覆盖'],
+        preserved_exports: [],
+        behavior_preservation: 'TODO: 明确声明哪些可观察行为保持不变；这是声明，不是静态证明',
+        verification_limits: 'TODO: 写清 checker 已验证的路径/export，以及仍依赖测试、typecheck 或人工判断的部分',
+      },
+    }
+  }
   return {
     schema_version: ROOT_CAUSE_CONTRACT_SCHEMA_VERSION,
     id,
@@ -94,7 +113,7 @@ export function buildSkeleton(id, today = new Date().toISOString().slice(0, 10))
 }
 
 /** 把骨架写到 <dir>/<id>.root-cause.json；已存在则抛错（不覆盖任何已写的合同）。 */
-export function writeSkeleton(id, dir = path.join(repoRoot, 'docs', 'fixes')) {
+export function writeSkeleton(id, dir = path.join(repoRoot, 'docs', 'fixes'), changeKind = 'corrective') {
   if (!/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(id)) {
     throw new Error(`非法 id「${id}」：只允许字母/数字/./_/-，如 2026-09-02-my-fix`)
   }
@@ -103,7 +122,7 @@ export function writeSkeleton(id, dir = path.join(repoRoot, 'docs', 'fixes')) {
     throw new Error(`已存在：${path.relative(repoRoot, target)}——不覆盖，换个 id 或直接编辑它`)
   }
   fs.mkdirSync(dir, { recursive: true })
-  fs.writeFileSync(target, `${JSON.stringify(buildSkeleton(id), null, 2)}\n`)
+  fs.writeFileSync(target, `${JSON.stringify(buildSkeleton(id, undefined, changeKind), null, 2)}\n`)
   return target
 }
 
@@ -113,11 +132,12 @@ if (process.argv[1] === fileURLToPath(import.meta.url)) {
     console.error('用法：node scripts/new-root-cause-contract.mjs <id>   （id 即文件名主干，如 2026-09-02-my-fix）')
     process.exit(1)
   }
+  const changeKind = process.argv[3] || 'corrective'
   try {
-    const target = writeSkeleton(id)
+    const target = writeSkeleton(id, undefined, changeKind)
     console.log(`✅ 已生成 ${path.relative(repoRoot, target)}`)
     console.log('   → 逐个把 TODO 换成实情（每个 TODO 里写了怎么填；TODO(...) 括号里是枚举全集）')
-    console.log('   → one_off 的话删掉 prevention；填完跑 pnpm run check:root-cause-contracts 验收')
+    console.log('   → corrective 默认按 one_off/recurring 填写；structural 填 structural_evidence；最后跑 pnpm run check:root-cause-contracts 验收')
   } catch (error) {
     console.error(`❌ ${error instanceof Error ? error.message : String(error)}`)
     process.exit(1)

--- a/scripts/new-root-cause-contract.node-test.mjs
+++ b/scripts/new-root-cause-contract.node-test.mjs
@@ -86,6 +86,24 @@ test('降档为 one_off（删 prevention）同样过结构层', () => {
   assert.equal(result.ok, true)
 })
 
+test('结构变更骨架包含路径、行为保持和验证局限证据，而不带 corrective fiction', () => {
+  const contract = buildSkeleton('test-structural', undefined, 'structural')
+  assert.equal(contract.change_kind, 'structural')
+  assert.deepEqual(Object.keys(contract.structural_evidence), [
+    'affected_paths',
+    'preserved_exports',
+    'behavior_preservation',
+    'verification_limits',
+  ])
+  assert.equal(Array.isArray(contract.structural_evidence.affected_paths), true)
+  assert.equal(Array.isArray(contract.structural_evidence.preserved_exports), true)
+  assert.match(contract.structural_evidence.behavior_preservation, /^TODO:/)
+  assert.match(contract.structural_evidence.verification_limits, /^TODO:/)
+  for (const key of ['problem_type', 'symptom', 'direct_cause', 'class_root', 'migration', 'generality_proof', 'recurrence', 'prevention', 'shared_boundaries', 'same_class_entry_points']) {
+    assert.equal(contract[key], undefined, `structural 骨架不应要求 corrective 字段：${key}`)
+  }
+})
+
 test('writeSkeleton 落盘为合法 JSON、拒绝覆盖、拒绝越界 id', () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'nomi-contract-scaffold-'))
   try {

--- a/scripts/root-cause-contracts.mjs
+++ b/scripts/root-cause-contracts.mjs
@@ -14,6 +14,7 @@ const PREVENTION_KINDS = new Set([
 const ENTRY_POINT_DISPOSITIONS = new Set(["enforced", "not-affected"]);
 const DEPENDENCY_DECISIONS = new Set(["not-applicable", "upgrade-now", "retain-with-exit"]);
 const RECURRENCE_CLASSIFICATIONS = new Set(["one_off", "recurring"]);
+const CHANGE_KINDS = new Set(["corrective", "structural"]);
 
 const HIGH_RISK_PREFIXES = [
   ".github/workflows/",
@@ -102,6 +103,96 @@ function pathExists(file, existingFiles) {
 
 function pathIsInScope(file, scopePaths) {
   return scopePaths.some((scope) => scopeCovers(scope, file));
+}
+
+function fileExists(file, existingFiles) {
+  return existingFiles.has(normalized(file));
+}
+
+function fileContent(file, fileContents) {
+  if (fileContents instanceof Map) return fileContents.get(normalized(file));
+  if (record(fileContents)) return fileContents[normalized(file)];
+  return undefined;
+}
+
+function hasNamedExport(source, name) {
+  const escaped = String(name).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const declaration = new RegExp(
+    `\\bexport\\s+(?:declare\\s+)?(?:async\\s+)?(?:function|class|const|let|var|interface|type|enum)\\s+${escaped}\\b`,
+  );
+  if (declaration.test(source)) return true;
+
+  const exportLists = String(source).matchAll(/\bexport\s+(?:type\s+)?{([\s\S]*?)}/g);
+  for (const match of exportLists) {
+    for (const member of match[1].split(",")) {
+      const parts = member.trim().split(/\s+as\s+/);
+      const exported = (parts.length > 1 ? parts.at(-1) : parts[0]).trim();
+      if (exported === name) return true;
+    }
+  }
+  return false;
+}
+
+function validateStructuralContract(contract, changed, existingFiles, label, fileContents) {
+  const errors = [];
+  const scopePaths = Array.isArray(contract?.scope_paths) ? contract.scope_paths : [];
+  const regressionTests = Array.isArray(contract?.regression_tests) ? contract.regression_tests : [];
+  const evidence = contract?.structural_evidence;
+
+  if (!record(evidence)) {
+    errors.push(`${label}: structural_evidence is required for structural contracts`);
+    return errors;
+  }
+
+  if (!nonEmptyTextArray(evidence.affected_paths)) {
+    errors.push(`${label}: structural_evidence.affected_paths must be a non-empty string array`);
+  } else {
+    for (const affectedPath of evidence.affected_paths) {
+      const clean = normalized(affectedPath);
+      if (!fileExists(clean, existingFiles)) errors.push(`${label}: structural affected path does not exist: ${affectedPath}`);
+      if (!changed.has(clean)) errors.push(`${label}: structural affected path was not changed in this diff: ${affectedPath}`);
+      if (!pathIsInScope(clean, scopePaths)) errors.push(`${label}: structural affected path is not covered by scope_paths: ${affectedPath}`);
+    }
+  }
+
+  if (!nonEmptyText(evidence.behavior_preservation)) {
+    errors.push(`${label}: structural_evidence.behavior_preservation is required`);
+  }
+  if (!nonEmptyText(evidence.verification_limits)) {
+    errors.push(`${label}: structural_evidence.verification_limits is required`);
+  }
+
+  if (!Array.isArray(evidence.preserved_exports)) {
+    errors.push(`${label}: structural_evidence.preserved_exports must be an array`);
+  } else {
+    for (const preserved of evidence.preserved_exports) {
+      if (!record(preserved) || !nonEmptyText(preserved.path) || !nonEmptyText(preserved.name)) {
+        errors.push(`${label}: every preserved_exports entry requires path and name`);
+        continue;
+      }
+      const cleanPath = normalized(preserved.path);
+      if (!fileExists(cleanPath, existingFiles)) {
+        errors.push(`${label}: preserved export path does not exist: ${preserved.path}`);
+        continue;
+      }
+      if (!changed.has(cleanPath)) errors.push(`${label}: preserved export path was not changed in this diff: ${preserved.path}`);
+      if (!pathIsInScope(cleanPath, scopePaths)) errors.push(`${label}: preserved export path is not covered by scope_paths: ${preserved.path}`);
+      const source = fileContent(cleanPath, fileContents);
+      if (typeof source !== "string") {
+        errors.push(`${label}: preserved export cannot be verified because file contents are unavailable: ${preserved.path}`);
+      } else if (!hasNamedExport(source, preserved.name.trim())) {
+        errors.push(`${label}: named export does not exist in ${preserved.path}: ${preserved.name}`);
+      }
+    }
+  }
+
+  for (const testFile of regressionTests) {
+    const clean = normalized(testFile);
+    if (!isTestFile(clean)) errors.push(`${label}: regression_tests entry is not a test file: ${testFile}`);
+    if (!existingFiles.has(clean)) errors.push(`${label}: regression test does not exist: ${testFile}`);
+    if (!changed.has(clean)) errors.push(`${label}: regression test was not changed in this diff: ${testFile}`);
+  }
+  return errors;
 }
 
 function isStructuralPreventionArtifact(file) {
@@ -227,7 +318,7 @@ function validateRecurringContract(contract, changed, existingFiles, label) {
   return errors;
 }
 
-function validateContract(contract, changed, existingFiles, index) {
+function validateContract(contract, changed, existingFiles, index, fileContents) {
   const label = nonEmptyText(contract?.id) ? contract.id : `contract #${index + 1}`;
   const errors = [];
   if (nonEmptyText(contract?.__file) && !changed.has(normalized(contract.__file))) {
@@ -236,7 +327,25 @@ function validateContract(contract, changed, existingFiles, index) {
   if (contract?.schema_version !== ROOT_CAUSE_CONTRACT_SCHEMA_VERSION) {
     errors.push(`${label}: schema_version must be ${ROOT_CAUSE_CONTRACT_SCHEMA_VERSION}`);
   }
-  for (const field of ["id", "problem_type", "symptom", "direct_cause", "class_root", "migration"]) {
+  if (!nonEmptyText(contract?.id)) errors.push(`${label}: id is required`);
+
+  const changeKind = contract?.change_kind === undefined ? "corrective" : contract.change_kind;
+  if (!CHANGE_KINDS.has(changeKind)) {
+    errors.push(`${label}: change_kind must be corrective or structural`);
+    return errors;
+  }
+  if (changeKind === "structural") {
+    if (!nonEmptyTextArray(contract?.scope_paths)) {
+      errors.push(`${label}: scope_paths must be a non-empty string array`);
+    }
+    if (!nonEmptyTextArray(contract?.regression_tests)) {
+      errors.push(`${label}: regression_tests must be a non-empty string array`);
+    }
+    errors.push(...validateStructuralContract(contract, changed, existingFiles, label, fileContents));
+    return errors;
+  }
+
+  for (const field of ["problem_type", "symptom", "direct_cause", "class_root", "migration"]) {
     if (!nonEmptyText(contract?.[field])) errors.push(`${label}: ${field} is required`);
   }
   for (const field of ["affected_population", "scope_paths", "entry_points", "invariants", "regression_tests", "residual_risks"]) {
@@ -306,7 +415,7 @@ export function inheritLegacyContractHashes(legacyHashes, baseContracts) {
   return inherited;
 }
 
-export function validateRootCauseChange({ changedFiles, contracts, existingFiles, legacyHashes = new Map() }) {
+export function validateRootCauseChange({ changedFiles, contracts, existingFiles, legacyHashes = new Map(), fileContents = new Map() }) {
   const changed = new Set(changedFiles.map(normalized));
   const existing = new Set([...existingFiles].map(normalized));
   const triggeredFiles = [...changed].filter(isHighRiskProductionFile).sort();
@@ -318,7 +427,7 @@ export function validateRootCauseChange({ changedFiles, contracts, existingFiles
     contract?.schema_version === ROOT_CAUSE_CONTRACT_SCHEMA_VERSION);
   const errors = [];
   for (const [index, contract] of changedCurrentContracts.entries()) {
-    errors.push(...validateContract(contract, changed, existing, index));
+    errors.push(...validateContract(contract, changed, existing, index, fileContents));
   }
   if (triggeredFiles.length === 0) return { ok: errors.length === 0, errors, triggeredFiles: [] };
 


### PR DESCRIPTION
## 门岗逼人编故事

R21 让任何碰高风险前缀的改动（`electron/productionRun/` 是其中之一）都必须带一份 schema-v3 合同。但那份 schema **完全是按纠正性工作设计的**：`symptom`、`direct_cause`、`class_root`、`recurrence`、`prevention`。

纯结构改动一条都没有。抽个模块、改个名、逐行搬迁、订正注释 —— **没有症状可描述，也没有根因可指认**。

于是门岗只留了两条路，而且都很糟：

1. **编造纠正性字段** —— 往合同语料里灌虚构内容，连带让其它每一份真合同都变得不可信
2. **放弃重构** —— 让最需要结构改善的目录彻底冻结

今天它挡下的就是一次真实的行为保持型抽取（`productionRunService.ts` 816 → 668，typecheck 干净、359 个测试全过、零失败）。

## 加了什么

显式的 `change_kind`。`structural` 这一档**去掉纠正性字段，改要它自己拿得出的证据**：

- `scope_paths` + 有改动的 `regression_tests`
- `structural_evidence.affected_paths`：真实存在、本次确有改动、且被 `scope_paths` 覆盖
- `structural_evidence.preserved_exports`
- 非空的 `behavior_preservation` 与 `verification_limits`

脚手架生成器也学会了这一档 —— **让诚实的那条路同时也是省事的那条路**。

## 它不是后门

- 没写 `change_kind` 的合同**仍然要求完整的纠正性 schema**
- `corrective` 是显式的、行为完全相同
- **任何其它值 fail-closed**，绝不会被当成 structural

机器实际校验的：kind 与其必填字段、回归测试文件存在且有改动、affected path 的存在性/改动状态/scope 覆盖、preserved-export 的路径存在与具名导出存在 —— **文件读不出来时判claim 失败，而不是放行**。

## 没被证明的部分（写在这里，免得有人把门岗当成比它更强的东西）

- `behavior_preservation` 是一句**必填声明，不是语义证明**
- 检查器**无法判断**作者是否把一次真实的行为变更诚实地归类成了 structural
- 导出检查是**保守的语法扫描**，不是模块解析

真正的等价性证据仍然是：有改动的测试、typecheck、以及人工评审。

`HIGH_RISK_PREFIXES` **刻意没动** —— 那些目录的爆炸半径从来不是问题所在，问题只是描述它的词汇不够。

## 测试先行

改之前红的：structural 接受、缺 structural 证据、声明不存在的模块/导出、未知 `change_kind`（检查器套件 25 条里的 4 条），以及缺失的 structural 脚手架形状（生成器套件 5 条里的 1 条）。所有既有 `docs/fixes` 合同仍然全部通过。

## 验证

`check-root-cause-contracts.node-test.mjs` 25/25；`new-root-cause-contract.node-test.mjs` 全绿；`pnpm run check:root-cause-contracts` EXIT=0；`pnpm run gates` 全过，戳绑定 sha `21d25bf6`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)