### PR TITLE
test(mcp): harden real user journeys

### DIFF
--- a/docs/qa/2026-09-04-mcp-real-journeys-hardening.md
+++ b/docs/qa/2026-09-04-mcp-real-journeys-hardening.md
@@ -1,11 +1,13 @@
 # MCP 真实用户旅程测试加固证据
 
 日期：2026-09-04
-基线：`origin/main` `53e3ab7c2f38561760a6b7262c76c098929a7c34`（包含 PR #455/#457 合并链）
+基线：`origin/main` `91af6c9a96ca729b7af1610810e994782e6c3aae`（同步 PR #453 后的 main）
 
 ## 范围
 
 新增测试从 `createMcpProtocol.handleIncoming` 进入生产 MCP `tools/call` 入口，使用真实 `MCP_TOOL_RESOLVER`、JSON Schema 校验、工具路由、`build` 和错误结果投影。唯一 mock 是 transport 的 `invoke` 边界；没有 live/paid credential、真实供应商或外部网络请求。
+
+真实软件使用复用既有 CI-safe Electron journey：`tests/ux/production-mcp-journey.e2e.mjs` 启动实际 Nomi Electron，spawn `electron <repoRoot>` 的真实 MCP stdio server，经过项目创建、Production Run、GUI 审批、重启恢复、物化和导出；它断言隔离项目磁盘副作用、最终 MP4、H.264/AAC 和 MCP `nomiUri`。这条 journey 使用仓库既有的双门控零额度 fixture，不代表 live provider certification。
 
 覆盖：
 
@@ -32,6 +34,25 @@ pnpm exec vitest run electron/capabilityCore/mcpRealUserJourneys.test.ts
 
 同一命令修复后：1 test passed。扩展矩阵后同一命令：8 tests passed。
 
+### Scoped V8 coverage red → green
+
+精确 include 的 production file 是 `electron/capabilityCore/mcpArgValidation.ts`，没有使用 `exclude`：
+
+```text
+RED raw reports: /tmp/nomi-mcp-v8-red.szymwo/coverage-summary.json
+pnpm exec vitest run electron/capabilityCore/mcpArgValidation.test.ts electron/capabilityCore/mcpRealUserJourneys.test.ts --coverage.enabled --coverage.provider=v8 --coverage.include=electron/capabilityCore/mcpArgValidation.ts --coverage.reportsDirectory=/tmp/nomi-mcp-v8-red.szymwo --coverage.thresholds.statements=100 --coverage.thresholds.branches=100
+Tests: 2 files / 12 passed; Statements 83/102 (81.37%); Branches 102/139 (73.38%); command failed thresholds.
+
+INTERMEDIATE RED raw reports: /tmp/nomi-mcp-v8-green.uIEKaw/coverage-summary.json
+After runtime schema cases: Statements 102/102 (100%); Branches 137/139 (98.56%); command failed the branch threshold.
+
+GREEN raw output: /tmp/nomi-mcp-v8-green-synced.ZJGKPx/console.txt
+GREEN raw reports: /tmp/nomi-mcp-v8-green-synced.ZJGKPx/coverage-final.json and /tmp/nomi-mcp-v8-green-synced.ZJGKPx/coverage-summary.json
+Same command after syncing to `origin/main` `91af6c9a`: 2 files / 14 passed; Statements 102/102 (100%); Branches 139/139 (100%); Functions 8/8 (100%); Lines 92/92 (100%).
+```
+
+The last two branches were not unreachable: they were the validator's explicit non-string `schema.type` fall-through and the false side of the boolean type guard. They are now exercised by a real schema-shaped test case; no coverage exclusion is used.
+
 ## 验证命令与结果
 
 | 命令 | 结果 |
@@ -45,10 +66,13 @@ pnpm exec vitest run electron/capabilityCore/mcpRealUserJourneys.test.ts
 | `pnpm run check:mcp-tool-refs` | 9/9 引用命中目录工具 |
 | `pnpm run check:boundaries` | 80 处既有基线，无新增越界 |
 | `pnpm run test:system:unit` | Vitest 1144 files passed / 1 skipped，10638 tests passed / 2 skipped；agent-worktree-janitor 13/13；agent-runtime 151/151 |
+| `pnpm run build` | Electron install identity 13/13 checks passed；renderer and Electron production builds passed |
+| `node tests/ux/production-mcp-journey.e2e.mjs` | **PRODUCTION MCP JOURNEY PASS: 52 assertions**；Run `run-4052ae33-0137-4d33-91f0-c1417ac8544a`；log `/tmp/nomi-production-mcp-journey-20260904.log` |
+| `git diff origin/main..HEAD --check` | passed after syncing `origin/main` to `91af6c9a` |
 
 ## 未覆盖与证据边界
 
-本轮没有声称 100% 覆盖，也没有运行 coverage 百分比。新增 suite 未覆盖：
+本轮只对本次修改的 `mcpArgValidation.ts` 声称 measured scoped V8 Statements/Branches 100%；这不等于整个 MCP 或仓库 100%。真实 Electron journey 也不等于所有 MCP surface 已覆盖。未覆盖：
 
 - Electron `startMcpStdioServer` 进程装配、stdio framing、GUI-open loopback `callViaRpc` 和打包 app。
 - elicitation/create 的 accept/decline/timeout 交互、取消通知和进度通知。

--- a/docs/qa/2026-09-04-mcp-real-journeys-hardening.md
+++ b/docs/qa/2026-09-04-mcp-real-journeys-hardening.md
@@ -1,0 +1,58 @@
+# MCP 真实用户旅程测试加固证据
+
+日期：2026-09-04
+基线：`origin/main` `53e3ab7c2f38561760a6b7262c76c098929a7c34`（包含 PR #455/#457 合并链）
+
+## 范围
+
+新增测试从 `createMcpProtocol.handleIncoming` 进入生产 MCP `tools/call` 入口，使用真实 `MCP_TOOL_RESOLVER`、JSON Schema 校验、工具路由、`build` 和错误结果投影。唯一 mock 是 transport 的 `invoke` 边界；没有 live/paid credential、真实供应商或外部网络请求。
+
+覆盖：
+
+- Happy path：`nomi_project_create` → `nomi_read(target=projects)` → `nomi_operation_plan` → `nomi_operation_preview`，并验证重复输入的独立调用。
+- Boundary：空字符串、长字符串、Unicode（含 emoji）、4000 码点上限和 4001 码点超限。
+- Error：缺必填参数、未知字段、未知 operation、`null` 参数、stale revision。
+- Failure：确定性 `capability_timeout`、network failure 和 provider failure；验证 `isError`、诊断码及 edge secret/URL 不泄漏。
+
+## Red → Green
+
+### Red
+
+命令：
+
+```text
+pnpm exec vitest run electron/capabilityCore/mcpRealUserJourneys.test.ts
+```
+
+结果：1 test failed。`accepts a max-length Unicode instruction through tools/call` 收到 `result.isError === true`，失败位置是新增测试的入口响应断言；原因是生产校验器用 UTF-16 `value.length` 计算 JSON Schema 字符长度，4000 个 emoji 被误算成 8000 个字符。
+
+### Green
+
+修复：`electron/capabilityCore/mcpArgValidation.ts` 在共享字符串边界改用 `Array.from(value).length`，并用同一计数值生成错误文案；没有改变其它 schema 或 dispatch 行为。
+
+同一命令修复后：1 test passed。扩展矩阵后同一命令：8 tests passed。
+
+## 验证命令与结果
+
+| 命令 | 结果 |
+|---|---|
+| `pnpm exec vitest run electron/capabilityCore/mcpRealUserJourneys.test.ts` | 8/8 passed |
+| `pnpm exec vitest run electron/capabilityCore/mcpArgValidation.test.ts electron/capabilityCore/mcpProtocol.test.ts electron/capabilityCore/mcpRequestLifecycle.test.ts electron/capabilityCore/nomiMcpProductionRevision.test.ts electron/capabilityCore/mcpRealUserJourneys.test.ts` | 5 files, 21/21 passed |
+| `pnpm run check:test-waits` | 0 私有墙钟等待；3 个既有预算断言 |
+| `pnpm exec eslint electron/capabilityCore/mcpArgValidation.ts electron/capabilityCore/mcpRealUserJourneys.test.ts` | exit 0 |
+| `pnpm run typecheck` | exit 0 |
+| `pnpm run check:mcp-payload` | 18416 bytes ≤ 20016 ratchet |
+| `pnpm run check:mcp-tool-refs` | 9/9 引用命中目录工具 |
+| `pnpm run check:boundaries` | 80 处既有基线，无新增越界 |
+| `pnpm run test:system:unit` | Vitest 1144 files passed / 1 skipped，10638 tests passed / 2 skipped；agent-worktree-janitor 13/13；agent-runtime 151/151 |
+
+## 未覆盖与证据边界
+
+本轮没有声称 100% 覆盖，也没有运行 coverage 百分比。新增 suite 未覆盖：
+
+- Electron `startMcpStdioServer` 进程装配、stdio framing、GUI-open loopback `callViaRpc` 和打包 app。
+- elicitation/create 的 accept/decline/timeout 交互、取消通知和进度通知。
+- 成功的付费确认、真实 provider HTTP 请求、真实供应商凭证和 live 网络；failure cases 仅证明入口错误投影，不能替代 live certification。
+- resources/prompts/artifact URI、画布写入、持久化重启恢复等其它 MCP surface。
+
+这些路径由既有 `tests/ux/mcp-l1-handshake.e2e.mjs`、`tests/ux/mcp-l2-journeys.e2e.mjs` 及相邻 MCP 测试分别承担；本 QA 记录只报告本次 bounded diff 的实测结果。

--- a/electron/capabilityCore/mcpArgValidation.test.ts
+++ b/electron/capabilityCore/mcpArgValidation.test.ts
@@ -30,6 +30,73 @@ describe('MCP tools/call schema boundary', () => {
     expect(validateToolArguments('demo', schema, ['model-a'])).toBeNull()
   })
 
+  it('exercises every runtime schema type and defensive input shape', () => {
+    expect(validateToolArguments('no-schema', undefined, {})).toBeNull()
+    expect(validateToolArguments('primitive-schema', 'not-a-schema', {})).toBeNull()
+    expect(validateToolArguments('untyped-schema', { type: 123 }, {})).toBeNull()
+
+    const objectSchema = {
+      type: 'object',
+      properties: {
+        name: { type: 'string' },
+        ignored: null,
+        optional: { type: 'string' },
+      },
+      required: ['name', 42],
+      additionalProperties: false,
+    }
+    expect(validateToolArguments('object', objectSchema, { name: 3, extra: true, ignored: 'kept' })?.message)
+      .toContain('必须是字符串')
+    expect(validateToolArguments('empty-object', { type: 'object', properties: {}, additionalProperties: false }, { extra: true })?.message)
+      .toContain('不接受任何参数')
+    expect(validateToolArguments('loose-object', { type: 'object', properties: 'invalid', required: 'invalid', additionalProperties: true }, {}))
+      .toBeNull()
+    expect(validateToolArguments('object-shape', { type: 'object' }, [])?.message).toContain('必须是对象')
+    expect(validateToolArguments('object-shape', { type: 'object' }, null)?.message).toContain('null')
+    expect(validateToolArguments('object-shape', { type: 'object' }, 'wrong')?.message).toContain('字符串')
+
+    const arraySchema = { type: 'array', minItems: 2, maxItems: 1, items: { type: 'string' } }
+    expect(validateToolArguments('array', arraySchema, [])?.message).toContain('至少')
+    expect(validateToolArguments('array', arraySchema, ['one', 'two'])?.message).toContain('最多')
+    expect(validateToolArguments('array', { type: 'array', items: { type: 'string' } }, [3])?.message).toContain('必须是字符串')
+    expect(validateToolArguments('array-shape', { type: 'array' }, 'wrong')?.message).toContain('必须是数组')
+    expect(validateToolArguments('array-items', { type: 'array', items: 'invalid' }, [])).toBeNull()
+
+    expect(validateToolArguments('min-length', { type: 'string', minLength: 1 }, '')?.message).toContain('不能为空')
+    expect(validateToolArguments('min-length', { type: 'string', minLength: 2, maxLength: 3 }, '')?.message).toContain('至少 2')
+    expect(validateToolArguments('max-length', { type: 'string', minLength: 2, maxLength: 3 }, 'abcd')?.message).toContain('最多 3')
+    expect(validateToolArguments('string-type', { type: 'string' }, null)?.message).toContain('null')
+    expect(validateToolArguments('string-type', { type: 'string' }, [])?.message).toContain('数组')
+    expect(validateToolArguments('string-type', { type: 'string' }, {})?.message).toContain('对象')
+    expect(validateToolArguments('string-type', { type: 'string' }, true)?.message).toContain('布尔值')
+    expect(validateToolArguments('string-type', { type: 'string' }, 1)?.message).toContain('数字')
+    expect(validateToolArguments('string-type', { type: 'string' }, undefined)?.message).toContain('undefined')
+
+    const numberSchema = { type: 'number', minimum: 1, maximum: 3 }
+    expect(validateToolArguments('number', numberSchema, 'wrong')?.message).toContain('必须是数字')
+    expect(validateToolArguments('number', numberSchema, Infinity)?.message).toContain('必须是数字')
+    expect(validateToolArguments('number', numberSchema, 0)?.message).toContain('不能小于')
+    expect(validateToolArguments('number', numberSchema, 4)?.message).toContain('不能大于')
+    expect(validateToolArguments('number', numberSchema, 2)).toBeNull()
+    expect(validateToolArguments('integer', { type: 'integer' }, 1.5)?.message).toContain('必须是整数')
+    expect(validateToolArguments('integer', { type: 'integer' }, Infinity)?.message).toContain('必须是整数')
+    expect(validateToolArguments('boolean', { type: 'boolean' }, 1)?.message).toContain('数字')
+    expect(validateToolArguments('boolean', { type: 'boolean' }, true)).toBeNull()
+  })
+
+  it('exercises schema structure rejection branches without excluding them from coverage', () => {
+    expect(findUnsupportedSchemaFeatures(null)).toEqual([])
+    expect(findUnsupportedSchemaFeatures('invalid')).toEqual([])
+    expect(findUnsupportedSchemaFeatures([])).toEqual([])
+    expect(findUnsupportedSchemaFeatures({ unknown: true })).toEqual(['<root>: 不支持的关键字 "unknown"'])
+    expect(findUnsupportedSchemaFeatures({ properties: { nested: { unknown: true } } })).toEqual(['nested: 不支持的关键字 "unknown"'])
+    expect(findUnsupportedSchemaFeatures({ type: 'unsupported' })).toEqual(['<root>: 不支持的 type "unsupported"'])
+    expect(findUnsupportedSchemaFeatures({ type: 123 })).toEqual([])
+    expect(findUnsupportedSchemaFeatures({ type: 'object', properties: null, items: null })).toEqual([])
+    expect(findUnsupportedSchemaFeatures({ properties: 'invalid' })).toEqual([])
+    expect(findUnsupportedSchemaFeatures({ properties: { nested: { type: 'string' } }, items: { type: 'string' } })).toEqual([])
+  })
+
   it('keeps the entire catalog inside the validator-supported schema subset', () => {
     const unsupported = MCP_TOOL_CATALOG.flatMap((tool) => findUnsupportedSchemaFeatures(tool.inputSchema).map((issue) => `${tool.name}: ${issue}`))
     expect(unsupported).toEqual([])

--- a/electron/capabilityCore/mcpArgValidation.ts
+++ b/electron/capabilityCore/mcpArgValidation.ts
@@ -123,15 +123,16 @@ function validateValue(value: unknown, schema: SchemaLike, path: string, issues:
       issues.push({ path, message: `必须是字符串（收到 ${describeType(value)}）` })
       return
     }
+    const characterCount = Array.from(value).length
     // minLength:1 在目录里是「不许给空串」的写法（如修改指令），必须真拦——否则空指令被当成合法定点修改。
-    if (typeof schema.minLength === 'number' && value.length < schema.minLength) {
+    if (typeof schema.minLength === 'number' && characterCount < schema.minLength) {
       issues.push({
         path,
-        message: schema.minLength === 1 ? '不能为空' : `至少 ${schema.minLength} 个字符（收到 ${value.length} 个）`,
+        message: schema.minLength === 1 ? '不能为空' : `至少 ${schema.minLength} 个字符（收到 ${characterCount} 个）`,
       })
     }
-    if (typeof schema.maxLength === 'number' && value.length > schema.maxLength) {
-      issues.push({ path, message: `最多 ${schema.maxLength} 个字符（收到 ${value.length} 个）` })
+    if (typeof schema.maxLength === 'number' && characterCount > schema.maxLength) {
+      issues.push({ path, message: `最多 ${schema.maxLength} 个字符（收到 ${characterCount} 个）` })
     }
     return
   }

--- a/electron/capabilityCore/mcpRealUserJourneys.test.ts
+++ b/electron/capabilityCore/mcpRealUserJourneys.test.ts
@@ -1,0 +1,286 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { createMcpProtocol, type McpTransport } from './mcpProtocol'
+
+type Frame = {
+  id?: number
+  result?: {
+    isError?: boolean
+    content?: Array<{ type?: string; text?: string }>
+    structuredContent?: { nomiOutcome?: Record<string, unknown> }
+  }
+  error?: { code?: number; message?: string }
+}
+
+async function settle() {
+  await new Promise<void>((resolve) => setImmediate(resolve))
+}
+
+function responseFor(frames: Frame[], id: number): Frame {
+  const response = frames.find((frame) => frame.id === id)
+  if (!response) throw new Error(`missing MCP response ${id}`)
+  return response
+}
+
+function resultFor(frames: Frame[], id: number) {
+  return responseFor(frames, id).result
+}
+
+function errorCode(result: Frame['result']): unknown {
+  return result?.structuredContent?.nomiOutcome?.errorCode
+}
+
+function createTransportHarness(failures: Map<string, Error> = new Map()) {
+  const frames: Frame[] = []
+  const calls: Array<{ method: string; params: Record<string, unknown> }> = []
+  const projects: Array<Record<string, unknown>> = []
+  let projectSequence = 0
+
+  const invoke = vi.fn(async (method: string, params: Record<string, unknown>) => {
+    calls.push({ method, params })
+    const failure = failures.get(method)
+    if (failure) throw failure
+
+    if (method === 'project.create') {
+      const project = {
+        id: `project-${++projectSequence}`,
+        name: typeof params.name === 'string' && params.name ? params.name : '未命名项目',
+        revision: 1,
+      }
+      projects.push(project)
+      return project
+    }
+    if (method === 'project.list') return { projects }
+    if (method === 'nomi_operation_create') {
+      return {
+        operation: {
+          operationId: 'operation-1',
+          projectId: params.projectId,
+          state: 'draft',
+          candidate: { prompt: params.prompt, revision: 1 },
+        },
+        nextAction: 'preview',
+      }
+    }
+    if (method === 'nomi_preview_execution') {
+      return { operationId: params.operationId, candidateRevision: 1, nextAction: 'request_gate' }
+    }
+    if (method === 'production.artifact.review') {
+      return {
+        projectId: params.projectId,
+        runId: params.runId,
+        artifactId: params.artifactId,
+        status: 'adopted',
+        version: params.expectedVersion,
+      }
+    }
+    throw new Error(`unexpected production MCP invoke: ${method}`)
+  })
+
+  const protocol = createMcpProtocol({
+    send: (frame) => frames.push(frame as Frame),
+    invoke: invoke as McpTransport['invoke'],
+    isAppOpen: () => false,
+  })
+  return { calls, frames, invoke, protocol }
+}
+
+async function callTool(
+  protocol: ReturnType<typeof createMcpProtocol>,
+  frames: Frame[],
+  id: number,
+  name: string,
+  args: unknown,
+) {
+  protocol.handleIncoming({
+    jsonrpc: '2.0',
+    id,
+    method: 'tools/call',
+    params: { name, arguments: args },
+  })
+  await settle()
+  return resultFor(frames, id)
+}
+
+describe('MCP production entrypoint user journeys', () => {
+  it('accepts a max-length Unicode instruction through tools/call', async () => {
+    const frames: Frame[] = []
+    const invoke = vi.fn(async () => ({
+      projectId: 'project-1',
+      runId: 'run-1',
+      artifactId: 'artifact-script-v2',
+      status: 'candidate',
+      version: 2,
+    }))
+    const protocol = createMcpProtocol({
+      send: (frame) => frames.push(frame as Frame),
+      invoke: invoke as McpTransport['invoke'],
+      isAppOpen: () => false,
+    })
+
+    protocol.handleIncoming({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'tools/call',
+      params: {
+        name: 'nomi_artifact_review',
+        arguments: {
+          projectId: 'project-1',
+          runId: 'run-1',
+          artifactId: 'artifact-script-v1',
+          expectedVersion: 1,
+          action: 'revise',
+          kind: 'script',
+          instruction: '😀'.repeat(4_000),
+        },
+      },
+    })
+    await settle()
+
+    expect(frames).toHaveLength(1)
+    expect(frames[0].result?.isError).not.toBe(true)
+    expect(invoke).toHaveBeenCalledWith('production.artifact.revise', expect.objectContaining({
+      expectedVersion: 1,
+      instruction: '😀'.repeat(4_000),
+    }))
+    protocol.dispose()
+  })
+
+  it('completes a project, read, plan, and preview journey through production tools', async () => {
+    const { calls, frames, protocol } = createTransportHarness()
+    try {
+      protocol.handleIncoming({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: { protocolVersion: '2025-11-25', capabilities: {}, clientInfo: { name: 'CI MCP user' } },
+      })
+      await settle()
+      expect((responseFor(frames, 1).result as unknown as { protocolVersion?: string })?.protocolVersion).toBe('2025-11-25')
+
+      protocol.handleIncoming({ jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} })
+      await settle()
+      const tools = (resultFor(frames, 2) as { tools?: Array<{ name: string }> })?.tools || []
+      expect(tools.map((tool) => tool.name)).toEqual(expect.arrayContaining([
+        'nomi_project_create', 'nomi_read', 'nomi_operation_plan', 'nomi_operation_preview',
+      ]))
+
+      const created = await callTool(protocol, frames, 3, 'nomi_project_create', { name: '湖边🎬用户旅程' })
+      expect(created?.isError).not.toBe(true)
+      expect(calls[0]).toEqual({ method: 'project.create', params: { name: '湖边🎬用户旅程' } })
+
+      const listed = await callTool(protocol, frames, 4, 'nomi_read', { target: 'projects' })
+      expect(listed?.isError).not.toBe(true)
+      expect(calls[1]).toEqual({ method: 'project.list', params: {} })
+      expect(JSON.stringify(listed)).toContain('湖边🎬用户旅程')
+
+      const planned = await callTool(protocol, frames, 5, 'nomi_operation_plan', {
+        projectId: 'project-1',
+        leaseHandle: 'lease-1',
+        prompt: '让纸船在月光里慢慢靠岸',
+      })
+      expect(planned?.isError).not.toBe(true)
+      expect(calls[2]).toEqual({
+        method: 'nomi_operation_create',
+        params: { projectId: 'project-1', leaseHandle: 'lease-1', prompt: '让纸船在月光里慢慢靠岸' },
+      })
+
+      const preview = await callTool(protocol, frames, 6, 'nomi_operation_preview', {
+        projectId: 'project-1', leaseHandle: 'lease-1', operationId: 'operation-1',
+      })
+      expect(preview?.isError).not.toBe(true)
+      expect(calls[3]).toEqual({
+        method: 'nomi_preview_execution',
+        params: { projectId: 'project-1', leaseHandle: 'lease-1', operationId: 'operation-1' },
+      })
+
+      const repeated = await callTool(protocol, frames, 7, 'nomi_project_create', { name: '湖边🎬用户旅程' })
+      expect(repeated?.isError).not.toBe(true)
+      expect(calls.filter(({ method, params }) => method === 'project.create' && params.name === '湖边🎬用户旅程')).toHaveLength(2)
+    } finally {
+      protocol.dispose()
+    }
+  })
+
+  it('keeps empty, long, and Unicode inputs at the production schema boundary', async () => {
+    const { calls, frames, protocol } = createTransportHarness()
+    try {
+      const empty = await callTool(protocol, frames, 11, 'nomi_operation_plan', { leaseHandle: 'lease-1', prompt: '' })
+      expect(empty?.isError).not.toBe(true)
+
+      const longUnicodePrompt = '重复的镜头意图😀'.repeat(1_000)
+      const long = await callTool(protocol, frames, 12, 'nomi_operation_plan', {
+        leaseHandle: 'lease-1', prompt: longUnicodePrompt,
+      })
+      expect(long?.isError).not.toBe(true)
+      expect(calls.filter(({ method }) => method === 'nomi_operation_create').at(-1)?.params.prompt).toBe(longUnicodePrompt)
+
+      const tooLong = await callTool(protocol, frames, 13, 'nomi_artifact_review', {
+        projectId: 'project-1', runId: 'run-1', artifactId: 'artifact-1', expectedVersion: 1,
+        action: 'revise', kind: 'script', instruction: '界'.repeat(4_001),
+      })
+      expect(tooLong?.isError).toBe(true)
+      expect(errorCode(tooLong)).toBe('capability_input_invalid')
+      expect(calls.some(({ method }) => method === 'production.artifact.revise')).toBe(false)
+    } finally {
+      protocol.dispose()
+    }
+  })
+
+  it('returns recoverable tool errors for malformed arguments and unknown operations', async () => {
+    const { calls, frames, protocol } = createTransportHarness()
+    try {
+      const cases: Array<{ id: number; name: string; args: unknown }> = [
+        { id: 21, name: 'nomi_operation_plan', args: {} },
+        { id: 22, name: 'nomi_operation_plan', args: { leaseHandle: 'lease-1', unexpected: true } },
+        { id: 23, name: 'nomi_operation_control', args: { leaseHandle: 'lease-1', operationId: 'operation-1', action: 'explode' } },
+        { id: 24, name: 'nomi_read', args: null },
+      ]
+
+      for (const testCase of cases) {
+        const result = await callTool(protocol, frames, testCase.id, testCase.name, testCase.args)
+        expect(result?.isError).toBe(true)
+        expect(errorCode(result)).toBe('capability_input_invalid')
+      }
+      expect(calls).toHaveLength(0)
+    } finally {
+      protocol.dispose()
+    }
+  })
+
+  it('projects a stale revision as a typed safe error at the MCP entrypoint', async () => {
+    const stale = Object.assign(new Error('artifact revision is stale: current=2'), { code: 'capability_policy_stale' })
+    const { frames, protocol } = createTransportHarness(new Map([['production.artifact.review', stale]]))
+    try {
+      const result = await callTool(protocol, frames, 31, 'nomi_artifact_review', {
+        projectId: 'project-1', runId: 'run-1', artifactId: 'artifact-1', expectedVersion: 1, action: 'approve',
+      })
+      expect(result?.isError).toBe(true)
+      expect(errorCode(result)).toBe('capability_policy_stale')
+      expect(JSON.stringify(result)).not.toContain('current=2')
+    } finally {
+      protocol.dispose()
+    }
+  })
+
+  it.each([
+    ['timeout', 'nomi_operation_preview', 'nomi_preview_execution', 'capability_timeout'],
+    ['network failure', 'nomi_operation_plan', 'nomi_operation_create', 'capability_execution_failed'],
+    ['provider failure', 'nomi_operation_plan', 'nomi_operation_create', 'capability_execution_failed'],
+  ])('returns a deterministic %s without leaking edge details', async (_label, toolName, method, code) => {
+    const failure = Object.assign(new Error(`${_label} at https://provider.invalid using apiKey=fixture-secret`), { code })
+    const { frames, protocol } = createTransportHarness(new Map([[method, failure]]))
+    try {
+      const args = toolName === 'nomi_operation_preview'
+        ? { leaseHandle: 'lease-1', operationId: 'operation-1' }
+        : { leaseHandle: 'lease-1', prompt: _label }
+      const result = await callTool(protocol, frames, 41, toolName, args)
+      expect(result?.isError).toBe(true)
+      expect(errorCode(result)).toBe(code)
+      expect(JSON.stringify(result)).not.toContain('fixture-secret')
+      expect(JSON.stringify(result)).not.toContain('provider.invalid')
+    } finally {
+      protocol.dispose()
+    }
+  })
+})


### PR DESCRIPTION
## Scope
- Sync branch onto `origin/main` `91af6c9a96ca729b7af1610810e994782e6c3aae` (PR #453 included).
- Cover MCP production entrypoint journeys for happy/boundary/error/timeout/network/provider cases.
- Measure the changed `electron/capabilityCore/mcpArgValidation.ts` with real V8 coverage using an exact production include; no `exclude`.
- Reuse the existing CI-safe real Electron MCP user task and record its receipt.

## Red → green evidence
- Validator journey red: `pnpm exec vitest run electron/capabilityCore/mcpRealUserJourneys.test.ts` — 1 failed because 4000 emoji were counted as 8000 UTF-16 units; minimal production fix uses code-point count.
- V8 red: `/tmp/nomi-mcp-v8-red.szymwo/coverage-summary.json` — 2 files / 12 passed, Statements 83/102 (81.37%), Branches 102/139 (73.38%), 100% thresholds failed.
- V8 intermediate red: `/tmp/nomi-mcp-v8-green.uIEKaw/coverage-summary.json` — Statements 102/102, Branches 137/139 (98.56%), branch threshold failed.
- V8 green: `/tmp/nomi-mcp-v8-green-synced.ZJGKPx/console.txt`, `coverage-final.json`, `coverage-summary.json` — exact include `electron/capabilityCore/mcpArgValidation.ts`; 2 files / 14 passed; Statements 102/102 (100%), Branches 139/139 (100%), Functions 8/8 (100%), Lines 92/92 (100%).
- Scoped tests: `pnpm exec vitest run electron/capabilityCore/mcpArgValidation.test.ts electron/capabilityCore/mcpRealUserJourneys.test.ts` — 2 files / 14 passed.

## Real software user task
- Build: `pnpm run build` — Electron identity checks 13/13; renderer and Electron builds passed.
- Journey: `node tests/ux/production-mcp-journey.e2e.mjs` — `PRODUCTION MCP JOURNEY PASS: 52 assertions`; real Electron app + real MCP stdio, isolated project creation, GUI approvals, restart recovery, materialization, disk project side effect, MP4 H.264/AAC and scoped MCP URI checks.
- Raw log: `/tmp/nomi-production-mcp-journey-20260904.log`. Fixture is double-gated and zero-credit; this is not live provider certification.

## Mock boundary
Timeout/network/provider failures inject deterministic errors only through the `McpTransport.invoke` adapter edge in `electron/capabilityCore/mcpRealUserJourneys.test.ts`. No `fetch`/provider internals are mocked in the production-entrypoint test, and no paid/live credentials are used.

## Coverage boundary
The measured 100% claim is scoped only to the changed `mcpArgValidation.ts` file and the stated V8 run. It is not a claim for all MCP or repository coverage. Stdio/loopback/packaging variants, elicitation/cancel/progress, live providers, and other resources/prompts/artifact/persistence surfaces remain outside this bounded PR and are listed in the QA evidence doc.