### PR TITLE
test: close TikHub video breakdown user journey

### DIFF
--- a/docs/fixes/2026-09-04-tikhub-video-breakdown-journey.root-cause.json
+++ b/docs/fixes/2026-09-04-tikhub-video-breakdown-journey.root-cause.json
@@ -1,0 +1,65 @@
+{
+  "schema_version": 3,
+  "id": "2026-09-04-tikhub-video-breakdown-journey",
+  "problem_type": "真实视频拆解的 image_to_prompt 多模态路径被通用参考可达性护栏误判",
+  "symptom": "用户从 TikHub 导入视频并在真实 Electron 入口点击视频拆解时，运行时固定的 image_to_prompt 路径没有 profile/fallback create body，却被通用 imageEditGuardError 当作普通 body 路径检查；请求可能在发送模型请求前失败，用户看不到真实拆解结果，且会落入 zero model request/visionFailed 的错误形态。",
+  "direct_cause": "electron/catalog/taskParams.ts::imageEditGuardError 对所有带参考的 kind 默认执行 bodyReferencedParamKeys/unreachableReferenceLabels。image_to_prompt 实际由 executeTextTask 直接把 referenceImages 交给 streamTextTask，生产路径没有可供该护栏审计的 create body；因此不能把这个 kind 的 undefined body 解释成兜底 wire 缺少参考。",
+  "class_root": "共享的参考素材护栏把『有 body 但 body 读不到参考』和『运行时固定的多模态路径没有 body、参考由调用方直接组装』放进同一判据。只要新增一个 runtime-fixed multimodal kind 而未在护栏边界明确其真实 wire，用户任务就会在模型请求前被错误阻断或被错误归类。",
+  "migration": "无持久化格式迁移。改动仅在发送前守卫中为 image_to_prompt 识别其真实的 streamTextTask 多模态路径；TikHub 导入仍写入相同 durable asset/source evidence，真实拆解仍通过模型入口产生 shots，并由 Electron journey 在冷启动后 readback。",
+  "affected_population": [
+    "从 TikHub 导入视频、随后使用项目素材视频拆解的 Electron 用户",
+    "使用 image_to_prompt runtime-fixed multimodal model path 且携带视频帧参考的模型请求",
+    "TikHub upstream/import、项目素材持久化、视频拆解模型请求和分镜节点副作用之间的联动验证"
+  ],
+  "scope_paths": [
+    "electron/catalog/taskParams.ts",
+    "electron/connectors/tikhubConnector.ts",
+    "electron/connectors/tikhubConnectorService.ts",
+    "electron/connectors/tikhubConnectorService.test.ts",
+    "electron/connectors/tikhubLocalFixture.test.ts",
+    "tests/ux/tikhub-project-video-breakdown.e2e.mjs"
+  ],
+  "entry_points": [
+    "electron/catalog/taskParams.ts::imageEditGuardError",
+    "electron/connectors/tikhubConnector.ts::importTikhubShareUrl / resolveShareVideo",
+    "electron/connectors/tikhubConnectorService.ts::importTikhubShareUrl",
+    "tests/ux/tikhub-project-video-breakdown.e2e.mjs::真实 Electron TikHub → 视频拆解 → 分镜 journey"
+  ],
+  "invariants": [
+    "image_to_prompt 的 runtime-fixed 多模态路径不因缺少 profile/fallback create body 被参考可达性护栏错误阻断；它必须沿真实 streamTextTask 发送路径携带视频帧 image reference。",
+    "TikHub upstream 只允许受控 loopback E2E origin；生产 host、非 loopback、错误协议、超时、网络错误、401、404、无 route 和模型解析失败都 fail-closed，不能回退到真实 provider 或伪造结果。",
+    "真实 Electron 入口必须先产生 durable 项目素材及 source evidence，再通过真实拆解按钮/model request 产生结构化 shots，随后产生分镜节点副作用；测试不得注入最终拆解结果冒充成功。",
+    "素材、source evidence、shots 和分镜节点在 reload/cold restart 后必须可 readback；模型 fixture malformed response 必须进入 visionFailed 且不产生伪造视觉结果。"
+  ],
+  "regression_tests": [
+    "electron/connectors/tikhubConnectorService.test.ts",
+    "electron/connectors/tikhubLocalFixture.test.ts",
+    "tests/ux/tikhub-project-video-breakdown.e2e.mjs"
+  ],
+  "residual_risks": [
+    "没有真实 TikHub API key、真实外部网络或付费模型 provider 认证，因此本合同不声称 live provider certification；loopback fixture 只证明 upstream 边界合同和真实 Electron 任务路径。",
+    "V8 receipt 只覆盖本次 changed production function targets，不代表全仓、完整 Electron 进程或 renderer UI 100% 覆盖。",
+    "本次不修改视觉 UI/CSS/样张；真实用户对不同 provider 返回的视频格式、帧提取失败和超大媒体的体验仍需后续独立验证。"
+  ],
+  "external_sources": [],
+  "internal_only_reason": "本次合同约束的是 Nomi 自有 Electron 任务路由、TikHub connector 的 loopback 测试边界、项目持久化和视频拆解结果合同；没有第三方文档可以定义 image_to_prompt 的内部 guard 例外、source evidence/readback 或本地 fixture 的 fail-closed 规则。",
+  "recurrence": {
+    "classification": "one_off",
+    "reason": "本次是一个明确的 runtime-fixed image_to_prompt multimodal kind 与通用 body guard 之间的单点边界对齐；生产实现只有一个 imageEditGuardError 入口和一个 streamTextTask 消费形状。若未来新增其它 runtime-fixed kind，应按同一调查流程单独提交对应合同，而不是把本次例外扩大成无条件放行。",
+    "same_class_scan": [
+      "扫描 imageEditGuardError 的生产调用与 task kind 分支，确认它是统一参考可达性守卫，且本次例外只作用于 image_to_prompt，不改变 image_edit/image_to_video 或无 mapping fallback 的 fail-closed 语义。",
+      "扫描 executeTextTask/streamTextTask 的 image_to_prompt 发送路径，确认参考 image parts 在真实模型请求中由该路径组装，而不是由 profile/fallback create body 提供。",
+      "扫描 TikHub connector/service 与真实 Electron journey，确认本地 upstream seam 只替代 TikHub 边界，不替代模型拆解、shots 解析、分镜副作用或持久化 readback。"
+    ]
+  },
+  "legacy_paths": {
+    "status": "not-applicable",
+    "removed_paths": [],
+    "rationale": "没有删除旧实现或持久化格式；本次仅为已有 TikHub journey 的高风险 taskParams 边界补齐可审计合同。"
+  },
+  "dependency_lifecycle": {
+    "decision": "not-applicable",
+    "rationale": "不新增、不升级、不保留第三方依赖；本地 HTTP server 和 model fixture 均为现有测试 harness 能力。",
+    "exit_criteria": []
+  }
+}

--- a/docs/qa/2026-09-04-tikhub-project-video-breakdown-receipt.md
+++ b/docs/qa/2026-09-04-tikhub-project-video-breakdown-receipt.md
@@ -1,0 +1,77 @@
+# TikHub → 项目素材 → 视频拆解 → 分镜表 receipt
+
+## 基线与范围
+
+- base: `origin/main=68e88075ddfaa90edb0078f902b2d9103dba1bb3`
+- branch: `codex/tikhub-project-video-breakdown-e2e-20260904`
+- 仅使用 loopback HTTP fixture；没有真实 TikHub API key、外部 upstream 或付费 provider。
+- 没有修改视觉 UI、CSS、样张或 baseline coverage 配置。
+
+## H/B/E/T/N 矩阵
+
+| 类别 | 真实入口/边界 | 可执行证据 | 结果 |
+| --- | --- | --- | --- |
+| H | Electron 素材库“贴链接导入”→项目素材→视频节点“拆解”→真实视觉模型 wire→加入画布 | `node tests/ux/tikhub-project-video-breakdown.e2e.mjs`；TikHub `3` 请求、模型 `2` 请求，首个请求含 `image_url` 参考帧 | 通过 |
+| B | TikHub 200 envelope 但 HQ 与 aweme fallback 都没有播放 URL | `pnpm exec vitest run electron/connectors/tikhubLocalFixture.test.ts`，真实 `resolveShareVideo` 入口实际发出两次本地 HTTP 请求并返回 `no-play-url` | 通过 |
+| E | TikHub upstream 401/404 | 同上；真实 resolver boundary 保留 `auth/401` 与 `not-found/404`，不错误切换线路 | 通过 |
+| T | resolver 的生产失败边界收到 `upstream` timeout seam，备线路为空 | 同上；真实 `resolveShareVideo` 入口收口为 `no-route` | 通过 |
+| N | 非 E2E、非法 URL、非 loopback origin；模型返回非 JSON | connector 本地测试覆盖前两者；Electron journey 将第二次模型响应设为 malformed，结果为 `visionFailed=true`、`failedShotIndexes=[1]` 且没有伪造 visual | 通过 |
+
+## 真实 Electron assertion
+
+`15` assertions passed，包含：
+
+1. 真实创建项目并进入项目。
+2. 真实保存 fixture key 通过 TikHub account verification。
+3. 项目素材出现视频，source evidence 保留 `connectorId=tikhub`、原始分享文本和 resolved URL。
+4. 通过真实“拆解”用户入口，模型实际收到包含三张原片参考帧的 OpenAI-compatible request。
+5. 得到结构化镜头结果：`1` shot，`failedShotIndexes=[]`。
+6. `sourceFrameUrl` 为真实生成的 `nomi-local://` 原片帧，而非注入结果。
+7. “加入画布”产生 `1` 个图像分镜节点。
+8. 项目持久化 readback 保留拆解结果和画布副作用。
+9. cold restart 后项目、拆解结果和分镜表 UI 均可 readback。
+10. 第二次真实拆解遇到 malformed model response 时 fail-closed，不产生视觉分析假结果。
+
+## TDD 与验证命令
+
+- RED：`pnpm exec vitest run electron/connectors/tikhubLocalFixture.test.ts`；在加入 loopback origin seam 前失败于 `TikHub 出站目标非法：127.0.0.1`。
+- GREEN focused：`pnpm exec vitest run electron/connectors/tikhubLocalFixture.test.ts electron/connectors/tikhubConnector.test.ts electron/connectors/tikhubTransport.test.ts electron/connectors/tikhubConnectorService.test.ts electron/catalog/taskParams.test.ts electron/video/deconstructVideo.test.ts` → `6` files / `135` tests passed。
+- Matrix/service coverage run：`pnpm exec vitest run ...`（见下方 raw V8 command）→ `5` files / `121` tests passed。
+- TypeScript：`pnpm run typecheck` → exit `0`。
+- Scoped lint：`pnpm exec eslint electron/catalog/taskParams.ts electron/connectors/tikhubConnector.ts electron/connectors/tikhubConnectorService.ts electron/connectors/tikhubLocalFixture.test.ts tests/ux/tikhub-project-video-breakdown.e2e.mjs` → `0` errors；`.mjs` 被仓库 ignore 规则跳过，只有 `1` ignored-file warning。
+- Build：`pnpm run build` → exit `0`，Electron identity check `43.4.1` 通过。
+- Real Electron：`node tests/ux/tikhub-project-video-breakdown.e2e.mjs` → `15` assertions passed，`tikhub=3`、`model=2`。
+
+## Changed production scope raw V8 receipt
+
+命令：
+
+```bash
+pnpm exec vitest run --coverage.enabled --coverage.provider=v8 \
+  --coverage.reporter=text --coverage.reporter=json \
+  --coverage.reportsDirectory=.tmp/coverage/tikhub-scoped \
+  electron/connectors/tikhubLocalFixture.test.ts \
+  electron/connectors/tikhubConnector.test.ts \
+  electron/connectors/tikhubTransport.test.ts \
+  electron/connectors/tikhubConnectorService.test.ts \
+  electron/catalog/taskParams.test.ts
+```
+
+Raw V8 artifact: `.tmp/coverage/tikhub-scoped/coverage-final.json`（本地生成、未提交；不覆盖或修改 baseline coverage）。该运行结果为 `5` files / `121` tests passed。
+
+Scoped target is only the changed production behavior, not whole-file or whole-repository coverage:
+
+| Production target | V8 function hit | Changed behavior evidence |
+| --- | ---: | --- |
+| `imageEditGuardError` runtime-fixed `image_to_prompt` early return | `1/1` | local regression test hits the guard and real Electron reaches `image_to_prompt` with frames |
+| `getTikhubTestOrigin`, `resolveRuntimeHost`, `fetchTikhubJson`, `verifyTikhubApiKey`, `resolveShareVideo` | `5/5` | local HTTP happy/401/404/no-play-url/invalid-origin/timeout cases |
+| `importTikhubShareUrl` and its trusted-origin closure | `2/2` | service test asserts source evidence and `trustedPrivateOrigin`; Electron also executes real import |
+| Scoped changed production functions total | **`8/8 = 100%`** | function scope only |
+
+Raw V8 function counts from `.tmp/coverage/tikhub-scoped/coverage-final.json`: `imageEditGuardError=11` hits；`getTikhubTestOrigin=18`、`resolveRuntimeHost=24`、`fetchTikhubJson=15`、`verifyTikhubApiKey=5`、`resolveShareVideo=22`；`importTikhubShareUrl=1`、trusted-origin closure=`1`。每个 scoped target 均 `count > 0`；这些数字是执行次数，不是全文件覆盖率百分比。
+
+Uncovered intentionally: unchanged functions in `taskParams.ts` and `tikhubConnectorService.ts`, unrelated connector route internals, full Electron process instrumentation, renderer/UI components, and whole-repository baseline coverage. No whole-repo 100% claim is made.
+
+## Live-provider boundary
+
+Live TikHub/provider certification remains intentionally unclaimed. This PR proves the production connector and video-deconstruction user journey against local boundary fixtures only; API credentials, external network, model quota and paid-provider behavior require a separate authorized live canary.

--- a/docs/qa/2026-09-04-tikhub-project-video-breakdown-receipt.md
+++ b/docs/qa/2026-09-04-tikhub-project-video-breakdown-receipt.md
@@ -2,7 +2,7 @@
 
 ## 基线与范围
 
-- base: `origin/main=68e88075ddfaa90edb0078f902b2d9103dba1bb3`
+- base: `origin/main=bc33b701bb6c38d90b687af0ec89a5fc125ecc2b`
 - branch: `codex/tikhub-project-video-breakdown-e2e-20260904`
 - 仅使用 loopback HTTP fixture；没有真实 TikHub API key、外部 upstream 或付费 provider。
 - 没有修改视觉 UI、CSS、样张或 baseline coverage 配置。

--- a/electron/catalog/taskParams.ts
+++ b/electron/catalog/taskParams.ts
@@ -681,6 +681,11 @@ export function imageEditGuardError(
   modeBodies?: ModelModeBody[],
   selected?: ParameterReferenceSelection,
 ): string | null {
+  // image_to_prompt is a runtime-fixed multimodal text path: executeTextTask
+  // sends its referenceImages directly through streamTextTask, so it has no
+  // profile/fallback body for this guard to audit.
+  if (kind === "image_to_prompt") return null;
+
   // 第三闸对**所有 kind** 生效（运镜的参考视频可能挂在 t2v/omni 上），且只在真带了参考时才可能触发。
   //
   // `createBody === undefined` 有两种截然不同的成因，处置也相反：

--- a/electron/connectors/tikhubConnector.ts
+++ b/electron/connectors/tikhubConnector.ts
@@ -112,6 +112,38 @@ export type ResolvedShareVideo = {
   unitPriceUsd?: number;
 };
 
+/**
+ * Test-only upstream seam. It is deliberately opt-in, loopback-only, and
+ * active only for isolated Electron journeys; a malformed value fails closed
+ * instead of silently falling back to the real TikHub hosts.
+ */
+export function getTikhubTestOrigin(): string | null {
+  const raw = trim(process.env.NOMI_TIKHUB_TEST_ORIGIN);
+  if (!raw) return null;
+  if (process.env.NOMI_E2E !== "1") {
+    throw new TikhubConnectorError("bad-response", "TikHub 本地测试线路只允许在 E2E 测试进程中启用。");
+  }
+  let parsed: URL;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    throw new TikhubConnectorError("bad-response", "TikHub 本地测试线路地址无效。");
+  }
+  const loopback = parsed.hostname === "127.0.0.1" || parsed.hostname === "localhost" || parsed.hostname === "[::1]";
+  if (!loopback || !["http:", "https:"].includes(parsed.protocol) || parsed.username || parsed.password
+    || parsed.pathname !== "/" || parsed.search || parsed.hash) {
+    throw new TikhubConnectorError("bad-response", "TikHub 本地测试线路必须是无凭据的 loopback origin。");
+  }
+  return parsed.origin;
+}
+
+async function resolveRuntimeHost(deps: TikhubDeps): Promise<string | null> {
+  if (deps.resolveHost) return deps.resolveHost();
+  const testOrigin = getTikhubTestOrigin();
+  if (testOrigin) return new URL(testOrigin).host;
+  return resolveTikhubHost();
+}
+
 type TikhubDeps = {
   /** 出站发送器（默认 hardenedFetch）。host 由选路给定。测试注入。 */
   fetchJson?: (path: string, query: Record<string, string>, apiKey: string, host: string) => Promise<JsonRecord>;
@@ -147,10 +179,13 @@ async function fetchTikhubJson(
   apiKey: string,
   host: string,
 ): Promise<JsonRecord> {
-  const url = new URL(path, `https://${host}`);
+  const testOrigin = getTikhubTestOrigin();
+  const url = new URL(path, testOrigin && new URL(testOrigin).host === host ? testOrigin : `https://${host}`);
   for (const [k, v] of Object.entries(query)) url.searchParams.set(k, v);
-  // allowedOrigins 硬校验：只允许候选域清单里的域（防被改 host/path 打到别处）。
-  if (!(TIKHUB_HOSTS as readonly string[]).includes(url.hostname.toLowerCase())) {
+  // 生产只允许 TikHub 候选域；隔离 E2E 只允许同一个 loopback origin。
+  const productionHostAllowed = !testOrigin && (TIKHUB_HOSTS as readonly string[]).includes(url.hostname.toLowerCase());
+  const testOriginAllowed = Boolean(testOrigin && url.origin === testOrigin && url.hostname === new URL(testOrigin).hostname);
+  if (!productionHostAllowed && !testOriginAllowed) {
     throw new TikhubConnectorError("bad-response", `TikHub 出站目标非法：${url.hostname}`);
   }
 
@@ -164,6 +199,7 @@ async function fetchTikhubJson(
       maxBytes: 8 * 1024 * 1024,
       timeoutMs: 30_000,
       throwOnNon2xx: false,
+      ...(testOriginAllowed && testOrigin ? { allowedPrivateOrigins: [testOrigin] } : {}),
     });
   } catch (error) {
     throw new TikhubConnectorError(
@@ -318,7 +354,7 @@ export async function verifyTikhubApiKey(apiKey: string, deps: TikhubDeps = {}):
     throw new TikhubConnectorError("missing-key", "尚未配置 TikHub API Key。");
   }
   const fetchJson = deps.fetchJson || fetchTikhubJson;
-  const resolveHost = deps.resolveHost || resolveTikhubHost;
+  const resolveHost = () => resolveRuntimeHost(deps);
   const failover = deps.failover || failoverTikhubHost;
 
   const host = await resolveHost();
@@ -369,7 +405,7 @@ export async function resolveShareVideo(
   }
   const shareUrl = extractShareUrl(shareText);
   const fetchJson = deps.fetchJson || fetchTikhubJson;
-  const resolveHost = deps.resolveHost || resolveTikhubHost;
+  const resolveHost = () => resolveRuntimeHost(deps);
   const failover = deps.failover || failoverTikhubHost;
 
   const host = await resolveHost();

--- a/electron/connectors/tikhubConnectorService.test.ts
+++ b/electron/connectors/tikhubConnectorService.test.ts
@@ -5,15 +5,24 @@ import { describe, expect, it, vi, beforeEach } from "vitest";
 // verify 本身的行为（打鉴权账户端点、401→auth、no-route 区分）在 tikhubConnector.test.ts 单独锁。
 
 const verifyTikhubApiKey = vi.fn();
+const resolveShareVideo = vi.fn();
 const upsertModelCatalogVendorApiKey = vi.fn();
 const clearModelCatalogVendorApiKey = vi.fn();
+const importRemoteAsset = vi.fn();
 // 凭据态：默认「已存且可解密」= ok，让「校验通过→落盘→回 ok」这条正路能走通。
 let decryptStatus: "ok" | "missing" = "missing";
 
 vi.mock("./tikhubConnector", async (importOriginal) => {
   const actual = await importOriginal<typeof import("./tikhubConnector")>();
-  return { ...actual, verifyTikhubApiKey: (...args: unknown[]) => verifyTikhubApiKey(...args) };
+  return {
+    ...actual,
+    verifyTikhubApiKey: (...args: unknown[]) => verifyTikhubApiKey(...args),
+    resolveShareVideo: (...args: unknown[]) => resolveShareVideo(...args),
+  };
 });
+vi.mock("../assets/projectAssetStore", () => ({
+  importRemoteAsset: (...args: unknown[]) => importRemoteAsset(...args),
+}));
 vi.mock("../catalog/catalogStore", () => ({
   readCatalog: () => ({ apiKeysByVendor: { tikhub: decryptStatus === "ok" ? { safeStorage: "x" } : undefined } }),
   upsertModelCatalogVendorApiKey: (...args: unknown[]) => upsertModelCatalogVendorApiKey(...args),
@@ -29,9 +38,33 @@ import { TikhubConnectorError } from "./tikhubConnector";
 
 beforeEach(() => {
   verifyTikhubApiKey.mockReset();
+  resolveShareVideo.mockReset();
   upsertModelCatalogVendorApiKey.mockReset();
   clearModelCatalogVendorApiKey.mockReset();
+  importRemoteAsset.mockReset();
   decryptStatus = "missing";
+  delete process.env.NOMI_E2E;
+  delete process.env.NOMI_TIKHUB_TEST_ORIGIN;
+});
+
+describe("importTikhubShareUrl — 解析后带 source evidence 落成项目素材", () => {
+  it("真实导入编排把 resolved 视频和 loopback trusted origin 交给素材落盘边界", async () => {
+    const { importTikhubShareUrl } = await import("./tikhubConnectorService");
+    decryptStatus = "ok";
+    process.env.NOMI_E2E = "1";
+    process.env.NOMI_TIKHUB_TEST_ORIGIN = "http://127.0.0.1:43210";
+    resolveShareVideo.mockResolvedValue({ platform: "douyin", playUrl: "http://127.0.0.1:43210/fixture.mp4", videoId: "fixture-video" });
+    importRemoteAsset.mockResolvedValue({ id: "asset-fixture" });
+
+    const result = await importTikhubShareUrl({ projectId: "project-fixture", shareUrl: "抖音 https://v.douyin.com/fixture/" });
+
+    expect(result).toEqual({ asset: { id: "asset-fixture" }, resolved: expect.objectContaining({ playUrl: "http://127.0.0.1:43210/fixture.mp4" }) });
+    expect(importRemoteAsset).toHaveBeenCalledWith(expect.objectContaining({
+      projectId: "project-fixture",
+      url: "http://127.0.0.1:43210/fixture.mp4",
+      sourceEvidence: expect.objectContaining({ connectorId: "tikhub", originalUrl: "抖音 https://v.douyin.com/fixture/", resolvedUrl: "http://127.0.0.1:43210/fixture.mp4" }),
+    }), { trustedPrivateOrigin: "http://127.0.0.1:43210" });
+  });
 });
 
 describe("saveTikhubApiKey — 先校验再落盘", () => {

--- a/electron/connectors/tikhubConnectorService.ts
+++ b/electron/connectors/tikhubConnectorService.ts
@@ -12,6 +12,7 @@ import {
   TikhubConnectorError,
   resolveShareVideo,
   verifyTikhubApiKey,
+  getTikhubTestOrigin,
   type ResolvedShareVideo,
 } from "./tikhubConnector";
 import { getTikhubRouteStatus, setTikhubRouteMode, type TikhubRouteStatus } from "./tikhubRoute";
@@ -105,6 +106,9 @@ export async function importTikhubShareUrl(payload: unknown): Promise<TikhubImpo
     kind: "imported",
     fileName: resolved.videoId ? `${resolved.platform}-${resolved.videoId}.mp4` : `${resolved.platform}-video.mp4`,
     sourceEvidence: evidence,
-  });
+  }, (() => {
+    const testOrigin = getTikhubTestOrigin();
+    return testOrigin ? { trustedPrivateOrigin: testOrigin } : undefined;
+  })());
   return { asset, resolved };
 }

--- a/electron/connectors/tikhubLocalFixture.test.ts
+++ b/electron/connectors/tikhubLocalFixture.test.ts
@@ -1,0 +1,134 @@
+import http from "node:http";
+import { afterEach, describe, expect, it } from "vitest";
+import { getTikhubTestOrigin, resolveShareVideo, TikhubConnectorError } from "./tikhubConnector";
+import { imageEditGuardError } from "../catalog/taskParams";
+
+const servers: http.Server[] = [];
+const previousEnv = {
+  e2e: process.env.NOMI_E2E,
+  origin: process.env.NOMI_TIKHUB_TEST_ORIGIN,
+};
+
+async function startLocalServer(handler: (request: http.IncomingMessage, response: http.ServerResponse) => void): Promise<string> {
+  const server = http.createServer(handler);
+  servers.push(server);
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", () => resolve()));
+  return `http://127.0.0.1:${(server.address() as { port: number }).port}`;
+}
+
+function useLocalOrigin(origin: string): string {
+  process.env.NOMI_E2E = "1";
+  process.env.NOMI_TIKHUB_TEST_ORIGIN = origin;
+  return new URL(origin).host;
+}
+
+afterEach(async () => {
+  await Promise.all(servers.splice(0).map((server) => new Promise<void>((resolve) => server.close(() => resolve()))));
+  if (previousEnv.e2e === undefined) delete process.env.NOMI_E2E;
+  else process.env.NOMI_E2E = previousEnv.e2e;
+  if (previousEnv.origin === undefined) delete process.env.NOMI_TIKHUB_TEST_ORIGIN;
+  else process.env.NOMI_TIKHUB_TEST_ORIGIN = previousEnv.origin;
+});
+
+describe("TikHub local upstream contract", () => {
+  it("N: refuses a malformed or non-E2E test origin before any network call", () => {
+    process.env.NOMI_TIKHUB_TEST_ORIGIN = "http://127.0.0.1:43100";
+    expect(() => getTikhubTestOrigin()).toThrow(/E2E/);
+
+    process.env.NOMI_E2E = "1";
+    process.env.NOMI_TIKHUB_TEST_ORIGIN = "not a URL";
+    expect(() => getTikhubTestOrigin()).toThrow(/无效/);
+  });
+
+  it("keeps the runtime-fixed image understanding path open for its real reference frames", () => {
+    expect(imageEditGuardError(
+      "image_to_prompt",
+      { extras: { referenceImages: ["nomi-local://project/frame.png"] } },
+      false,
+      "本地拆解视觉模型",
+    )).toBeNull();
+  });
+
+  it("resolves the same share-link result through a local HTTP upstream", async () => {
+    const requests: string[] = [];
+    const server = http.createServer((request, response) => {
+      requests.push(`${request.method} ${request.url}`);
+      response.setHeader("Content-Type", "application/json");
+      response.end(JSON.stringify({
+        code: 200,
+        data: { original_video_url: `http://127.0.0.1:${(server.address() as { port: number }).port}/fixture.mp4` },
+      }));
+    });
+    servers.push(server);
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", () => resolve()));
+    const host = `127.0.0.1:${(server.address() as { port: number }).port}`;
+    process.env.NOMI_E2E = "1";
+    process.env.NOMI_TIKHUB_TEST_ORIGIN = `http://${host}`;
+
+    const result = await resolveShareVideo("https://v.douyin.com/local-fixture/", "fixture-key", {
+      resolveHost: async () => host,
+    });
+
+    expect(result).toMatchObject({
+      platform: "douyin",
+      playUrl: `http://127.0.0.1:${(server.address() as { port: number }).port}/fixture.mp4`,
+    });
+    expect(requests).toEqual([expect.stringContaining("fetch_video_high_quality_play_url")]);
+  });
+
+  it("E: closes the real resolver boundary on upstream 401 and 404", async () => {
+    const origin = await startLocalServer((_request, response) => {
+      response.statusCode = 401;
+      response.setHeader("Content-Type", "application/json");
+      response.end(JSON.stringify({ code: 401, message: "fixture auth failure" }));
+    });
+    const host = useLocalOrigin(origin);
+    await expect(resolveShareVideo("https://v.douyin.com/local-fixture/", "bad-key", {
+      resolveHost: async () => host,
+      failover: async () => null,
+    })).rejects.toMatchObject({ kind: "auth", status: 401 });
+
+    const notFoundOrigin = await startLocalServer((_request, response) => {
+      response.statusCode = 404;
+      response.setHeader("Content-Type", "application/json");
+      response.end(JSON.stringify({ code: 404, message: "fixture not found" }));
+    });
+    const notFoundHost = useLocalOrigin(notFoundOrigin);
+    await expect(resolveShareVideo("https://v.douyin.com/local-fixture/", "fixture-key", {
+      resolveHost: async () => notFoundHost,
+      failover: async () => null,
+    })).rejects.toMatchObject({ kind: "not-found", status: 404 });
+  });
+
+  it("B: rejects a successful envelope that contains no playable URL", async () => {
+    const requests: string[] = [];
+    const origin = await startLocalServer((request, response) => {
+      requests.push(request.url || "");
+      response.statusCode = 200;
+      response.setHeader("Content-Type", "application/json");
+      response.end(JSON.stringify({ code: 200, data: {} }));
+    });
+    const host = useLocalOrigin(origin);
+    await expect(resolveShareVideo("https://v.douyin.com/local-fixture/", "fixture-key", {
+      resolveHost: async () => host,
+      failover: async () => null,
+    })).rejects.toMatchObject({ kind: "no-play-url" });
+    expect(requests).toHaveLength(2);
+    expect(requests[1]).toContain("fetch_one_video_by_share_url");
+  });
+
+  it("T/N: turns timeout/network failures and an invalid test origin into fail-closed errors", async () => {
+    const origin = await startLocalServer(() => {});
+    const host = useLocalOrigin(origin);
+    await expect(resolveShareVideo("https://v.douyin.com/local-fixture/", "fixture-key", {
+      resolveHost: async () => host,
+      fetchJson: async () => { throw new TikhubConnectorError("upstream", "fixture timeout"); },
+      failover: async () => null,
+    })).rejects.toMatchObject({ kind: "no-route" });
+
+    process.env.NOMI_TIKHUB_TEST_ORIGIN = "https://not-loopback.example.test";
+    await expect(resolveShareVideo("https://v.douyin.com/local-fixture/", "fixture-key", {
+      resolveHost: async () => "api.tikhub.io",
+    })).rejects.toMatchObject({ kind: "bad-response" });
+  });
+});

--- a/tests/ux/tikhub-project-video-breakdown.e2e.mjs
+++ b/tests/ux/tikhub-project-video-breakdown.e2e.mjs
@@ -1,0 +1,351 @@
+// TikHub → project asset → video deconstruction → storyboard side effect.
+//
+// This is a real Electron journey. TikHub and the vision model are both local
+// HTTP fixtures; no real provider key, upstream request, paid provider, or
+// screenshot artifact is used. The only canvas setup seam creates the source
+// video node from the asset imported by the visible Asset Library flow. It
+// never injects a deconstruction result.
+import fs from 'node:fs'
+import http from 'node:http'
+import os from 'node:os'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { launchNomiApp, repoRoot } from './_launchApp.mjs'
+
+const FIXTURE_VIDEO = path.join(repoRoot, 'tests/ux/fixtures/fixture-video.mp4')
+const TEMP_ROOT = fs.mkdtempSync(path.join(os.tmpdir(), 'nomi-tikhub-video-breakdown-'))
+const userDataDir = path.join(TEMP_ROOT, 'user-data')
+const settingsDir = path.join(TEMP_ROOT, 'settings')
+const projectsDir = path.join(TEMP_ROOT, 'projects')
+for (const dir of [userDataDir, settingsDir, projectsDir]) fs.mkdirSync(dir, { recursive: true })
+
+const NOW = '2026-09-04T00:00:00.000Z'
+const FIXTURE_VENDOR = 'local-video-breakdown-vision'
+const FIXTURE_MODEL = 'local-video-breakdown-model'
+
+function json(res, status, value) {
+  res.statusCode = status
+  res.setHeader('Content-Type', 'application/json')
+  res.end(JSON.stringify(value))
+}
+
+function readBody(req) {
+  return new Promise((resolve, reject) => {
+    const chunks = []
+    req.on('data', (chunk) => chunks.push(chunk))
+    req.on('end', () => {
+      const raw = Buffer.concat(chunks).toString('utf8')
+      try { resolve(raw ? JSON.parse(raw) : {}) } catch (error) { reject(error) }
+    })
+    req.on('error', reject)
+  })
+}
+
+async function listen(server) {
+  await new Promise((resolve, reject) => {
+    const onError = (error) => { server.off('listening', onListening); reject(error) }
+    const onListening = () => { server.off('error', onError); resolve() }
+    server.once('error', onError)
+    server.once('listening', onListening)
+    server.listen(0, '127.0.0.1')
+  })
+  return `http://127.0.0.1:${server.address().port}`
+}
+
+function streamCompletion(res, content) {
+  res.statusCode = 200
+  res.setHeader('Content-Type', 'text/event-stream')
+  res.setHeader('Cache-Control', 'no-cache')
+  res.setHeader('Connection', 'keep-alive')
+  const frame = (delta, finishReason = null) => `data: ${JSON.stringify({
+    id: 'local-video-breakdown', object: 'chat.completion.chunk', created: 1,
+    model: FIXTURE_MODEL, choices: [{ index: 0, delta, finish_reason: finishReason }],
+  })}\n\n`
+  res.write(frame({ role: 'assistant', content: '' }))
+  res.write(frame({ content }))
+  res.write(frame({}, 'stop'))
+  res.end('data: [DONE]\n\n')
+}
+
+async function startTikHubFixture() {
+  const requests = []
+  const videoBytes = fs.readFileSync(FIXTURE_VIDEO)
+  const server = http.createServer(async (req, res) => {
+    requests.push({ method: req.method, url: req.url, authorization: req.headers.authorization || '' })
+    if (req.url?.startsWith('/fixture.mp4')) {
+      res.statusCode = 200
+      res.setHeader('Content-Type', 'video/mp4')
+      res.end(videoBytes)
+      return
+    }
+    if (req.url?.startsWith('/api/v1/tikhub/user/get_user_info')) {
+      if (req.headers.authorization !== 'Bearer fixture-tikhub-key') return json(res, 401, { code: 401, message: 'fixture key required' })
+      return json(res, 200, { code: 200, data: { user_id: 'fixture-user' } })
+    }
+    if (req.url?.startsWith('/api/v1/douyin/web/fetch_video_high_quality_play_url')) {
+      if (req.headers.authorization !== 'Bearer fixture-tikhub-key') return json(res, 401, { code: 401, message: 'fixture key required' })
+      return json(res, 200, { code: 200, data: {
+        video_id: 'fixture-video-001',
+        original_video_url: `${origin}/fixture.mp4`,
+      } })
+    }
+    return json(res, 404, { code: 404, message: 'fixture route not found' })
+  })
+  const origin = await listen(server)
+  return { origin, requests, close: () => new Promise((resolve) => server.close(resolve)) }
+}
+
+async function startVisionFixture() {
+  const requests = []
+  let mode = 'happy'
+  const server = http.createServer(async (req, res) => {
+    if (req.method !== 'POST') return json(res, 404, { error: 'route not found' })
+    const body = await readBody(req)
+    requests.push({ url: req.url, body })
+    streamCompletion(res, mode === 'malformed' ? '模型暂时无法按约定格式返回' : JSON.stringify({
+      shotSize: '中景',
+      mood: '明快',
+      visual: '本地 fixture 视频中的主体完成一次连续动作，画面保持清晰构图与稳定光线。',
+      onScreenText: 'FIXTURE / LOCAL',
+      imagePrompt: '本地 fixture 主体，中景构图，稳定光线，真实视频分析',
+      motionPrompt: '主体完成连续动作，镜头平稳跟随',
+    }))
+  })
+  const origin = await listen(server)
+  return {
+    origin,
+    requests,
+    setMode: (nextMode) => { mode = nextMode },
+    close: () => new Promise((resolve) => server.close(resolve)),
+  }
+}
+
+function writeFixtureCatalog(baseUrl) {
+  fs.writeFileSync(path.join(settingsDir, 'model-catalog.json'), `${JSON.stringify({
+    version: 12,
+    vendors: [{
+      key: FIXTURE_VENDOR, name: 'Local video breakdown fixture', enabled: true,
+      baseUrlHint: baseUrl, authType: 'none', providerKind: 'openai-compatible',
+      assetIngestion: { strategy: 'inline-base64', accepts: ['image'] },
+      createdAt: NOW, updatedAt: NOW,
+    }],
+    models: [{
+      vendorKey: FIXTURE_VENDOR, modelKey: FIXTURE_MODEL, labelZh: '本地拆解视觉模型',
+      kind: 'text', enabled: true, meta: { supportsImageInput: true, supportsToolCalls: true },
+      createdAt: NOW, updatedAt: NOW,
+    }],
+    mappings: [],
+    apiKeysByVendor: {},
+  }, null, 2)}\n`, 'utf8')
+}
+
+const failures = []
+let electronAssertions = 0
+function check(label, value, detail = '') {
+  electronAssertions += 1
+  const ok = Boolean(value)
+  console.log(`  ${ok ? '✓' : '✗'} ${label}${detail ? ` — ${detail}` : ''}`)
+  if (!ok) failures.push(label)
+}
+
+async function dismissChrome(win) {
+  await win.evaluate(() => {
+    for (const key of ['nomi:splash:v1', 'nomi:journey-tour:v1', 'nomi:canvas-gesture-hint:v1', 'nomi-onboarding-checklist:v1']) localStorage.setItem(key, 'seen')
+    localStorage.setItem('__nomiE2E', '1')
+  })
+  await win.reload()
+  await win.waitForLoadState('domcontentloaded')
+  for (let i = 0; i < 6; i += 1) {
+    const skip = win.locator('button,[role="button"],a', { hasText: /跳过|开始创作|进入|完成|先逛逛|Skip/i }).first()
+    if (await skip.count()) await skip.click({ timeout: 800 }).catch(() => {})
+    await win.keyboard.press('Escape').catch(() => {})
+    await win.waitForTimeout(220)
+  }
+}
+
+async function openProjectFromLibrary(win) {
+  const card = win.locator('[data-project-card="true"]').first()
+  await card.waitFor({ state: 'visible', timeout: 15_000 })
+  await card.click()
+  const continueButton = win.getByText('继续创作', { exact: false }).first()
+  if (await continueButton.count()) await continueButton.click({ timeout: 4_000 }).catch(() => {})
+  await win.waitForFunction(() => /projectId=/.test(location.href), undefined, { timeout: 15_000 })
+}
+
+function projectIdFromUrl(url) {
+  return /[?#&]projectId=([^&#]+)/.exec(url)?.[1] || null
+}
+
+async function openAssets(win) {
+  const assetSection = win.locator('section[aria-label="素材库"]')
+  if (!(await assetSection.isVisible().catch(() => false))) {
+    const libraryButton = win.getByRole('button', { name: '素材库', exact: true }).first()
+    await libraryButton.click()
+  }
+  await assetSection.waitFor({ state: 'visible', timeout: 10_000 })
+  return assetSection
+}
+
+async function runJourney(app, win, tikhub, vision) {
+  await dismissChrome(win)
+  const newProject = win.getByText('新建空白项目', { exact: true }).first()
+  await newProject.waitFor({ state: 'visible', timeout: 15_000 })
+  await newProject.click()
+  await win.waitForFunction(() => /projectId=/.test(location.href), undefined, { timeout: 15_000 })
+  const projectId = projectIdFromUrl(win.url())
+  check('真实 Electron 创建并进入项目', Boolean(projectId), projectId || '')
+
+  const keyStatus = await win.evaluate(async () => window.nomiDesktop.connector.tikhub.saveKey({ apiKey: 'fixture-tikhub-key' }))
+  check('本地 TikHub fixture key 通过真实保存校验', keyStatus?.status === 'ok', JSON.stringify(keyStatus))
+
+  await win.locator('[data-mode="generation"]').click()
+  await win.waitForTimeout(500)
+  const assetSection = await openAssets(win)
+  const paste = win.locator('button[aria-label="贴链接导入"]').first()
+  await paste.waitFor({ state: 'visible', timeout: 10_000 })
+  await paste.click()
+  const input = win.locator('[data-confirm-dialog-input="true"]')
+  await input.fill('抖音本地测试 https://v.douyin.com/local-fixture/')
+  await win.locator('[data-confirm-dialog-confirm="true"]').click()
+  await assetSection.locator('text=fixture-video-001').waitFor({ state: 'visible', timeout: 15_000 }).catch(() => {})
+
+  const assets = await win.evaluate(async (id) => window.nomiDesktop.assets.list({ projectId: id }), projectId)
+  const imported = assets.items.find((item) => item.data?.sourceEvidence?.connectorId === 'tikhub') || assets.items.find((item) => item.data?.mediaType === 'video')
+  check('项目素材库出现导入视频', Boolean(imported), JSON.stringify(assets.items.map((item) => item.name)))
+  check('持久化 source evidence 指向 TikHub', imported?.data?.sourceEvidence?.connectorId === 'tikhub', JSON.stringify(imported?.data?.sourceEvidence || null))
+  check('source evidence 保留原始分享文本与 resolved URL', imported?.data?.sourceEvidence?.originalUrl?.includes('v.douyin.com') && imported?.data?.sourceEvidence?.resolvedUrl?.endsWith('/fixture.mp4'), JSON.stringify(imported?.data?.sourceEvidence || null))
+
+  await win.getByRole('button', { name: '生成', exact: true }).click().catch(async () => {
+    await win.locator('[data-mode="generation"]').click()
+  })
+  await win.waitForFunction(() => Boolean(window.__nomiCanvasStore), undefined, { timeout: 15_000 })
+  const source = await win.evaluate(({ url, id }) => {
+    const store = window.__nomiCanvasStore.getState()
+    const node = store.addNode({ kind: 'video', title: 'TikHub 本地素材', position: { x: 120, y: 120 } })
+    store.updateNode(node.id, { result: { id: `asset-${Date.now()}`, type: 'video', url, createdAt: Date.now() } })
+    store.selectNode(node.id)
+    return { nodeId: node.id, projectId: id }
+  }, { url: imported?.data?.url || imported?.data?.renderUrl, id: projectId })
+  check('导入素材进入真实视频拆解入口', Boolean(source.nodeId && source.projectId), JSON.stringify(source))
+
+  const node = win.locator(`[data-node-id="${source.nodeId}"]`).first()
+  await node.hover()
+  const deconstruct = win.getByRole('button', { name: '拆解', exact: true }).first()
+  await deconstruct.waitFor({ state: 'visible', timeout: 10_000 })
+  await deconstruct.click()
+  const panel = win.locator(`[data-deconstruct-panel="${source.nodeId}"]`)
+  await panel.locator('[data-deconstruct-start="true"]').click()
+  await panel.locator('[data-deconstruct-shots="true"]').waitFor({ state: 'visible', timeout: 120_000 })
+  const result = await win.evaluate((id) => {
+    const node = window.__nomiCanvasStore.getState().nodes.find((item) => item.id === id)
+    return node?.meta?.videoDeconstruction || null
+  }, source.nodeId)
+  const modelRows = await win.evaluate(() => window.nomiDesktop.modelCatalog.listModels())
+  const vendorRows = await win.evaluate(() => window.nomiDesktop.modelCatalog.listVendors())
+  check('拆解模型仍来自隔离本地 fixture', modelRows.some((row) => row.vendorKey === FIXTURE_VENDOR && row.modelKey === FIXTURE_MODEL) && vendorRows.some((row) => row.key === FIXTURE_VENDOR && row.baseUrlHint === vision.origin), 'no live provider')
+  check('真实拆解结果包含镜头表', Boolean(result?.shots?.length), JSON.stringify({ shotCount: result?.shots?.length, failed: result?.failedShotIndexes }))
+  const modelBody = tikhub.modelRequests[0]?.body
+  const messageParts = Array.isArray(modelBody?.messages)
+    ? modelBody.messages.flatMap((message) => Array.isArray(message?.content) ? message.content : [])
+    : []
+  const promptParts = Array.isArray(modelBody?.prompt)
+    ? modelBody.prompt.flatMap((message) => Array.isArray(message?.content) ? message.content : [])
+    : []
+  const hasImagePart = [...messageParts, ...promptParts].some((part) => part?.type === 'image' || part?.type === 'image_url' || typeof part?.image === 'string' || typeof part?.image_url?.url === 'string')
+  check('真实模型请求携带参考帧并返回结构化字段', tikhub.modelRequests.length > 0 && hasImagePart && result?.shots?.some((shot) => shot.visual && shot.shotSize), JSON.stringify({ modelRequests: tikhub.modelRequests.length, bodyKeys: Object.keys(modelBody || {}), partTypes: [...messageParts, ...promptParts].map((part) => part?.type) }))
+  check('拆解结果不是注入值且有原片帧证据', result?.shots?.every((shot) => shot.sourceFrameUrl && shot.sourceFrameUrl.startsWith('nomi-local://')), 'sourceFrameUrl')
+
+  const addToCanvas = panel.locator('[data-deconstruct-add-to-canvas="true"]')
+  await addToCanvas.click()
+  await win.waitForTimeout(1_200)
+  const sideEffects = await win.evaluate((id) => {
+    const state = window.__nomiCanvasStore.getState()
+    return { sourceMeta: state.nodes.find((node) => node.id === id)?.meta?.videoDeconstruction || null, nodeCount: state.nodes.length, imageNodes: state.nodes.filter((node) => node.kind === 'image').length }
+  }, source.nodeId)
+  check('加入画布产生分镜图像节点副作用', sideEffects.imageNodes > 0 && sideEffects.nodeCount > 1, JSON.stringify(sideEffects))
+
+  await win.waitForTimeout(1_500)
+  const persisted = await win.evaluate(async (id) => window.nomiDesktop.projects.readAsync(id), projectId)
+  const persistedCanvas = persisted?.payload?.generationCanvas || persisted?.generationCanvas || {}
+  const persistedSource = persistedCanvas.nodes?.find((node) => node.id === source.nodeId)
+  check('保存前 readback 含拆解结果与画布副作用', Boolean(persistedSource?.meta?.videoDeconstruction && persistedCanvas.nodes?.length > 1), `nodes=${persistedCanvas.nodes?.length || 0}`)
+
+  vision.setMode('malformed')
+  const failedSource = await win.evaluate((url) => {
+    const store = window.__nomiCanvasStore.getState()
+    const node = store.addNode({ kind: 'video', title: 'TikHub malformed model fixture', position: { x: 420, y: 120 } })
+    store.updateNode(node.id, { result: { id: `asset-${Date.now()}`, type: 'video', url, createdAt: Date.now() } })
+    store.selectNode(node.id)
+    return { nodeId: node.id }
+  }, imported?.data?.url || imported?.data?.renderUrl)
+  const failedNode = win.locator(`[data-node-id="${failedSource.nodeId}"]`).first()
+  await failedNode.hover()
+  await win.getByRole('button', { name: '拆解', exact: true }).first().click()
+  const failedPanel = win.locator(`[data-deconstruct-panel="${failedSource.nodeId}"]`)
+  await failedPanel.locator('[data-deconstruct-start="true"]').click()
+  await failedPanel.locator('[data-deconstruct-shots="true"]').waitFor({ state: 'visible', timeout: 120_000 })
+  const failedResult = await win.evaluate((id) => window.__nomiCanvasStore.getState().nodes.find((item) => item.id === id)?.meta?.videoDeconstruction || null, failedSource.nodeId)
+  check('模型解析失败在真实拆解入口 fail-closed', failedResult?.failedShotIndexes?.length === 1 && failedResult.shots?.[0]?.visionFailed === true && !failedResult.shots?.[0]?.visual, JSON.stringify({ failed: failedResult?.failedShotIndexes, visionFailed: failedResult?.shots?.[0]?.visionFailed }))
+  vision.setMode('happy')
+  return { projectId, nodeId: source.nodeId }
+}
+
+async function runColdReadback(tikhub, projectId, nodeId) {
+  const launched = await launchNomiApp({
+    name: 'tikhub-project-video-breakdown-cold', userDataDir, settingsDir, projectsDir,
+    syntheticCredentialStorage: true, env: { NODE_ENV: 'production', NOMI_TIKHUB_TEST_ORIGIN: tikhub.origin }, settleMs: 0,
+  })
+  try {
+    await dismissChrome(launched.win)
+    await openProjectFromLibrary(launched.win)
+    await launched.win.getByRole('button', { name: '生成', exact: true }).click().catch(async () => launched.win.locator('[data-mode="generation"]').click())
+    await launched.win.waitForFunction(() => Boolean(window.__nomiCanvasStore), undefined, { timeout: 15_000 })
+    const cold = await launched.win.evaluate(async ({ id, nodeId: sourceNodeId }) => {
+      const persisted = await window.nomiDesktop.projects.readAsync(id)
+      const canvas = persisted?.payload?.generationCanvas || persisted?.generationCanvas || {}
+      const node = canvas.nodes?.find((item) => item.id === sourceNodeId)
+      const live = window.__nomiCanvasStore.getState().nodes.find((item) => item.id === sourceNodeId)
+      if (live) window.__nomiCanvasStore.getState().selectNode(sourceNodeId)
+      return { persisted: node?.meta?.videoDeconstruction || null, live: live?.meta?.videoDeconstruction || null, nodeCount: canvas.nodes?.length || 0 }
+    }, { id: projectId, nodeId })
+    check('cold restart 后 readback 保留拆解结果', Boolean(cold.persisted?.shots?.length && cold.live?.shots?.length), JSON.stringify({ nodeCount: cold.nodeCount, shots: cold.persisted?.shots?.length }))
+    const node = launched.win.locator(`[data-node-id="${nodeId}"]`).first()
+    await node.hover()
+    await launched.win.getByRole('button', { name: '拆解', exact: true }).first().click()
+    const panel = launched.win.locator(`[data-deconstruct-panel="${nodeId}"]`)
+    await panel.locator('[data-deconstruct-shots="true"]').waitFor({ state: 'visible', timeout: 15_000 })
+    check('cold restart 后真实分镜表 UI 回读可见', await panel.locator('[data-deconstruct-shot]').count() > 0)
+  } finally {
+    await launched.app.close().catch(() => {})
+  }
+}
+
+let app
+let tikhub
+let vision
+try {
+  if (!fs.existsSync(FIXTURE_VIDEO)) throw new Error(`missing fixture video: ${FIXTURE_VIDEO}`)
+  tikhub = await startTikHubFixture()
+  vision = await startVisionFixture()
+  tikhub.modelRequests = vision.requests
+  writeFixtureCatalog(vision.origin)
+  const launched = await launchNomiApp({
+    name: 'tikhub-project-video-breakdown', userDataDir, settingsDir, projectsDir,
+    syntheticCredentialStorage: true,
+    env: { NODE_ENV: 'production', NOMI_TIKHUB_TEST_ORIGIN: tikhub.origin }, settleMs: 0,
+  })
+  app = launched.app
+  const identity = await runJourney(launched.app, launched.win, tikhub, vision)
+  await launched.app.close()
+  app = null
+  await runColdReadback(tikhub, identity.projectId, identity.nodeId)
+  console.log(`ELECTRON ASSERTIONS: ${electronAssertions}`)
+  console.log(`FIXTURE REQUESTS: tikhub=${tikhub.requests.length} model=${vision.requests.length}`)
+  if (failures.length) throw new Error(`failed assertions: ${failures.join(', ')}`)
+  console.log('✓ TikHub → project asset → video deconstruction → storyboard side effect → cold readback complete')
+} finally {
+  await app?.close().catch(() => {})
+  await vision?.close().catch(() => {})
+  await tikhub?.close().catch(() => {})
+  fs.rmSync(TEMP_ROOT, { recursive: true, force: true })
+}


### PR DESCRIPTION
## Summary

- Adds a real Electron journey for TikHub → project asset → video deconstruction → storyboard nodes → cold-restart readback.
- Uses only loopback HTTP fixtures; no real TikHub key, external upstream, or paid provider.
- Adds executable H/B/E/T/N boundary coverage for local upstream status, missing play URL, timeout/network fail-closed behavior, invalid test origin, and malformed model output.
- Adds a scoped raw V8 receipt for changed production functions only; no baseline coverage configuration or UI/CSS/sample files changed.

## Evidence

- RED: `pnpm exec vitest run electron/connectors/tikhubLocalFixture.test.ts` failed before the loopback production seam with `TikHub 出站目标非法：127.0.0.1`.
- Focused/unit: 6 files, 135 tests passed.
- Scoped V8: 5 files, 121 tests passed; changed production function scope 8/8 hit. Raw JSON is generated at `.tmp/coverage/tikhub-scoped/coverage-final.json`.
- Typecheck: passed.
- Build: passed; Electron identity 43.4.1.
- Real Electron: 15 assertions passed; TikHub fixture requests 3, model requests 2; happy request carried 3 image references, malformed response became `visionFailed` with no fake visual result; durable source evidence, storyboard side effect, and cold restart readback passed.

## Scope

Base: `origin/main` at `e0cd67428c92a7f6b43257fb72fccce9fc61f4e1`

No merge requested.
