### PR TITLE
test: add Resident Composer production journey evidence

### DIFF
--- a/docs/plan/2026-09-04-resident-composer-production-journey.md
+++ b/docs/plan/2026-09-04-resident-composer-production-journey.md
@@ -1,0 +1,42 @@
+# Resident Composer real-user production journey
+
+## Scope
+
+Add one real Electron user-task walk from the Resident Composer through Agent planning, a real production write, human approval or rejection, receipt/revision, durable project state, and a cold restart read-back. The walk must use the visible composer and the real Electron/IPC/Host path; it must not seed Host items, reducer state, conversation results, or final project state.
+
+This change does not touch the #462 storyboard canonical files and does not change CSS or visual direction.
+
+## Gate contract
+
+The journey is split into two explicit production boundaries:
+
+1. Resident Composer: loopback HTTP is the only mocked external dependency. The real renderer, Agent runner, ProjectAgentHost, verified document-write adapter, approval card, receipt/revision journal, project persistence, and cold restart are exercised.
+2. MCP stdio: the real `electron <repo>` stdio process and JSON-RPC framing are exercised against the isolated project. The test must prove that a production write is governed by the same Resident Host approval/receipt contract. If stdio writes directly through the MCP dispatcher, the journey records a blocker and fails closed; it does not treat direct disk mutation as approval evidence.
+
+The H/B/E/T/N matrix is represented by the same task harness:
+
+- H: normal intent, plan, approval, receipt, persistence, restart.
+- B: empty, overlong, Unicode, cancellation, and duplicate submission behavior.
+- E: malformed/illegal request, user rejection, stale revision, and no mutation after denial.
+- T: Agent/model timeout and MCP/RPC timeout are distinct observations.
+- N: loopback network failure and provider failure are distinct observations.
+
+## TDD order
+
+1. Add the journey with an assertion that MCP stdio production writes produce the Resident Host receipt/revision and approval boundary; run only that assertion and capture the red result.
+2. Inspect the failure against the dispatcher, stdio server, Host receipt store, and real UI evidence.
+3. Apply the smallest production change only if the missing capability is local and contract-safe. Otherwise leave the assertion red and document the exact blocker.
+4. Run the same assertion green if repaired, then run the complete real Electron walk, persistence/restart checks, and packaged parity when a packaged binary is available.
+
+## Evidence and coverage
+
+The walk writes a machine-readable report containing mode, isolated project root, process identities, MCP request/response evidence, receipt/revision observations, restart observations, and the H/B/E/T/N outcome matrix. Screenshots are evidence only; no visual acceptance or CSS change is part of this task.
+
+V8 coverage is reported only for changed production source. If the capability remains blocked and this patch changes no production source, the receipt explicitly says `changedProductionScope: []` and `v8: not-applicable`; it must not claim repository-wide 100% coverage. If production code changes, the receipt must show 100% statements and branches for that exact changed scope.
+
+## Non-goals
+
+- No #462 storyboard canonical edits.
+- No CSS, layout, copy, or visual-direction redesign.
+- No direct state injection to make a UI assertion pass.
+- No merge, default-branch push, or PR approval.

--- a/docs/plan/2026-09-04-resident-composer-production-journey.md
+++ b/docs/plan/2026-09-04-resident-composer-production-journey.md
@@ -13,13 +13,13 @@ The journey is split into two explicit production boundaries:
 1. Resident Composer: loopback HTTP is the only mocked external dependency. The real renderer, Agent runner, ProjectAgentHost, verified document-write adapter, approval card, receipt/revision journal, project persistence, and cold restart are exercised.
 2. MCP stdio: the real `electron <repo>` stdio process and JSON-RPC framing are exercised against the isolated project. The test must prove that a production write is governed by the same Resident Host approval/receipt contract. If stdio writes directly through the MCP dispatcher, the journey records a blocker and fails closed; it does not treat direct disk mutation as approval evidence.
 
-The H/B/E/T/N matrix is represented by the same task harness:
+The journey harness records the H/B/E/N observations from its real Electron/MCP run and links T/N fault semantics to the existing production contract test:
 
 - H: normal intent, plan, approval, receipt, persistence, restart.
-- B: empty, overlong, Unicode, cancellation, and duplicate submission behavior.
-- E: malformed/illegal request, user rejection, stale revision, and no mutation after denial.
-- T: Agent/model timeout and MCP/RPC timeout are distinct observations.
-- N: loopback network failure and provider failure are distinct observations.
+- B: the journey exercises empty and Unicode inputs; overlong, cancellation, and duplicate submission cases remain explicit follow-up gaps until the UI contract is defined.
+- E: the journey exercises user rejection and no mutation after denial; malformed/illegal request and stale revision remain covered by the existing MCP production contract tests.
+- T: Agent/model timeout and MCP/RPC timeout are distinct observations in the existing production contract tests; this journey does not claim a UI timeout pass.
+- N: the journey exercises the real MCP stdio production boundary; network/provider failure sanitization remains covered by the existing production contract tests.
 
 ## TDD order
 

--- a/docs/qa/2026-09-04-resident-composer-production-journey-receipt.md
+++ b/docs/qa/2026-09-04-resident-composer-production-journey-receipt.md
@@ -1,0 +1,66 @@
+# Resident Composer production journey receipt
+
+Date: 2026-09-04  
+Base: `origin/main` at `68e88075` (#462 merged)  
+Branch: `codex/agent-resident-composer-journey-20260904`
+
+## Execution status
+
+The journey was executed against the real development Electron app after a fresh `pnpm run build`.
+It is a real user-input walk: the test fills the visible Resident Composer textarea, sends the intent, receives a tool plan from the loopback model boundary, observes the real pending approval card, clicks the real approval or rejection button, and reads the persisted project through the real project IPC. It does not inject Host items, reducer state, conversation results, or final project content.
+
+Command:
+
+```text
+node tests/ux/resident-composer-production-journey.e2e.mjs
+```
+
+Evidence report:
+
+`.tmp/pi-resident-composer-production-development-1788511580860/report.json`
+
+(The leading space above is not part of the path.) The run launched Electron twice with different PIDs (`35467` then `35509`), used an isolated temp root, made zero paid calls, and had no unexpected model requests.
+
+## Red evidence and blocker
+
+The original strict receipt assertion was red because the approved document write persisted the appended content into `project.json` but did not create `.nomi/project-agent-proposal-receipt.json`. The revised harness keeps this assertion as a fail-closed blocker, records the evidence, continues to the real MCP stdio write and cold restart, and exits non-zero when the blocker remains. The final rerun reproduced the same result with `textRequests: 4`, `unexpected: []`, `paidCalls: 0`, and `result: "failed"`.
+
+The same run also showed that the real `electron <repo>` MCP stdio server accepted `nomi_document_edit` and persisted `MCP_APPEND`, but did not create or advance the same Resident Host receipt/revision journal. This is consistent with the current production dispatcher route in `electron/capabilityCore/dispatcher.ts`, where `document.write` calls `writeProjectDocument` directly.
+
+Blockers recorded by the harness:
+
+1. `resident-host-document-receipt-missing`: Resident Host document approval mutates the project but does not persist the required durable proposal receipt/revision journal.
+2. `mcp-stdio-bypasses-resident-receipt`: real MCP stdio `document.write` mutates the project without minting or advancing that shared Host receipt/revision journal.
+
+These are product capability blockers, not test setup failures. The harness does not manufacture a receipt to make the journey green.
+
+## Matrix
+
+| Area | Evidence in this change | Result |
+| --- | --- | --- |
+| H | Visible intent → real Agent planning request → pending approval → approval → project persistence; receipt assertion remains strict | Blocked by missing durable document receipt |
+| B | Empty Composer input remains disabled; Unicode intent and content pass through the real Agent/project path | Passed for exercised cases; overlong and duplicate cases remain open |
+| E | A second real intent creates a real approval card; user clicks reject; rejected content is absent from the project | Passed for rejection/no-mutation case |
+| T | Existing MCP production contract test covers Agent/MCP timeout as typed `capability_timeout`; no unsupported UI timeout pass is claimed here | Contract-covered, Resident UI continuation open |
+| N | Real MCP stdio production write is exercised; the shared receipt convergence fails. Existing contract test separately covers network and provider failure sanitization | Blocked on receipt convergence; UI network/provider journey remains open |
+
+The real cold restart still passed its narrower persistence/read-back assertion: after closing the first Electron process and launching a second process, the project was opened through the UI and both the Resident-approved append and MCP stdio append were read back from the document.
+
+## Coverage receipt
+
+```json
+{
+  "changedProductionScope": [],
+  "v8": {
+    "statements": "not-applicable",
+    "branches": "not-applicable"
+  },
+  "reason": "This patch changes tests and QA documentation only; it changes no production source."
+}
+```
+
+This is not a whole-repository 100% claim. A V8 100% statements/branches receipt becomes applicable only when production code is changed to close the blockers, and then it must be collected for that exact changed production scope.
+
+## Remaining gap
+
+The next implementation must make document writes from both Resident Host and MCP stdio use one approval/receipt/revision contract, then rerun this same harness and require a committed receipt with an advanced revision. Until that implementation exists, this journey remains intentionally red/blocked.

--- a/tests/ux/resident-composer-production-journey.e2e.mjs
+++ b/tests/ux/resident-composer-production-journey.e2e.mjs
@@ -1,0 +1,132 @@
+#!/usr/bin/env node
+// Real user task: visible Resident Composer -> real Agent/Host proposal -> approval -> durable receipt,
+// then the same isolated GUI project through the real MCP stdio production write boundary.
+// No Host item, reducer state, conversation result, or final project state is injected.
+import fs from 'node:fs'
+import path from 'node:path'
+
+import { clickOrFail, expect, proveProbe } from './_assert.mjs'
+import { parseToolResult, spawnMcpStdioClient } from './_mcpJourney.mjs'
+import { flattenRequestText } from './agent-runtime-fixture.mjs'
+import {
+  DOCUMENT, createRuntimeWalk, readProject, recorded,
+} from './agent-runtime-walk-support.mjs'
+
+const ORIGINAL = '真实用户任务基线：创作者准备在文末补充收尾。'
+const RESIDENT_INTENT = '请在文末补一句收尾，保留原文并等待我确认。'
+const RESIDENT_APPEND = 'RESIDENT_HOST_APPROVED：她按下录制键，开始拍摄。'
+const RESIDENT_TOOL = 'resident-mcp-alias-1'
+const MCP_APPEND = 'MCP_STDIO_PRODUCTION_WRITE：这次写入必须经过同一确认回执。'
+const CREATION_PANEL = '[data-agent-resident="true"]'
+
+async function sendResidentIntent(win, text) {
+  const input = win.getByRole('textbox', { name: '给 Nomi 的消息', exact: true })
+  await expect(input).toBeVisible()
+  await input.fill(text)
+  await clickOrFail(win.getByRole('button', { name: '发送', exact: true }), '发送 Resident Composer 意图')
+}
+
+const walk = await createRuntimeWalk('resident-composer-production')
+let mcp
+let failure
+try {
+  // The current catalog requires explicit publication evidence and refuses legacy plaintext
+  // credentials for Agent execution. Keep the external dependency at the loopback boundary, but
+  // make this isolated test vendor auth-free so no keychain or paid credential is involved.
+  const catalogPath = path.join(walk.report.tempRoot, 'settings', 'model-catalog.json')
+  const catalog = JSON.parse(fs.readFileSync(catalogPath, 'utf8'))
+  catalog.version = 12
+  catalog.vendors[0].authType = 'none'
+  catalog.apiKeysByVendor = {}
+  catalog.models[0].meta = {
+    ...(catalog.models[0].meta || {}),
+    adapter: { activeRevision: 'resident-journey-v1', modes: [{ taskKind: 'chat', state: 'verified' }] },
+  }
+  fs.writeFileSync(catalogPath, `${JSON.stringify(catalog, null, 2)}\n`, { mode: 0o600 })
+  let { win } = await walk.start({ first: true })
+  // Host is an explicit user preference. Set only the preference, reload, then create the project via UI.
+  await win.evaluate(() => localStorage.setItem('nomi.agentHost.enabled', 'true'))
+  await win.reload({ waitUntil: 'domcontentloaded' })
+
+  const project = await walk.newProject()
+  const { projectId, projectRoot } = project
+  const document = win.locator(DOCUMENT)
+  await document.fill(ORIGINAL)
+  await expect(document).toHaveText(ORIGINAL)
+  await expect.poll(async () => JSON.stringify((await readProject(win, projectId)).payload.workbenchDocuments),
+    { message: 'Human-entered baseline must reach the real project persistence path', timeout: 30_000 }).toContain(ORIGINAL)
+  await clickOrFail(win.getByRole('button', { name: '创作', exact: true }), '进入创作工作区')
+
+  const proposalRequest = walk.fixture.expectText({
+    label: 'Resident Composer plans a real document write',
+    match: (body) => flattenRequestText(body).includes(RESIDENT_INTENT) && !body.messages?.some((message) => message.role === 'tool'),
+    reply: { type: 'tool', id: RESIDENT_TOOL, name: 'nomi_document_edit', args: { operation: 'append', content: RESIDENT_APPEND } },
+  })
+  const approvedFollowup = walk.fixture.expectText({
+    label: 'Agent receives the real approved write result',
+    match: (body) => body.messages?.some((message) => message.role === 'tool' && message.tool_call_id === RESIDENT_TOOL),
+    reply: { type: 'text', text: '已按确认写入文稿，并保留可追溯回执。' },
+  })
+  await sendResidentIntent(win, RESIDENT_INTENT)
+  await recorded(proposalRequest.received, 'the real Agent planning request')
+  const approval = win.locator(`${CREATION_PANEL} [data-agent-approval="true"][data-agent-approval-state="pending"]`)
+  const approvalProof = await proveProbe(approval, 'Resident Composer shows a real pending approval')
+  await expect(document, 'A proposal must not mutate the document before user approval').toHaveText(ORIGINAL)
+  await clickOrFail(approval.getByRole('button', { name: '批准', exact: true }), '用户确认 Resident 文稿提案')
+  await recorded(approvedFollowup.received, 'the approved write result')
+  await expect(document).toContainText(RESIDENT_APPEND)
+  await expect.poll(async () => JSON.stringify((await readProject(win, projectId)).payload.workbenchDocuments),
+    { message: 'Approved Resident write must persist to the project', timeout: 30_000 }).toContain(RESIDENT_APPEND)
+  await expect(approval, 'An applied approval must no longer be actionable').toHaveCount(0)
+
+  const receiptPath = path.join(projectRoot, '.nomi', 'project-agent-proposal-receipt.json')
+  await expect.poll(() => fs.existsSync(receiptPath),
+    { message: 'Approved Host write must persist a durable proposal receipt', timeout: 30_000 }).toBe(true)
+  const beforeMcp = JSON.parse(fs.readFileSync(receiptPath, 'utf8'))
+  expect(beforeMcp.lifecycle).toBe('committed')
+  expect(beforeMcp.revision).toBeGreaterThan(0)
+
+  const tempRoot = walk.report.tempRoot
+  mcp = spawnMcpStdioClient({
+    settingsDir: path.join(tempRoot, 'settings'),
+    userDataDir: path.join(tempRoot, 'user-data'),
+    projectsDir: path.join(tempRoot, 'projects'),
+    capabilityDir: path.join(tempRoot, 'capability'),
+    captureStderr: true,
+    env: { NOMI_RPC_TIMEOUT_MS: '2_000' },
+  })
+  await mcp.initialize()
+  const opened = parseToolResult(await mcp.callTool('nomi_session_open', { bootstrap: { mode: 'current_project' } }))
+  const leaseHandle = opened.json?.leaseHandle || opened.outcome?.leaseHandle
+  expect(leaseHandle, 'Real MCP stdio must open the current GUI project session').toBeTruthy()
+  const mcpResult = parseToolResult(await mcp.callTool('nomi_document_edit', {
+    leaseHandle,
+    projectId,
+    operation: 'append',
+    content: MCP_APPEND,
+  }))
+  expect(mcpResult.isError, 'The real production MCP write must return a typed result').toBe(false)
+  await expect.poll(async () => JSON.stringify((await readProject(win, projectId)).payload.workbenchDocuments),
+    { message: 'Real MCP stdio write must be observable in the open project', timeout: 30_000 }).toContain(MCP_APPEND)
+
+  const afterMcp = JSON.parse(fs.readFileSync(receiptPath, 'utf8'))
+  // Deliberately strict: this is the currently missing convergence contract. The existing dispatcher
+  // mutates the document but does not mint the Resident Host approval/revision receipt.
+  expect(afterMcp.revision,
+    'MCP stdio production write must use the same Resident Host receipt/revision contract').toBeGreaterThan(beforeMcp.revision)
+
+  await walk.stopApp()
+  ;({ win } = await walk.start())
+  await clickOrFail(win.locator('[data-project-card="true"]').filter({ hasText: project.name }), '冷重启后打开同一项目')
+  await clickOrFail(win.getByRole('button', { name: '创作', exact: true }), '打开 Resident Composer')
+  await expect(win.locator(DOCUMENT)).toContainText(RESIDENT_APPEND)
+  await expect(win.locator(DOCUMENT)).toContainText(MCP_APPEND)
+  expect(walk.report.launches[1].pid).not.toBe(walk.report.launches[0].pid)
+} catch (error) {
+  failure = error
+} finally {
+  if (mcp) await mcp.terminate().catch(() => {})
+  await walk.finish(failure)
+}
+
+if (failure) process.exitCode = 1

--- a/tests/ux/resident-composer-production-journey.e2e.mjs
+++ b/tests/ux/resident-composer-production-journey.e2e.mjs
@@ -8,15 +8,13 @@ import path from 'node:path'
 import { clickOrFail, expect, proveProbe } from './_assert.mjs'
 import { parseToolResult, spawnMcpStdioClient } from './_mcpJourney.mjs'
 import { flattenRequestText } from './agent-runtime-fixture.mjs'
-import {
-  DOCUMENT, createRuntimeWalk, readProject, recorded,
-} from './agent-runtime-walk-support.mjs'
+import { DOCUMENT, createRuntimeWalk, readProject, recorded } from './agent-runtime-walk-support.mjs'
 
 const ORIGINAL = '真实用户任务基线：创作者准备在文末补充收尾。'
 const RESIDENT_INTENT = '请在文末补一句收尾，保留原文并等待我确认。'
-const RESIDENT_APPEND = 'RESIDENT_HOST_APPROVED：她按下录制键，开始拍摄。'
+const RESIDENT_APPEND = 'ResidentHostApproved她按下录制键，开始拍摄。'
 const RESIDENT_TOOL = 'resident-mcp-alias-1'
-const MCP_APPEND = 'MCP_STDIO_PRODUCTION_WRITE：这次写入必须经过同一确认回执。'
+const MCP_APPEND = 'McpStdioProductionWrite这次写入必须经过同一确认回执。'
 const CREATION_PANEL = '[data-agent-resident="true"]'
 
 async function sendResidentIntent(win, text) {
@@ -29,6 +27,18 @@ async function sendResidentIntent(win, text) {
 const walk = await createRuntimeWalk('resident-composer-production')
 let mcp
 let failure
+const blockers = []
+walk.report.matrix = {
+  H: { status: 'running', evidence: [] },
+  B: { status: 'not-run', evidence: [] },
+  E: { status: 'not-run', evidence: [] },
+  T: { status: 'covered-by-contract', evidence: ['electron/capabilityCore/mcpRealUserJourneys.test.ts'] },
+  N: { status: 'covered-by-contract', evidence: ['electron/capabilityCore/mcpRealUserJourneys.test.ts'] },
+}
+walk.report.blockers = blockers
+function recordBlocker(code, message) {
+  blockers.push({ code, message })
+}
 try {
   // The current catalog requires explicit publication evidence and refuses legacy plaintext
   // credentials for Agent execution. Keep the external dependency at the loopback boundary, but
@@ -53,38 +63,110 @@ try {
   const document = win.locator(DOCUMENT)
   await document.fill(ORIGINAL)
   await expect(document).toHaveText(ORIGINAL)
-  await expect.poll(async () => JSON.stringify((await readProject(win, projectId)).payload.workbenchDocuments),
-    { message: 'Human-entered baseline must reach the real project persistence path', timeout: 30_000 }).toContain(ORIGINAL)
+  await expect
+    .poll(async () => JSON.stringify((await readProject(win, projectId)).payload.workbenchDocuments), {
+      message: 'Human-entered baseline must reach the real project persistence path',
+      timeout: 30_000,
+    })
+    .toContain(ORIGINAL)
   await clickOrFail(win.getByRole('button', { name: '创作', exact: true }), '进入创作工作区')
 
   const proposalRequest = walk.fixture.expectText({
     label: 'Resident Composer plans a real document write',
-    match: (body) => flattenRequestText(body).includes(RESIDENT_INTENT) && !body.messages?.some((message) => message.role === 'tool'),
-    reply: { type: 'tool', id: RESIDENT_TOOL, name: 'nomi_document_edit', args: { operation: 'append', content: RESIDENT_APPEND } },
+    match: (body) =>
+      flattenRequestText(body).includes(RESIDENT_INTENT) && !body.messages?.some((message) => message.role === 'tool'),
+    reply: {
+      type: 'tool',
+      id: RESIDENT_TOOL,
+      name: 'nomi_document_edit',
+      args: { operation: 'append', content: RESIDENT_APPEND },
+    },
   })
   const approvedFollowup = walk.fixture.expectText({
     label: 'Agent receives the real approved write result',
-    match: (body) => body.messages?.some((message) => message.role === 'tool' && message.tool_call_id === RESIDENT_TOOL),
+    match: (body) =>
+      body.messages?.some((message) => message.role === 'tool' && message.tool_call_id === RESIDENT_TOOL),
     reply: { type: 'text', text: '已按确认写入文稿，并保留可追溯回执。' },
   })
   await sendResidentIntent(win, RESIDENT_INTENT)
   await recorded(proposalRequest.received, 'the real Agent planning request')
   const approval = win.locator(`${CREATION_PANEL} [data-agent-approval="true"][data-agent-approval-state="pending"]`)
-  const approvalProof = await proveProbe(approval, 'Resident Composer shows a real pending approval')
+  await proveProbe(approval, 'Resident Composer shows a real pending approval')
+  walk.report.matrix.H.evidence.push('visible intent -> real Agent planning request -> pending approval')
   await expect(document, 'A proposal must not mutate the document before user approval').toHaveText(ORIGINAL)
   await clickOrFail(approval.getByRole('button', { name: '批准', exact: true }), '用户确认 Resident 文稿提案')
   await recorded(approvedFollowup.received, 'the approved write result')
   await expect(document).toContainText(RESIDENT_APPEND)
-  await expect.poll(async () => JSON.stringify((await readProject(win, projectId)).payload.workbenchDocuments),
-    { message: 'Approved Resident write must persist to the project', timeout: 30_000 }).toContain(RESIDENT_APPEND)
-  await expect(approval, 'An applied approval must no longer be actionable').toHaveCount(0)
+  await expect
+    .poll(async () => JSON.stringify((await readProject(win, projectId)).payload.workbenchDocuments), {
+      message: 'Approved Resident write must persist to the project',
+      timeout: 30_000,
+    })
+    .toContain(RESIDENT_APPEND)
+  await expect(
+    approval.getByRole('button', { name: '批准', exact: true }),
+    'An applied approval must no longer be actionable',
+  ).toHaveCount(0)
 
   const receiptPath = path.join(projectRoot, '.nomi', 'project-agent-proposal-receipt.json')
-  await expect.poll(() => fs.existsSync(receiptPath),
-    { message: 'Approved Host write must persist a durable proposal receipt', timeout: 30_000 }).toBe(true)
-  const beforeMcp = JSON.parse(fs.readFileSync(receiptPath, 'utf8'))
-  expect(beforeMcp.lifecycle).toBe('committed')
-  expect(beforeMcp.revision).toBeGreaterThan(0)
+  const beforeMcp = fs.existsSync(receiptPath) ? JSON.parse(fs.readFileSync(receiptPath, 'utf8')) : null
+  if (!beforeMcp) {
+    walk.report.matrix.H.status = 'blocked'
+    walk.report.matrix.H.evidence.push(
+      'project.json persisted the approved append, but .nomi/project-agent-proposal-receipt.json is absent',
+    )
+    recordBlocker(
+      'resident-host-document-receipt-missing',
+      'Resident Host document approval mutates project.json but does not persist the required durable proposal receipt/revision journal',
+    )
+  } else {
+    expect(beforeMcp.lifecycle).toBe('committed')
+    expect(beforeMcp.revision).toBeGreaterThan(0)
+    walk.report.matrix.H.status = 'passed'
+  }
+
+  // Boundary B: the real Composer rejects an empty user task at the UI boundary; Unicode is
+  // already exercised by the human-entered intent and approved document content above.
+  const composerInput = win.getByRole('textbox', { name: '给 Nomi 的消息', exact: true })
+  const composerSend = win.getByRole('button', { name: '发送', exact: true })
+  await composerInput.fill('')
+  await expect(composerSend, 'Empty Resident Composer intent must not be submitted').toBeDisabled()
+  walk.report.matrix.B = {
+    status: 'passed',
+    evidence: ['real Composer empty input remains disabled', 'Unicode intent/content persisted through the real path'],
+  }
+
+  // Boundary E: a second real task is planned by the Agent, displayed as a real approval card,
+  // and denied by the user. The document must remain unchanged.
+  const rejectedAppend = 'RejectedResidentWrite不得写入。'
+  const rejectedRequest = walk.fixture.expectText({
+    label: 'Resident Composer rejection proposal',
+    match: (body) =>
+      flattenRequestText(body).includes('请提出一个需要拒绝的收尾') &&
+      !body.messages?.some((message) => message.role === 'tool'),
+    reply: {
+      type: 'tool',
+      id: 'resident-mcp-rejected-1',
+      name: 'nomi_document_edit',
+      args: { operation: 'append', content: rejectedAppend },
+    },
+  })
+  const rejectedFollowup = walk.fixture.expectText({
+    label: 'Agent receives the real denied write result',
+    match: (body) =>
+      body.messages?.some((message) => message.role === 'tool' && message.tool_call_id === 'resident-mcp-rejected-1'),
+    reply: { type: 'text', text: '已记录拒绝，本次没有写入文稿。' },
+  })
+  await sendResidentIntent(win, '请提出一个需要拒绝的收尾，不要自行写入。')
+  await recorded(rejectedRequest.received, 'the real rejection proposal')
+  const rejectedApproval = win.locator(
+    `${CREATION_PANEL} [data-agent-approval="true"][data-agent-approval-state="pending"]`,
+  )
+  await proveProbe(rejectedApproval, 'Resident Composer shows the rejection approval')
+  await clickOrFail(rejectedApproval.getByRole('button', { name: '拒绝', exact: true }), '用户拒绝 Resident 文稿提案')
+  await recorded(rejectedFollowup.received, 'the denied write result')
+  await expect(document).not.toContainText(rejectedAppend)
+  walk.report.matrix.E = { status: 'passed', evidence: ['real approval card -> user refusal -> no project mutation'] }
 
   const tempRoot = walk.report.tempRoot
   mcp = spawnMcpStdioClient({
@@ -99,21 +181,44 @@ try {
   const opened = parseToolResult(await mcp.callTool('nomi_session_open', { bootstrap: { mode: 'current_project' } }))
   const leaseHandle = opened.json?.leaseHandle || opened.outcome?.leaseHandle
   expect(leaseHandle, 'Real MCP stdio must open the current GUI project session').toBeTruthy()
-  const mcpResult = parseToolResult(await mcp.callTool('nomi_document_edit', {
-    leaseHandle,
-    projectId,
-    operation: 'append',
-    content: MCP_APPEND,
-  }))
+  const mcpResult = parseToolResult(
+    await mcp.callTool('nomi_document_edit', {
+      leaseHandle,
+      projectId,
+      operation: 'append',
+      content: MCP_APPEND,
+    }),
+  )
   expect(mcpResult.isError, 'The real production MCP write must return a typed result').toBe(false)
-  await expect.poll(async () => JSON.stringify((await readProject(win, projectId)).payload.workbenchDocuments),
-    { message: 'Real MCP stdio write must be observable in the open project', timeout: 30_000 }).toContain(MCP_APPEND)
+  await expect
+    .poll(async () => JSON.stringify((await readProject(win, projectId)).payload.workbenchDocuments), {
+      message: 'Real MCP stdio write must be observable in the open project',
+      timeout: 30_000,
+    })
+    .toContain(MCP_APPEND)
 
-  const afterMcp = JSON.parse(fs.readFileSync(receiptPath, 'utf8'))
-  // Deliberately strict: this is the currently missing convergence contract. The existing dispatcher
-  // mutates the document but does not mint the Resident Host approval/revision receipt.
-  expect(afterMcp.revision,
-    'MCP stdio production write must use the same Resident Host receipt/revision contract').toBeGreaterThan(beforeMcp.revision)
+  const afterMcp = fs.existsSync(receiptPath) ? JSON.parse(fs.readFileSync(receiptPath, 'utf8')) : null
+  if (!afterMcp) {
+    walk.report.matrix.N = {
+      status: 'blocked',
+      evidence: ['real MCP stdio write changed project.json while the shared Host receipt file remained absent'],
+    }
+    recordBlocker(
+      'mcp-stdio-bypasses-resident-receipt',
+      'Real MCP stdio document.write reaches the production dispatcher and persists content, but does not mint or advance the Resident Host receipt/revision journal',
+    )
+  } else if (!beforeMcp || afterMcp.revision <= beforeMcp.revision) {
+    walk.report.matrix.N = {
+      status: 'blocked',
+      evidence: ['real MCP stdio write did not advance the shared Host receipt revision'],
+    }
+    recordBlocker(
+      'mcp-stdio-revision-not-advanced',
+      'Real MCP stdio document.write did not advance the shared Resident Host receipt/revision journal',
+    )
+  } else {
+    expect(afterMcp.lifecycle).toBe('committed')
+  }
 
   await walk.stopApp()
   ;({ win } = await walk.start())
@@ -122,10 +227,22 @@ try {
   await expect(win.locator(DOCUMENT)).toContainText(RESIDENT_APPEND)
   await expect(win.locator(DOCUMENT)).toContainText(MCP_APPEND)
   expect(walk.report.launches[1].pid).not.toBe(walk.report.launches[0].pid)
+  walk.report.restart = {
+    status: 'passed',
+    firstPid: walk.report.launches[0].pid,
+    secondPid: walk.report.launches[1].pid,
+    readBack: [RESIDENT_APPEND, MCP_APPEND],
+  }
+  if (blockers.length) failure = new Error(blockers.map(({ code, message }) => `${code}: ${message}`).join('\n'))
 } catch (error) {
   failure = error
 } finally {
   if (mcp) await mcp.terminate().catch(() => {})
+  walk.report.coverage = {
+    changedProductionScope: [],
+    v8: 'not-applicable',
+    reason: 'This change adds test/docs only; no production source was modified.',
+  }
   await walk.finish(failure)
 }
 


### PR DESCRIPTION
Adds a real Electron Resident Composer journey: visible intent to real Agent tool plan to approval or rejection to project persistence and cold restart read-back. Exercises the real electron MCP stdio production write boundary in the same isolated project. The journey is fail-closed and documents two blockers: Resident Host document approval persists project.json but does not create .nomi/project-agent-proposal-receipt.json; real MCP stdio document.write persists project.json without minting or advancing the same Host receipt/revision journal. The journey exits non-zero with result=failed while collecting rejection, persistence, and restart evidence. Base origin/main=68e88075. Verification: targeted Vitest 6 files 24 tests passed; pnpm run build passed; typecheck passed; mjs parse passed; test waits passed; packaging passed; real Electron run recorded paidCalls=0 and unexpected=[] with B/E/restart assertions passing. No production, CSS, UI, or #462 storyboard files changed. V8 not-applicable because changedProductionScope=[]; do not merge.