### PR TITLE
feat(agent): enforce resident work modes at host boundary

### DIFF
--- a/electron/projectAgentHost/projectAgentExecutionCoordinator.test.ts
+++ b/electron/projectAgentHost/projectAgentExecutionCoordinator.test.ts
@@ -620,6 +620,44 @@ describe("ProjectAgentExecutionCoordinator", () => {
     expect((observedRequest as AgentChatRequest & { approvalPolicy?: unknown }).approvalPolicy).toBeUndefined();
   });
 
+  it("denies an Ask-mode write before it reaches the document adapter", async () => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), "nomi-project-agent-ask-read-only-"));
+    const documentAdapter = documentWriteAdapter();
+    let observedDecision: AgentChatToolDecision | undefined;
+    const coordinator = createProjectAgentExecutionCoordinator(
+      createProjectAgentRepositoryRouter({ rootDir: root }),
+      () => "subscription-ask-read-only",
+      {
+        runAgent: async (_request, hooks) => {
+          const call = { toolCallId: "tool-ask-write", toolName: "append_to_end", args: { content: "x" } };
+          observedDecision = await hooks.awaitToolConfirmation(call, hooks.abortSignal!);
+          return documentWriteResponse(call, observedDecision);
+        },
+      },
+    );
+    const opened = await coordinator.open(binding, { documentWrite: documentAdapter });
+    const base = executionInput("ask-read-only", 0);
+    const input: ExecutionInput = {
+      ...base,
+      mutation: {
+        ...base.mutation,
+        payload: {
+          ...base.mutation.payload,
+          turn: { ...base.mutation.payload.turn, workMode: "ask" },
+          queueItem: { ...base.mutation.payload.queueItem, workMode: "ask" },
+        },
+      },
+      request: { ...base.request, workMode: "agent" } as AgentChatRequest,
+    };
+
+    await coordinator.enqueue(opened.subscriptionId, input);
+    await coordinator.waitForTurn(opened.subscriptionId, input.mutation.payload.turn.turnId);
+
+    expect(observedDecision).toMatchObject({ ok: false, denied: true, message: expect.stringContaining("Ask") });
+    expect(documentAdapter.prepare).not.toHaveBeenCalled();
+    expect(documentAdapter.execute).not.toHaveBeenCalled();
+  });
+
   it("reuses one approval for reversible edits while preserving a receipt per write", async () => {
     root = fs.mkdtempSync(path.join(os.tmpdir(), "nomi-project-agent-safe-auto-"));
     const documentAdapter = documentWriteAdapter();

--- a/electron/projectAgentHost/projectAgentExecutionCoordinator.ts
+++ b/electron/projectAgentHost/projectAgentExecutionCoordinator.ts
@@ -40,7 +40,7 @@ import {
   stableJson,
 } from "./projectAgentExecutionHelpers";
 import { projectAgentWorkModeOf } from "../shared/projectAgentContracts";
-import { projectAgentExecutionRisk, projectAgentMayReuseSafeApproval } from "./projectAgentExecutionPolicy";
+import { projectAgentExecutionRisk, projectAgentMayReuseSafeApproval, projectAgentWorkModeDecision } from "./projectAgentExecutionPolicy";
 import {
   ProjectAgentSubscriptionError,
   deferred,
@@ -484,6 +484,10 @@ export function createProjectAgentExecutionCoordinator(
       return { ok: false, denied: true, message: "Agent request cancelled" };
     const existing = execution.pending.get(call.toolCallId);
     if (existing) return Promise.reject(new Error("Duplicate pending Project Agent tool call"));
+    const workModeDecision = projectAgentWorkModeDecision(execution.turn.workMode, call.toolName, call.args);
+    if (!workModeDecision.allowed) {
+      return { ok: false, denied: true, message: workModeDecision.reason ?? "Agent work mode denied this action" };
+    }
     const policy = execution.turn.approvalPolicy;
     if (projectAgentMayReuseSafeApproval(policy, call.toolName, call.args, execution.safeApprovalGranted === true)) {
       return { ok: true, silent: true };

--- a/electron/projectAgentHost/projectAgentExecutionPolicy.test.ts
+++ b/electron/projectAgentHost/projectAgentExecutionPolicy.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   projectAgentExecutionRisk,
   projectAgentMayReuseSafeApproval,
+  projectAgentWorkModeDecision,
 } from "./projectAgentExecutionPolicy";
 
 describe("Project Agent approval policy", () => {
@@ -32,5 +33,23 @@ describe("Project Agent approval policy", () => {
     expect(projectAgentMayReuseSafeApproval(project, "export_timeline", {}, true)).toBe(false);
     expect(projectAgentMayReuseSafeApproval(project, "nomi_operation_create", {}, true)).toBe(false);
     expect(projectAgentMayReuseSafeApproval(undefined, "append_to_end", {}, true)).toBe(false);
+  });
+
+  it("makes Ask read-only at the Host boundary", () => {
+    expect(projectAgentWorkModeDecision("ask", "read_full_text", {})).toEqual({ allowed: true });
+    expect(projectAgentWorkModeDecision("ask", "append_to_end", { content: "draft" })).toMatchObject({
+      allowed: false,
+      reason: expect.stringContaining("Ask"),
+    });
+    expect(projectAgentWorkModeDecision("ask", "unknown_tool", {})).toMatchObject({
+      allowed: false,
+      reason: expect.stringContaining("Ask"),
+    });
+  });
+
+  it("keeps edit-selection from starting paid or destructive work", () => {
+    expect(projectAgentWorkModeDecision("editSelection", "replace_selection", { content: "new" })).toEqual({ allowed: true });
+    expect(projectAgentWorkModeDecision("editSelection", "nomi_start_generation", {})).toMatchObject({ allowed: false });
+    expect(projectAgentWorkModeDecision("editSelection", "delete_canvas_nodes", {})).toMatchObject({ allowed: false });
   });
 });

--- a/electron/projectAgentHost/projectAgentExecutionPolicy.ts
+++ b/electron/projectAgentHost/projectAgentExecutionPolicy.ts
@@ -1,10 +1,18 @@
 import { isPiGenerationToolName } from "../capabilityCore/generationTransportAdapters";
+import { resolveCapabilityAlias } from "../shared/agentCapabilities/registry";
 import {
   projectAgentApprovalPolicyOf,
+  projectAgentWorkModeOf,
   type ProjectAgentApprovalPolicy,
+  type ProjectAgentWorkMode,
 } from "../shared/projectAgentContracts";
 
 export type ProjectAgentExecutionRisk = "safe-reversible" | "hard-gate";
+
+export type ProjectAgentWorkModeDecision = Readonly<{
+  allowed: boolean;
+  reason?: string;
+}>;
 
 /**
  * Classify at the Host boundary, before any adapter can write. The allow-list
@@ -26,6 +34,37 @@ export function projectAgentExecutionRisk(toolName: string, args?: unknown): Pro
   const safePattern = /(^|[._:-])(append_to_end|insert_at_cursor|replace_selection|document\.write|document_write|canvas\.write|create_canvas_nodes|set_node_prompt|timeline\.write|apply_edit_plan|undo_timeline_edit)([._:-]|$)/;
   if (safePattern.test(normalized) || safePattern.test(operation)) return "safe-reversible";
   return "hard-gate";
+}
+
+/**
+ * Apply the renderer-selected work posture at the Host boundary. The model
+ * prompt is guidance only; this decision is the enforcement point before a
+ * tool call can reach an adapter. Unknown aliases fail closed for the narrow
+ * modes because the Host cannot prove that they are read-only or selection
+ * scoped.
+ */
+export function projectAgentWorkModeDecision(
+  mode: ProjectAgentWorkMode | undefined,
+  toolName: string,
+  args?: unknown,
+): ProjectAgentWorkModeDecision {
+  const workMode = projectAgentWorkModeOf(mode);
+  if (workMode === "agent") return { allowed: true };
+
+  const effect = resolveCapabilityAlias(toolName)?.contract.effect;
+  if (workMode === "ask") {
+    return effect === "read"
+      ? { allowed: true }
+      : { allowed: false, reason: "Ask mode only permits read-only Agent actions" };
+  }
+
+  // Edit-selection may inspect the project and propose reversible edits, but
+  // it must not start paid/destructive work. The existing target/precondition
+  // gate remains the owner of the exact frozen selection scope.
+  if (effect === "read" || (effect === "reversible_write" && projectAgentExecutionRisk(toolName, args) === "safe-reversible")) {
+    return { allowed: true };
+  }
+  return { allowed: false, reason: "Edit-selection mode only permits read or reversible selection edits" };
 }
 
 /**

--- a/electron/projectAgentHost/projectAgentTurnExecution.ts
+++ b/electron/projectAgentHost/projectAgentTurnExecution.ts
@@ -14,6 +14,7 @@ import type { OfflineProjectAgentHost } from "./projectAgentHost";
 import { proposalSettlementsFor, readProposalReceiptSafely, type ActiveExecution, type CanvasWriteCapabilityOutcomeCode, type ExecutionPartition, type ProjectAgentExecutionCoordinatorDeps } from "./projectAgentExecutionCoordinatorTypes";
 import { executeProductionApproval, reprepareEffectiveCall } from "./projectAgentApprovalHelpers";
 import { resolveCapabilityAlias } from "../shared/agentCapabilities/registry";
+import { projectAgentWorkModeDecision } from "./projectAgentExecutionPolicy";
 import { DOCUMENT_READ_CAPABILITY } from "../shared/agentCapabilities/documentRead";
 import { CANVAS_DELETE_CAPABILITY } from "../shared/agentCapabilities/canvasDelete";
 import { CANVAS_WRITE_CAPABILITY } from "../shared/agentCapabilities/canvasWrite";
@@ -159,6 +160,15 @@ export async function executeProjectAgentTurn(context: ProjectAgentTurnExecution
       awaitToolConfirmation: async (call, signal) => {
         const frozen = partition.requests.get(execution.turn.turnId);
         const canonicalCapability = resolveCapabilityAlias(call.toolName)?.contract;
+        const workModeDecision = projectAgentWorkModeDecision(execution.turn.workMode, call.toolName, call.args);
+        if (!workModeDecision.allowed) {
+          return {
+            ok: false,
+            denied: true,
+            code: "work_mode_denied",
+            message: workModeDecision.reason ?? "Agent work mode denied this action",
+          };
+        }
         const isCanvasMutation = canonicalCapability?.id === CANVAS_WRITE_CAPABILITY.id || canonicalCapability?.id === CANVAS_DELETE_CAPABILITY.id || ["nomi_canvas_plan", "nomi_canvas_edit", "nomi_canvas_maintenance"].includes(call.toolName);
         const isRendererHandledStoryboardProposal =
           canonicalCapability?.id === CANVAS_WRITE_CAPABILITY.id && call.toolName === "propose_storyboard_plan";


### PR DESCRIPTION
## Summary

This is the first functional follow-up to Agent UI PR #447, kept independent so it can be reviewed and reused without depending on the still-open exception-state PR.

- Enforce `Ask` as read-only at the Project Agent Host boundary.
- Keep `编辑选中` limited to reads and safe reversible edits; paid, destructive, and unknown actions are denied.
- Short-circuit denied calls before document/canvas/timeline/production adapters are reached.
- Add policy tests and a coordinator integration test proving an Ask-mode write never calls the document adapter.

## Scope boundary

This closes the first Host-side work-mode enforcement slice. It does not claim the full functional Agent UI contract: exact frozen-selection target/precondition enforcement, receipts/undo, usage/spend source convergence, queue/deviation/elicitation behavior, and the remaining P0/P1 runtime journeys remain follow-up work from #447's explicit 件3 boundary.

## Verification

- `pnpm exec vitest run electron/projectAgentHost/projectAgentExecutionPolicy.test.ts electron/projectAgentHost/projectAgentExecutionCoordinator.test.ts` — 71 tests passed
- `pnpm run typecheck` — passed
- `pnpm run gates` — passed
  - 1137 test files passed, 1 skipped
  - 10594 tests passed, 2 skipped
  - Electron build passed
  - lint: 0 errors, 81 existing warnings within the repository limit
- `git diff --check` — passed
