### PR TITLE
perf(mcp): slim tool descriptions without changing schemas

### DIFF
--- a/electron/capabilityCore/mcpGenerationTools.ts
+++ b/electron/capabilityCore/mcpGenerationTools.ts
@@ -80,7 +80,7 @@ export function coldstartEtaForGate(outputKinds: readonly string[], shotCount: n
 // —— 生成草稿三入口字段（prompt 单镜 / shots 逐镜 / scriptText 剧本），create 与 patch 共用形状 ——
 const OPERATION_PLAN_SHARED_FIELDS = {
   projectId: { type: "string" },
-  prompt: { type: "string", description: "单镜自然语言目标；省略 candidate 时由设置中的默认模型创建草稿。" },
+  prompt: { type: "string", description: "单镜目标；无 candidate 时用默认模型创建草稿。" },
   taskKind: { type: "string", enum: ["text_to_image", "image_edit", "text_to_video", "image_to_video"] },
   moduleId: { type: "string" },
   providerId: { type: "string" },
@@ -90,10 +90,10 @@ const OPERATION_PLAN_SHARED_FIELDS = {
   variantId: { type: "string" },
   parameters: { type: "object" },
   references: { type: "array" },
-  candidate: { type: "object", description: "单镜：一份完整的生成 candidate。" },
+  candidate: { type: "object", description: "单镜完整 candidate。" },
   shots: {
     type: "array",
-    description: "多镜：逐镜计划。每项含可选 shotId/role(anchor 形象参考|shot 视频镜)/included(试拍/分批)，与一份完整 candidate。",
+    description: "多镜逐镜计划；可含 shotId、role(anchor/shot)、included 和 candidate。",
     items: {
       type: "object",
       properties: {
@@ -106,7 +106,7 @@ const OPERATION_PLAN_SHARED_FIELDS = {
       additionalProperties: false,
     },
   },
-  scriptText: { type: "string", description: "多镜：剧本/分镜文本，服务端拟镜出镜表（每镜提示词 + 建议模型/模式 + 锚声明）。" },
+  scriptText: { type: "string", description: "多镜剧本/分镜文本；服务端生成逐镜提示词、模型/模式建议和锚声明。" },
 } as const;
 
 /** create（无 operationId）用的 candidate/shots/scriptText 字段拷贝（build 里透传）。 */
@@ -135,14 +135,14 @@ export const MCP_GENERATION_TOOL_CATALOG = [
     // T5 · 起/改一份可编辑的生成草稿（不提交、不花额度）。无 operationId=新建(create)；有 operationId+patch=改(plan)。
     name: "nomi_operation_plan",
     title: "起/改一份可编辑的生成草稿（单镜 prompt / 多镜 shots / 剧本 scriptText 三选一）；不提交、不花额度。",
-    description: "创建或编辑一份生成草稿；不提交、不花额度。无 operationId=新建（普通 prompt 单镜，分钟级/成片自动拟剧本分镜）；给 operationId+patch=改现有草稿。",
+    description: "创建/编辑生成草稿；不提交、不花额度。无 operationId=新建（prompt 单镜，分钟级/成片自动拟剧本分镜）；带 operationId+patch=编辑。",
     inputSchema: {
       type: "object",
       properties: {
         leaseHandle: { type: "string" },
-        operationId: { type: "string", description: "缺省=新建草稿；给了则连同 patch 改现有草稿。" },
+        operationId: { type: "string", description: "缺省新建；给出则配合 patch 编辑。" },
         ...OPERATION_PLAN_SHARED_FIELDS,
-        patch: { type: "object", description: "给了 operationId 时：对现有草稿的定点修改。" },
+        patch: { type: "object", description: "有 operationId 时的定点修改。" },
       },
       required: ["leaseHandle"],
       additionalProperties: false,
@@ -160,7 +160,7 @@ export const MCP_GENERATION_TOOL_CATALOG = [
     // T6 · 预览草稿将用的模型/模式/参数/参考 + 定价；不调用模型、不封存（RO，编译预演相位）。
     name: "nomi_operation_preview",
     title: "预览草稿将用的模型/模式/参数/参考与不支持字段 + 定价；不调用模型、不封存。",
-    description: "预览将使用的模型、模式、参数和参考素材，并显示不支持字段与定价；不调用模型。未知价诚实显示，不伪造 0。",
+    description: "预览模型、模式、参数、参考、不支持字段与定价；不调用模型，未知价不显示为 0。",
     inputSchema: {
       type: "object",
       properties: { projectId: { type: "string" }, leaseHandle: { type: "string" }, operationId: { type: "string" } },
@@ -176,17 +176,17 @@ export const MCP_GENERATION_TOOL_CATALOG = [
     // 付费 seam（assertKnownShotPrice fail-closed / receipt MAC / gate_decide 抛错走 Run-owned seam）原地不动在 handler。
     name: "nomi_operation_gate",
     title: "单次生成的付费确认门：request 发起真人确认挑战 / decide 提交客户端已完成的确认凭据。",
-    description: "按 phase 处理单次生成付费门：request 封存计划并算 maximumCost、发确认挑战（不提交模型）；decide 提交客户端确认凭据（裸 confirm/approved 不被接受）。",
+    description: "付费门：request 封存计划、计算 maximumCost 并发确认挑战（不提交）；decide 提交客户端确认凭据；不接受裸 confirm/approved。",
     inputSchema: {
       type: "object",
       properties: {
         projectId: { type: "string" },
         leaseHandle: { type: "string" },
         operationId: { type: "string" },
-        phase: { type: "string", enum: ["request", "decide"], description: "request 发起确认挑战；decide 提交收据。" },
-        attempt: { type: "integer", minimum: 1, description: "phase=decide：确认尝试序号。" },
-        receiptId: { type: "string", description: "phase=decide：确认收据 id。" },
-        receiptToken: { type: "string", description: "phase=decide：确认收据 token。" },
+        phase: { type: "string", enum: ["request", "decide"], description: "request 发挑战；decide 提交收据。" },
+        attempt: { type: "integer", minimum: 1, description: "phase=decide 的尝试序号。" },
+        receiptId: { type: "string", description: "phase=decide 的收据 id。" },
+        receiptToken: { type: "string", description: "phase=decide 的收据 token。" },
       },
       required: ["leaseHandle", "operationId", "phase"],
       additionalProperties: false,
@@ -202,7 +202,7 @@ export const MCP_GENERATION_TOOL_CATALOG = [
     // T8 · 在计划已封存且确认有效后开始单次生成（$ 提交）。前置 approvedReceiptId 有效，与 T7 分家（形状约束3）。
     name: "nomi_operation_execute",
     title: "在计划已封存且确认有效后开始单次生成；提交只走统一 Runtime Adapter。",
-    description: "在计划已封存且确认有效后开始生成；提交只走统一 Runtime Adapter（replay 幂等）。",
+    description: "计划封存且确认有效后生成；经统一 Runtime Adapter 提交，replay 幂等。",
     inputSchema: {
       type: "object",
       properties: { projectId: { type: "string" }, leaseHandle: { type: "string" }, operationId: { type: "string" }, receiptId: { type: "string" }, receiptToken: { type: "string" } },
@@ -216,7 +216,7 @@ export const MCP_GENERATION_TOOL_CATALOG = [
     // T9 · 控制单次生成：cancel 取消草稿 / reconcile 核对提交状态（未知结果不盲目重提）。
     name: "nomi_operation_control",
     title: "控制单次生成：cancel 取消草稿 / reconcile 核对提交状态（未知结果不盲目重提）。",
-    description: "按 action 控制单次生成：cancel 取消尚未提交的草稿（已提交只进入可核账取消流程）；reconcile 核对提交状态（配 outcome，未知结果不盲目重提）。",
+    description: "cancel 取消未提交草稿（已提交进入可核账取消）；reconcile 核对提交状态，未知结果不重提。",
     inputSchema: {
       type: "object",
       properties: {
@@ -224,7 +224,7 @@ export const MCP_GENERATION_TOOL_CATALOG = [
         leaseHandle: { type: "string" },
         operationId: { type: "string" },
         action: { type: "string", enum: ["cancel", "reconcile"] },
-        outcome: { type: "string", enum: [...GENERATION_RECONCILE_OUTCOMES], description: "action=reconcile 必填：found 供应商侧查到提交 / not_found 没查到。" },
+        outcome: { type: "string", enum: [...GENERATION_RECONCILE_OUTCOMES], description: "action=reconcile 必填：found 查到提交 / not_found 未查到。" },
       },
       required: ["leaseHandle", "operationId", "action"],
       additionalProperties: false,

--- a/electron/capabilityCore/mcpIntegrationManagementTools.ts
+++ b/electron/capabilityCore/mcpIntegrationManagementTools.ts
@@ -4,7 +4,7 @@ const str = (value: unknown): string => (typeof value === 'string' ? value : '')
 export const MCP_INTEGRATION_MANAGEMENT_TOOL = {
   name: 'nomi_integration_manage',
   title: '管理已接入连接：改配置、删除、切换单连接代理。',
-  description: '只接收公开配置；key 只进 Nomi 安全页。',
+  description: '只收公开配置；密钥只能在 Nomi 安全页管理。',
   inputSchema: {
     type: 'object',
     properties: {

--- a/electron/capabilityCore/mcpIntegrationTools.ts
+++ b/electron/capabilityCore/mcpIntegrationTools.ts
@@ -48,7 +48,7 @@ const proposalSchema = {
 export const MCP_INTEGRATION_TOOL = {
   name: 'nomi_integration',
   title: '模型 / ComfyUI 接入：公开配置、凭据页、提案、确认、启动、取消。',
-  description: 'Agent 负责发现与适配；Nomi 负责密钥隔离、落库、认证和付费两相。不得传 key。',
+  description: 'Agent 发现/适配；Nomi 隔离密钥、落库、认证并执行付费两相；不得传 key。',
   inputSchema: {
     type: 'object',
     properties: {
@@ -60,8 +60,8 @@ export const MCP_INTEGRATION_TOOL = {
       docs: { type: 'string', maxLength: 65536 },
       providerKind: { type: 'string', maxLength: 80 },
       authType: { type: 'string', enum: ['none', 'bearer', 'x-api-key', 'query'] },
-      authHeader: { type: 'string', maxLength: 200, description: 'header 名，不是值。' },
-      authQueryParam: { type: 'string', maxLength: 200, description: 'query 名，不是值。' },
+      authHeader: { type: 'string', maxLength: 200, description: 'header 名（非值）。' },
+      authQueryParam: { type: 'string', maxLength: 200, description: 'query 名（非值）。' },
       clientRequestId: { type: 'string', maxLength: 200 },
       proposal: proposalSchema,
       idempotencyKey: { type: 'string', minLength: 1, maxLength: 200 },

--- a/electron/capabilityCore/mcpProjectSessionTool.ts
+++ b/electron/capabilityCore/mcpProjectSessionTool.ts
@@ -2,7 +2,7 @@
 export const MCP_PROJECT_SESSION_TOOL = Object.freeze({
   name: 'nomi_session_open',
   title: '打开当前项目的安全会话，拿一个短期项目句柄。',
-  description: '打开当前项目的安全会话；只返回一个可短期使用、绑定当前连接的项目句柄。',
+  description: '打开当前项目安全会话，返回绑定当前连接的短期项目句柄。',
   inputSchema: Object.freeze({
     type: 'object',
     properties: Object.freeze({

--- a/electron/capabilityCore/mcpToolCatalog.ts
+++ b/electron/capabilityCore/mcpToolCatalog.ts
@@ -78,20 +78,20 @@ export const READ_RUN_DATA_TARGETS = Object.freeze(['run', 'run_events', 'artifa
 const READ_TOOL = {
   name: 'nomi_read',
   title: '读 Nomi 的任意只读投影（画布/项目/模型/生成上下文/Run/产物/接入会话）。',
-  description: '按 target 读一份安全只读投影；不改状态、不花钱。',
+  description: '按 target 读取只读投影；不改状态、不花钱。',
   inputSchema: {
     type: 'object',
     properties: {
-      target: { type: 'string', enum: READ_TARGETS, description: '读什么：canvas 画布 / projects 项目 / models 模型 / generation_context 生成上下文 / operation 生成草稿 / run 制作 Run / run_events 长轮询事件 / artifact 产物元数据 / artifact_content 产物全文 / integration 接入会话。' },
+      target: { type: 'string', enum: READ_TARGETS, description: '读取：canvas/projects/models/generation_context/operation/run/run_events/artifact/artifact_content/integration。' },
       projectId: { type: 'string' },
-      leaseHandle: { type: 'string', description: 'target∈{canvas,generation_context,operation} 需要。' },
-      runId: { type: 'string', description: 'target∈{run,run_events,artifact,artifact_content} 需要。' },
-      operationId: { type: 'string', description: 'target=operation 需要。' },
-      artifactId: { type: 'string', description: 'target∈{artifact,artifact_content} 需要。' },
-      sessionId: { type: 'string', description: 'target=integration 需要。' },
-      afterCursor: { type: 'integer', minimum: 0, default: 0, description: 'target=run_events 长轮询起点游标。' },
-      waitMs: { type: 'integer', minimum: 0, maximum: 25_000, default: 0, description: 'target=run_events 最多等待毫秒（≤25s）。' },
-      page: { type: 'integer', minimum: 0, description: 'target∈{projects,models} 分页页码。' },
+      leaseHandle: { type: 'string', description: 'target=canvas/generation_context/operation 必填。' },
+      runId: { type: 'string', description: 'target=run/run_events/artifact/artifact_content 必填。' },
+      operationId: { type: 'string', description: 'target=operation 必填。' },
+      artifactId: { type: 'string', description: 'target=artifact/artifact_content 必填。' },
+      sessionId: { type: 'string', description: 'target=integration 必填。' },
+      afterCursor: { type: 'integer', minimum: 0, default: 0, description: 'run_events 的起点游标。' },
+      waitMs: { type: 'integer', minimum: 0, maximum: 25_000, default: 0, description: 'run_events 最多等待 25 秒。' },
+      page: { type: 'integer', minimum: 0 },
     },
     required: ['target'],
     additionalProperties: false,
@@ -131,13 +131,13 @@ const READ_TOOL = {
 const ASSET_IMPORT_TOOL = {
   name: 'nomi_asset_import',
   title: '把本机图片/视频文件导入项目当素材，返回可引用的 nomi-local:// 地址。',
-  description: '导入本机文件为项目素材。只收 png/jpg/webp/gif/bmp/tiff/heic/mp4/mov/webm/m4v，单个 ≤64MB，须传绝对路径；系统/凭据目录（~/.ssh、~/.nomi）会被拒绝。',
+  description: '导入本机图片/视频素材；支持 png/jpg/webp/gif/bmp/tiff/heic/mp4/mov/webm/m4v，单文件≤64MB，须绝对路径；拒绝 ~/.ssh、~/.nomi。',
   inputSchema: {
     type: 'object',
     properties: {
       projectId: { type: 'string' },
-      path: { type: 'string', description: '本机文件的绝对路径，如 /Users/你/Desktop/参考.png' },
-      title: { type: 'string', description: '可选：素材名（不带扩展名也行，会自动补）' },
+      path: { type: 'string', description: '本机文件绝对路径。' },
+      title: { type: 'string', description: '可选素材名；自动补扩展名。' },
     },
     required: ['projectId', 'path'],
     additionalProperties: false,
@@ -150,17 +150,17 @@ const ASSET_IMPORT_TOOL = {
 const ARTIFACT_REVIEW_TOOL = {
   name: 'nomi_artifact_review',
   title: '审阅/修订版本化剧本或分镜：approve 采用 / request_changes 请求改 / reject 否决 / revise 起定点修订候选。',
-  description: '按 action 对当前版本的剧本或分镜表态或修订；只能操作你刚读到的版本（乐观锁）。',
+  description: '按 action 审阅/修订当前剧本或分镜版本；仅接受刚读到的版本（乐观锁）。',
   inputSchema: {
     type: 'object',
     properties: {
       projectId: { type: 'string' },
       runId: { type: 'string' },
       artifactId: { type: 'string' },
-      expectedVersion: { type: 'integer', minimum: 1, description: '你刚读到的当前版本；版本变化后请求会被拒绝。' },
+      expectedVersion: { type: 'integer', minimum: 1, description: '刚读到的版本；变更后拒绝。' },
       action: { type: 'string', enum: ['approve', 'request_changes', 'reject', 'revise'] },
-      kind: { type: 'string', enum: ['script', 'storyboard'], description: 'action=revise 必填：改剧本还是分镜。' },
-      instruction: { type: 'string', minLength: 1, maxLength: 4_000, description: 'action=revise 必填：只描述这次定点修改。' },
+      kind: { type: 'string', enum: ['script', 'storyboard'], description: 'action=revise 必填。' },
+      instruction: { type: 'string', minLength: 1, maxLength: 4_000, description: 'action=revise 必填；描述定点修改。' },
     },
     required: ['projectId', 'runId', 'artifactId', 'expectedVersion', 'action'],
     additionalProperties: false,
@@ -181,7 +181,7 @@ const ARTIFACT_REVIEW_TOOL = {
 const RUN_GATE_TOOL = {
   name: 'nomi_run_gate',
   title: 'Run 的确认门：decide 对可逆创意门（方向/定妆照）approve/reject / materialize 把已批分镜落画布并登记 jobs+预算。',
-  description: '按 action 处理 Run 的授权边界：decide 表态可逆创意门（不新增授权）；materialize 把已批分镜落地（登记 jobs/预算合同，不批准剧本/预算、不直接调付费模型）。',
+  description: '按 action 处理 Run 授权：decide 表态可逆创意门；materialize 将已批分镜落画布并登记 jobs/预算；不批剧本/预算、不直接调用付费模型。',
   inputSchema: {
     type: 'object',
     properties: {
@@ -189,12 +189,12 @@ const RUN_GATE_TOOL = {
       runId: { type: 'string' },
       action: { type: 'string', enum: ['decide', 'materialize'] },
       // action=decide（可逆创意门）
-      gateId: { type: 'string', description: 'action=decide：门 id，例如 gate-direction-v1。' },
-      decision: { type: 'string', enum: ['approved', 'rejected'], description: 'action=decide：批准或否决。' },
-      choiceKey: { type: 'string', description: 'action=decide 方向门专用：选中候选 key（来自 gate.waiting 的 directionCandidates）。' },
+      gateId: { type: 'string', description: 'action=decide 的门 id。' },
+      decision: { type: 'string', enum: ['approved', 'rejected'], description: 'action=decide 的决定。' },
+      choiceKey: { type: 'string', description: 'action=decide 方向门的候选 key。' },
       // action=materialize（$ 落地）
-      artifactId: { type: 'string', description: 'action=materialize：已批准的 storyboard artifact id。' },
-      expectedVersion: { type: 'integer', minimum: 1, description: 'action=materialize：你刚读到的分镜版本；版本变化后拒绝，避免覆盖新稿。' },
+      artifactId: { type: 'string', description: 'action=materialize 的已批准 storyboard artifact id。' },
+      expectedVersion: { type: 'integer', minimum: 1, description: 'action=materialize 的分镜版本；变更后拒绝。' },
     },
     required: ['projectId', 'runId', 'action'],
     additionalProperties: false,
@@ -212,21 +212,21 @@ const RUN_GATE_TOOL = {
 const RUN_START_TOOL = {
   name: 'nomi_run_start',
   title: '在项目里建一个可审阅的持久制作草稿（只记 brief + playbook，不批预算、不调付费模型）。',
-  description: '创建一个可审阅的制作草稿。只记录 brief 与 playbook，不批准预算、不调用付费模型。',
+  description: '创建制作草稿；只记 brief/playbook，不批预算、不调用付费模型。',
   inputSchema: {
     type: 'object',
     properties: {
-      projectId: { type: 'string', description: '目标 Nomi 项目 id' },
+      projectId: { type: 'string' },
       playbook: {
         type: 'string',
         enum: listProductionPlaybookNames(),
-        description: `制作 playbook。当前只实现了：${listProductionPlaybookNames().join('、')}；传其它值会被拒绝。`,
+        description: `可用 playbook：${listProductionPlaybookNames().join('、')}；其他值拒绝。`,
       },
-      playbookVersion: { type: 'string', description: '可选版本；默认 1.0.0' },
+      playbookVersion: { type: 'string', description: '可选；默认 1.0.0。' },
       brief: {
         type: 'object',
         properties: {
-          goal: { type: 'string', description: '要完成什么' },
+          goal: { type: 'string' },
           audience: { type: 'string' },
           channel: { type: 'string' },
           tone: { type: 'string' },
@@ -240,7 +240,7 @@ const RUN_START_TOOL = {
       trustLevel: {
         type: 'string',
         enum: ['key_confirm', 'budget_only', 'confirm_all'],
-        description: '可选信任档位：key_confirm 默认（方向/样片门都停）/ budget_only 只管钱（跳过创意与样片门）/ confirm_all 每镜确认。用户一上来就说「别问了直接出」时设 budget_only。',
+        description: '信任档位：key_confirm 默认（停方向/样片门）；budget_only 跳过创意/样片门、只管钱；confirm_all 每镜确认。要求直接出时用 budget_only。',
       },
     },
     required: ['projectId', 'playbook', 'brief'],
@@ -260,14 +260,14 @@ const RUN_START_TOOL = {
 const RUN_CONTROL_TOOL = {
   name: 'nomi_run_control',
   title: '控制持久制作 Run：pause 暂停 / resume 从断点继续 / cancel 取消 / set_trust 改信任档位。',
-  description: 'pause 保住已花预算与已完成镜头 / resume 不重做不重付 / cancel 未提交不计费 / set_trust 改档（配 trustLevel）。用户说「停一下/继续/别做了」用前三个；「别问了直接出」= set_trust 到 budget_only。',
+  description: 'pause 保留已花预算/已完成镜头；resume 不重做/不重付；cancel 未提交不计费；set_trust 改档（需 trustLevel）。',
   inputSchema: {
     type: 'object',
     properties: {
       projectId: { type: 'string' },
       runId: { type: 'string' },
       action: { type: 'string', enum: ['pause', 'resume', 'cancel', 'set_trust'] },
-      trustLevel: { type: 'string', enum: ['key_confirm', 'budget_only', 'confirm_all'], description: 'action=set_trust 时必填：key_confirm 五门全开 / budget_only 只管钱 / confirm_all 每镜确认' },
+      trustLevel: { type: 'string', enum: ['key_confirm', 'budget_only', 'confirm_all'], description: 'action=set_trust 必填：key_confirm 五门全开 / budget_only 只管钱 / confirm_all 每镜确认。' },
     },
     required: ['projectId', 'runId', 'action'],
     additionalProperties: false,
@@ -280,8 +280,8 @@ const RUN_CONTROL_TOOL = {
 const PROJECT_CREATE_TOOL = {
   name: 'nomi_project_create',
   title: '新建一个空白 Nomi 项目，返回项目 id。',
-  description: '新建一个空白 Nomi 项目，返回项目 id。',
-  inputSchema: { type: 'object', properties: { name: { type: 'string', description: '项目名（可选）' } }, additionalProperties: false },
+  description: '新建空白 Nomi 项目并返回 projectId。',
+  inputSchema: { type: 'object', properties: { name: { type: 'string' } }, additionalProperties: false },
   method: 'project.create',
   build: (a: Record<string, unknown>): Record<string, unknown> => (a.name ? { name: a.name } : {}),
 } as const

--- a/electron/shared/agentCapabilities/assetRead.ts
+++ b/electron/shared/agentCapabilities/assetRead.ts
@@ -234,6 +234,6 @@ export const ASSET_READ_CAPABILITY = {
   approval: "none",
   projections: {
     pi: { description: "Read bounded technical facts about active-project media." },
-    mcp: { description: "Query project media, metadata, source usage, or waveform data without changing the project." },
+    mcp: { description: "Query project media, metadata, sources, or waveforms." },
   },
 } as const satisfies CapabilityContract<AssetReadInput, AssetReadResult>;

--- a/electron/shared/agentCapabilities/canvasDelete.ts
+++ b/electron/shared/agentCapabilities/canvasDelete.ts
@@ -59,6 +59,6 @@ export const CANVAS_DELETE_CAPABILITY = {
   approval: "proposal",
   projections: {
     pi: { description: "Delete exact Canvas nodes after explicit approval." },
-    mcp: { description: "Confirm and undo a destructive Canvas maintenance operation." },
+    mcp: { description: "Confirm or undo destructive Canvas maintenance." },
   },
 } as const satisfies CapabilityContract<CanvasDeleteInput, CanvasDeleteResult>;

--- a/electron/shared/agentCapabilities/canvasRead.test.ts
+++ b/electron/shared/agentCapabilities/canvasRead.test.ts
@@ -122,7 +122,7 @@ describe("canvas.read canonical contract", () => {
           description: "Read the current generation canvas (nodes + edges).",
         },
         mcp: {
-          description: "Read a project's generation canvas as compact nodes and edges for planning.",
+          description: "Read the project canvas as compact nodes and edges.",
         },
       },
     });

--- a/electron/shared/agentCapabilities/canvasRead.ts
+++ b/electron/shared/agentCapabilities/canvasRead.ts
@@ -336,7 +336,7 @@ export const CANVAS_READ_CAPABILITY = {
       description: "Read the current generation canvas (nodes + edges).",
     },
     mcp: {
-      description: "Read a project's generation canvas as compact nodes and edges for planning.",
+      description: "Read the project canvas as compact nodes and edges.",
     },
   },
 } as const satisfies CapabilityContract<CanvasReadInput, CanvasReadResult>;

--- a/electron/shared/agentCapabilities/canvasWrite.test.ts
+++ b/electron/shared/agentCapabilities/canvasWrite.test.ts
@@ -39,7 +39,7 @@ describe("canvas.write canonical contract", () => {
       approval: "proposal",
       projections: {
         pi: { description: "Propose an exact, reversible prompt update to one generation canvas node." },
-        mcp: { description: "Read the current canvas intent and propose a validated, reversible canvas edit." },
+        mcp: { description: "Propose a validated, reversible canvas edit from current intent." },
       },
     });
     expect(CANVAS_WRITE_CAPABILITY.aliases.mcp).toBe("nomi_canvas_edit");

--- a/electron/shared/agentCapabilities/canvasWrite.ts
+++ b/electron/shared/agentCapabilities/canvasWrite.ts
@@ -430,7 +430,7 @@ export const CANVAS_WRITE_CAPABILITY = {
       description: "Propose an exact, reversible prompt update to one generation canvas node.",
     },
     mcp: {
-      description: "Read the current canvas intent and propose a validated, reversible canvas edit.",
+      description: "Propose a validated, reversible canvas edit from current intent.",
     },
   },
 } as const satisfies CapabilityContract<CanvasWriteInput, CanvasWriteResult>;

--- a/electron/shared/agentCapabilities/documentRead.ts
+++ b/electron/shared/agentCapabilities/documentRead.ts
@@ -59,7 +59,7 @@ export const DOCUMENT_READ_CAPABILITY = {
       description: "Read the current creation document or selection as plain text.",
     },
     mcp: {
-      description: "Read the current creation document or a bounded selection as plain text.",
+      description: "Read the creation document or a bounded selection as text.",
     },
   },
 } as const satisfies CapabilityContract<DocumentReadInput, DocumentReadResult>;

--- a/electron/shared/agentCapabilities/documentWrite.ts
+++ b/electron/shared/agentCapabilities/documentWrite.ts
@@ -61,7 +61,7 @@ export const DOCUMENT_WRITE_CAPABILITY = {
       description: "Propose an insertion, selection replacement, or append to the current creation document.",
     },
     mcp: {
-      description: "Propose an insertion, selection replacement, or append to the current creation document.",
+      description: "Propose document insertion, selection replacement, or append.",
     },
   },
 } as const satisfies CapabilityContract<DocumentWriteInput, DocumentWriteResult>;

--- a/electron/shared/agentCapabilities/exportCapabilities.ts
+++ b/electron/shared/agentCapabilities/exportCapabilities.ts
@@ -186,7 +186,7 @@ export const EXPORT_READ_CAPABILITY = {
   approval: "none",
   projections: {
     pi: { description: "Inspect and verify active-project export receipts." },
-    mcp: { description: "Inspect or verify an export job receipt; starting and cancelling exports remain Host-only." },
+    mcp: { description: "Inspect/verify export receipts; Host starts/cancels exports." },
   },
 } as const satisfies CapabilityContract<ExportReadInput, ExportReadResult>;
 

--- a/electron/shared/agentCapabilities/timelineRead.ts
+++ b/electron/shared/agentCapabilities/timelineRead.ts
@@ -300,6 +300,6 @@ export const TIMELINE_READ_CAPABILITY = {
   approval: "none",
   projections: {
     pi: { description: "Read and preview the current project timeline." },
-    mcp: { description: "Read the current project timeline or a bounded frame range without changing it." },
+    mcp: { description: "Read the project timeline or a bounded frame range." },
   },
 } as const satisfies CapabilityContract<TimelineReadInput, TimelineReadResult>;

--- a/electron/shared/agentCapabilities/timelineWrite.ts
+++ b/electron/shared/agentCapabilities/timelineWrite.ts
@@ -122,6 +122,6 @@ export const TIMELINE_WRITE_CAPABILITY = {
   approval: "proposal",
   projections: {
     pi: { description: "Apply or undo an approved project timeline edit." },
-    mcp: { description: "Preview, apply, or undo a revision-guarded timeline edit after Host approval." },
+    mcp: { description: "Preview/apply/undo revision-guarded timeline edits after Host approval." },
   },
 } as const satisfies CapabilityContract<TimelineWriteInput, TimelineWriteResult>;


### PR DESCRIPTION
## Summary

精简 24 个 MCP 工具的顶层 description、MCP 专用 projection description，以及 schema 内重复说明文字。未改变工具名、能力范围、参数字段、类型、required、enum、约束或路由；同步更新了 2 个对 canonical MCP 文案做深等值断言的测试预期。

## 字节对比

| 指标 | 精简前 | 精简后 | 变化 |
|---|---:|---:|---:|
| mcpToolCatalog.ts 源文件 | 21,541 B | 20,625 B | -916 B |
| 顶层工具 description 合计 | 2,809 B | 2,176 B | -633 B |
| tools/list payload（name + description + inputSchema） | 19,925 B | 18,416 B | -1,509 B |
| inputSchema 合计 | 15,623 B | 14,747 B | -876 B |

现有 payload ratchet 为 20,016 B，精简后继续下降并通过。

## 逐工具改动

- nomi_session_open：去掉“只返回一个”等重复限定，保留短期、连接绑定句柄。
- nomi_read：压缩只读保证、target/条件字段和长轮询说明。
- nomi_canvas_edit：压缩英文 MCP projection，保留 validated/reversible/current intent。
- nomi_asset_import：压缩导入格式、64MB、绝对路径和敏感目录提示；删掉路径示例。
- nomi_operation_plan：压缩草稿创建/编辑、默认模型和多镜字段说明。
- nomi_operation_preview：合并模型/参数/参考/不支持字段/定价说明，保留“不调用模型、未知价不为 0”。
- nomi_operation_gate：压缩两阶段付费门说明，保留封存、maximumCost、确认挑战、拒绝裸确认。
- nomi_operation_execute：压缩封存/确认/Runtime Adapter/replay 说明。
- nomi_operation_control：压缩 cancel/reconcile 说明，保留已提交核账和未知结果不重提。
- nomi_run_start：压缩草稿、brief/playbook、预算和付费模型边界；删除参数名重复解释。
- nomi_run_control：保留 pause/resume/cancel/set_trust 的预算与重付语义，删除口语触发例子。
- nomi_artifact_review：压缩 action、版本锁和定点修订说明。
- nomi_run_gate：压缩 decide/materialize 授权边界，保留已批分镜、jobs/预算及禁止直接付费。
- nomi_integration：压缩 Agent/Nomi 分工，保留密钥隔离、落库、认证、付费两相和禁止传 key。
- nomi_integration_manage：压缩公开配置/安全页提示。
- nomi_project_create：删除与 title 重复的“空白项目”措辞。
- nomi_canvas_plan：同步压缩 canvas read 英文 MCP projection。
- nomi_canvas_maintenance：压缩 destructive maintenance 英文说明。
- nomi_document_read：压缩当前文档/selection/plain text 英文说明。
- nomi_document_edit：压缩 insertion/replacement/append 英文说明。
- nomi_timeline_read：压缩 timeline/range 英文说明。
- nomi_timeline_edit：压缩 preview/apply/undo/revision guard/Host approval 英文说明。
- nomi_export_job：压缩 receipt 与 Host-only start/cancel 英文说明。
- nomi_media_query：压缩 media/metadata/source/waveform 英文说明。

刻意保留了真实安全和费用提示：格式/大小/敏感目录、maximumCost、确认凭据、未知价不伪造 0、预算/已完成镜头、不重付、未知提交不重提、版本锁、破坏性维护、Host-only export、密钥不得进入 MCP。

## 验证证据

- 基线：两项 MCP 门岗均通过；精简前 tools/list 19,925 B，工具引用 9/9 命中 24 个工具。
- 精简后：`pnpm exec tsx scripts/check-mcp-payload.ts` 通过（18,416 B）；`pnpm exec tsx scripts/check-mcp-tool-references.ts` 通过。
- 相关单测：50/50 通过；canvasWrite 修正后 6/6 通过。
- `pnpm run build`：通过。
- `node tests/ux/mcp-l1-handshake.e2e.mjs`：MCP-L1 PASS，C1–C6 全部通过。
- 全量 `pnpm run gates`：最终 EXIT=0；1135 test files passed / 1 skipped，10,586 tests passed / 2 skipped；lint 81 warnings / 0 errors；gate receipt SHA `1dca0033c68b`。
- 提交：`1dca0033 perf(mcp): slim tool descriptions`。
- 分支：`feat/mcp-tool-description-slim-20260903`。

第一次全量 gates 捕获了一个未同步的 canvasWrite 精确文案预期；已修正、重新提交并完整重跑，最终结果为 EXIT=0。

## 10KB 边界说明

在“不改变参数结构”的前提下，10KB 不是当前目录可达到的真实下限：精简后仅保留类型、字段、required、enum 和约束的 inputSchema 仍约 12,446 B；payload 还必须包含工具名和描述。没有删除参数约束，也没有降低安全/费用提示来凑数字。