### PR TITLE
feat(agent): persist resident turn usage in Host state

### DIFF
--- a/docs/audit/pr452-failure-diagnosis-20260904.md
+++ b/docs/audit/pr452-failure-diagnosis-20260904.md
@@ -1,0 +1,88 @@
+# PR #452 失败门诊断
+
+日期：2026-09-04  
+PR：[#452](https://github.com/aqm857886159/Nomi/pull/452)  
+审计 head：`75f8e4148ee6d539d2e54250e3c7bb5b75497f5a`  
+基线：`origin/main`=`45912ae01a155a3f6592f65368d0ce3d12fc034e`
+
+## 隔离状态
+
+诊断在独立 worktree 完成：
+
+`/Users/aoqimin/Documents/Codex/2026-09-04/pr452-usage-repair/work/Nomi-pr452-failure-gates-red`
+
+分支：`codex/pr452-failure-gates-red-20260904`。目标 head 分支仍在原 worktree，`main` 工作树的既有脏文件未触碰；本 worktree 初始干净。本轮没有改生产代码、没有推送、没有合并，也没有伪造绿灯。
+
+## CI 最早真实失败
+
+Run `33790669994` 的 `E2E Walkthroughs (Linux)` / `MCP L1 handshake journey` 执行：
+
+```text
+xvfb-run -a pnpm run test:mcp-journey
+pnpm run check:electron-install && node tests/ux/mcp-l1-handshake.e2e.mjs && node tests/ux/mcp-l2-journeys.e2e.mjs && node tests/ux/mcp-skills-integration.e2e.mjs
+```
+
+Electron 安装检查 13/13 通过；MCP L1 C1–C8 通过；C9 在真人生成确认门失败。最早真实失败是：
+
+```text
+nomi_operation_gate error= ...
+"errorCode":"receipt_invalid"
+"message":"Generation approval receipt projectRevision does not match the current scope"
+"recoveryActions":["This confirmation is no longer valid; confirm again in Nomi."]
+
+Error: nomi_operation_gate: ✗ This confirmation is no longer valid; confirm again in Nomi.
+    at tests/ux/mcp-l2-journeys.e2e.mjs:39:11
+```
+
+发生在 C9 `operation_plan`、`operation_preview` 和确认卡出现之后，点击 `[data-production-action="confirm"]` 返回 gate 结果时；供应商提交尚未发生。日志中的 DBus `Unknown address type` 是 Electron/Linux 环境噪声，不是最早失败点。
+
+Run `33790669994` 的 `Quality Gate` / `Require every validation surface` 只执行了 fail-closed 汇总：
+
+```text
+test "failure" = "success"
+```
+
+因此它不是第二个独立根因。其余该 run 的 Validation Scope、Contracts、Unit、Workers Builds 通过；Canvas、Mac Package 按 scope 跳过。
+
+## 单一根因假设
+
+假设：C9 在新项目切换并导入参考资产后，没有在发起付费 gate 前证明项目 manifest revision 已稳定；授权封存时读取的 revision 与确认回执提交时从 live project resolver 读取的 revision 不同，安全校验按设计拒绝了收据。
+
+证据链：
+
+1. C9 直接执行 `project_create` → hash 切换 → `session_open`，随后 `asset_import`，然后立即 `operation_plan` / `operation_preview` / `operation_gate`（`tests/ux/mcp-l2-journeys.e2e.mjs:220-275`）；这里没有 revision-stable 等待或 revision 取证。
+2. 生产接线在 `mcpStdioServer.ts:283-298` 以当前 `readWorkspaceProject(...).revision` 创建授权 envelope。
+3. `runOwnedGenerationGateAuthority.ts:78-92` 把该 envelope revision 写入 challenge/receipt 范围。
+4. `productionRunApprovalReceipt.ts:24-39` 在 gate decide 时重新读取 live project revision，并要求 receipt revision 完全相等；不相等即 `ReceiptScopeError`，再由 MCP 层映射为 `receipt_invalid`。
+5. 另一个多镜真实旅程已有同类时序说明：新项目建好后 board 初始化会继续改 revision，必须等 digest 稳定后再开 session。PR #452 的生产 diff 只涉及 Host usage 字段、状态校验和 resident projection，没有修改 generation gate、project revision 或 receipt 代码；因此当前失败不能归因于 usage ledger 的直接逻辑改动。
+
+这只是已被 CI 日志和代码路径支持的最小假设；本轮未声称已通过一次本地真实 Electron 重跑。
+
+## PR #452 已有改动（现状，不是本轮新增）
+
+- `electron/projectAgentHost/projectAgentExecutionCoordinator.test.ts`：新增 terminal usage 写入并 reopen 恢复的协调器测试。
+- `electron/projectAgentHost/projectAgentReducer.ts`：async result 接受并校验 usage，再写入 terminal turn。
+- `electron/projectAgentHost/projectAgentState.ts`、`projectAgentStateValidationPrimitives.ts`：snapshot usage schema 与整数校验。
+- `electron/projectAgentHost/projectAgentTurnExecution.ts`、`electron/shared/projectAgentContracts.ts`：Host async result/envelope/turn 类型携带 usage。
+- `src/workbench/ai/ProjectAgentResidentShell.tsx`：优先从 Host snapshot 投影当前线程的累计/最近 usage，legacy 时回退旧 store。
+
+这些改动没有在本轮修改，也没有宣称它们已通过失败的 C9 gate。
+
+## 最小修复范围建议
+
+优先修复测试/真实 harness 的时序，不放宽 receipt revision 安全边界：在 C9 的 asset import 和/或 session open 后，通过真实项目读取边界等待 project revision 连续稳定，再进行 plan/preview/gate；若需要共享 helper，范围应限于 `tests/ux/mcp-l2-journeys.e2e.mjs` 及其 journey helper。
+
+只有在能用真实 app harness 重现“项目无用户写入却在 gate 确认期间继续 revision 漂移”后，才考虑生产层修复；候选 seam 是 `electron/capabilityCore/mcpStdioServer.ts` 的授权快照与 `electron/productionRun/productionRunApprovalReceipt.ts` 的校验，但不得简单删除或放宽 `projectRevision` 比较。
+
+本轮没有足够证据证明需要生产改动，因此没有新增红测或生产修复代码。
+
+## 后续绿测最低要求
+
+修复后必须重新取得真实证据：
+
+- Host async result boundary：terminal response 的 usage 进入 durable Host snapshot；非法 usage 被拒绝。
+- 磁盘持久化：关闭/重新创建 coordinator 后 snapshot 中仍保留 usage，格式通过 state validator。
+- coordinator reopen/restore：恢复的是同一 turn/thread 的 Host 状态，不是 renderer store 的假数据。
+- renderer resident UI：真实 Electron UI 从 Host snapshot 投影累计与最近 usage，并覆盖 legacy fallback。
+- C9 真实 app harness：真实项目、asset import、operation plan/preview、确认卡、receipt decide 全链路通过，且供应商 fixture hit 仍为零额度/仅预期调用。
+- Quality Gate：必须由真实 E2E 成功驱动汇总绿灯；不能用 `test "failure" = "success"` 的汇总日志替代。

--- a/electron/projectAgentHost/projectAgentExecutionCoordinator.test.ts
+++ b/electron/projectAgentHost/projectAgentExecutionCoordinator.test.ts
@@ -658,6 +658,38 @@ describe("ProjectAgentExecutionCoordinator", () => {
     expect(documentAdapter.execute).not.toHaveBeenCalled();
   });
 
+  it("persists terminal model usage on the Host turn and restores it after reopening", async () => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), "nomi-project-agent-usage-ledger-"));
+    const usage = { promptTokens: 17, completionTokens: 5, cachedPromptTokens: 3, totalTokens: 22 } as const;
+    const createCoordinator = () => createProjectAgentExecutionCoordinator(
+      createProjectAgentRepositoryRouter({ rootDir: root }),
+      () => "subscription-usage-ledger",
+      {
+        runAgent: async () => ({
+          id: "usage-result",
+          status: "finished",
+          text: "done",
+          finishReason: "stop",
+          artifacts: [],
+          toolCalls: [],
+          usage,
+        }),
+      },
+    );
+    const input = executionInput("usage-ledger", 0);
+    const first = createCoordinator();
+    const opened = await first.open(input.mutation.binding);
+    await first.enqueue(opened.subscriptionId, input);
+    await first.waitForTurn(opened.subscriptionId, input.mutation.payload.turn.turnId);
+    expect(first.snapshot(opened.subscriptionId).turns[0]?.usage).toEqual(usage);
+    first.release(opened.subscriptionId);
+
+    const reopened = createCoordinator();
+    const restored = await reopened.open(input.mutation.binding);
+    expect(reopened.snapshot(restored.subscriptionId).turns[0]?.usage).toEqual(usage);
+    reopened.release(restored.subscriptionId);
+  });
+
   it("reuses one approval for reversible edits while preserving a receipt per write", async () => {
     root = fs.mkdtempSync(path.join(os.tmpdir(), "nomi-project-agent-safe-auto-"));
     const documentAdapter = documentWriteAdapter();

--- a/electron/projectAgentHost/projectAgentReducer.ts
+++ b/electron/projectAgentHost/projectAgentReducer.ts
@@ -81,6 +81,19 @@ function findQueueForTurn(queue: readonly ProjectAgentQueueItem[], turnId: strin
   return item;
 }
 
+const AGENT_USAGE_KEYS = ["promptTokens", "completionTokens", "cachedPromptTokens", "totalTokens"] as const;
+
+function assertAsyncResultUsage(value: unknown): void {
+  if (!value || typeof value !== "object" || Array.isArray(value)) fail("async_result_stale");
+  const usage = value as Record<string, unknown>;
+  if (Object.keys(usage).some((key) => !AGENT_USAGE_KEYS.includes(key as (typeof AGENT_USAGE_KEYS)[number]))) {
+    fail("async_result_stale");
+  }
+  for (const key of AGENT_USAGE_KEYS) {
+    if (!Number.isSafeInteger(usage[key]) || (usage[key] as number) < 0) fail("async_result_stale");
+  }
+}
+
 function assertSingleRunningTurn(state: ProjectAgentHostState, turnId: string): void {
   if (state.turns.some((turn) => turn.turnId !== turnId && turn.status === "running")) {
     fail("running_turn_exists");
@@ -573,6 +586,7 @@ export function reduceProjectAgentMutation(
           "expectedRevision",
           "items",
           "turnStatus",
+          "usage",
           "retryable",
           "proposalApprovalId",
           "proposalStatus",
@@ -583,6 +597,7 @@ export function reduceProjectAgentMutation(
         const result = mutation.payload;
         assertCanonicalMutationTimestamp(result.receivedAt);
         assertOptionalMutationBoolean(result.retryable);
+        if (result.usage !== undefined) assertAsyncResultUsage(result.usage);
         assertExactMutationKeys(result.binding, ["projectId", "immutableProjectUuid", "projectGeneration"]);
         if (
           result.expectedRevision !== mutation.expectedRevision ||
@@ -682,7 +697,7 @@ export function reduceProjectAgentMutation(
         const assistantFinal = reduceProjectAgentAssistantFinal(items, result);
         items = assistantFinal.items;
         changes.push(...assistantFinal.changes);
-        const updatedTurn = transitionRecord(
+        const updatedTurnBase = transitionRecord(
           turn,
           {
             status: result.turnStatus,
@@ -691,6 +706,10 @@ export function reduceProjectAgentMutation(
           },
           true,
         );
+        const updatedTurn = freezeProjectAgentIncremental({
+          ...updatedTurnBase,
+          ...(result.usage !== undefined ? { usage: result.usage } : {}),
+        }) as ProjectAgentTurn;
         const updatedQueue = transitionRecord(
           queueItem,
           {

--- a/electron/projectAgentHost/projectAgentReducer.ts
+++ b/electron/projectAgentHost/projectAgentReducer.ts
@@ -26,6 +26,7 @@ import {
   assertProjectAgentMutationEnvelope,
   hashProjectAgentMutation,
 } from "./projectAgentMutationValidation";
+import { assertProjectAgentUsage } from "./projectAgentStateValidationPrimitives";
 import type { ProjectAgentReduction } from "./projectAgentReduction";
 import {
   isProjectAgentAbortStatus,
@@ -79,19 +80,6 @@ function findQueueForTurn(queue: readonly ProjectAgentQueueItem[], turnId: strin
   const item = queue.find((value) => value.turnId === turnId);
   if (!item) fail("record_not_found");
   return item;
-}
-
-const AGENT_USAGE_KEYS = ["promptTokens", "completionTokens", "cachedPromptTokens", "totalTokens"] as const;
-
-function assertAsyncResultUsage(value: unknown): void {
-  if (!value || typeof value !== "object" || Array.isArray(value)) fail("async_result_stale");
-  const usage = value as Record<string, unknown>;
-  if (Object.keys(usage).some((key) => !AGENT_USAGE_KEYS.includes(key as (typeof AGENT_USAGE_KEYS)[number]))) {
-    fail("async_result_stale");
-  }
-  for (const key of AGENT_USAGE_KEYS) {
-    if (!Number.isSafeInteger(usage[key]) || (usage[key] as number) < 0) fail("async_result_stale");
-  }
 }
 
 function assertSingleRunningTurn(state: ProjectAgentHostState, turnId: string): void {
@@ -597,7 +585,13 @@ export function reduceProjectAgentMutation(
         const result = mutation.payload;
         assertCanonicalMutationTimestamp(result.receivedAt);
         assertOptionalMutationBoolean(result.retryable);
-        if (result.usage !== undefined) assertAsyncResultUsage(result.usage);
+        if (result.usage !== undefined) {
+          try {
+            assertProjectAgentUsage(result.usage);
+          } catch {
+            fail("async_result_stale");
+          }
+        }
         assertExactMutationKeys(result.binding, ["projectId", "immutableProjectUuid", "projectGeneration"]);
         if (
           result.expectedRevision !== mutation.expectedRevision ||

--- a/electron/projectAgentHost/projectAgentState.ts
+++ b/electron/projectAgentHost/projectAgentState.ts
@@ -44,10 +44,8 @@ import {
 import {
   asRecord,
   assertAllowedKeys,
-  assertCanonicalTimestamp,
-  assertCanonicalId,
-  assertNonEmpty,
-  assertSafeInteger, assertSkillLoadReference,
+  assertCanonicalTimestamp, assertCanonicalId, assertNonEmpty,
+  assertSafeInteger, assertSkillLoadReference, assertProjectAgentUsage,
   assertStatusRecord,
   assertTimestampOrder,
   assertVersionRef,
@@ -123,21 +121,13 @@ function assertTurn(
   assertVersionRef(turn.model);
   if (turn.workMode !== undefined) assertWorkMode(turn.workMode);
   if (turn.approvalPolicy !== undefined) assertApprovalPolicy(turn.approvalPolicy);
-  if (turn.usage !== undefined) assertAgentUsage(turn.usage);
+  if (turn.usage !== undefined) assertProjectAgentUsage(turn.usage);
   assertVersionRefs(turn.skillVersions);
   assertVersionRefs(turn.capabilityVersions);
   assertContextRef(turn.contextRef, binding, turn.threadId);
   assertCanonicalTimestamp(turn.createdAt);
   assertCanonicalTimestamp(turn.updatedAt);
   assertTimestampOrder(turn.createdAt, turn.updatedAt);
-}
-
-function assertAgentUsage(value: unknown): void {
-  const usage = asRecord(value);
-  assertAllowedKeys(usage, ["promptTokens", "completionTokens", "cachedPromptTokens", "totalTokens"]);
-  for (const key of ["promptTokens", "completionTokens", "cachedPromptTokens", "totalTokens"] as const) {
-    assertSafeInteger(usage[key]);
-  }
 }
 
 function assertTaskRef(value: unknown): asserts value is TaskRef {

--- a/electron/projectAgentHost/projectAgentState.ts
+++ b/electron/projectAgentHost/projectAgentState.ts
@@ -108,6 +108,7 @@ function assertTurn(
     "model",
     "workMode",
     "approvalPolicy",
+    "usage",
     "skillVersions",
     "capabilityVersions",
     "contextRef",
@@ -122,12 +123,21 @@ function assertTurn(
   assertVersionRef(turn.model);
   if (turn.workMode !== undefined) assertWorkMode(turn.workMode);
   if (turn.approvalPolicy !== undefined) assertApprovalPolicy(turn.approvalPolicy);
+  if (turn.usage !== undefined) assertAgentUsage(turn.usage);
   assertVersionRefs(turn.skillVersions);
   assertVersionRefs(turn.capabilityVersions);
   assertContextRef(turn.contextRef, binding, turn.threadId);
   assertCanonicalTimestamp(turn.createdAt);
   assertCanonicalTimestamp(turn.updatedAt);
   assertTimestampOrder(turn.createdAt, turn.updatedAt);
+}
+
+function assertAgentUsage(value: unknown): void {
+  const usage = asRecord(value);
+  assertAllowedKeys(usage, ["promptTokens", "completionTokens", "cachedPromptTokens", "totalTokens"]);
+  for (const key of ["promptTokens", "completionTokens", "cachedPromptTokens", "totalTokens"] as const) {
+    assertSafeInteger(usage[key]);
+  }
 }
 
 function assertTaskRef(value: unknown): asserts value is TaskRef {

--- a/electron/projectAgentHost/projectAgentStateValidationPrimitives.ts
+++ b/electron/projectAgentHost/projectAgentStateValidationPrimitives.ts
@@ -53,6 +53,14 @@ export function assertSafeInteger(value: unknown, minimum = 0): asserts value is
   }
 }
 
+export function assertProjectAgentUsage(value: unknown): void {
+  const usage = asRecord(value);
+  assertAllowedKeys(usage, ["promptTokens", "completionTokens", "cachedPromptTokens", "totalTokens"]);
+  for (const key of ["promptTokens", "completionTokens", "cachedPromptTokens", "totalTokens"] as const) {
+    assertSafeInteger(usage[key]);
+  }
+}
+
 export function assertStringArray(value: unknown): asserts value is readonly string[] {
   if (!Array.isArray(value) || value.some((item) => typeof item !== "string" || !item.trim())) {
     throw new ProjectAgentStateError("invalid_state");

--- a/electron/projectAgentHost/projectAgentTurnExecution.ts
+++ b/electron/projectAgentHost/projectAgentTurnExecution.ts
@@ -632,6 +632,7 @@ export async function executeProjectAgentTurn(context: ProjectAgentTurnExecution
           expectedRevision: state.hostRevision,
           items: outcomeFailure ? [...resultItems, outcomeFailure] : resultItems,
           turnStatus: status,
+          usage: response.usage,
           ...(capabilityOutcome ? { retryable: capabilityOutcome.retryable } : {}),
           ...(proposalSettlements.length > 0
             ? { proposalSettlements }

--- a/electron/shared/projectAgentContracts.ts
+++ b/electron/shared/projectAgentContracts.ts
@@ -219,6 +219,8 @@ export type ProjectAgentTurn = ProjectAgentRecordBase &
     workMode?: ProjectAgentWorkMode;
     /** Optional for legacy snapshots; new turns freeze both approval axes. */
     approvalPolicy?: ProjectAgentApprovalPolicy;
+    /** Provider-reported usage for this terminal turn; absent on legacy/running records. */
+    usage?: AgentChatResponse["usage"];
     skillVersions: readonly ProjectAgentVersionRef[];
     capabilityVersions: readonly ProjectAgentVersionRef[];
     contextRef: ProjectAgentContextRef;
@@ -404,6 +406,8 @@ export type ProjectAgentAsyncResultEnvelope = Readonly<{
   expectedRevision: number;
   items: readonly ProjectAgentItem[];
   turnStatus: ProjectAgentStatus;
+  /** Provider-reported usage is committed with the terminal Host turn. */
+  usage?: AgentChatResponse["usage"];
   retryable?: boolean;
   proposalApprovalId?: string;
   proposalStatus?: ProjectAgentStatus;

--- a/src/workbench/ai/ProjectAgentResidentShell.tsx
+++ b/src/workbench/ai/ProjectAgentResidentShell.tsx
@@ -31,7 +31,7 @@ import { getAssistantModelPref, setAssistantModelPref } from './assistantModelPr
 import { useAgentUsageStore } from './agentUsageStore'
 import type { ComposerAttachment } from './composer/composerAttachmentTypes'
 import type { CreationDocumentTools } from '../workbenchTypes'
-import type { ProjectAgentApprovalMode, ProjectAgentItem, ProjectAgentSpendPolicy, ProjectAgentStatus } from '../../../electron/shared/projectAgentContracts'
+import type { ProjectAgentApprovalMode, ProjectAgentItem, ProjectAgentSpendPolicy, ProjectAgentStatus, ProjectAgentTurn } from '../../../electron/shared/projectAgentContracts'
 import type { DocumentAnchorRef, PreconditionSet, TargetRef } from '../../../electron/shared/capabilityTargeting'
 import { timelineRevision } from '../timeline/kernel/timelineKernel'
 import { useProductionRunStore } from '../production/productionRunStore'
@@ -64,6 +64,15 @@ const pendingKey = (call: Pick<ToolCallEvent, 'turnId' | 'toolCallId'>): string 
 const bindingKey = (binding: { immutableProjectUuid: string; projectGeneration: number }): string => `${binding.immutableProjectUuid}:${binding.projectGeneration}`
 const isLive = (status: ProjectAgentStatus): boolean => ['drafting', 'proposed', 'queued', 'running'].includes(status)
 const emitPending = (): void => residentPendingListeners.forEach((listener) => listener())
+
+function hostUsageForThread(turns: readonly ProjectAgentTurn[] | undefined, threadId: string | null): { turns: number; totalTokens: number; lastTurnTokens: number } {
+  const completed = (turns ?? []).filter((turn) => turn.threadId === threadId && turn.usage)
+  return completed.reduce((total, turn) => ({
+    turns: total.turns + 1,
+    totalTokens: total.totalTokens + (turn.usage?.totalTokens ?? 0),
+    lastTurnTokens: turn.usage?.totalTokens ?? total.lastTurnTokens,
+  }), { turns: 0, totalTokens: 0, lastTurnTokens: 0 })
+}
 
 function cacheResidentToolProjection(scope: string, turnId: string, toolCallId: string, projection: ResidentToolProjection): void {
   if (!scope) return
@@ -374,8 +383,12 @@ export default function ProjectAgentResidentShell({ surface }: { surface: Reside
   const activeTurn = snapshot?.turns.find((turn) => turn.threadId === activeThreadId && isLive(turn.status))
   const runningTurn = snapshot?.turns.find((turn) => turn.threadId === activeThreadId && turn.status === 'running')
   const planningTurn = snapshot?.turns.find((turn) => turn.threadId === activeThreadId && turn.status === 'drafting')
-  const sessionTotalTokens = useAgentUsageStore((state) => state.totalTokens)
-  const sessionTurns = useAgentUsageStore((state) => state.turns)
+  const sessionStoreTotalTokens = useAgentUsageStore((state) => state.totalTokens)
+  const sessionStoreTurns = useAgentUsageStore((state) => state.turns)
+  const hostUsage = React.useMemo(() => hostUsageForThread(snapshot?.turns, activeThreadId), [activeThreadId, snapshot?.turns])
+  const sessionTotalTokens = hostUsage.turns ? hostUsage.totalTokens : sessionStoreTotalTokens
+  const sessionTurns = hostUsage.turns ? hostUsage.turns : sessionStoreTurns
+  const displayedLastTurnTokens = hostUsage.turns ? hostUsage.lastTurnTokens : lastTurnTokens
   const toolProjectionScope = binding && activeThreadId ? residentToolProjectionScope(bindingKey(binding), activeThreadId) : ''
   const selectedModelRow = models.find((model) => encodeModelIdentity(model) === selectedModel)
   React.useEffect(() => {
@@ -681,7 +694,7 @@ export default function ProjectAgentResidentShell({ surface }: { surface: Reside
   return <section id="project-agent-resident" onKeyDownCapture={(event) => { if (event.key === 'Escape') { setThreadsOpen(false); setMenu(null); setQueueMenuOpen(null) } }} className="relative isolate flex h-full min-h-0 w-full min-w-0 flex-col bg-[var(--workbench-ai-panel-bg)] text-nomi-ink" aria-label={t('agentResident.aria')} data-agent-resident="true" data-agent-panel="true" data-agent-surface={surface} data-agent-run-mode={runMode} data-agent-approval-mode={approvalPolicy.mode} data-agent-spend-policy={approvalPolicy.spend}>
     <header className="relative flex min-h-11 shrink-0 items-center gap-2 border-b border-nomi-line-soft px-3 py-1.5" data-agent-header="true">
       <div className="flex min-w-0 items-center gap-2"><NomiLogoMark size={19} /><span className="text-body-sm font-semibold">{t('agentResident.brand')}</span></div>
-      <span className="relative inline-flex h-6 shrink-0 items-center gap-1.5 rounded-pill border border-nomi-line bg-nomi-paper px-2 text-micro tabular-nums text-nomi-ink-60" data-agent-usage-pill="true" title={t('agentResident.usageTitle', { last: lastTurnTokens, total: sessionTotalTokens })} aria-label={t('agentResident.usageRoundsTitle', { count: remainingRounds })}><IconCircleDashed size={13} className="text-nomi-accent" aria-hidden="true" />{t('agentResident.usageRounds', { count: remainingRounds })}</span>
+      <span className="relative inline-flex h-6 shrink-0 items-center gap-1.5 rounded-pill border border-nomi-line bg-nomi-paper px-2 text-micro tabular-nums text-nomi-ink-60" data-agent-usage-pill="true" title={t('agentResident.usageTitle', { last: displayedLastTurnTokens, total: sessionTotalTokens })} aria-label={t('agentResident.usageRoundsTitle', { count: remainingRounds })}><IconCircleDashed size={13} className="text-nomi-accent" aria-hidden="true" />{t('agentResident.usageRounds', { count: remainingRounds })}</span>
       <span className="min-w-0 flex-1" aria-hidden="true" />
       <WorkbenchIconButton size="sm" label={t('agentResident.threadList')} icon={<IconHistory size={15} />} onClick={() => setThreadsOpen((value) => !value)} data-agent-history="true" />
       <WorkbenchIconButton size="sm" label={t('agentResident.collapse')} icon={<IconLayoutSidebarRightCollapse size={15} />} onClick={() => setCollapsed(true)} data-agent-collapse="true" />


### PR DESCRIPTION
## Summary

This is the follow-up to the already merged Agent work-mode boundary in PR #451. It closes the next functional Agent UI gap: model usage is owned by the Project Agent Host and survives renderer restart/reopen.

- Persist model usage on terminal Host turns from the async result boundary.
- Validate the persisted usage shape in the durable Host snapshot without duplicating validation logic.
- Restore usage from disk through a newly opened coordinator.
- Project Host usage into the resident UI usage capsule, with the renderer store retained only as a compatibility fallback.
- Add an integration test covering terminal persistence and reopen/restore.

## Scope boundary

This PR is limited to usage ownership and persistence. It does not claim the remaining creative workflow slice from #447, including exact selection preconditions, receipts/undo, queue/deviation/elicitation behavior, and the remaining document/canvas/timeline/production journeys.

## Verification

- `pnpm run gates` — passed
  - 1136 test files passed, 1 skipped
  - 10584 tests passed, 2 skipped
  - typecheck passed
  - Electron build passed
  - all contracts passed
  - lint: 0 errors, 81 existing warnings within the repository limit
- Targeted Agent Host/UI tests — 108/108 passed
- `git diff --check` — passed
