### PR TITLE
test(mcp): cover semantic document and canvas journeys

### DIFF
--- a/docs/plan/2026-09-04-mcp-semantic-operation-matrix.md
+++ b/docs/plan/2026-09-04-mcp-semantic-operation-matrix.md
@@ -1,5 +1,7 @@
 # MCP semantic operation matrix
 
+> 状态：✅ 已交付
+
 ## Scope
 
 - Base: `origin/main` at `68e88075ddfaa90edb0078f902b2d9103dba1bb3` (#462 merged).

--- a/docs/plan/2026-09-04-mcp-semantic-operation-matrix.md
+++ b/docs/plan/2026-09-04-mcp-semantic-operation-matrix.md
@@ -1,0 +1,39 @@
+# MCP semantic operation matrix
+
+## Scope
+
+- Base: `origin/main` at `68e88075ddfaa90edb0078f902b2d9103dba1bb3` (#462 merged).
+- Test only the published MCP semantic operations that have a real current
+  headless production path: `nomi_document_read`, `nomi_document_edit`, and
+  `nomi_canvas_maintenance`.
+- Exercise the MCP protocol, catalog/schema validation, verified project
+  session lease, dispatcher, disk gateway, and the actual workspace project
+  repository. The fixture seeds only an initial user project; it never writes
+  the asserted final result.
+- Inject failures only at the MCP invoke/transport boundary or the gateway
+  boundary, matching the production seams.
+
+## Explicit gaps
+
+- `nomi_timeline_read` and `nomi_timeline_edit` are renderer-surface routes in
+  the current GUI path. The headless dispatcher does not own `timeline.read`
+  or `timeline.write`; this change records that as a blocked contract rather
+  than routing it to a reducer or accepting a fabricated result.
+- `nomi_media_query` and `nomi_export_job` likewise require the registered
+  renderer asset/export surface. Export write is Host-only and is not an MCP
+  capability. No test will claim those operations are live from this path.
+- Document writes currently have no revision parameter in the published
+  contract. The matrix records stale-revision as a schema/contract gap instead
+  of inventing optimistic concurrency.
+
+## Acceptance
+
+- Every selected operation has normal, boundary/empty-extreme-Unicode-
+  duplicate, invalid/stale, timeout, and transport/provider-failure evidence.
+- Normal writes are verified by reading the persisted workspace project after
+  the MCP call; canvas delete is verified again after undo.
+- The key effect assertions are written red first, then made green by the
+  smallest production-path test harness change. No UI files or storyboard
+  files from #462 are changed.
+- A V8 receipt reports only the changed production scope and its statement /
+  branch result; it does not claim repository-wide coverage.

--- a/docs/plan/INDEX.md
+++ b/docs/plan/INDEX.md
@@ -99,6 +99,7 @@
 
 | 文件 | 一句话 | 状态 |
 |---|---|---|
+| [2026-09-04-mcp-semantic-operation-matrix.md](2026-09-04-mcp-semantic-operation-matrix.md) | MCP 语义操作矩阵：document/canvas 真实生产链路 H/B/E/T/N、scoped V8 收据与 timeline/media/export blocked evidence | ✅ |
 | [2026-09-04-agent-usage-ledger-rebaseline-followup.md](2026-09-04-agent-usage-ledger-rebaseline-followup.md) | #452 rebaseline follow-up：Host usage persistence/projection 与生成 approval receipt 的 projectRevision C9 防漂移 | ✅ |
 | [2026-09-02-mcp-testnet-l1-handshake.md](2026-09-02-mcp-testnet-l1-handshake.md) | MCP 测试网第 1 片：真实 stdio L1 握手六条回归、tools/list payload 棘轮与 listChanged A1 | 🚧 |
 | [2026-09-02-mcp-l2-journeys.md](2026-09-02-mcp-l2-journeys.md) | MCP 测试网第 2 片：C7-C12 真实语义生成、断连回收、产物审片与导出对账 | ✅ |

--- a/docs/qa/2026-09-04-mcp-semantic-operation-matrix-coverage-receipt.md
+++ b/docs/qa/2026-09-04-mcp-semantic-operation-matrix-coverage-receipt.md
@@ -1,0 +1,79 @@
+# MCP semantic operation matrix coverage receipt
+
+## Delivery baseline and scope
+
+- Baseline: `origin/main` at `68e88075ddfaa90edb0078f902b2d9103dba1bb3`.
+- Changed production scope: `electron/capabilityCore/documentSurface.ts` only.
+- The matrix exercises the published MCP protocol and dispatcher for
+  `nomi_document_read`, `nomi_document_edit`, and
+  `nomi_canvas_maintenance`. It also records the renderer-only gaps for
+  timeline, media, and export operations.
+- This receipt does not claim 100% coverage for the repository.
+
+## Red to green evidence
+
+The production write path originally retained a fallback for
+`workbenchDocuments`. The preceding `projectDocument()` call already rejects a
+missing or non-array collection and requires a selected document, so that
+fallback branch is unreachable on the same production call path. The matrix
+test covered the real write effect and exposed that branch as the only scoped
+coverage miss.
+
+Red command (temporary pre-fix source, latest baseline):
+
+```sh
+pnpm exec vitest run electron/capabilityCore/mcpSemanticOperationMatrix.test.ts \
+  --coverage.enabled --coverage.provider=v8 \
+  --coverage.include=electron/capabilityCore/documentSurface.ts \
+  --coverage.reportsDirectory=/tmp/nomi-mcp-semantic-matrix-v8-latest-red \
+  --coverage.thresholds.statements=100 \
+  --coverage.thresholds.branches=100
+```
+
+Result: exit 1. Tests were 3/3 green, statements 30/30 (100%), branches
+40/41 (97.56%), functions 9/9 (100%), lines 26/26 (100%); the unreachable
+fallback branch left line 56 uncovered and failed the 100% branch threshold.
+
+Green command (minimal production fix applied):
+
+```sh
+pnpm exec vitest run electron/capabilityCore/mcpSemanticOperationMatrix.test.ts \
+  --coverage.enabled --coverage.provider=v8 \
+  --coverage.include=electron/capabilityCore/documentSurface.ts \
+  --coverage.reportsDirectory=/tmp/nomi-mcp-semantic-matrix-v8-final-green \
+  --coverage.thresholds.statements=100 \
+  --coverage.thresholds.branches=100
+```
+
+Result: exit 0. Tests 3/3 passed; statements 30/30 (100%), branches 39/39
+(100%), functions 9/9 (100%), lines 26/26 (100%).
+
+## Verification receipt
+
+- Targeted matrix plus related production-path suites: 4 files, 15 tests
+  passed.
+- `pnpm run typecheck`: passed.
+- `pnpm run build`: passed, including Electron install verification (13/13).
+- `node tests/ux/production-mcp-journey.e2e.mjs`: passed with 58 assertions
+  in a real built Electron run. The run opened a real MCP-created project,
+  used the real stdio MCP server, created a canvas node through MCP, deleted
+  and undid it through the renderer gateway, and read it back after a real
+  Nomi restart.
+
+## Remaining gaps
+
+- A newly MCP-created project has no creation document, so the real Electron
+  journey records `nomi_document_read` as an explicit
+  `document_not_found` contract gap. Positive document read/edit persistence
+  is covered through the real workspace repository fixture and dispatcher
+  path; there is currently no MCP document-create operation to seed it through
+  the production journey.
+- `nomi_timeline_read`, `nomi_timeline_edit`, `nomi_media_query`, and
+  `nomi_export_job` are advertised but are renderer-only in the current
+  production path; the headless dispatcher returns unknown-method errors for
+  these routes. Timeline writes additionally require Host approval, and export
+  write is Host-only. The tests record this as blocked/gap evidence rather than
+  fabricating successful semantic operations.
+- The published document edit contract has no revision parameter, so stale
+  revision is recorded as a schema/contract gap instead of inventing a
+  concurrency protocol.

--- a/electron/capabilityCore/documentSurface.ts
+++ b/electron/capabilityCore/documentSurface.ts
@@ -53,7 +53,10 @@ export function writeProjectDocument(
   const { project, document, text } = projectDocument(projectId, documentId)
   const nextText = operation === 'replace' ? content : operation === 'append' ? `${text}${text ? '\n' : ''}${content}` : `${content}${text ? '\n' : ''}${text}`
   const payload = record(project.payload)
-  const documents = (Array.isArray(payload.workbenchDocuments) ? payload.workbenchDocuments : []).map((candidate) => {
+  // projectDocument already rejected a missing/non-array document collection;
+  // keep the write path on that same validated collection instead of carrying
+  // an unreachable fallback that can never preserve the selected document.
+  const documents = (payload.workbenchDocuments as DocumentRecord[]).map((candidate) => {
     const item = record(candidate)
     return item.id === document.id ? { ...item, contentJson: contentFor(nextText), updatedAt: Date.now() } : candidate
   })

--- a/electron/capabilityCore/mcpSemanticOperationMatrix.test.ts
+++ b/electron/capabilityCore/mcpSemanticOperationMatrix.test.ts
@@ -52,10 +52,6 @@ function restoreEnvironment(name: string, value: string | undefined): void {
   else process.env[name] = value
 }
 
-function settle(): Promise<void> {
-  return new Promise((resolve) => setImmediate(resolve))
-}
-
 function outcomeCode(frame: Frame): unknown {
   return frame.result?.structuredContent?.nomiOutcome?.errorCode
 }
@@ -136,7 +132,6 @@ function makeClient(
 ) {
   const frames: Frame[] = []
   const waiters: Array<(frame: Frame) => void> = []
-  let protocol!: ReturnType<typeof createMcpProtocol>
   const invoke = vi.fn(async (method: string, params: Record<string, unknown>) => {
     if (method !== 'nomi_session_open' && fault === 'timeout') {
       throw Object.assign(new Error('MCP transport timeout'), { code: 'capability_timeout' })
@@ -160,7 +155,7 @@ function makeClient(
     if (waiter) waiter(message)
     else frames.push(message)
   }
-  protocol = createMcpProtocol({
+  const protocol = createMcpProtocol({
     send,
     invoke: invoke as McpTransport['invoke'],
     isAppOpen: () => false,

--- a/electron/capabilityCore/mcpSemanticOperationMatrix.test.ts
+++ b/electron/capabilityCore/mcpSemanticOperationMatrix.test.ts
@@ -1,0 +1,425 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('electron', () => ({
+  app: {
+    getName: () => 'Nomi',
+    getPath: (name: string) => path.join(os.tmpdir(), `nomi-mcp-semantic-matrix-${name}`),
+  },
+}))
+
+import { PROJECT_ROOT_ENV, getWorkspaceRepositoryDeps } from '../runtimePaths'
+import { SETTINGS_ROOT_ENV } from '../settings/settingsRoot'
+import { createWorkspaceProject, readWorkspaceProject, saveWorkspaceProject } from '../workspace/workspaceRepository'
+import { ensureWorkspaceProjectIdentity } from '../workspace/workspaceProjectIdentity'
+import { CAPABILITY_DIR_ENV, ensureToken, signMcpClient } from './security'
+import { createMcpConnectionContext } from './mcpConnectionContext'
+import { createMcpGenerationPolicy } from './mcpGenerationPolicy'
+import { createProductionProjectSessionRuntime } from './projectSessionRuntime'
+import { createMcpProtocol, type McpTransport } from './mcpProtocol'
+import { dispatch } from './dispatcher'
+import { createDiskGateway } from './gateway'
+import { MCP_CAPABILITY_RESOLVER } from './mcpCapabilityProjection'
+import { readProjectDocument } from './documentSurface'
+import * as projectRepository from '../projects/repository'
+
+const PROJECT_ID = 'semantic-matrix-project'
+const tempDirs: string[] = []
+const previousEnvironment = {
+  capability: process.env[CAPABILITY_DIR_ENV],
+  projects: process.env[PROJECT_ROOT_ENV],
+  settings: process.env[SETTINGS_ROOT_ENV],
+}
+
+type Frame = {
+  id?: number | string
+  method?: string
+  result?: {
+    isError?: boolean
+    content?: Array<{ type?: string; text?: string }>
+    structuredContent?: { nomiOutcome?: Record<string, unknown> } & Record<string, unknown>
+  }
+  error?: { code?: number; message?: string }
+}
+
+type Fault = 'timeout' | 'network'
+
+function restoreEnvironment(name: string, value: string | undefined): void {
+  if (value === undefined) delete process.env[name]
+  else process.env[name] = value
+}
+
+function settle(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve))
+}
+
+function outcomeCode(frame: Frame): unknown {
+  return frame.result?.structuredContent?.nomiOutcome?.errorCode
+}
+
+async function makeFixture() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'nomi-mcp-semantic-matrix-'))
+  tempDirs.push(root)
+  process.env[CAPABILITY_DIR_ENV] = path.join(root, 'capability')
+  process.env[PROJECT_ROOT_ENV] = path.join(root, 'projects')
+  process.env[SETTINGS_ROOT_ENV] = path.join(root, 'settings')
+
+  const deps = getWorkspaceRepositoryDeps()
+  const projectRoot = path.join(deps.defaultProjectsRoot, 'fixture')
+  createWorkspaceProject({
+    rootPath: projectRoot,
+    record: {
+      id: PROJECT_ID,
+      name: 'MCP semantic matrix fixture',
+      payload: {
+        generationCanvas: {
+          nodes: [
+            { id: 'node-a', kind: 'text', title: 'Initial text', prompt: '原始节点' },
+            { id: 'node-b', kind: 'image', title: 'Keep me', prompt: '保留节点' },
+          ],
+          edges: [],
+          groups: [],
+          selectedNodeIds: [],
+        },
+        workbenchDocuments: [{
+          id: 'doc-1',
+          version: 1,
+          title: '语义操作测试文档',
+          contentJson: { type: 'doc', content: [{ type: 'paragraph', content: [{ type: 'text', text: '初稿' }] }] },
+          updatedAt: 1,
+        }, {
+          id: 'doc-2',
+          version: 1,
+          title: '空内容文档',
+          contentJson: null,
+          updatedAt: 1,
+        }, {
+          id: 'doc-3',
+          version: 1,
+          title: '非文本节点文档',
+          contentJson: { type: 'unknown', content: 'not-an-array' },
+          updatedAt: 1,
+        }],
+        activeDocumentId: 'doc-1',
+      },
+    },
+  }, deps)
+
+  const identity = await ensureWorkspaceProjectIdentity(projectRoot)
+  const committedSelection = Object.freeze({
+    projectId: identity.projectId,
+    immutableProjectUuid: identity.immutableProjectUuid,
+    projectGeneration: identity.projectGeneration,
+    canonicalRootDigest: identity.canonicalRootDigest,
+  })
+  ensureToken()
+  const connection = createMcpConnectionContext({
+    client: 'codex',
+    proof: signMcpClient('codex'),
+    randomSecret: () => 'S'.repeat(43),
+  })
+  const generationPolicy = createMcpGenerationPolicy({ env: {} })
+  const runtime = createProductionProjectSessionRuntime({
+    generationPolicy,
+    getOpenProjectSelection: () => committedSelection,
+    isServerAllowlisted: () => false,
+  })
+  return { deps, connection, generationPolicy, runtime }
+}
+
+function makeClient(
+  context: Parameters<typeof dispatch>[2],
+  fault?: Fault,
+) {
+  const frames: Frame[] = []
+  const waiters: Array<(frame: Frame) => void> = []
+  let protocol!: ReturnType<typeof createMcpProtocol>
+  const invoke = vi.fn(async (method: string, params: Record<string, unknown>) => {
+    if (method !== 'nomi_session_open' && fault === 'timeout') {
+      throw Object.assign(new Error('MCP transport timeout'), { code: 'capability_timeout' })
+    }
+    if (method !== 'nomi_session_open' && fault === 'network') {
+      throw Object.assign(new Error('MCP provider/network boundary failed'), { code: 'capability_execution_failed' })
+    }
+    return dispatch(method, params, context)
+  })
+  const send = (frame: unknown) => {
+    const message = frame as Frame
+    if (message.method === 'elicitation/create') {
+      protocol.handleIncoming({
+        jsonrpc: '2.0',
+        id: message.id,
+        result: { action: 'accept', content: { confirm: true } },
+      })
+      return
+    }
+    const waiter = waiters.shift()
+    if (waiter) waiter(message)
+    else frames.push(message)
+  }
+  protocol = createMcpProtocol({
+    send,
+    invoke: invoke as McpTransport['invoke'],
+    isAppOpen: () => false,
+  })
+  async function call(id: number, name: string, args: Record<string, unknown>): Promise<Frame> {
+    const response = new Promise<Frame>((resolve) => waiters.push(resolve))
+    protocol.handleIncoming({ jsonrpc: '2.0', id, method: 'tools/call', params: { name, arguments: args } })
+    return response
+  }
+  async function initialize(): Promise<Frame> {
+    const response = new Promise<Frame>((resolve) => waiters.push(resolve))
+    protocol.handleIncoming({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: {
+        protocolVersion: '2025-11-25',
+        capabilities: { elicitation: {} },
+        clientInfo: { name: 'Codex semantic matrix' },
+      },
+    })
+    return response
+  }
+  return { call, frames, initialize, invoke, protocol }
+}
+
+async function openLease(client: ReturnType<typeof makeClient>): Promise<string> {
+  const opened = await client.call(2, 'nomi_session_open', { bootstrap: { mode: 'current_project' } })
+  if (opened.result?.isError) throw new Error(`session open failed: ${JSON.stringify(opened)}`)
+  const text = opened.result?.content?.find((item) => item.type === 'text')?.text
+  const payload = JSON.parse(text || '{}') as { leaseHandle?: string }
+  expect(payload.leaseHandle).toEqual(expect.any(String))
+  return payload.leaseHandle as string
+}
+
+describe('MCP semantic operation production-path matrix', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  afterEach(() => {
+    restoreEnvironment(CAPABILITY_DIR_ENV, previousEnvironment.capability)
+    restoreEnvironment(PROJECT_ROOT_ENV, previousEnvironment.projects)
+    restoreEnvironment(SETTINGS_ROOT_ENV, previousEnvironment.settings)
+    for (const dir of tempDirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('proves document read/edit H/B/E/T/N through MCP and persisted repository state', async () => {
+    const fixture = await makeFixture()
+    const baseContext = {
+      runTask: vi.fn(),
+      makeGateway: (projectId: string) => createDiskGateway(projectId),
+      productionRuns: {},
+      generationPolicy: fixture.generationPolicy,
+      origin: { host: 'codex' as const },
+      projectSession: { authority: fixture.runtime.authority, connection: fixture.connection },
+    }
+    const client = makeClient(baseContext as never)
+    await client.initialize()
+    const leaseHandle = await openLease(client)
+
+    // H: the MCP call reaches document.write/read and the effect survives a fresh repository read.
+    const normal = await client.call(3, 'nomi_document_edit', {
+      leaseHandle, projectId: PROJECT_ID, operation: 'append', content: '第二稿 😀',
+    })
+    expect(normal.result?.isError).not.toBe(true)
+    expect(normal.result?.structuredContent).toEqual(expect.objectContaining({ applied: true, revision: expect.any(Number) }))
+    const read = await client.call(4, 'nomi_document_read', { leaseHandle, projectId: PROJECT_ID, scope: 'full' })
+    expect(read.result?.structuredContent).toEqual({ text: '初稿\n第二稿 😀' })
+    const persisted = readWorkspaceProject(PROJECT_ID, fixture.deps)
+    expect(JSON.stringify(persisted?.payload)).toContain('第二稿 😀')
+
+    // B: empty content, a max-ish Unicode payload, and a repeated edit are explicit edits at the schema boundary.
+    const empty = await client.call(5, 'nomi_document_edit', { leaseHandle, operation: 'append', content: '' })
+    expect(empty.result?.isError).toBe(true)
+    expect(client.invoke).toHaveBeenCalledTimes(3) // session open + edit + read; the invalid call never invokes dispatch
+    const unicode = '重复😀'.repeat(2_048)
+    const large = await client.call(6, 'nomi_document_edit', { leaseHandle, operation: 'append', content: unicode })
+    expect(large.result?.isError).not.toBe(true)
+    const repeated = await client.call(7, 'nomi_document_edit', { leaseHandle, operation: 'append', content: '重复编辑' })
+    expect(repeated.result?.isError).not.toBe(true)
+    const repeatedAgain = await client.call(8, 'nomi_document_edit', { leaseHandle, operation: 'append', content: '重复编辑' })
+    expect(repeatedAgain.result?.isError).not.toBe(true)
+    const afterRepeated = await client.call(9, 'nomi_document_read', { leaseHandle, scope: 'full' })
+    expect(afterRepeated.result?.structuredContent?.text).toContain('重复编辑\n重复编辑')
+    const explicitDocument = await client.call(23, 'nomi_document_read', { leaseHandle, documentId: 'doc-2', scope: 'selection' })
+    expect(explicitDocument.result?.structuredContent).toEqual({ text: '' })
+    const nonTextDocument = await client.call(24, 'nomi_document_read', { leaseHandle, documentId: 'doc-3', scope: 'full' })
+    expect(nonTextDocument.result?.structuredContent).toEqual({ text: '' })
+    const emptyAppend = await client.call(29, 'nomi_document_edit', {
+      leaseHandle, documentId: 'doc-2', operation: 'append', content: '空文档追加',
+    })
+    expect(emptyAppend.result?.isError).not.toBe(true)
+    const emptyInsert = await client.call(30, 'nomi_document_edit', {
+      leaseHandle, documentId: 'doc-3', operation: 'insert', content: '空节点插入',
+    })
+    expect(emptyInsert.result?.isError).not.toBe(true)
+    const fallbackDocument = await client.call(25, 'nomi_document_read', { leaseHandle, documentId: 'missing-document', scope: 'full' })
+    expect(fallbackDocument.result?.structuredContent).toEqual(expect.objectContaining({ text: expect.any(String) }))
+    const currentRecord = readWorkspaceProject(PROJECT_ID, fixture.deps)!
+    saveWorkspaceProject(PROJECT_ID, {
+      ...currentRecord,
+      payload: { ...(currentRecord.payload as Record<string, unknown>), activeDocumentId: 42 },
+    }, fixture.deps)
+    const noActiveId = await client.call(31, 'nomi_document_read', { leaseHandle, scope: 'full' })
+    expect(noActiveId.result?.structuredContent).toEqual(expect.objectContaining({ text: expect.any(String) }))
+    const multiline = await client.call(26, 'nomi_document_edit', {
+      leaseHandle, documentId: 'doc-1', operation: 'replace', content: '第一行\n\n第三行',
+    })
+    expect(multiline.result?.isError).not.toBe(true)
+    const inserted = await client.call(28, 'nomi_document_edit', {
+      leaseHandle, documentId: 'doc-1', operation: 'insert', content: '插入到开头',
+    })
+    expect(inserted.result?.isError).not.toBe(true)
+    const originalSaveProject = projectRepository.saveProject
+    const noRevisionSave = vi.spyOn(projectRepository, 'saveProject').mockImplementation((projectId: string, input: unknown) => ({
+      ...originalSaveProject(projectId, input),
+      revision: undefined,
+    }))
+    const noRevision = await client.call(32, 'nomi_document_edit', {
+      leaseHandle, documentId: 'doc-1', operation: 'replace', content: 'revision fallback',
+    })
+    expect(noRevision.result?.structuredContent).toEqual(expect.objectContaining({ applied: true, revision: 0 }))
+    noRevisionSave.mockRestore()
+
+    // E: the published document contract has no expectedRevision field; reject stale-revision attempts instead of pretending to support them.
+    const stale = await client.call(10, 'nomi_document_edit', {
+      leaseHandle, operation: 'replace', content: 'stale', expectedRevision: 1,
+    })
+    expect(stale.result?.isError).toBe(true)
+    expect(outcomeCode(stale)).toBe('capability_input_invalid')
+
+    // T/N: only the MCP invoke boundary is faulted; no internal reducer or final state is injected.
+    for (const [id, fault, expected] of [[11, 'timeout', 'capability_timeout'], [12, 'network', 'capability_execution_failed']] as const) {
+      const faulty = makeClient(baseContext as never, fault)
+      await faulty.initialize()
+      const faultyLease = await openLease(faulty)
+      const failed = await faulty.call(id, 'nomi_document_edit', { leaseHandle: faultyLease, operation: 'append', content: 'should not persist' })
+      expect(failed.result?.isError).toBe(true)
+      expect(outcomeCode(failed)).toBe(expected)
+      faulty.protocol.dispose()
+    }
+    saveWorkspaceProject(PROJECT_ID, {
+      ...(readWorkspaceProject(PROJECT_ID, fixture.deps) as Record<string, unknown>),
+      payload: { workbenchDocuments: [], activeDocumentId: 'doc-1' },
+    }, fixture.deps)
+    const missingDocument = await client.call(27, 'nomi_document_read', { leaseHandle, scope: 'full' })
+    expect(missingDocument.result?.isError).toBe(true)
+    expect(outcomeCode(missingDocument)).toBe('document_not_found')
+    saveWorkspaceProject(PROJECT_ID, {
+      ...((readWorkspaceProject(PROJECT_ID, fixture.deps) as Record<string, unknown>)),
+      payload: { activeDocumentId: 'doc-1' },
+    }, fixture.deps)
+    const missingDocumentNoArray = await client.call(33, 'nomi_document_read', { leaseHandle, scope: 'full' })
+    expect(missingDocumentNoArray.result?.isError).toBe(true)
+    expect(outcomeCode(missingDocumentNoArray)).toBe('document_not_found')
+    expect(() => readProjectDocument('missing-project', undefined, 'full')).toThrow(/project not found/i)
+    client.protocol.dispose()
+  })
+
+  it('proves destructive canvas maintenance H/B/E/T/N with human confirmation, undo, and disk evidence', async () => {
+    const fixture = await makeFixture()
+    const baseContext = {
+      runTask: vi.fn(),
+      makeGateway: (projectId: string) => createDiskGateway(projectId),
+      productionRuns: {},
+      generationPolicy: fixture.generationPolicy,
+      origin: { host: 'codex' as const },
+      projectSession: { authority: fixture.runtime.authority, connection: fixture.connection },
+    }
+    const client = makeClient(baseContext as never)
+    await client.initialize()
+    const leaseHandle = await openLease(client)
+
+    // H: MCP elicitation confirms the exact destructive operation, then the real disk gateway deletes and restores it.
+    const deleted = await client.call(13, 'nomi_canvas_maintenance', {
+      leaseHandle, projectId: PROJECT_ID, operation: 'delete_canvas_nodes', nodeIds: ['node-a'], reason: '清理旧节点 😀',
+    })
+    expect(deleted.result?.isError).not.toBe(true)
+    const deleteReceipt = deleted.result?.structuredContent as { undoToken?: string; deletedNodeIds?: string[] }
+    expect(deleteReceipt.deletedNodeIds).toEqual(['node-a'])
+    expect(JSON.stringify(readWorkspaceProject(PROJECT_ID, fixture.deps)?.payload)).not.toContain('node-a')
+    const undone = await client.call(14, 'nomi_canvas_maintenance', {
+      leaseHandle, projectId: PROJECT_ID, operation: 'undo_canvas_delete', undoToken: deleteReceipt.undoToken,
+    })
+    expect(undone.result?.isError).not.toBe(true)
+    expect((undone.result?.structuredContent as { restoredNodeIds?: string[] }).restoredNodeIds).toEqual(['node-a'])
+    expect(JSON.stringify(readWorkspaceProject(PROJECT_ID, fixture.deps)?.payload)).toContain('node-a')
+
+    // B/E: empty and duplicate node ids fail before dispatch; an invalid undo token fails in the real dispatcher.
+    const empty = await client.call(15, 'nomi_canvas_maintenance', { leaseHandle, operation: 'delete_canvas_nodes', nodeIds: [] })
+    expect(empty.result?.isError).toBe(true)
+    const duplicate = await client.call(16, 'nomi_canvas_maintenance', { leaseHandle, operation: 'delete_canvas_nodes', nodeIds: ['node-b', 'node-b'] })
+    expect(duplicate.result?.isError).toBe(true)
+    expect(client.invoke).toHaveBeenCalledTimes(3) // session open + delete + undo; B cases never invoke dispatch
+    const invalidUndo = await client.call(17, 'nomi_canvas_maintenance', { leaseHandle, operation: 'undo_canvas_delete', undoToken: 'undo-stale' })
+    expect(invalidUndo.result?.isError).toBe(true)
+    expect(outcomeCode(invalidUndo)).toBe('capability_input_invalid')
+
+    // The delete contract has no revision field. Keep stale-revision evidence explicit at the MCP boundary.
+    const stale = await client.call(18, 'nomi_canvas_maintenance', {
+      leaseHandle, operation: 'delete_canvas_nodes', nodeIds: ['node-b'], expectedRevision: 1,
+    })
+    expect(stale.result?.isError).toBe(true)
+    expect(outcomeCode(stale)).toBe('capability_input_invalid')
+
+    // T/N: boundary faults are typed and prove no delete occurred when transport/provider access fails.
+    for (const [id, fault, expected] of [[19, 'timeout', 'capability_timeout'], [20, 'network', 'capability_execution_failed']] as const) {
+      const faulty = makeClient(baseContext as never, fault)
+      await faulty.initialize()
+      const faultyLease = await openLease(faulty)
+      const failed = await faulty.call(id, 'nomi_canvas_maintenance', { leaseHandle: faultyLease, operation: 'delete_canvas_nodes', nodeIds: ['node-b'] })
+      expect(failed.result?.isError).toBe(true)
+      expect(outcomeCode(failed)).toBe(expected)
+      expect(JSON.stringify(readWorkspaceProject(PROJECT_ID, fixture.deps)?.payload)).toContain('node-b')
+      faulty.protocol.dispose()
+    }
+    client.protocol.dispose()
+  })
+
+  it('records renderer-only semantic operations as blocked gaps, never as headless success', async () => {
+    expect(MCP_CAPABILITY_RESOLVER.resolve('nomi_timeline_read')).toBeDefined()
+    expect(MCP_CAPABILITY_RESOLVER.resolve('nomi_timeline_edit')).toBeDefined()
+    expect(MCP_CAPABILITY_RESOLVER.resolve('nomi_media_query')).toBeDefined()
+    expect(MCP_CAPABILITY_RESOLVER.resolve('nomi_export_job')).toBeDefined()
+
+    const fixture = await makeFixture()
+    const context = {
+      runTask: vi.fn(),
+      makeGateway: (projectId: string) => createDiskGateway(projectId),
+      productionRuns: {},
+      generationPolicy: fixture.generationPolicy,
+      origin: { host: 'codex' as const },
+      projectSession: { authority: fixture.runtime.authority, connection: fixture.connection },
+    }
+    const client = makeClient(context as never)
+    await client.initialize()
+    const leaseHandle = await openLease(client)
+    const blockedCalls = [
+      ['nomi_timeline_read', { leaseHandle, projectId: PROJECT_ID, operation: 'read' }],
+      ['nomi_timeline_edit', {
+        leaseHandle,
+        projectId: PROJECT_ID,
+        operation: 'preview',
+        plan: {
+          planId: 'blocked-plan',
+          baseRevision: '0',
+          summary: 'blocked preview',
+          operations: [{ kind: 'remove', clipId: 'clip-not-present' }],
+        },
+      }],
+      ['nomi_media_query', { leaseHandle, projectId: PROJECT_ID, operation: 'list', query: '', limit: 1 }],
+      ['nomi_export_job', { leaseHandle, projectId: PROJECT_ID, operation: 'status', jobId: 'job-not-started' }],
+    ] as const
+    for (const [index, [name, args]] of blockedCalls.entries()) {
+      const blocked = await client.call(21 + index, name, args)
+      expect(blocked.result?.isError).toBe(true)
+      expect(blocked.result?.content?.[0]?.text).toMatch(/未知方法|unknown/i)
+    }
+    client.protocol.dispose()
+  })
+})

--- a/tests/ux/production-mcp-journey.e2e.mjs
+++ b/tests/ux/production-mcp-journey.e2e.mjs
@@ -28,7 +28,10 @@ fs.mkdirSync(shotsDir, { recursive: true })
 const mcpDirs = { settingsDir: userDataDir, userDataDir, projectsDir, capabilityDir }
 const mcpEnv = { NOMI_E2E_PRODUCTION_FIXTURE: '1' }
 const mcpClientInfo = { name: 'OpenAI Codex', version: 'e2e' }
-const mcpCapabilities = { extensions: { 'io.modelcontextprotocol/ui': { mimeTypes: ['text/html;profile=mcp-app'] } } }
+const mcpCapabilities = {
+  elicitation: {},
+  extensions: { 'io.modelcontextprotocol/ui': { mimeTypes: ['text/html;profile=mcp-app'] } },
+}
 
 const launchGuiOptions = {
   name: 'production-mcp-journey',
@@ -165,6 +168,48 @@ try {
     check(tools.some((tool) => tool.name === name), `${name} is registered over real stdio`)
   }
 
+  // Semantic editing smoke: use the same real GUI+stdio connection as the Run
+  // journey. Stdio's production binding intentionally has no implicit current
+  // project selection, so create an explicit MCP project and open its returned
+  // selection handle; this is the supported production authorization path.
+  const semanticProjectResult = await callTool('nomi_project_create', { name: 'MCP semantic production fixture' })
+  const semanticProjectText = semanticProjectResult.content?.find((block) => block.type === 'text')?.text || '{}'
+  const semanticProject = JSON.parse(semanticProjectText)
+  const semanticProjectId = semanticProject.id
+  const openedSession = await callTool('nomi_session_open', { projectSelectionHandle: semanticProject.projectSelectionHandle })
+  const sessionText = openedSession.content?.find((block) => block.type === 'text')?.text || '{}'
+  const session = JSON.parse(sessionText)
+  const leaseHandle = session.leaseHandle
+  check(typeof leaseHandle === 'string' && leaseHandle.length > 0, 'semantic MCP session opens a verified project lease')
+  const missingDocument = await mcp.callTool('nomi_document_read', { leaseHandle, projectId: semanticProjectId, scope: 'full' })
+  check(missingDocument.isError === true && missingDocument.structuredContent?.nomiOutcome?.errorCode === 'document_not_found', 'document MCP gap is explicit for a newly created project without a creation document')
+
+  const createdSemanticNode = await callTool('nomi_canvas_edit', {
+    leaseHandle,
+    projectId: semanticProjectId,
+    operation: 'create_canvas_nodes',
+    summary: 'semantic maintenance fixture node',
+    nodes: [{ clientId: 'semantic-maintenance-node', kind: 'text', title: 'Semantic maintenance fixture', prompt: 'temporary MCP maintenance node' }],
+  })
+  const nodeId = createdSemanticNode.structuredContent?.clientIdToNodeId?.['semantic-maintenance-node']
+  check(typeof nodeId === 'string' && nodeId.length > 0, 'canvas edit creates a real node before maintenance')
+  const deletedSemanticNode = await callTool('nomi_canvas_maintenance', {
+    leaseHandle,
+    projectId: semanticProjectId,
+    operation: 'delete_canvas_nodes',
+    nodeIds: [nodeId],
+    reason: 'semantic maintenance cleanup',
+  })
+  const undoToken = deletedSemanticNode.structuredContent?.undoToken
+  check(deletedSemanticNode.structuredContent?.deletedNodeIds?.includes(nodeId) && typeof undoToken === 'string', 'canvas maintenance deletes through the real renderer gateway and returns undo')
+  const restoredSemanticNode = await callTool('nomi_canvas_maintenance', {
+    leaseHandle,
+    projectId: semanticProjectId,
+    operation: 'undo_canvas_delete',
+    undoToken,
+  })
+  check(restoredSemanticNode.structuredContent?.restoredNodeIds?.includes(nodeId), 'canvas maintenance undo restores the real node')
+
   const resources = (await mcp.rpc('resources/list', {}, 20_000)).result?.resources || []
   // Host cutover content-addresses skill resources: nomi-skill://<dir>/<packageVersion>/<contentHash>.
   // Match by directory-name prefix and read via the returned uri (same as packaged-mcp-smoke).
@@ -265,6 +310,8 @@ try {
   gui = await launchGui()
   await gui.window.locator('[data-project-card="true"]').first().click()
   await gui.window.waitForFunction(() => window.location.hash.includes('projectId='), undefined, { timeout: 10_000 })
+  const afterRestartCanvas = await callTool('nomi_read', { target: 'canvas', leaseHandle, projectId: semanticProjectId })
+  check(afterRestartCanvas.structuredContent?.nodes?.some((node) => node.id === nodeId), 'canvas semantic undo survives real Nomi restart')
   await openRunFromTaskCenter(gui.window)
   atShot = await waitForWaitingGate(projectId, runId, 'gate-shot-')
   check(atShot.jobs.every((job) => job.status === 'authorized'), 'restart recovers the waiting shot gate without submitting or spending')


### PR DESCRIPTION
Summary: add H/B/E/T/N production-path matrix coverage for document read/edit and canvas maintenance; add explicit blocked evidence for renderer-only timeline/media/export operations; extend the real Electron MCP journey with project creation, session lease, canvas delete/undo, and restart readback; include scoped V8 receipt on baseline 68e88075. Verification: targeted Vitest 4 files/15 tests passed; pnpm run typecheck passed; scoped documentSurface V8 statements 30/30, branches 39/39, functions 9/9, lines 26/26; real Electron journey 58 assertions passed with real stdio MCP and restart recovery; delivery preflight passed. Gaps: newly MCP-created projects have no creation document and the real journey records document_not_found explicitly; timeline/media/export remain advertised renderer-only routes blocked from the headless dispatcher. Do not merge automatically.