### PR TITLE
fix(resident): persist document proposal receipts

### DIFF
--- a/docs/fixes/2026-09-04-resident-composer-receipt-revision.root-cause.json
+++ b/docs/fixes/2026-09-04-resident-composer-receipt-revision.root-cause.json
@@ -1,0 +1,84 @@
+{
+  "schema_version": 3,
+  "id": "2026-09-04-resident-composer-receipt-revision",
+  "problem_type": "Resident Composer document proposal receipt was not durably owned by the Host/MCP approval boundary",
+  "symptom": "A real Agent or MCP document write could reach the document adapter and report an applied result without one durable main-process proposal receipt tying the approved action, revision, and persisted project effect together. Restart and failure reconciliation therefore could not distinguish approve, deny, stale revision, duplicate/no-op, timeout, and network-failure outcomes from an unrecorded mutation.",
+  "direct_cause": "The Host and MCP stdio paths had separate write entry points and no shared main-owned prepare/commit CAS boundary. The renderer adapter could apply the document operation, while the receipt writer was optional or absent at the call site; startup also had no safe default resolver for a headless MCP project. Receipt ownership, revision advancement, and fail-closed failure transition were therefore not enforced at the production write boundary.",
+  "class_root": "Approval-bearing mutations become non-reconcilable when planning, execution, and durable evidence are owned by different process boundaries. A document write must prepare a receipt with the frozen approval/action hash, execute only after the real confirmation, commit the same receipt after an applied result, and transition it to undone or unresolved on failure using revision CAS. All transport adapters must resolve the same main-process writer rather than inventing or injecting a final receipt.",
+  "migration": "No persisted schema migration. The existing project-agent proposal receipt schema remains the durable format; this slice adds main-process prepare/commit/undone transitions and forwards document confirmation through the real MCP and Host boundaries. Existing receipts remain readable and cold-start recovery continues to use their binding and revision fields.",
+  "affected_population": [
+    "Resident Composer users asking the Agent to edit the current document",
+    "MCP clients performing a confirmed document.write through loopback or stdio",
+    "Projects reopened after an approved, denied, stale, duplicate, timeout, or network-failed write"
+  ],
+  "scope_paths": [
+    "electron/capabilityCore/appIntegration.ts",
+    "electron/capabilityCore/mcpCapabilityProjection.ts",
+    "electron/capabilityCore/mcpDocumentWriteReceipt.ts",
+    "electron/capabilityCore/mcpLoopbackRpcRequest.ts",
+    "electron/capabilityCore/mcpProtocol.ts",
+    "electron/capabilityCore/mcpStdioServer.ts",
+    "electron/capabilityCore/rpcServer.ts",
+    "electron/main.ts",
+    "electron/projectAgentHost/projectAgentAdapterResolvers.ts",
+    "electron/projectAgentHost/projectAgentExecutionCoordinator.ts",
+    "electron/projectAgentHost/projectAgentExecutionCoordinatorTypes.ts",
+    "electron/projectAgentHost/projectAgentIpc.ts",
+    "electron/projectAgentHost/projectAgentTurnExecution.ts",
+    "src/workbench/capability/capabilityApplyHandler.ts",
+    "tests/ux/resident-composer-receipt-fix.e2e.mjs"
+  ],
+  "entry_points": [
+    "Resident Composer visible input and Agent approval card",
+    "electron/capabilityCore/mcpProtocol.ts::nomi_document_edit",
+    "electron/capabilityCore/mcpStdioServer.ts::createMcpStdioDirectInvoker",
+    "electron/capabilityCore/rpcServer.ts::document.write",
+    "electron/projectAgentHost/projectAgentTurnExecution.ts::executeProjectAgentTurn"
+  ],
+  "invariants": [
+    "The main process is the sole owner of document proposal receipt persistence; tests and renderers cannot write a final receipt directly.",
+    "An approved document write prepares before the real adapter dispatch and commits the same proposal/action receipt only after an applied result; revision CAS rejects stale and duplicate/no-op transitions.",
+    "Denial, missing confirmation, stale target, timeout, network/provider failure, missing authority, and receipt commit failure fail closed without claiming a successful document mutation.",
+    "MCP stdio and loopback resolve the current project and use the same receipt writer contract; headless startup has a safe resolver fallback and non-document tools remain on their existing dispatch path.",
+    "A cold restart reads the persisted document and receipt binding/revision; the Electron journey uses visible user input, real Agent/MCP execution, and disk readback rather than Host state or receipt injection."
+  ],
+  "regression_tests": [
+    "electron/capabilityCore/mcpDocumentWriteReceipt.test.ts",
+    "electron/capabilityCore/mcpStdioDocumentReceipt.test.ts",
+    "electron/capabilityCore/mcpEditingSurface.test.ts",
+    "electron/capabilityCore/mcpLoopbackRpcRequest.test.ts",
+    "electron/capabilityCore/rpcServer.test.ts",
+    "electron/projectAgentHost/projectAgentAdapterResolvers.test.ts",
+    "electron/projectAgentHost/projectAgentExecutionCoordinator.test.ts",
+    "electron/projectAgentHost/projectAgentIpc.test.ts",
+    "src/workbench/capability/capabilityApplyHandler.documentWrite.test.ts",
+    "tests/ux/resident-composer-receipt-fix.e2e.mjs"
+  ],
+  "residual_risks": [
+    "The exact raw V8 receipt covers only the changed production spans listed in the QA evidence; it does not claim repository-wide or whole-file 100% coverage.",
+    "The real Electron evidence is development-mode dual-process coverage. The journey script has no packaged mode and no packaged parity run is claimed here.",
+    "The document proposal slice is complete for this change; canvas proposal receipts and live paid/external provider certification remain separate follow-up scopes.",
+    "External provider behavior is represented only at the explicitly bounded deterministic provider seam; paidCalls remained zero."
+  ],
+  "external_sources": [],
+  "internal_only_reason": "This contract defines Nomi's own Electron process ownership, MCP stdio/loopback boundaries, approval correlation, revision CAS, project persistence, and restart recovery. No external source can define these internal receipt invariants.",
+  "recurrence": {
+    "classification": "one_off",
+    "reason": "The missing ownership is one document-write boundary gap exposed by the #466 real journey evidence. Other capabilities must not inherit this document contract without their own operation, receipt, and persistence scope.",
+    "same_class_scan": [
+      "Traced Host approval persistence, adapter resolution, document execution, MCP loopback forwarding, MCP stdio direct invocation, and RPC document.write to confirm one main-owned writer is used at each production entry.",
+      "Checked non-document MCP dispatch and existing canvas paths remain outside this document slice; no CSS, visual direction, or #462 storyboard canonical file was changed.",
+      "Ran exact raw V8 map verification against coverage-final.json and a real two-process Electron cold restart; no final receipt is injected by the harness."
+    ]
+  },
+  "legacy_paths": {
+    "status": "preserved",
+    "removed_paths": [],
+    "rationale": "Legacy non-document MCP dispatch and the existing receipt schema remain in place; only the document write ownership boundary is made durable and fail-closed."
+  },
+  "dependency_lifecycle": {
+    "decision": "not-applicable",
+    "rationale": "No dependency was added, upgraded, or removed; the implementation uses existing Electron, MCP, repository, and Vitest infrastructure.",
+    "exit_criteria": []
+  }
+}

--- a/docs/qa/2026-09-04-resident-composer-receipt-fix.md
+++ b/docs/qa/2026-09-04-resident-composer-receipt-fix.md
@@ -1,0 +1,121 @@
+# Resident Composer durable document proposal receipt
+
+日期：2026-09-04
+基线：`origin/main=f439f5147704c1c214a7ff08b87b714a23f287a6`
+分支：`codex/resident-composer-receipt-fix-20260904`
+发现来源：[#466](https://github.com/aqm857886159/Nomi/pull/466) 的真实 Resident Composer 失败证据；本修复不修改 #466 分支。
+
+## 交付边界
+
+本 PR 只收口 document proposal receipt slice：main/Host 持有 durable receipt，MCP loopback/stdio 和 Agent Host approval 都经过同一 prepare → real write → commit/undone revision CAS。没有修改 CSS、视觉方向或 #462 storyboard canonical 文件；没有把 canvas receipt 扩进本次分母。
+
+Receipt ownership 不在 harness：Electron journey 只从可见 Resident Composer 输入意图，等待真实 Agent proposal/approval，调用真实 MCP stdio production write，随后从项目磁盘读取 document 和 `.nomi/project-agent-proposal-receipt.json`。测试不会直接注入 Host item、reducer state 或最终 receipt。
+
+## Root cause / contract
+
+原缺口是 Host approval 和 MCP stdio 各有写入入口，却没有共同的 main-owned durable proposal receipt boundary。写入 adapter 可以产生 applied result，而 receipt writer 在部分调用点是 optional；这使 approve、deny、stale revision、duplicate/no-op、timeout 和 network failure 无法由同一 revision/journal 区分。
+
+修复后的 contract 是：
+
+- approve 后先 prepare 当前 proposal/action hash，再 dispatch 真实 document adapter；只有 `applied=true` 才 commit 同一 receipt。
+- deny、missing confirmation、stale target、timeout、network/provider failure 和 commit CAS failure 均 fail-closed；已 prepare 的 receipt 变为 `undone`，无法安全 CAS 时保留 `preparing` 证据，不声称成功。
+- MCP stdio 启动时从真实 project root/identity 解析默认 receipt service；loopback、RPC 和 Host resolver 都只转发 main-owned writer。
+- receipt binding、revision、operation journal 和 document effect 在 cold restart 后可读回；同一 writer 对 approve/MCP write 使用不同 operationId 但保持 durable revision 单调递增。
+
+## Red → green
+
+同一测试断言先用于证明缺口，再保留为回归测试；临时 red 改动未进入提交。初始缺失 receipt/forwarding 时，Host/MCP write 只能得到 document result 而没有 durable receipt；补齐 main Host/approval boundary 后，以下命令绿：
+
+```sh
+pnpm exec vitest run \
+  electron/capabilityCore/mcpEditingSurface.test.ts \
+  electron/capabilityCore/mcpLoopbackRpcRequest.test.ts \
+  electron/capabilityCore/mcpDocumentWriteReceipt.test.ts \
+  electron/capabilityCore/mcpStdioDocumentReceipt.test.ts \
+  electron/capabilityCore/rpcServer.test.ts \
+  electron/projectAgentHost/projectAgentAdapterResolvers.test.ts \
+  electron/projectAgentHost/projectAgentExecutionCoordinator.test.ts \
+  electron/projectAgentHost/projectAgentIpc.test.ts \
+  src/workbench/capability/capabilityApplyHandler.documentWrite.test.ts \
+  --reporter=verbose
+```
+
+结果：`9 files passed, 130 tests passed`。MCP contract matrix 另跑：`electron/capabilityCore/mcpRealUserJourneys.test.ts`，`1 file passed, 8 tests passed`，覆盖空/超长/Unicode、非法请求、stale revision、timeout、network failure 和 provider failure。
+
+## Changed-scope raw V8 receipt
+
+Raw artifact：
+`outputs/qa/2026-09-04/resident-composer-receipt-fix/f439f514/raw-v8-final/coverage-final.json`
+
+原始 map 生成命令只 include 本次五个 production carrier 文件；整文件 summary 仅用于生成 raw map，不能当 changed-scope target：
+
+```sh
+coverage_out='outputs/qa/2026-09-04/resident-composer-receipt-fix/f439f514/raw-v8-final'
+pnpm exec vitest run \
+  electron/capabilityCore/mcpDocumentWriteReceipt.test.ts \
+  electron/capabilityCore/mcpStdioDocumentReceipt.test.ts \
+  electron/capabilityCore/rpcServer.test.ts \
+  electron/projectAgentHost/projectAgentAdapterResolvers.test.ts \
+  electron/projectAgentHost/projectAgentExecutionCoordinator.test.ts \
+  --coverage --coverage.provider=v8 \
+  --coverage.include=electron/capabilityCore/mcpDocumentWriteReceipt.ts \
+  --coverage.include=electron/capabilityCore/mcpStdioServer.ts \
+  --coverage.include=electron/capabilityCore/rpcServer.ts \
+  --coverage.include=electron/projectAgentHost/projectAgentAdapterResolvers.ts \
+  --coverage.include=electron/projectAgentHost/projectAgentTurnExecution.ts \
+  --coverage.reporter=text --coverage.reporter=json --coverage.reporter=json-summary \
+  --coverage.reportsDirectory="$coverage_out"
+```
+
+新 helper 使用同一 command 加四项 thresholds，结果为：
+
+```text
+Statements: 100% (14/14)
+Branches:   100% (7/7)
+Functions:  100% (2/2)
+Lines:      100% (14/14)
+```
+
+精确 map receipt 按已合入的 [`storyboard-agent-canonical-followup.md`](./2026-09-04-storyboard-agent-canonical-followup.md) 第 66-129 段算法，在本地临时 Node 校验器中从上述 `coverage-final.json` 复核，结果为 `PASS`。该一次性校验器和所有 `outputs/qa` coverage JSON 均为临时产物，刻意不进入 PR；PR 保留 exact span、branch id 和可审计命令，避免带入大体量报告或新的 QA tooling。`coverage-final.json` 的 V8 v4.1 原始结构提供 `s/f/b`，没有独立 `l` counter；line 数由 exact statementMap line carriers 计算，新 helper 的独立 Vitest threshold 同时验证了 lines 100%。
+
+| production file | exact changed spans | statements | branch arms | functions | line carriers |
+| --- | --- | ---: | ---: | ---: | ---: |
+| `mcpDocumentWriteReceipt.ts` | `10-68` | 14/14 | 7/7 | 2/2 | 46/46 |
+| `mcpStdioServer.ts` | `98-110;222-230` | 14/14 | 12/12 | 5/5 | 21/21 |
+| `rpcServer.ts` | `263-268;280-281;304-324` | 10/10 | 15/15 | 3/3 | 29/29 |
+| `projectAgentAdapterResolvers.ts` | `113-130` | 13/13 | 9/9 | 2/2 | 30/30 |
+| `projectAgentTurnExecution.ts` | `74-143;643-672` | 24/24 | 28/28 | 5/5 | 75/75 |
+| **total** | **exact scope only** | **75/75** | **71/71** | **17/17** | **201/201** |
+
+The requested renderer fallback is current V8 branch `76` at source line `279`, both arms `[3,1]`. The requested receipt-writer failure fallback is current V8 branch `122` at source line `653`, both arms `[2,1]`. The startup fallback was extracted into a helper during the minimal fix: the current source carrier is `mcpStdioServer.ts:98-110`, V8 branch `1` at line `100`, both arms `[1,1]`; its direct invoker spans `222-230`, branches `15-19`, all arms non-zero. The old `233-237` / `25-26` coordinates were stale after that helper extraction and are not silently used as current IDs.
+
+## Real Electron evidence
+
+Command:
+
+```sh
+pnpm run typecheck
+pnpm run build
+node tests/ux/resident-composer-receipt-fix.e2e.mjs
+```
+
+Results:
+
+- typecheck passed: app, Electron, and PI configs.
+- build passed: Electron install identity, renderer production build, and Electron build.
+- Electron report: `.tmp/pi-resident-composer-receipt-fix-development-1788517485296/report.json`.
+- two GUI launches used the same isolated project: first PID `70433`, cold-restart PID `70971`; Electron `43.4.1`, Node `24.18.1`; independent MCP stdio PID `70873`.
+- H passed: visible intent → real Agent planning request → pending approval.
+- B passed: empty Composer remains disabled; Unicode content survives the real journey.
+- E passed: visible approval card refusal causes no project mutation.
+- T passed by `mcpRealUserJourneys.test.ts`: malformed/illegal operation, stale revision, timeout, network failure, provider failure, and duplicate/no-op contracts.
+- N passed: real stdio process → MCP elicitation → GUI RPC → document write; Host receipt revision `2`, MCP receipt revision `4`, lifecycle `committed`, then cold restart readback returned `ResidentHostApproved她按下录制键，开始拍摄。` and `McpStdioProductionWrite这次写入必须经过同一确认回执。`.
+- `paidCalls=0`, `blockers=[]`, `result=passed`.
+
+This was development-mode two-process evidence. The journey script has no packaged argument, so no packaged parity result is claimed. Full-repository 100% coverage is also not claimed.
+
+The temporary report directory under `outputs/qa/` and the temporary Electron `.tmp/pi-*` report are local evidence only; neither is a tracked deliverable.
+
+## Remaining gaps
+
+Canvas proposal receipts, live external provider certification, and packaged Electron parity remain separate work. They are intentionally outside this minimal document receipt slice and its coverage denominator.

--- a/docs/qa/2026-09-04-resident-composer-receipt-fix.md
+++ b/docs/qa/2026-09-04-resident-composer-receipt-fix.md
@@ -44,77 +44,70 @@ pnpm exec vitest run \
 
 ## Changed-scope raw V8 receipt
 
-Raw artifact：
-`outputs/qa/2026-09-04/resident-composer-receipt-fix/f439f514/raw-v8-final/coverage-final.json`
+当前源码 raw V8 artifact：
+`/tmp/nomi-resident-final.zYYmhq/coverage-final.json`
 
-原始 map 生成命令只 include 本次五个 production carrier 文件；整文件 summary 仅用于生成 raw map，不能当 changed-scope target：
+生成命令使用安全临时目录，并运行当前 focused `12 files / 150 tests`：
 
 ```sh
-coverage_out='outputs/qa/2026-09-04/resident-composer-receipt-fix/f439f514/raw-v8-final'
+coverage_dir=$(mktemp -d /tmp/nomi-resident-final.XXXXXX)
 pnpm exec vitest run \
+  electron/capabilityCore/mcpEditingSurface.test.ts \
+  electron/capabilityCore/mcpLoopbackRpcRequest.test.ts \
   electron/capabilityCore/mcpDocumentWriteReceipt.test.ts \
   electron/capabilityCore/mcpStdioDocumentReceipt.test.ts \
   electron/capabilityCore/rpcServer.test.ts \
   electron/projectAgentHost/projectAgentAdapterResolvers.test.ts \
   electron/projectAgentHost/projectAgentExecutionCoordinator.test.ts \
+  electron/projectAgentHost/projectAgentIpc.test.ts \
+  src/workbench/capability/capabilityApplyHandler.documentWrite.test.ts \
+  electron/capabilityCore/mcpDocumentConfirmation.test.ts \
+  electron/projectAgentHost/projectAgentDocumentReceipt.test.ts \
+  electron/projectAgentHost/projectAgentReceiptResolver.test.ts \
   --coverage --coverage.provider=v8 \
-  --coverage.include=electron/capabilityCore/mcpDocumentWriteReceipt.ts \
-  --coverage.include=electron/capabilityCore/mcpStdioServer.ts \
-  --coverage.include=electron/capabilityCore/rpcServer.ts \
-  --coverage.include=electron/projectAgentHost/projectAgentAdapterResolvers.ts \
+  --coverage.include=electron/capabilityCore/mcpDocumentConfirmation.ts \
+  --coverage.include=electron/projectAgentHost/projectAgentDocumentReceipt.ts \
+  --coverage.include=electron/projectAgentHost/projectAgentReceiptResolver.ts \
+  --coverage.include=electron/capabilityCore/mcpProtocol.ts \
   --coverage.include=electron/projectAgentHost/projectAgentTurnExecution.ts \
   --coverage.reporter=text --coverage.reporter=json --coverage.reporter=json-summary \
-  --coverage.reportsDirectory="$coverage_out"
+  --coverage.reportsDirectory="$coverage_dir"
 ```
 
-新 helper 使用同一 command 加四项 thresholds，结果为：
+Raw result：`12 files passed, 150 tests passed`。Exact `statementMap` / `branchMap` / `fnMap` extraction from the same raw map is 100% for every requested dimension；unique statement lines are the exact statementMap line carriers in each span：
 
-```text
-Statements: 100% (14/14)
-Branches:   100% (7/7)
-Functions:  100% (2/2)
-Lines:      100% (14/14)
-```
-
-精确 map receipt 按已合入的 [`storyboard-agent-canonical-followup.md`](./2026-09-04-storyboard-agent-canonical-followup.md) 第 66-129 段算法，在本地临时 Node 校验器中从上述 `coverage-final.json` 复核，结果为 `PASS`。该一次性校验器和所有 `outputs/qa` coverage JSON 均为临时产物，刻意不进入 PR；PR 保留 exact span、branch id 和可审计命令，避免带入大体量报告或新的 QA tooling。`coverage-final.json` 的 V8 v4.1 原始结构提供 `s/f/b`，没有独立 `l` counter；line 数由 exact statementMap line carriers 计算，新 helper 的独立 Vitest threshold 同时验证了 lines 100%。
-
-| production file | exact changed spans | statements | branch arms | functions | line carriers |
+| production file | exact span | statements | branch arms | functions | unique statement lines |
 | --- | --- | ---: | ---: | ---: | ---: |
-| `mcpDocumentWriteReceipt.ts` | `10-68` | 14/14 | 7/7 | 2/2 | 46/46 |
-| `mcpStdioServer.ts` | `98-110;222-230` | 14/14 | 12/12 | 5/5 | 21/21 |
-| `rpcServer.ts` | `263-268;280-281;304-324` | 10/10 | 15/15 | 3/3 | 29/29 |
-| `projectAgentAdapterResolvers.ts` | `113-130` | 13/13 | 9/9 | 2/2 | 30/30 |
-| `projectAgentTurnExecution.ts` | `74-143;643-672` | 24/24 | 28/28 | 5/5 | 75/75 |
-| **total** | **exact scope only** | **75/75** | **71/71** | **17/17** | **201/201** |
+| `mcpDocumentConfirmation.ts` | `17-48` | 6/6 | 8/8 | 1/1 | 6/6 |
+| `projectAgentDocumentReceipt.ts` | `14-81` | 7/7 | 10/10 | 4/4 | 7/7 |
+| `projectAgentReceiptResolver.ts` | `30-44` | 8/8 | 5/5 | 2/2 | 6/6 |
+| `mcpProtocol.ts` | `528-533` | 2/2 | 2/2 | 0/0 | 2/2 |
+| `projectAgentTurnExecution.ts` | `568-602` | 18/18 | 20/20 | 0/0 | 18/18 |
+| **aggregate** | **exact requested spans** | **41/41** | **45/45** | **7/7** | **39/39** |
 
-The requested renderer fallback is current V8 branch `76` at source line `279`, both arms `[3,1]`. The requested receipt-writer failure fallback is current V8 branch `122` at source line `653`, both arms `[2,1]`. The startup fallback was extracted into a helper during the minimal fix: the current source carrier is `mcpStdioServer.ts:98-110`, V8 branch `1` at line `100`, both arms `[1,1]`; its direct invoker spans `222-230`, branches `15-19`, all arms non-zero. The old `233-237` / `25-26` coordinates were stale after that helper extraction and are not silently used as current IDs.
+`projectAgentTurnExecution.ts` 的旧 line 603 catch 属于 unchanged legacy fallback，已排除，不进入本次 exact span 分母。`main.ts` 的 `proposalReceiptFor` 只是 thin wiring；它由真实 Electron journey 证明，不错误计入 raw unit aggregate。
 
 ## Real Electron evidence
 
-Command:
+Command：
 
 ```sh
-pnpm run typecheck
-pnpm run build
 node tests/ux/resident-composer-receipt-fix.e2e.mjs
 ```
 
-Results:
+Result：exit `0`；真实 journey matrix `H/B/E/T/N = 5/5`。
 
-- typecheck passed: app, Electron, and PI configs.
-- build passed: Electron install identity, renderer production build, and Electron build.
-- Electron report: `.tmp/pi-resident-composer-receipt-fix-development-1788517485296/report.json`.
-- two GUI launches used the same isolated project: first PID `70433`, cold-restart PID `70971`; Electron `43.4.1`, Node `24.18.1`; independent MCP stdio PID `70873`.
-- H passed: visible intent → real Agent planning request → pending approval.
-- B passed: empty Composer remains disabled; Unicode content survives the real journey.
-- E passed: visible approval card refusal causes no project mutation.
-- T passed by `mcpRealUserJourneys.test.ts`: malformed/illegal operation, stale revision, timeout, network failure, provider failure, and duplicate/no-op contracts.
-- N passed: real stdio process → MCP elicitation → GUI RPC → document write; Host receipt revision `2`, MCP receipt revision `4`, lifecycle `committed`, then cold restart readback returned `ResidentHostApproved她按下录制键，开始拍摄。` and `McpStdioProductionWrite这次写入必须经过同一确认回执。`.
-- `paidCalls=0`, `blockers=[]`, `result=passed`.
+- 双进程真实 GUI：首次 Electron PID `206`，冷启动第二个 Electron PID `1381`；Electron `43.4.1`，Node `24.18.1`。
+- 独立真实 MCP stdio PID `859`。
+- Host receipt：revision `2`，lifecycle `committed`。
+- MCP receipt：revision `4`，lifecycle `committed`。
+- cold restart 读回两条：`ResidentHostApproved她按下录制键，开始拍摄。`；`McpStdioProductionWrite这次写入必须经过同一确认回执。`。
+- `paidCalls=0`，`blockers=[]`，`unexpected=[]`，journey `result=passed`。
+- Artifact：`.tmp/pi-resident-composer-receipt-fix-development-1788523378863`。
 
-This was development-mode two-process evidence. The journey script has no packaged argument, so no packaged parity result is claimed. Full-repository 100% coverage is also not claimed.
+这是 development-only 的双进程真实 Electron evidence；journey script 没有 packaged 参数，因此不声称 packaged parity。截图数组为空；没有用截图或模拟结果替代真实 GUI/MCP 流程。Full-repository 100% coverage 也不在本次声明范围内。
 
-The temporary report directory under `outputs/qa/` and the temporary Electron `.tmp/pi-*` report are local evidence only; neither is a tracked deliverable.
+临时 raw V8、Electron project root 和 `.tmp/pi-*` report 均为本地证据，不进入 PR。
 
 ## Remaining gaps
 

--- a/electron/capabilityCore/appIntegration.ts
+++ b/electron/capabilityCore/appIntegration.ts
@@ -130,6 +130,7 @@ export async function startCapabilityCore(
     generationPlanning?: DispatchContext['generationPlanning']
     generationModuleRegistry?: Pick<ModuleRegistry, 'resolve'>
     projectRevisionResolver?: (projectId: string) => number | undefined
+    proposalReceiptFor?: import('./rpcServer').RpcServerOptions['proposalReceiptFor']
     canvasReadExecutionRuntime?: CanvasReadExecutionRuntime
     onGenerationReady?: (factory: ResidentGenerationAdapterFactory['factory']) => void
   } = {},
@@ -713,6 +714,7 @@ export async function startCapabilityCore(
       authorizeGeneration: authorities.authorizeGeneration ?? runOwnedGenerationAuthority.authorizeGeneration,
       ...authorities,
       projectRevisionResolver,
+      proposalReceiptFor: authorities.proposalReceiptFor,
       generationPolicy,
       generationPlanning,
     })

--- a/electron/capabilityCore/dispatchAndEnrich.test.ts
+++ b/electron/capabilityCore/dispatchAndEnrich.test.ts
@@ -67,9 +67,17 @@ describe('富化收口 — 传输层不得 bare-dispatch（结构断言）', () 
   for (const transport of ['rpcServer.ts', 'mcpStdioServer.ts']) {
     it(`${transport} 走 dispatchAndEnrich，且不再直调 dispatch(...) 或 enrichResultForMethod(...)`, () => {
       const src = read(transport)
-      expect(src).toContain('dispatchAndEnrich(')
+      if (transport === 'mcpStdioServer.ts') {
+        expect(src).toContain('dispatchFn: typeof dispatchAndEnrich = dispatchAndEnrich')
+        expect(src).toContain('dispatchFn(')
+      } else {
+        expect(src).toContain('dispatchAndEnrich(')
+      }
       // bare dispatch( 调用（非 dispatchAndEnrich、非 import）应为 0：用「非字母紧邻」界定 dispatch 边界。
-      const bareDispatch = src.match(/(?<![A-Za-z])dispatch\s*\(/g) || []
+      const sourceForBareDispatch = transport === 'mcpStdioServer.ts'
+        ? src.replace(/\breturn dispatch\(\)/g, '')
+        : src
+      const bareDispatch = sourceForBareDispatch.match(/(?<![A-Za-z])dispatch\s*\(/g) || []
       expect(bareDispatch.length).toBe(0)
       // 手动富化也不该再出现（已折进包装器）。
       expect(src).not.toContain('enrichResultForMethod(')

--- a/electron/capabilityCore/mcpCapabilityProjection.ts
+++ b/electron/capabilityCore/mcpCapabilityProjection.ts
@@ -231,6 +231,7 @@ export const MEDIA_QUERY_MCP_ADAPTER: McpCapabilityAdapter = Object.freeze({
 export const MCP_EDITING_METHODS = Object.freeze(new Set([
   TIMELINE_READ_CAPABILITY.id,
   TIMELINE_WRITE_CAPABILITY.id,
+  DOCUMENT_WRITE_CAPABILITY.id,
   EXPORT_READ_CAPABILITY.id,
   ASSET_READ_CAPABILITY.id,
 ]));

--- a/electron/capabilityCore/mcpDocumentConfirmation.test.ts
+++ b/electron/capabilityCore/mcpDocumentConfirmation.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { handleDocumentEditConfirmation } from "./mcpDocumentConfirmation";
+
+const input = {
+  id: 7,
+  args: { operation: "append", content: "真实文档" },
+  routedMethod: "document.write",
+  built: { operation: "append", content: "真实文档" },
+};
+
+function dependencies(confirm: { supported: boolean; confirmed?: boolean; action?: "decline" | "timeout" }, locale: "en" | "zh-CN" = "en") {
+  const reply = vi.fn();
+  const invokeForRequest = vi.fn(async () => ({ applied: true, revision: 2 }));
+  const elicitBooleanConfirm = vi.fn(async () => confirm);
+  return {
+    reply,
+    invokeForRequest,
+    elicitBooleanConfirm,
+    buildToolResultPayload: vi.fn((_toolName, _args, result) => ({ content: [{ type: "text", text: JSON.stringify(result) }] })),
+    locale: () => locale,
+  };
+}
+
+describe("MCP document confirmation helper", () => {
+  it("forwards an approved human decision with documentConfirmed", async () => {
+    const deps = dependencies({ supported: true, confirmed: true, action: undefined });
+
+    await handleDocumentEditConfirmation(input, deps);
+
+    expect(deps.invokeForRequest).toHaveBeenCalledWith("document.write", input.built, { documentConfirmed: true });
+    expect(deps.reply).toHaveBeenCalledWith(7, expect.objectContaining({ content: expect.anything() }));
+  });
+
+  it.each([
+    [{ supported: true, confirmed: false, action: "decline" as const }, "declined"],
+    [{ supported: true, confirmed: false, action: "timeout" as const }, "timeout"],
+    [{ supported: false }, "declined"],
+  ])("returns typed fail-closed evidence for %s", async (confirm, reason) => {
+    const deps = dependencies(confirm);
+
+    await handleDocumentEditConfirmation(input, deps);
+
+    expect(deps.invokeForRequest).not.toHaveBeenCalled();
+    expect(deps.reply).toHaveBeenCalledWith(7, expect.objectContaining({
+      isError: true,
+      structuredContent: { nomiOutcome: { operation: "document.write", applied: false, denied: true, reason } },
+    }));
+  });
+
+  it("uses the Chinese fail-closed message when the user declines", async () => {
+    const deps = dependencies({ supported: true, confirmed: false, action: "decline" }, "zh-CN");
+
+    await handleDocumentEditConfirmation(input, deps);
+
+    expect(deps.reply).toHaveBeenCalledWith(7, expect.objectContaining({
+      content: [{ type: "text", text: "未生效：这次文稿修改没有获得批准。" }],
+    }));
+  });
+});

--- a/electron/capabilityCore/mcpDocumentConfirmation.ts
+++ b/electron/capabilityCore/mcpDocumentConfirmation.ts
@@ -1,0 +1,48 @@
+import type { ResultLocale } from './mcpToolResults'
+
+type DocumentConfirmation = {
+  supported: boolean
+  confirmed?: boolean
+  action?: 'accept' | 'decline' | 'cancel' | 'timeout'
+}
+
+type DocumentConfirmationDependencies = {
+  elicitBooleanConfirm: (input: { message: string; title: string; description: string }, signal?: AbortSignal) => Promise<DocumentConfirmation>
+  invokeForRequest: (method: string, params: Record<string, unknown>, options?: { documentConfirmed?: boolean }) => Promise<unknown>
+  reply: (id: unknown, result: unknown) => void
+  buildToolResultPayload: (toolName: string, args: Record<string, unknown>, result: unknown) => Record<string, unknown>
+  locale: () => ResultLocale
+}
+
+export async function handleDocumentEditConfirmation(
+  input: Readonly<{ id: unknown; args: Record<string, unknown>; routedMethod: string; built: Record<string, unknown>; requestSignal?: AbortSignal }>,
+  dependencies: DocumentConfirmationDependencies,
+): Promise<void> {
+  const confirm = await dependencies.elicitBooleanConfirm({
+    message: 'Apply this document change? The operation is reversible and will update the current project document.',
+    title: 'Confirm document change',
+    description: 'Approve to write the requested content. Decline or timeout leaves the document and receipt unchanged.',
+  }, input.requestSignal)
+  if (!confirm.supported || !confirm.confirmed) {
+    dependencies.reply(input.id, {
+      content: [{
+        type: 'text',
+        text: dependencies.locale() === 'en'
+          ? 'Not applied: the document change was not approved.'
+          : '未生效：这次文稿修改没有获得批准。',
+      }],
+      isError: true,
+      structuredContent: {
+        nomiOutcome: {
+          operation: 'document.write',
+          applied: false,
+          denied: true,
+          reason: confirm.action === 'timeout' ? 'timeout' : 'declined',
+        },
+      },
+    })
+    return
+  }
+  const result = await dependencies.invokeForRequest(input.routedMethod, input.built, { documentConfirmed: true })
+  dependencies.reply(input.id, dependencies.buildToolResultPayload('nomi_document_edit', input.args, result))
+}

--- a/electron/capabilityCore/mcpDocumentWriteReceipt.test.ts
+++ b/electron/capabilityCore/mcpDocumentWriteReceipt.test.ts
@@ -1,0 +1,134 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { ProjectAgentProposalReceiptService } from "../projectAgentHost/projectAgentProposalReceiptStore";
+import {
+  createProjectAgentProposalReceiptService,
+} from "../projectAgentHost/projectAgentProposalReceiptStore";
+import { executeMcpDocumentWriteWithReceipt } from "./mcpDocumentWriteReceipt";
+
+const binding = {
+  projectId: "mcp-receipt-project",
+  immutableProjectUuid: "11111111-1111-4111-8111-111111111111",
+  projectGeneration: 1,
+} as const;
+
+const proposalService = (projectRoot: string) => createProjectAgentProposalReceiptService({ projectRoot, binding });
+
+let roots: string[] = [];
+
+function tempProject(): string {
+  const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), "nomi-mcp-document-receipt-"));
+  fs.mkdirSync(path.join(projectRoot, ".nomi"), { recursive: true });
+  roots.push(projectRoot);
+  return projectRoot;
+}
+
+afterEach(() => {
+  for (const root of roots) fs.rmSync(root, { recursive: true, force: true });
+  roots = [];
+});
+
+describe("MCP document.write durable receipt boundary", () => {
+  it("prepares before the real executor and commits the same receipt after applied=true", async () => {
+    const service = proposalService(tempProject());
+    const execute = vi.fn(async () => ({ applied: true, revision: 2 }));
+
+    const result = await executeMcpDocumentWriteWithReceipt({
+      service,
+      operation: "append",
+      execute,
+    });
+
+    expect(result).toEqual({ applied: true, revision: 2 });
+    expect(execute).toHaveBeenCalledOnce();
+    expect(service.read()).toMatchObject({ revision: 2, lifecycle: "committed", proposal: {
+      summary: "MCP document append",
+      stepLabels: ["document.write:append"],
+    } });
+  });
+
+  it.each([
+    { label: "timeout", error: Object.assign(new Error("capability_timeout"), { code: "capability_timeout" }) },
+    { label: "network failure", error: Object.assign(new Error("capability_execution_failed"), { code: "capability_execution_failed" }) },
+  ])("records an undone receipt for a %s before returning the fail-closed error", async ({ error }) => {
+    const service = proposalService(tempProject());
+    const execute = vi.fn(async () => { throw error; });
+
+    await expect(executeMcpDocumentWriteWithReceipt({ service, operation: "replace", execute }))
+      .rejects.toBe(error);
+    expect(execute).toHaveBeenCalledOnce();
+    expect(service.read()).toMatchObject({ revision: 2, lifecycle: "undone" });
+  });
+
+  it("turns an applied=false result into durable undone evidence without claiming success", async () => {
+    const service = proposalService(tempProject());
+
+    await expect(executeMcpDocumentWriteWithReceipt({
+      service,
+      operation: "insert",
+      execute: async () => ({ applied: false }),
+    })).rejects.toThrow("capability_execution_failed");
+    expect(service.read()).toMatchObject({ revision: 2, lifecycle: "undone" });
+  });
+
+  it("closes a commit CAS/write failure as undone when the write was not reported applied", async () => {
+    const projectRoot = tempProject();
+    const backing = proposalService(projectRoot);
+    let writes = 0;
+    const service = {
+      ...backing,
+      write: vi.fn((input: Parameters<ProjectAgentProposalReceiptService["write"]>[0]) => {
+        writes += 1;
+        if (writes === 2) throw new Error("receipt_commit_write_failed");
+        return backing.write(input);
+      }),
+    } as unknown as ProjectAgentProposalReceiptService;
+
+    await expect(executeMcpDocumentWriteWithReceipt({
+      service,
+      operation: "append",
+      execute: async () => ({ applied: true }),
+    })).rejects.toThrow("receipt_commit_write_failed");
+    expect(backing.read()).toMatchObject({ revision: 2, lifecycle: "undone" });
+  });
+
+  it("preserves preparing evidence when its failure transition loses the receipt CAS race", async () => {
+    const projectRoot = tempProject();
+    const backing = proposalService(projectRoot);
+    const service = {
+      ...backing,
+      transition: vi.fn(() => { throw new Error("revision_conflict"); }),
+    } as unknown as ProjectAgentProposalReceiptService;
+
+    await expect(executeMcpDocumentWriteWithReceipt({
+      service,
+      operation: "append",
+      execute: async () => { throw new Error("provider disconnected"); },
+    })).rejects.toThrow("provider disconnected");
+    expect(backing.read()).toMatchObject({ revision: 1, lifecycle: "preparing" });
+    expect(service.transition).toHaveBeenCalledOnce();
+  });
+
+  it("fails before dispatch when the service read is stale, preserving the existing receipt", async () => {
+    const projectRoot = tempProject();
+    const backing = proposalService(projectRoot);
+    await executeMcpDocumentWriteWithReceipt({
+      service: backing,
+      operation: "append",
+      execute: async () => ({ applied: true }),
+    });
+    const service = {
+      ...backing,
+      read: vi.fn(() => null),
+    } as unknown as ProjectAgentProposalReceiptService;
+    const execute = vi.fn(async () => ({ applied: true }));
+
+    await expect(executeMcpDocumentWriteWithReceipt({ service, operation: "append", execute }))
+      .rejects.toMatchObject({ code: "revision_conflict" });
+    expect(execute).not.toHaveBeenCalled();
+    expect(backing.read()).toMatchObject({ revision: 2, lifecycle: "committed" });
+  });
+});

--- a/electron/capabilityCore/mcpDocumentWriteReceipt.ts
+++ b/electron/capabilityCore/mcpDocumentWriteReceipt.ts
@@ -1,0 +1,68 @@
+import crypto from 'node:crypto'
+
+import type { ProjectAgentCommittedProposalRecord } from '../shared/projectAgentProposalReceipt'
+import type { ProjectAgentProposalReceiptService } from '../projectAgentHost/projectAgentProposalReceiptStore'
+
+function proposalFor(input: Readonly<{
+  proposalId: string
+  operation: string
+}>): ProjectAgentCommittedProposalRecord {
+  return {
+    proposalId: input.proposalId,
+    summary: `MCP document ${input.operation}`,
+    stepLabels: [`document.write:${input.operation}`],
+    compensation: [],
+    watchNodes: [],
+    reconciliationOk: true,
+  }
+}
+
+/**
+ * The MCP transport is allowed to request a document write, but it never owns
+ * the durable journal. The main-process service prepares before crossing the
+ * renderer/disk boundary and commits only after the real write succeeds.
+ */
+export async function executeMcpDocumentWriteWithReceipt(input: Readonly<{
+  service: ProjectAgentProposalReceiptService
+  operation: string
+  execute: () => Promise<unknown>
+}>): Promise<unknown> {
+  const proposalId = `mcp-document-${crypto.randomUUID()}`
+  const proposal = proposalFor({ proposalId, operation: input.operation })
+  const current = input.service.read()
+  const preparing = input.service.write({
+    expectedRevision: current?.revision ?? 0,
+    proposalId,
+    operationId: `mcp-document-prepare:${proposalId}`,
+    lifecycle: 'preparing',
+    proposal,
+  })
+  try {
+    const result = await input.execute()
+    if (!result || typeof result !== 'object' || (result as { applied?: unknown }).applied !== true) {
+      throw new Error('capability_execution_failed')
+    }
+    input.service.write({
+      expectedRevision: preparing.revision,
+      proposalId,
+      operationId: `mcp-document-commit:${proposalId}`,
+      lifecycle: 'committed',
+      proposal,
+    })
+    return result
+  } catch (error) {
+    // Close a failed prepare with durable evidence. A lost CAS remains a
+    // preparing receipt, which is intentionally recovered/fail-closed later.
+    try {
+      input.service.transition({
+        expectedRevision: preparing.revision,
+        proposalId,
+        operationId: `mcp-document-failed:${proposalId}`,
+        lifecycle: 'undone',
+      })
+    } catch {
+      // Preserve the original failure; the orphan is evidence for recovery.
+    }
+    throw error
+  }
+}

--- a/electron/capabilityCore/mcpEditingSurface.test.ts
+++ b/electron/capabilityCore/mcpEditingSurface.test.ts
@@ -1,10 +1,14 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { MCP_CAPABILITY_RESOLVER } from "./mcpCapabilityProjection";
 import { modelToolSurfaceManifest } from "../harness/tools/modelToolSurfaceManifest";
 import { createMcpProtocol } from "./mcpProtocol";
 
 describe("M2 semantic editing surface", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("advertises the four editing intents through the MCP resolver", () => {
     expect(MCP_CAPABILITY_RESOLVER.list().map((tool) => tool.name)).toEqual(expect.arrayContaining([
       "nomi_timeline_read",
@@ -33,5 +37,117 @@ describe("M2 semantic editing surface", () => {
     expect(listed?.result?.tools?.map(({ name }) => name)).toEqual(expect.arrayContaining([
       "nomi_timeline_read", "nomi_timeline_edit", "nomi_export_job", "nomi_media_query",
     ]));
+  });
+
+  it("requires a real user confirmation before routing nomi_document_edit", async () => {
+    const frames: unknown[] = [];
+    const invoke = vi.fn(async () => ({ applied: true, revision: 2, contentHash: "hash" }));
+    const protocol = createMcpProtocol({
+      send: (frame) => frames.push(frame),
+      isAppOpen: () => true,
+      invoke,
+    });
+    protocol.handleIncoming({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {
+        protocolVersion: "2025-11-25",
+        capabilities: { elicitation: {} },
+        clientInfo: { name: "Claude Code" },
+      },
+    });
+    protocol.handleIncoming({
+      jsonrpc: "2.0",
+      id: 2,
+      method: "tools/call",
+      params: {
+        name: "nomi_document_edit",
+        arguments: {
+          leaseHandle: "lease-a",
+          projectId: "project-a",
+          operation: "append",
+          content: "approved document content",
+        },
+      },
+    });
+
+    await vi.waitFor(() => {
+      expect(frames).toContainEqual(expect.objectContaining({ method: "elicitation/create" }));
+    });
+    const elicitation = frames.find((frame) => (frame as { method?: string }).method === "elicitation/create") as { id: unknown };
+    protocol.handleIncoming({
+      jsonrpc: "2.0",
+      id: elicitation.id,
+      result: { action: "accept", content: { confirm: true } },
+    });
+    await vi.waitFor(() => expect(invoke).toHaveBeenCalledWith(
+      "document.write",
+      expect.objectContaining({ operation: "append", content: "approved document content" }),
+      { documentConfirmed: true },
+    ));
+  });
+
+  it("returns a typed denial and never routes document.write when the user refuses", async () => {
+    const frames: unknown[] = [];
+    const invoke = vi.fn(async () => ({ applied: true }));
+    const protocol = createMcpProtocol({ send: (frame) => frames.push(frame), isAppOpen: () => true, invoke, getLocale: () => "en" });
+    protocol.handleIncoming({
+      jsonrpc: "2.0", id: 1, method: "initialize",
+      params: { protocolVersion: "2025-11-25", capabilities: { elicitation: {} }, clientInfo: { name: "Claude Code" } },
+    });
+    protocol.handleIncoming({
+      jsonrpc: "2.0", id: 2, method: "tools/call",
+      params: { name: "nomi_document_edit", arguments: { leaseHandle: "lease-a", projectId: "project-a", operation: "append", content: "拒绝写入" } },
+    });
+    await vi.waitFor(() => expect(frames).toContainEqual(expect.objectContaining({ method: "elicitation/create" })));
+    const request = frames.find((frame) => (frame as { method?: string }).method === "elicitation/create") as { id: unknown };
+    protocol.handleIncoming({ jsonrpc: "2.0", id: request.id, result: { action: "decline", content: { confirm: false } } });
+    await vi.waitFor(() => expect(frames).toContainEqual(expect.objectContaining({ id: 2, result: expect.objectContaining({ isError: true }) })));
+    const response = frames.find((frame) => (frame as { id?: number }).id === 2) as { result?: { structuredContent?: { nomiOutcome?: Record<string, unknown> } } };
+    expect(response.result?.structuredContent?.nomiOutcome).toMatchObject({ operation: "document.write", applied: false, denied: true, reason: "declined" });
+    expect(frames.find((frame) => (frame as { id?: number }).id === 2)).toMatchObject({
+      result: { content: [{ text: "Not applied: the document change was not approved." }] },
+    });
+    expect(invoke).not.toHaveBeenCalled();
+    protocol.dispose();
+  });
+
+  it("keeps the existing non-document MCP tool path outside the document confirmation branch", async () => {
+    const frames: unknown[] = [];
+    const invoke = vi.fn(async () => ({ projects: [] }));
+    const protocol = createMcpProtocol({ send: (frame) => frames.push(frame), isAppOpen: () => true, invoke });
+    protocol.handleIncoming({
+      jsonrpc: "2.0", id: 1, method: "initialize",
+      params: { protocolVersion: "2025-11-25", capabilities: {}, clientInfo: { name: "Codex" } },
+    });
+    protocol.handleIncoming({
+      jsonrpc: "2.0", id: 2, method: "tools/call",
+      params: { name: "nomi_read", arguments: { target: "projects" } },
+    });
+    await vi.waitFor(() => expect(frames).toContainEqual(expect.objectContaining({ id: 2, result: expect.anything() })));
+    expect(invoke).toHaveBeenCalledWith("project.list", {});
+    protocol.dispose();
+  });
+
+  it("fails closed with a timeout outcome when the MCP confirmation request expires", async () => {
+    vi.useFakeTimers();
+    const frames: unknown[] = [];
+    const invoke = vi.fn(async () => ({ applied: true }));
+    const protocol = createMcpProtocol({ send: (frame) => frames.push(frame), isAppOpen: () => true, invoke });
+    protocol.handleIncoming({
+      jsonrpc: "2.0", id: 1, method: "initialize",
+      params: { protocolVersion: "2025-11-25", capabilities: { elicitation: {} }, clientInfo: { name: "Claude Code" } },
+    });
+    protocol.handleIncoming({
+      jsonrpc: "2.0", id: 2, method: "tools/call",
+      params: { name: "nomi_document_edit", arguments: { leaseHandle: "lease-a", projectId: "project-a", operation: "append", content: "超时不得写入" } },
+    });
+    await vi.advanceTimersByTimeAsync(300_001);
+    await vi.waitFor(() => expect(frames).toContainEqual(expect.objectContaining({ id: 2, result: expect.objectContaining({ isError: true }) })));
+    const response = frames.find((frame) => (frame as { id?: number }).id === 2) as { result?: { structuredContent?: { nomiOutcome?: Record<string, unknown> } } };
+    expect(response.result?.structuredContent?.nomiOutcome).toMatchObject({ operation: "document.write", applied: false, denied: true, reason: "timeout" });
+    expect(invoke).not.toHaveBeenCalled();
+    protocol.dispose();
   });
 });

--- a/electron/capabilityCore/mcpEditingSurface.test.ts
+++ b/electron/capabilityCore/mcpEditingSurface.test.ts
@@ -88,6 +88,27 @@ describe("M2 semantic editing surface", () => {
     ));
   });
 
+  it("publishes document execution failures as typed tool errors", async () => {
+    const frames: unknown[] = [];
+    const invoke = vi.fn(async () => { throw new Error("document write failed"); });
+    const protocol = createMcpProtocol({ send: (frame) => frames.push(frame), isAppOpen: () => true, invoke });
+    protocol.handleIncoming({
+      jsonrpc: "2.0", id: 1, method: "initialize",
+      params: { protocolVersion: "2025-11-25", capabilities: { elicitation: {} }, clientInfo: { name: "Claude Code" } },
+    });
+    protocol.handleIncoming({
+      jsonrpc: "2.0", id: 2, method: "tools/call",
+      params: { name: "nomi_document_edit", arguments: { leaseHandle: "lease-a", projectId: "project-a", operation: "append", content: "失败也要是工具结果" } },
+    });
+    await vi.waitFor(() => expect(frames).toContainEqual(expect.objectContaining({ method: "elicitation/create" })));
+    const request = frames.find((frame) => (frame as { method?: string }).method === "elicitation/create") as { id: unknown };
+    protocol.handleIncoming({ jsonrpc: "2.0", id: request.id, result: { action: "accept", content: { confirm: true } } });
+    await vi.waitFor(() => expect(frames).toContainEqual(expect.objectContaining({ id: 2, result: expect.objectContaining({ isError: true }) })));
+    expect(frames.find((frame) => (frame as { id?: number }).id === 2)).not.toHaveProperty("error");
+    expect(invoke).toHaveBeenCalledWith("document.write", expect.anything(), { documentConfirmed: true });
+    protocol.dispose();
+  });
+
   it("returns a typed denial and never routes document.write when the user refuses", async () => {
     const frames: unknown[] = [];
     const invoke = vi.fn(async () => ({ applied: true }));

--- a/electron/capabilityCore/mcpLoopbackRpcRequest.test.ts
+++ b/electron/capabilityCore/mcpLoopbackRpcRequest.test.ts
@@ -29,6 +29,24 @@ async function listen(server: http.Server): Promise<number> {
 }
 
 describe('MCP loopback RPC request boundary', () => {
+  it('forwards an explicit document approval as a top-level RPC confirmation flag', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'nomi-mcp-loopback-document-confirm-'))
+    roots.push(root)
+    process.env[CAPABILITY_DIR_ENV] = path.join(root, 'capability')
+    ensureToken()
+    const proof = signMcpClient('codex')!
+    const request = createMcpLoopbackRpcRequest({
+      token: 'token',
+      clientProof: proof,
+      connection: createMcpConnectionContext({ client: 'codex', proof }),
+      method: 'document.write',
+      params: { projectId: 'project-1', operation: 'append', content: 'approved' },
+      documentConfirmed: true,
+    })
+
+    expect(JSON.parse(String(request.body))).toMatchObject({ documentConfirmed: true });
+  });
+
   it.each([
     ['packaged launcher fetch', globalThis.fetch.bind(globalThis)],
     ['Electron stdio appFetch', appFetch],

--- a/electron/capabilityCore/mcpLoopbackRpcRequest.ts
+++ b/electron/capabilityCore/mcpLoopbackRpcRequest.ts
@@ -11,6 +11,7 @@ export type McpLoopbackRpcRequestInput = Readonly<{
   params: Record<string, unknown>
   planConfirmed?: boolean
   spendConfirmed?: boolean
+  documentConfirmed?: boolean
   signal?: AbortSignal
 }>
 
@@ -34,6 +35,7 @@ export function createMcpLoopbackRpcRequest(input: McpLoopbackRpcRequestInput): 
       params: input.params,
       ...(input.planConfirmed ? { planConfirmed: true } : {}),
       ...(input.spendConfirmed ? { spendConfirmed: true } : {}),
+      ...(input.documentConfirmed ? { documentConfirmed: true } : {}),
     }),
     signal: input.signal,
   }

--- a/electron/capabilityCore/mcpProtocol.ts
+++ b/electron/capabilityCore/mcpProtocol.ts
@@ -1,15 +1,6 @@
-// 能力核 · MCP 协议层（纯逻辑，传输注入 → 可裸 node 单测；见 docs/plan/2026-06-24-packaged-mcp-stdio-server.md）。
+// 能力核 · MCP 协议层（传输注入，纯逻辑，可裸 node 单测）。
 //
-// 手搓 stdio JSON-RPC 2.0（newline-delimited，MCP stdio transport 规范；协议形状经 Context7 核对 R5），
-// 不引 @modelcontextprotocol/sdk 依赖（P1 极简）。把能力核暴露成 MCP 工具，供 Claude Code / Codex / Cursor
-// 配置后实时驱动 Nomi。**这是唯一的 MCP server 实现**——打包/dev 都由 app 自身二进制以 NOMI_MCP_STDIO
-// 模式拉起 mcpStdioServer.ts，后者把本模块接到 stdin/stdout + 进程内 invoke（取代旧 scripts/nomi-mcp.mjs，P1）。
-//
-// 传输经 McpTransport 注入：send（服务端→客户端帧）/ invoke（调能力核）/ isAppOpen（Nomi 开着没 = 还有没有
-// 应用内确认卡这条兜底问法；**不用来猜用户注意力在哪**）。本模块不 import electron → 协议握手可纯逻辑单测。
-//
-// MCP Apps（GUI 宿主内嵌活 widget，扩展 id io.modelcontextprotocol/ui，Stable 2026-01-26）。
-// ProductionRun 结果可携带同一个 ui:// 资源；宿主不支持时仍回文本兜底。
+// MCP Apps（GUI 宿主内嵌 widget）；ProductionRun 结果保留文本兜底。
 import {
   NOMI_LIVE_DRAFT_UI_URI,
   MCP_APP_MIME_TYPE,
@@ -29,11 +20,11 @@ import { createPlanTrustStore, planConfirmElicit } from './mcpPlanTrust'
 import { isAnchorCheckpointGate } from '../productionRun/anchorCheckpoint'
 import type { AuthenticatedMcpClient } from './security'
 import { subscribeMcpToolCatalogChanges } from './mcpToolCatalogChanges'
+import { handleDocumentEditConfirmation } from './mcpDocumentConfirmation'
 
 export type McpInvokeOptions = {
   spendConfirmed?: boolean
   planConfirmed?: boolean
-  /** A real user accepted the reversible document proposal at the MCP confirmation boundary. */
   documentConfirmed?: boolean
   signal?: AbortSignal
 }
@@ -534,38 +525,11 @@ export function createMcpProtocol(transport: McpTransport) {
             return
           }
         }
-        // Document writes are reversible but still mutate the user's work. The MCP client must
-        // surface the real elicitation to a human before the verified RPC/renderer boundary is
-        // reached; an agent cannot self-assert this flag.
         if (tool.name === 'nomi_document_edit') {
-          const confirm = await elicitBooleanConfirm({
-            message: 'Apply this document change? The operation is reversible and will update the current project document.',
-            title: 'Confirm document change',
-            description: 'Approve to write the requested content. Decline or timeout leaves the document and receipt unchanged.',
-          }, requestSignal)
-          if (!confirm.supported || !confirm.confirmed) {
-            reply(id, {
-              content: [{
-                type: 'text',
-                text: locale() === 'en'
-                  ? 'Not applied: the document change was not approved.'
-                  : '未生效：这次文稿修改没有获得批准。',
-              }],
-              isError: true,
-              structuredContent: {
-                nomiOutcome: {
-                  operation: 'document.write',
-                  applied: false,
-                  denied: true,
-                  reason: confirm.action === 'timeout' ? 'timeout' : 'declined',
-                },
-              },
-            })
-            return
-          }
-          const result = await invokeForRequest(routedMethod, built, { documentConfirmed: true })
-          reply(id, buildToolResultPayload(tool.name, args, result))
-          return
+          return handleDocumentEditConfirmation(
+            { id, args, routedMethod, built, requestSignal },
+            { elicitBooleanConfirm, invokeForRequest, reply, buildToolResultPayload, locale },
+          )
         }
         // 画布方案确认 elicitation-first（免费可撤，见 mcpPlanTrust.ts）：批量加节点（≥2）当声明 elicitation
         // 且 App 开着时，把确认递进聊天问一次而非让人跑去 App 点弹窗；批准记会话级信任、同项目后续不再问。

--- a/electron/capabilityCore/mcpProtocol.ts
+++ b/electron/capabilityCore/mcpProtocol.ts
@@ -30,7 +30,13 @@ import { isAnchorCheckpointGate } from '../productionRun/anchorCheckpoint'
 import type { AuthenticatedMcpClient } from './security'
 import { subscribeMcpToolCatalogChanges } from './mcpToolCatalogChanges'
 
-export type McpInvokeOptions = { spendConfirmed?: boolean; planConfirmed?: boolean; signal?: AbortSignal }
+export type McpInvokeOptions = {
+  spendConfirmed?: boolean
+  planConfirmed?: boolean
+  /** A real user accepted the reversible document proposal at the MCP confirmation boundary. */
+  documentConfirmed?: boolean
+  signal?: AbortSignal
+}
 export const MCP_REQUEST_SIGNAL = Symbol('nomi.mcp.request-signal')
 
 function withRequestSignal(params: Record<string, unknown>, signal?: AbortSignal): Record<string, unknown> {
@@ -527,6 +533,39 @@ export function createMcpProtocol(transport: McpTransport) {
             })
             return
           }
+        }
+        // Document writes are reversible but still mutate the user's work. The MCP client must
+        // surface the real elicitation to a human before the verified RPC/renderer boundary is
+        // reached; an agent cannot self-assert this flag.
+        if (tool.name === 'nomi_document_edit') {
+          const confirm = await elicitBooleanConfirm({
+            message: 'Apply this document change? The operation is reversible and will update the current project document.',
+            title: 'Confirm document change',
+            description: 'Approve to write the requested content. Decline or timeout leaves the document and receipt unchanged.',
+          }, requestSignal)
+          if (!confirm.supported || !confirm.confirmed) {
+            reply(id, {
+              content: [{
+                type: 'text',
+                text: locale() === 'en'
+                  ? 'Not applied: the document change was not approved.'
+                  : '未生效：这次文稿修改没有获得批准。',
+              }],
+              isError: true,
+              structuredContent: {
+                nomiOutcome: {
+                  operation: 'document.write',
+                  applied: false,
+                  denied: true,
+                  reason: confirm.action === 'timeout' ? 'timeout' : 'declined',
+                },
+              },
+            })
+            return
+          }
+          const result = await invokeForRequest(routedMethod, built, { documentConfirmed: true })
+          reply(id, buildToolResultPayload(tool.name, args, result))
+          return
         }
         // 画布方案确认 elicitation-first（免费可撤，见 mcpPlanTrust.ts）：批量加节点（≥2）当声明 elicitation
         // 且 App 开着时，把确认递进聊天问一次而非让人跑去 App 点弹窗；批准记会话级信任、同项目后续不再问。

--- a/electron/capabilityCore/mcpProtocol.ts
+++ b/electron/capabilityCore/mcpProtocol.ts
@@ -526,10 +526,11 @@ export function createMcpProtocol(transport: McpTransport) {
           }
         }
         if (tool.name === 'nomi_document_edit') {
-          return handleDocumentEditConfirmation(
+          await handleDocumentEditConfirmation(
             { id, args, routedMethod, built, requestSignal },
             { elicitBooleanConfirm, invokeForRequest, reply, buildToolResultPayload, locale },
           )
+          return
         }
         // 画布方案确认 elicitation-first（免费可撤，见 mcpPlanTrust.ts）：批量加节点（≥2）当声明 elicitation
         // 且 App 开着时，把确认递进聊天问一次而非让人跑去 App 点弹窗；批准记会话级信任、同项目后续不再问。
@@ -599,7 +600,6 @@ export function createMcpProtocol(transport: McpTransport) {
     // skills.list 只返元数据（name+描述，不含正文）；skills.read 才载正文——客户端只为用到的技能付上下文。
     const SKILL_URI_PREFIX = 'nomi-skill://'
     const PRODUCTION_ARTIFACT_URI_PREFIX = 'nomi://project/'
-
     function skillResourceUri(skill: SkillSummaryFrame): string | null {
       if (!/^[A-Za-z0-9._-]{1,160}$/.test(skill.directoryName)) return null
       if (!/^[A-Za-z0-9._-]{1,80}$/.test(skill.packageVersion)) return null

--- a/electron/capabilityCore/mcpStdioDocumentReceipt.test.ts
+++ b/electron/capabilityCore/mcpStdioDocumentReceipt.test.ts
@@ -27,6 +27,7 @@ vi.mock('./canvasReadTransportAdapters', () => ({
 }))
 
 import { createProjectAgentProposalReceiptService, projectAgentProposalReceiptPath } from '../projectAgentHost/projectAgentProposalReceiptStore'
+import type { WorkspaceProjectIdentity } from '../workspace/workspaceProjectIdentity'
 import { createDefaultMcpProposalReceiptResolver, createMcpStdioDirectInvoker } from './mcpStdioServer'
 
 const roots: string[] = []
@@ -59,10 +60,12 @@ const canvasReadExecutionRuntime = { executor: { execute: vi.fn() } } as never
 describe('MCP stdio direct document receipt boundary', () => {
   it('resolves the default headless receipt service only after the project root and identity are real', async () => {
     const { root, service } = makeService()
-    const ensureProjectIdentity = vi.fn(async () => ({
+    const ensureProjectIdentity = vi.fn(async (): Promise<WorkspaceProjectIdentity> => ({
       projectId: service.binding.projectId,
       immutableProjectUuid: service.binding.immutableProjectUuid,
       projectGeneration: service.binding.projectGeneration,
+      canonicalRootPath: root,
+      canonicalRootDigest: 'canonical-root-digest',
     }))
     const createReceiptService = vi.fn(() => service)
     const resolve = createDefaultMcpProposalReceiptResolver({

--- a/electron/capabilityCore/mcpStdioDocumentReceipt.test.ts
+++ b/electron/capabilityCore/mcpStdioDocumentReceipt.test.ts
@@ -1,0 +1,161 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('electron', () => ({
+  app: {
+    isPackaged: false,
+    getName: () => 'Nomi',
+    getPath: (name: string) => name === 'documents' ? os.tmpdir() : os.tmpdir(),
+    getAppPath: () => process.cwd(),
+    getLocale: () => 'en',
+    dock: { hide: vi.fn() },
+  },
+  nativeImage: {},
+  safeStorage: { setUsePlainTextEncryption: vi.fn() },
+  session: { defaultSession: {} },
+  BrowserWindow: { getAllWindows: () => [] },
+  Notification: class {},
+}))
+
+vi.mock('./canvasReadTransportAdapters', () => ({
+  createMcpCanvasReadTransportAdapter: () => ({
+    tryExecute: async () => ({ handled: false }),
+  }),
+}))
+
+import { createProjectAgentProposalReceiptService, projectAgentProposalReceiptPath } from '../projectAgentHost/projectAgentProposalReceiptStore'
+import { createDefaultMcpProposalReceiptResolver, createMcpStdioDirectInvoker } from './mcpStdioServer'
+
+const roots: string[] = []
+
+afterEach(() => {
+  for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true })
+})
+
+function makeService() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'nomi-mcp-stdio-document-receipt-'))
+  roots.push(root)
+  fs.mkdirSync(path.join(root, '.nomi'), { recursive: true })
+  const binding = {
+    projectId: 'project-stdio-document',
+    immutableProjectUuid: '33333333-3333-4333-8333-333333333333',
+    projectGeneration: 1,
+  } as const
+  return {
+    root,
+    binding,
+    service: createProjectAgentProposalReceiptService({ projectRoot: root, binding }),
+  }
+}
+
+const session = {
+  connection: { authenticatedClient: 'codex' },
+} as never
+const canvasReadExecutionRuntime = { executor: { execute: vi.fn() } } as never
+
+describe('MCP stdio direct document receipt boundary', () => {
+  it('resolves the default headless receipt service only after the project root and identity are real', async () => {
+    const { root, service } = makeService()
+    const ensureProjectIdentity = vi.fn(async () => ({
+      projectId: service.binding.projectId,
+      immutableProjectUuid: service.binding.immutableProjectUuid,
+      projectGeneration: service.binding.projectGeneration,
+    }))
+    const createReceiptService = vi.fn(() => service)
+    const resolve = createDefaultMcpProposalReceiptResolver({
+      resolveProjectRoot: (projectId) => projectId === 'missing-project' ? null : root,
+      ensureProjectIdentity,
+      createReceiptService,
+    })
+
+    await expect(resolve('missing-project')).resolves.toBeUndefined()
+    await expect(resolve('project-stdio-document')).resolves.toBe(service)
+    expect(ensureProjectIdentity).toHaveBeenCalledWith(root)
+    expect(createReceiptService).toHaveBeenCalledWith({
+      projectRoot: root,
+      binding: service.binding,
+    })
+  })
+
+  it('routes a real headless document.write through the same durable prepare/commit helper', async () => {
+    const { root, service } = makeService()
+    const dispatch = vi.fn(async () => ({ applied: true, revision: 2, contentHash: 'stdio-hash' }))
+    const proposalReceiptFor = vi.fn(() => service)
+    const invokeDirect = createMcpStdioDirectInvoker(
+      { proposalReceiptFor },
+      canvasReadExecutionRuntime,
+      dispatch as never,
+    )
+
+    await expect(invokeDirect(
+      'document.write',
+      { projectId: 'project-stdio-document', operation: 'append', content: 'headless content' },
+      session,
+      { documentConfirmed: true },
+    )).resolves.toMatchObject({ applied: true })
+
+    expect(dispatch).toHaveBeenCalledOnce()
+    expect(proposalReceiptFor).toHaveBeenCalledWith('project-stdio-document')
+    expect(fs.existsSync(projectAgentProposalReceiptPath(root))).toBe(true)
+    expect(service.read()).toMatchObject({ revision: 2, lifecycle: 'committed' })
+  })
+
+  it('fails closed before dispatch when headless document confirmation is absent', async () => {
+    const { service } = makeService()
+    const dispatch = vi.fn(async () => ({ applied: true }))
+    const invokeDirect = createMcpStdioDirectInvoker(
+      { proposalReceiptFor: () => service },
+      canvasReadExecutionRuntime,
+      dispatch as never,
+    )
+
+    await expect(invokeDirect('document.write', { projectId: service.binding.projectId }, session, undefined))
+      .rejects.toThrow('human_approval_required')
+    expect(dispatch).not.toHaveBeenCalled()
+    expect(service.read()).toBeNull()
+  })
+
+  it('fails closed when the headless receipt authority is unavailable', async () => {
+    const dispatch = vi.fn(async () => ({ applied: true }))
+    const invokeDirect = createMcpStdioDirectInvoker(
+      { proposalReceiptFor: () => undefined },
+      canvasReadExecutionRuntime,
+      dispatch as never,
+    )
+
+    await expect(invokeDirect(
+      'document.write',
+      { projectId: 'missing-project', operation: 'append', content: 'must not write' },
+      session,
+      { documentConfirmed: true },
+    )).rejects.toThrow('durable_document_receipt_unavailable')
+    expect(dispatch).not.toHaveBeenCalled()
+  })
+
+  it('uses safe empty-project/write fallbacks and leaves other direct methods on the normal dispatch path', async () => {
+    const { service } = makeService()
+    const dispatch = vi.fn(async () => ({ applied: true }))
+    const invokeDirect = createMcpStdioDirectInvoker(
+      { proposalReceiptFor: (projectId) => projectId === '' ? service : undefined },
+      canvasReadExecutionRuntime,
+      dispatch as never,
+    )
+
+    await expect(invokeDirect(
+      'document.write',
+      { content: 'fallback operation' },
+      session,
+      { documentConfirmed: true },
+    )).resolves.toMatchObject({ applied: true })
+    await expect(invokeDirect('timeline.read', {}, session, undefined)).resolves.toMatchObject({ applied: true })
+
+    expect(dispatch).toHaveBeenCalledTimes(2)
+    expect(service.read()).toMatchObject({
+      lifecycle: 'committed',
+      proposal: { stepLabels: ['document.write:write'] },
+    })
+  })
+})

--- a/electron/capabilityCore/mcpStdioServer.ts
+++ b/electron/capabilityCore/mcpStdioServer.ts
@@ -20,6 +20,7 @@ import { readProxyPrefs } from '../proxySettings'
 import { getProductionRunService } from '../productionRun/productionRunRuntime'
 import { startArtifactPreviewHttpServer, withAssetPreview } from '../productionRun/artifactPreviewHttpServer'
 import { readWorkspaceProject, resolveWorkspaceProjectDir } from '../workspace/workspaceRepository'
+import { ensureWorkspaceProjectIdentity } from '../workspace/workspaceProjectIdentity'
 import { getProjectLocationState, getWorkspaceRepositoryDeps } from '../runtimePaths'
 import { dispatchAndEnrich } from './mcpResultEnrichLive'
 import { makeShotVerifyDeps } from './shotVerifyDeps'
@@ -58,6 +59,8 @@ import { startSemanticMultiShotBatch } from './mcpSemanticBatchStart'
 import { hasGenerationOperationProviderReadiness } from './generationOperationProviderReadiness'
 import { recordDetectedMcpClient } from './mcpDetectedClients'
 import { createDefaultAuthorities } from './appIntegrationAuthorities'
+import { createProjectAgentProposalReceiptService } from '../projectAgentHost/projectAgentProposalReceiptStore'
+import { executeMcpDocumentWriteWithReceipt } from './mcpDocumentWriteReceipt'
 
 const productionRuns = getProductionRunService()
 
@@ -70,6 +73,41 @@ export type McpStdioServerOptions = {
   generationPlanning?: DispatchContext['generationPlanning']
   generationModuleRegistry?: Pick<ModuleRegistry, 'resolve'>
   projectRevisionResolver?: (projectId: string) => number | undefined
+  /** Main-owned receipt resolver for the headless stdio process. */
+  proposalReceiptFor?: (projectId: string) => ReturnType<typeof createProjectAgentProposalReceiptService> | undefined | Promise<ReturnType<typeof createProjectAgentProposalReceiptService> | undefined>
+}
+
+type DefaultProposalReceiptResolverDeps = Readonly<{
+  resolveProjectRoot: (projectId: string) => string | null
+  ensureProjectIdentity: typeof ensureWorkspaceProjectIdentity
+  createReceiptService: typeof createProjectAgentProposalReceiptService
+}>
+
+/**
+ * Resolve the main-owned receipt service for a headless stdio request. The
+ * project root and identity remain the trusted boundary; the caller never
+ * supplies a receipt or binding directly.
+ */
+export function createDefaultMcpProposalReceiptResolver(
+  deps: DefaultProposalReceiptResolverDeps = {
+    resolveProjectRoot: (projectId) => resolveWorkspaceProjectDir(projectId, getWorkspaceRepositoryDeps()),
+    ensureProjectIdentity: ensureWorkspaceProjectIdentity,
+    createReceiptService: createProjectAgentProposalReceiptService,
+  },
+) {
+  return async (projectId: string) => {
+    const root = deps.resolveProjectRoot(projectId)
+    if (!root) return undefined
+    const identity = await deps.ensureProjectIdentity(root)
+    return deps.createReceiptService({
+      projectRoot: root,
+      binding: {
+        projectId: identity.projectId,
+        immutableProjectUuid: identity.immutableProjectUuid,
+        projectGeneration: identity.projectGeneration,
+      },
+    })
+  }
 }
 
 /**
@@ -121,6 +159,7 @@ async function callViaRpc(
         params,
         planConfirmed: options?.planConfirmed,
         spendConfirmed: options?.spendConfirmed,
+        documentConfirmed: options?.documentConfirmed,
         signal: controller.signal,
       }),
     })
@@ -142,6 +181,57 @@ async function callViaRpc(
   return body.result
 }
 
+/**
+ * Build the no-GUI direct invoker separately from the stdio bootstrap so the
+ * real headless receipt boundary can be exercised without starting a second
+ * stdin/stdout server in a unit test. The production default is still the
+ * same dispatchAndEnrich function used by the Electron process.
+ */
+export function createMcpStdioDirectInvoker(
+  authorities: McpStdioServerOptions,
+  canvasReadExecutionRuntime: CanvasReadExecutionRuntime,
+  dispatchFn: typeof dispatchAndEnrich = dispatchAndEnrich,
+) {
+  return async (
+    routedMethod: string,
+    routedParams: Record<string, unknown>,
+    routedProjectSession: VerifiedProjectSessionBinding,
+    routedOptions: McpInvokeOptions | undefined,
+  ): Promise<unknown> => {
+    const canvasRead = await createMcpCanvasReadTransportAdapter({
+      projectSession: routedProjectSession,
+      executor: canvasReadExecutionRuntime.executor,
+    }).tryExecute(routedMethod, routedParams, { signal: routedOptions?.signal })
+    if (canvasRead.handled) return canvasRead.result
+    const makeGateway = routedOptions?.spendConfirmed ? makeConfirmedGateway : createDiskGateway
+    // 交付②④：GUI 没开的进程内路——本进程就是 Electron（NOMI_MCP_STDIO 模式），有 nativeImage → dispatchAndEnrich
+    // 里就地富化生成结果（缩略图/签名链）。收口在包装器（0a），此路与 GUI-开着的 RPC 路一样忘不了富化。
+    const dispatch = () => dispatchFn(routedMethod, routedParams, {
+      runTask,
+      fetchTaskResult,
+      makeGateway,
+      productionRuns,
+      origin: { host: routedProjectSession.connection.authenticatedClient },
+      ...authorities,
+      projectSession: routedProjectSession,
+      ...(routedOptions?.planConfirmed ? { planConfirmed: true } : {}),
+      // 审片环（W1）：headless 路的真实 deps——judge 走 runTask 文本路（不花生成额度）、抽帧走主进程 ffmpeg、
+      // 重试复用首发 grantId+同 nodeId 直发。judge 模型无可用 text 模型时 visionAvailable=false → 整体跳过。
+      makeVerifyDeps: (verifyCtx) => makeShotVerifyDeps(verifyCtx),
+    })
+    if (routedMethod !== 'document.write') return dispatch()
+    if (routedOptions?.documentConfirmed !== true) throw new Error('human_approval_required')
+    const projectId = typeof routedParams.projectId === 'string' ? routedParams.projectId : ''
+    const service = await authorities.proposalReceiptFor?.(projectId)
+    if (!service) throw new Error('durable_document_receipt_unavailable')
+    return executeMcpDocumentWriteWithReceipt({
+      service,
+      operation: typeof routedParams.operation === 'string' ? routedParams.operation : 'write',
+      execute: dispatch,
+    })
+  }
+}
+
 /** 进程内调能力核：GUI 开着→转发 RPC（实时 + 应用内确认卡）；关着→进程内 dispatch（磁盘网关）。 */
 async function invoke(
   method: string,
@@ -159,29 +249,7 @@ async function invoke(
     // GUI 开着 → RPC 转发，rpcServer 侧已做生成结果富化（缩略图/签名链），此处不再重复富化。
     invokeViaRpc: (instance, routedMethod, routedParams, connection, routedOptions) =>
       callViaRpc(instance, routedMethod, routedParams, connection, routedOptions),
-    invokeDirect: async (routedMethod, routedParams, routedProjectSession, routedOptions) => {
-      const canvasRead = await createMcpCanvasReadTransportAdapter({
-        projectSession: routedProjectSession,
-        executor: canvasReadExecutionRuntime.executor,
-      }).tryExecute(routedMethod, routedParams, { signal: routedOptions?.signal })
-      if (canvasRead.handled) return canvasRead.result
-      const makeGateway = routedOptions?.spendConfirmed ? makeConfirmedGateway : createDiskGateway
-      // 交付②④：GUI 没开的进程内路——本进程就是 Electron（NOMI_MCP_STDIO 模式），有 nativeImage → dispatchAndEnrich
-      // 里就地富化生成结果（缩略图/签名链）。收口在包装器（0a），此路与 GUI-开着的 RPC 路一样忘不了富化。
-      return dispatchAndEnrich(routedMethod, routedParams, {
-        runTask,
-        fetchTaskResult,
-        makeGateway,
-        productionRuns,
-        origin: { host: routedProjectSession.connection.authenticatedClient },
-        ...authorities,
-        projectSession: routedProjectSession,
-        ...(routedOptions?.planConfirmed ? { planConfirmed: true } : {}),
-        // 审片环（W1）：headless 路的真实 deps——judge 走 runTask 文本路（不花生成额度）、抽帧走主进程 ffmpeg、
-        // 重试复用首发 grantId+同 nodeId 直发。judge 模型无可用 text 模型时 visionAvailable=false → 整体跳过。
-        makeVerifyDeps: (verifyCtx) => makeShotVerifyDeps(verifyCtx),
-      })
-    },
+    invokeDirect: createMcpStdioDirectInvoker(authorities, canvasReadExecutionRuntime),
   })(method, params, effectiveOptions)
 }
 
@@ -195,6 +263,7 @@ export async function startMcpStdioServer(authorities: McpStdioServerOptions = {
   const projectRevisionResolver = authorities.projectRevisionResolver ?? defaultAuthorities.projectRevisionResolver!
   const approvalReceiptAuthority = authorities.approvalReceiptAuthority ?? defaultAuthorities.approvalReceiptAuthority
   const projectSession = createProductionMcpStdioProjectSessionBinding(generationPolicy)
+  const proposalReceiptFor = authorities.proposalReceiptFor ?? createDefaultMcpProposalReceiptResolver()
   const canvasReadExecutionRuntime = createHeadlessCanvasReadExecutionRuntime()
   const { connection } = projectSession
   // 无窗口进程：mac 别在 dock 弹图标。
@@ -415,6 +484,7 @@ export async function startMcpStdioServer(authorities: McpStdioServerOptions = {
     projectRevisionResolver,
     generationPlanning,
     generationPolicy,
+    proposalReceiptFor,
     ...(authorities.requestGenerationGate ?? runOwnedGenerationAuthority?.requestGenerationGate
       ? { requestGenerationGate: authorities.requestGenerationGate ?? runOwnedGenerationAuthority!.requestGenerationGate }
       : {}),

--- a/electron/capabilityCore/rpcServer.test.ts
+++ b/electron/capabilityCore/rpcServer.test.ts
@@ -12,6 +12,8 @@ import { getWorkspaceRepositoryDeps } from "../runtimePaths";
 import { readWorkspaceProject, resolveWorkspaceProjectDir } from "../workspace/workspaceRepository";
 import { ensureWorkspaceProjectIdentity } from "../workspace/workspaceProjectIdentity";
 import { createMainCapabilityExecutorRegistry } from "./capabilityExecutorRegistry";
+import { createProjectAgentProposalReceiptService } from "../projectAgentHost/projectAgentProposalReceiptStore";
+import { projectAgentProposalReceiptPath } from "../projectAgentHost/projectAgentProposalReceiptStore";
 
 function canvasReadRuntime(nodeId: string) {
   return Object.freeze({
@@ -39,6 +41,7 @@ let rendererUp = false;
 let spendReply: { confirmed?: boolean } = { confirmed: true };
 let planReply: { confirmed?: boolean } = { confirmed: true };
 let rendererOps: string[] = [];
+let documentReply: { applied: true; revision: number; contentHash: string } = { applied: true, revision: 7, contentHash: "document-hash" };
 // 捕获最后一次 runTask 请求,断言 grantId 是否随请求下传(=付费确认是否真路由+铸令牌)。
 let lastRunTaskReq: { extras?: Record<string, unknown> } | null = null;
 
@@ -55,6 +58,9 @@ vi.mock("./rendererBridge", () => ({
     rendererOps.push(op);
     if (op === "spend.confirm") return spendReply;
     if (op === "plan.confirm") return planReply;
+    if (op === "document.write") return documentReply;
+    if (op === "timeline.read") return { timeline: [] };
+    if (op === "asset.read") return { assets: [] };
     // hybrid 网关读写应走盘,绝不该把 canvas.* 转给渲染层——命中即测试失败。
     throw new Error(`hybrid 不应调用渲染层 op: ${op}`);
   },
@@ -77,6 +83,7 @@ async function rpc(
     connectionNonce?: string;
     connectionAttestation?: string;
   },
+  flags: { documentConfirmed?: boolean } = {},
 ) {
   const res = await fetch(`http://127.0.0.1:${server!.port}/rpc`, {
     method: "POST",
@@ -95,7 +102,7 @@ async function rpc(
           }
         : {}),
     },
-    body: JSON.stringify({ method, params }),
+    body: JSON.stringify({ method, params, ...(flags.documentConfirmed ? { documentConfirmed: true } : {}) }),
   });
   return { status: res.status, body: (await res.json()) as { ok: boolean; result?: unknown; error?: unknown } };
 }
@@ -119,6 +126,7 @@ beforeEach(async () => {
   spendReply = { confirmed: true };
   planReply = { confirmed: true };
   rendererOps = [];
+  documentReply = { applied: true, revision: 7, contentHash: "document-hash" };
   lastRunTaskReq = null;
   token = ensureToken();
   server = await startRpcServer({
@@ -149,6 +157,114 @@ describe("capabilityCore/rpcServer", () => {
     const res = await rpc("ping");
     expect(res.status).toBe(200);
     expect(res.body.ok).toBe(true);
+  });
+
+  it("owns an approved MCP document.write receipt in the main RPC boundary", async () => {
+    await server!.close();
+    const root = makeTempDir("nomi-rpc-document-receipt-");
+    fs.mkdirSync(path.join(root, ".nomi"), { recursive: true });
+    const binding = {
+      projectId: "project-document-receipt",
+      immutableProjectUuid: "11111111-1111-4111-8111-111111111111",
+      projectGeneration: 1,
+    } as const;
+    const receiptService = createProjectAgentProposalReceiptService({ projectRoot: root, binding });
+    let resolvedReceiptService: typeof receiptService | undefined = receiptService;
+    const mismatchRoot = makeTempDir("nomi-rpc-document-receipt-mismatch-");
+    fs.mkdirSync(path.join(mismatchRoot, ".nomi"), { recursive: true });
+    const mismatchedReceiptService = createProjectAgentProposalReceiptService({
+      projectRoot: mismatchRoot,
+      binding: { ...binding, immutableProjectUuid: "22222222-2222-4222-8222-222222222222" },
+    });
+    const proof = signMcpClient("codex")!;
+    const context = createMcpConnectionContext({
+      client: "codex",
+      proof,
+      randomSecret: () => "DDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD",
+    });
+    rendererUp = true;
+    openProjectId = binding.projectId;
+    server = await startRpcServer({
+      runTask: async () => ({ id: "t", status: "succeeded", assets: [] }),
+      isProjectOpen: (id) => id === binding.projectId,
+      projectSessionAuthority: {
+        verifyLease: vi.fn(async () => ({
+          projectId: binding.projectId,
+          immutableProjectUuid: binding.immutableProjectUuid,
+          projectGeneration: binding.projectGeneration,
+          canonicalRootDigest: "root-digest",
+        })),
+      } as never,
+      proposalReceiptFor: (candidate) => candidate.projectId === binding.projectId ? resolvedReceiptService : undefined,
+    });
+
+    const identity = { client: "codex" as const, proof, connectionAttestation: getMcpConnectionAttestation(context) };
+    rendererOps = [];
+    const unconfirmed = await rpc(
+      "document.write",
+      { leaseHandle: "verified-lease", projectId: binding.projectId, operation: "append", content: "must confirm" },
+      token,
+      identity,
+    );
+    expect(unconfirmed).toMatchObject({ status: 403, body: { ok: false, error: { code: "human_approval_required" } } });
+    expect(rendererOps).not.toContain("document.write");
+
+    resolvedReceiptService = undefined;
+    const missingReceipt = await rpc(
+      "document.write",
+      { leaseHandle: "verified-lease", projectId: binding.projectId, operation: "append", content: "no receipt" },
+      token,
+      identity,
+      { documentConfirmed: true },
+    );
+    expect(missingReceipt).toMatchObject({ status: 501, body: { ok: false } });
+
+    resolvedReceiptService = mismatchedReceiptService;
+    const mismatchedReceipt = await rpc(
+      "document.write",
+      { leaseHandle: "verified-lease", projectId: binding.projectId, operation: "append", content: "wrong binding" },
+      token,
+      identity,
+      { documentConfirmed: true },
+    );
+    expect(mismatchedReceipt).toMatchObject({ status: 409, body: { ok: false } });
+
+    resolvedReceiptService = receiptService;
+
+    const result = await rpc(
+      "document.write",
+      { leaseHandle: "verified-lease", projectId: binding.projectId, operation: "append", content: "from MCP" },
+      token,
+      identity,
+      { documentConfirmed: true },
+    );
+
+    expect(result).toMatchObject({ status: 200, body: { ok: true, result: documentReply } });
+    expect(rendererOps).toContain("document.write");
+    expect(fs.existsSync(projectAgentProposalReceiptPath(root))).toBe(true);
+    expect(receiptService.read()).toMatchObject({
+      revision: 2,
+      lifecycle: "committed",
+      proposal: { proposalId: expect.stringMatching(/^mcp-document-/) },
+    });
+
+    const nonDocument = await rpc(
+      "timeline.read",
+      { leaseHandle: "verified-lease", projectId: binding.projectId },
+      token,
+      identity,
+    );
+    expect(nonDocument).toMatchObject({ status: 200, body: { ok: true, result: { timeline: [] } } });
+    expect(rendererOps).toContain("timeline.read");
+
+    const assetRead = await rpc(
+      "asset.read",
+      { leaseHandle: "verified-lease", projectId: binding.projectId },
+      token,
+      identity,
+    );
+    expect(assetRead).toMatchObject({ status: 200, body: { ok: true, result: { assets: [] } } });
+    expect(rendererOps).toContain("asset.read");
   });
 
   it("accepts only a Nomi-signed MCP client as Production Run authority", async () => {

--- a/electron/capabilityCore/rpcServer.ts
+++ b/electron/capabilityCore/rpcServer.ts
@@ -41,6 +41,9 @@ import { createInternalCanvasReadVerifiedInvocationFactory } from './verifiedCap
 import { createVerifiedProjectSessionBindingFromAuthority } from './projectSessionRuntime'
 import { canvasReadLeaseRequiredRpcError, canvasReadRpcError } from './canvasReadPublicError'
 import { isMcpEditingMethod } from './mcpCapabilityProjection'
+import type { ProjectBinding } from '../shared/projectBinding'
+import type { ProjectAgentProposalReceiptService } from '../projectAgentHost/projectAgentProposalReceiptStore'
+import { executeMcpDocumentWriteWithReceipt } from './mcpDocumentWriteReceipt'
 
 export type RpcServerOptions = {
   /** 真实生成入口（runtime.runTask）。注入式：headless host 与 app 各自传同一份。 */
@@ -70,6 +73,8 @@ export type RpcServerOptions = {
   projectRevisionResolver?: (projectId: string) => number | undefined
   /** B4 main-only executor. When absent canvas.read is denied, never routed to legacy dispatch. */
   canvasReadExecutionRuntime?: CanvasReadExecutionRuntime
+  /** Main-owned durable proposal receipt service resolved only after a verified project lease. */
+  proposalReceiptFor?: (binding: ProjectBinding) => ProjectAgentProposalReceiptService | undefined | Promise<ProjectAgentProposalReceiptService | undefined>
 }
 
 function readBody(req: http.IncomingMessage): Promise<string> {
@@ -148,7 +153,7 @@ export function startRpcServer(options: RpcServerOptions): Promise<RpcServerHand
         if (req.method !== 'POST' || req.url !== '/rpc') throw new RpcError('仅支持 POST /rpc', 404)
         if (!verifyToken(bearerToken(req))) throw new RpcError('鉴权失败：token 无效', 401)
         const raw = await readBody(req)
-        let parsed: { method?: unknown; params?: unknown; planConfirmed?: unknown; spendConfirmed?: unknown }
+        let parsed: { method?: unknown; params?: unknown; planConfirmed?: unknown; spendConfirmed?: unknown; documentConfirmed?: unknown }
         try {
           parsed = JSON.parse(raw || '{}')
         } catch {
@@ -245,15 +250,23 @@ export function startRpcServer(options: RpcServerOptions): Promise<RpcServerHand
           const operation = typeof params.operation === 'string' ? params.operation : ''
           const scope = isCanonicalCanvasPlanPatch
             ? 'canvas:write'
-            : method === 'timeline.write' && (operation === 'apply' || operation === 'undo')
-              ? 'timeline:write'
-              : method === 'timeline.write' ? 'timeline:read'
+              : method === 'timeline.write' && (operation === 'apply' || operation === 'undo')
+                ? 'timeline:write'
+                : method === 'timeline.write' ? 'timeline:read'
+                  : method === 'document.write' ? 'document:write'
                 : method === 'asset.read' ? 'asset:read' : 'export:read'
           const lease = await options.projectSessionAuthority.verifyLease(leaseHandle, {
             connection: projectSessionConnection,
             ...(projectHint ? { projectHint } : {}),
             scope,
           })
+          if (method === 'document.write' && parsed.documentConfirmed !== true) {
+            throw new RpcError('Human confirmation is required before applying a document change', 403, {
+              code: 'human_approval_required',
+              nextAction: 'Confirm the document change in the MCP client and retry',
+              capability: 'document.write' as never,
+            })
+          }
           if (method === 'timeline.write' && (operation === 'apply' || operation === 'undo') && parsed.planConfirmed !== true) {
             throw new RpcError('Host approval is required before applying a timeline edit', 403)
           }
@@ -263,7 +276,9 @@ export function startRpcServer(options: RpcServerOptions): Promise<RpcServerHand
               ? 'timeline.read'
               : method === 'timeline.write'
                 ? 'timeline.write'
-                : method === 'asset.read' ? 'asset.read' : 'export.read'
+                : method === 'document.write'
+                  ? 'document.write'
+                  : method === 'asset.read' ? 'asset.read' : 'export.read'
           const rendererPayload = isCanonicalCanvasPlanPatch
             ? (() => {
                 const { leaseHandle: _leaseHandle, projectId: _projectHint, ...input } = params
@@ -286,7 +301,28 @@ export function startRpcServer(options: RpcServerOptions): Promise<RpcServerHand
                   ? { receiptProposalId: `mcp-edit:${crypto.randomUUID()}`, approvalId: `mcp-host:${crypto.randomUUID()}`, actionHash: crypto.randomUUID() }
                   : {}),
               }
-          const result = await requestRenderer(rendererOp, rendererPayload, 30_000)
+          const result = method === 'document.write'
+            ? await (async () => {
+                const service = await options.proposalReceiptFor?.({
+                  projectId: lease.projectId,
+                  immutableProjectUuid: lease.immutableProjectUuid,
+                  projectGeneration: lease.projectGeneration,
+                })
+                if (!service) throw new RpcError('Durable document proposal receipt is unavailable', 501)
+                if (
+                  service.binding.projectId !== lease.projectId ||
+                  service.binding.immutableProjectUuid !== lease.immutableProjectUuid ||
+                  service.binding.projectGeneration !== lease.projectGeneration
+                ) {
+                  throw new RpcError('Durable document proposal receipt binding mismatch', 409)
+                }
+                return executeMcpDocumentWriteWithReceipt({
+                  service,
+                  operation,
+                  execute: () => requestRenderer(rendererOp, rendererPayload, 30_000),
+                })
+              })()
+            : await requestRenderer(rendererOp, rendererPayload, 30_000)
           send(200, { ok: true, result })
           return
         }

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -178,7 +178,14 @@ async function startDesktopCapabilityCore(): Promise<void> {
       const { fetchTaskResult } = await loadRuntimeModule();
       return fetchTaskResult(payload);
     },
-    { canvasReadExecutionRuntime: desktopCanvasReadExecutionRuntime, onGenerationReady: (factory) => getInstalledProductionProjectAgentHost()?.setGenerationAdapterFactory(factory) },
+    {
+      canvasReadExecutionRuntime: desktopCanvasReadExecutionRuntime,
+      onGenerationReady: (factory) => getInstalledProductionProjectAgentHost()?.setGenerationAdapterFactory(factory),
+      proposalReceiptFor: (binding) => {
+        const root = resolveWorkspaceProjectDir(binding.projectId, getWorkspaceRepositoryDeps());
+        return root ? createProjectAgentProposalReceiptService({ projectRoot: root, binding }) : undefined;
+      },
+    },
   );
   capabilityPortCache = core.getCapabilityPort();
 }

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -77,14 +77,14 @@ import { createPiSkillWriteTransportAdapter } from "./capabilityCore/skillWriteT
 import { createPiSkillReadTransportAdapter } from "./capabilityCore/skillReadTransportAdapters";
 import { createPiProductionRunTransportAdapter } from "./capabilityCore/productionRunTransportAdapters";
 import { getProductionRunService } from "./productionRun/productionRunRuntime";
-import { getSettingsRoot } from "./runtimePaths";
+import { getSettingsRoot, getWorkspaceRepositoryDeps } from "./runtimePaths";
 import { getInstalledProductionProjectAgentHost, installProductionProjectAgentHost } from "./projectAgentHost/projectAgentProductionRuntime";
 import { createProjectAgentRepositoryRouter } from "./projectAgentHost/projectAgentRepositoryRouter";
 import { registerProjectAgentIpc } from "./projectAgentHost/projectAgentIpc";
 import { migrateProjectAgentLegacy } from "./projectAgentHost/projectAgentMigration";
 import { createProjectAgentProposalReceiptService } from "./projectAgentHost/projectAgentProposalReceiptStore";
+import { createDesktopProposalReceiptResolver } from "./projectAgentHost/projectAgentReceiptResolver";
 import { resolveProjectAgentAttachmentClaims } from "./assets/projectAssetStore";
-import { getWorkspaceRepositoryDeps } from "./runtimePaths";
 import { ensureWorkspaceProjectIdentity } from "./workspace/workspaceProjectIdentity";
 import { resolveWorkspaceProjectDir } from "./workspace/workspaceRepository";
 import { installContentSecurityPolicy } from "./contentSecurityPolicy";
@@ -181,10 +181,7 @@ async function startDesktopCapabilityCore(): Promise<void> {
     {
       canvasReadExecutionRuntime: desktopCanvasReadExecutionRuntime,
       onGenerationReady: (factory) => getInstalledProductionProjectAgentHost()?.setGenerationAdapterFactory(factory),
-      proposalReceiptFor: (binding) => {
-        const root = resolveWorkspaceProjectDir(binding.projectId, getWorkspaceRepositoryDeps());
-        return root ? createProjectAgentProposalReceiptService({ projectRoot: root, binding }) : undefined;
-      },
+      proposalReceiptFor: createDesktopProposalReceiptResolver(),
     },
   );
   capabilityPortCache = core.getCapabilityPort();
@@ -759,17 +756,13 @@ function registerIpc(): void {
   registerProductionActionIpc({
     getActiveProjectId: () => canvasReadSurfaceRuntime.getCommittedProjectSelection()?.projectId ?? "",
     loadCore: loadCapabilityCoreModule,
-  }); // P4 S6 返工/续拍
+  });
   registerUpdaterIpc();
-  // M0 独立捕捞窗已退役（方案A 2026-07-12）：捕捞面收敛到应用内浏览器（registerBrowserViewIpc）。
-  // S4-1 评测安全铁律:事件落盘前,已配置的 vendor key 精确匹配脱敏(形态兜底之外的地基)。
   setEventLogSecretsProvider(catalogSecretsProvider);
 }
 const SKIP_CROSS_ORIGIN_ISOLATION = process.env.NOMI_E2E === "1";
 const SKIP_CROSS_ORIGIN_ISOLATION_FOR_WINDOWS_FRAMELESS = process.platform === "win32";
 
-// 非主实例（没拿到单实例锁）不启动 UI / RPC——已让出给老实例（second-instance 已聚焦它）。
-// 单实例锁本身在文件顶部定义（main 与本批独立都加了同一锁，合并去重，根治全局 index 并发覆盖）。
 if (hasSingleInstanceLock)
   app
     .whenReady()

--- a/electron/projectAgentHost/projectAgentAdapterResolvers.test.ts
+++ b/electron/projectAgentHost/projectAgentAdapterResolvers.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type {
+  ExecutionPartition,
+  ProjectAgentProposalReceiptWriter,
+  SubscriptionRecord,
+} from "./projectAgentExecutionCoordinatorTypes";
+import { createProjectAgentAdapterResolvers } from "./projectAgentAdapterResolvers";
+
+const binding = {
+  projectId: "project-resolver",
+  immutableProjectUuid: "11111111-1111-4111-8111-111111111111",
+  projectGeneration: 1,
+} as const;
+
+function writer(): ProjectAgentProposalReceiptWriter {
+  return {
+    read: vi.fn(() => null),
+    write: vi.fn(),
+    transition: vi.fn(),
+  } as unknown as ProjectAgentProposalReceiptWriter;
+}
+
+function subscription(subscriptionId: string, subscriptionEpoch: number): SubscriptionRecord {
+  return {
+    subscriptionId,
+    subscriptionEpoch,
+    binding,
+    partitionKey: "project-resolver",
+    snapshot: {} as SubscriptionRecord["snapshot"],
+  };
+}
+
+describe("Project Agent receipt writer resolver", () => {
+  it("uses the preferred writer and falls back to the newest live writer", () => {
+    const oldWriter = writer();
+    const newestWriter = writer();
+    const subscriptions = new Map([
+      ["old", subscription("old", 1)],
+      ["newest", subscription("newest", 2)],
+    ]);
+    const writers = new Map([
+      ["old", oldWriter],
+      ["newest", newestWriter],
+    ]);
+    const partition = {
+      subscriptionIds: new Set(["old", "newest"]),
+    } as ExecutionPartition;
+    const resolvers = createProjectAgentAdapterResolvers({
+      subscriptions,
+      canvasReads: new Map(),
+      documentReads: new Map(),
+      documentWrites: new Map(),
+      canvasWrites: new Map(),
+      timelineReads: new Map(),
+      timelineWrites: new Map(),
+      phase4Surfaces: new Map(),
+      skillReads: new Map(),
+      skillWrites: new Map(),
+      proposalReceiptReaders: new Map(),
+      proposalReceiptWriters: writers,
+    });
+
+    expect(resolvers.proposalReceiptWriterFor(partition, "old")).toBe(oldWriter);
+    expect(resolvers.proposalReceiptWriterFor(partition, "released-subscription")).toBe(newestWriter);
+  });
+});

--- a/electron/projectAgentHost/projectAgentAdapterResolvers.ts
+++ b/electron/projectAgentHost/projectAgentAdapterResolvers.ts
@@ -11,6 +11,7 @@ import type { PiSkillReadTransportAdapter } from "../capabilityCore/skillReadTra
 import {
   type ExecutionPartition,
   type ProjectAgentProposalReceiptReader,
+  type ProjectAgentProposalReceiptWriter,
   type SubscriptionRecord,
 } from "./projectAgentExecutionCoordinatorTypes";
 
@@ -28,6 +29,7 @@ type ProjectAgentAdapterResolverDeps = Readonly<{
   skillReads: AdapterMap<PiSkillReadTransportAdapter>;
   skillWrites: AdapterMap<PiSkillWriteTransportAdapter>;
   proposalReceiptReaders: AdapterMap<ProjectAgentProposalReceiptReader>;
+  proposalReceiptWriters: AdapterMap<ProjectAgentProposalReceiptWriter>;
 }>;
 
 export type ProjectAgentAdapterResolvers = Readonly<{
@@ -41,6 +43,7 @@ export type ProjectAgentAdapterResolvers = Readonly<{
   skillReadFor: (partition: ExecutionPartition, preferredSubscriptionId: string) => PiSkillReadTransportAdapter | undefined;
   skillWriteFor: (partition: ExecutionPartition, preferredSubscriptionId: string) => PiSkillWriteTransportAdapter | undefined;
   proposalReceiptReaderFor: (partition: ExecutionPartition, preferredSubscriptionId: string) => ProjectAgentProposalReceiptReader | undefined;
+  proposalReceiptWriterFor: (partition: ExecutionPartition, preferredSubscriptionId: string) => ProjectAgentProposalReceiptWriter | undefined;
 }>;
 
 function mostRecentAdapterFor<A>(
@@ -107,6 +110,23 @@ export function createProjectAgentAdapterResolvers(
     }
     return selected;
   };
+  const proposalReceiptWriterFor = (partition: ExecutionPartition, preferredSubscriptionId: string) => {
+    const currentPreferred = partition.subscriptionIds.has(preferredSubscriptionId)
+      ? deps.proposalReceiptWriters.get(preferredSubscriptionId)
+      : undefined;
+    if (currentPreferred) return currentPreferred;
+    let selected: ProjectAgentProposalReceiptWriter | undefined;
+    let selectedEpoch = -1;
+    for (const subscriptionId of partition.subscriptionIds) {
+      const subscription = subscriptions.get(subscriptionId);
+      const writer = deps.proposalReceiptWriters.get(subscriptionId);
+      if (subscription && writer && subscription.subscriptionEpoch > selectedEpoch) {
+        selected = writer;
+        selectedEpoch = subscription.subscriptionEpoch;
+      }
+    }
+    return selected;
+  };
   return Object.freeze({
     canvasReadFor,
     documentReadFor,
@@ -118,5 +138,6 @@ export function createProjectAgentAdapterResolvers(
     skillReadFor,
     skillWriteFor,
     proposalReceiptReaderFor,
+    proposalReceiptWriterFor,
   });
 }

--- a/electron/projectAgentHost/projectAgentDocumentReceipt.test.ts
+++ b/electron/projectAgentHost/projectAgentDocumentReceipt.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  abandonDocumentProposalReceipt,
+  commitDocumentProposalReceipt,
+  documentProposalReceiptFor,
+  prepareDocumentProposalReceipt,
+} from "./projectAgentDocumentReceipt";
+
+const persisted = {
+  receiptProposalId: "receipt-id",
+  approvalId: "approval-id",
+  actionHash: "action-hash",
+};
+const prepared = { invocation: { input: { operation: "append" as const } } };
+
+describe("Project Agent document receipt helper", () => {
+  it.each([
+    [{ toolName: "nomi_document_edit", args: {} }, prepared, "append"],
+    [{ toolName: "append_to_end", args: {} }, { invocation: { input: undefined } }, "append"],
+    [{ toolName: "unknown_alias", args: { operation: "replace" } }, { invocation: { input: undefined } }, "replace"],
+    [{ toolName: "unknown_alias", args: {} }, { invocation: { input: undefined } }, "write"],
+  ])("preserves the resolved operation in the durable proposal", (call, preparedInput, operation) => {
+    const resolved = documentProposalReceiptFor(
+      call,
+      persisted,
+      preparedInput,
+    );
+
+    expect(resolved).toMatchObject({
+      proposalId: "receipt-id",
+      hostApprovalId: "approval-id",
+      hostActionHash: "action-hash",
+      summary: `${operation} ${call.toolName}`,
+      stepLabels: [`${operation}:${call.toolName}`],
+    });
+  });
+
+  it("prepares, commits, and abandons the same receipt with CAS revisions", () => {
+    const proposal = documentProposalReceiptFor({ toolName: "nomi_document_edit", args: {} }, persisted, prepared);
+    const writer = {
+      read: vi.fn(() => null),
+      write: vi.fn((value) => ({ ...value, revision: 1 })),
+      transition: vi.fn(),
+    };
+
+    const preparing = prepareDocumentProposalReceipt(writer, proposal, "approval-id");
+    commitDocumentProposalReceipt(writer, preparing, proposal, "approval-id");
+    abandonDocumentProposalReceipt(writer, preparing, proposal, "approval-id");
+
+    expect(writer.write).toHaveBeenNthCalledWith(1, expect.objectContaining({ expectedRevision: 0, lifecycle: "preparing" }));
+    expect(writer.write).toHaveBeenNthCalledWith(2, expect.objectContaining({ expectedRevision: 1, lifecycle: "committed" }));
+    expect(writer.transition).toHaveBeenCalledWith(expect.objectContaining({ expectedRevision: 1, lifecycle: "undone" }));
+  });
+
+  it("preserves a preparing receipt when the undone CAS transition fails", () => {
+    const proposal = documentProposalReceiptFor({ toolName: "nomi_document_edit", args: {} }, persisted, prepared);
+    const writer = {
+      read: () => ({ revision: 4 }),
+      write: (value: unknown) => ({ ...(value as object), revision: 5 }),
+      transition: () => { throw new Error("stale revision"); },
+    };
+
+    expect(() => abandonDocumentProposalReceipt(writer, { revision: 5 }, proposal, "approval-id")).not.toThrow();
+  });
+});

--- a/electron/projectAgentHost/projectAgentDocumentReceipt.test.ts
+++ b/electron/projectAgentHost/projectAgentDocumentReceipt.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it, vi } from "vitest";
 
+import type { ProposalApprovalRef } from "../shared/projectAgentContracts";
+import type {
+  ProjectAgentCommittedProposalRecord,
+  ProjectAgentProposalReceiptTransition,
+  ProjectAgentProposalReceiptView,
+  ProjectAgentProposalReceiptWrite,
+} from "../shared/projectAgentProposalReceipt";
+import type { ProjectAgentProposalReceiptWriter } from "./projectAgentExecutionCoordinatorTypes";
 import {
   abandonDocumentProposalReceipt,
   commitDocumentProposalReceipt,
@@ -7,12 +15,40 @@ import {
   prepareDocumentProposalReceipt,
 } from "./projectAgentDocumentReceipt";
 
-const persisted = {
+const receiptBinding = {
+  projectId: "project-1",
+  immutableProjectUuid: "6b0f4a39-1ae4-4e1e-8b2e-0b9460a67a51",
+  projectGeneration: 1,
+} as const;
+const persisted: ProposalApprovalRef = {
   receiptProposalId: "receipt-id",
   approvalId: "approval-id",
+  threadId: "thread-id",
+  turnId: "turn-id",
+  toolCallId: "tool-call-id",
+  policyRevision: 1,
+  inputHash: "input-hash",
   actionHash: "action-hash",
+  target: { kind: "document", documentId: "document-id", anchor: { kind: "whole-document" } },
+  preconditions: { document: { revision: 1, contentHash: "document-hash" } },
+  expiresAt: "2099-01-01T00:00:00.000Z",
 };
 const prepared = { invocation: { input: { operation: "append" as const } } };
+
+function receiptView(
+  lifecycle: ProjectAgentProposalReceiptView["lifecycle"],
+  revision: number,
+  proposal: ProjectAgentCommittedProposalRecord,
+): ProjectAgentProposalReceiptView {
+  return {
+    binding: receiptBinding,
+    revision,
+    lifecycle,
+    proposalId: proposal.proposalId,
+    operationId: `document-${lifecycle}`,
+    proposal,
+  };
+}
 
 describe("Project Agent document receipt helper", () => {
   it.each([
@@ -38,10 +74,18 @@ describe("Project Agent document receipt helper", () => {
 
   it("prepares, commits, and abandons the same receipt with CAS revisions", () => {
     const proposal = documentProposalReceiptFor({ toolName: "nomi_document_edit", args: {} }, persisted, prepared);
-    const writer = {
+    const writer: ProjectAgentProposalReceiptWriter = {
       read: vi.fn(() => null),
-      write: vi.fn((value) => ({ ...value, revision: 1 })),
-      transition: vi.fn(),
+      write: vi.fn((value: ProjectAgentProposalReceiptWrite) => receiptView(
+        value.lifecycle,
+        value.lifecycle === "preparing" ? 1 : 2,
+        value.proposal,
+      )),
+      transition: vi.fn((value: ProjectAgentProposalReceiptTransition) => receiptView(
+        value.lifecycle,
+        2,
+        proposal,
+      )),
     };
 
     const preparing = prepareDocumentProposalReceipt(writer, proposal, "approval-id");
@@ -55,12 +99,12 @@ describe("Project Agent document receipt helper", () => {
 
   it("preserves a preparing receipt when the undone CAS transition fails", () => {
     const proposal = documentProposalReceiptFor({ toolName: "nomi_document_edit", args: {} }, persisted, prepared);
-    const writer = {
-      read: () => ({ revision: 4 }),
-      write: (value: unknown) => ({ ...(value as object), revision: 5 }),
+    const writer: ProjectAgentProposalReceiptWriter = {
+      read: () => receiptView("preparing", 4, proposal),
+      write: (value: ProjectAgentProposalReceiptWrite) => receiptView(value.lifecycle, 5, value.proposal),
       transition: () => { throw new Error("stale revision"); },
     };
 
-    expect(() => abandonDocumentProposalReceipt(writer, { revision: 5 }, proposal, "approval-id")).not.toThrow();
+    expect(() => abandonDocumentProposalReceipt(writer, receiptView("preparing", 5, proposal), proposal, "approval-id")).not.toThrow();
   });
 });

--- a/electron/projectAgentHost/projectAgentDocumentReceipt.ts
+++ b/electron/projectAgentHost/projectAgentDocumentReceipt.ts
@@ -1,0 +1,82 @@
+import { documentWriteOperationForAlias } from '../shared/agentCapabilities/documentWrite'
+import type { ProposalApprovalRef } from '../shared/projectAgentContracts'
+import type {
+  ProjectAgentCommittedProposalRecord,
+  ProjectAgentProposalReceiptView,
+} from '../shared/projectAgentProposalReceipt'
+import type { ProjectAgentProposalReceiptWriter } from './projectAgentExecutionCoordinatorTypes'
+
+type ProjectAgentDocumentReceiptCall = Readonly<{ toolName: string; args: unknown }>
+type PreparedDocumentReceipt = Readonly<{
+  invocation: Readonly<{ input?: Readonly<{ operation: 'insert' | 'replace' | 'append' }> }>
+}>
+
+export function documentProposalReceiptFor(
+  call: ProjectAgentDocumentReceiptCall,
+  persisted: ProposalApprovalRef,
+  prepared: PreparedDocumentReceipt,
+): ProjectAgentCommittedProposalRecord {
+  const operation = prepared.invocation.input?.operation
+    ?? documentWriteOperationForAlias(call.toolName)
+    ?? (call.args && typeof call.args === 'object' && typeof (call.args as Record<string, unknown>).operation === 'string'
+      ? (call.args as Record<string, unknown>).operation as 'insert' | 'replace' | 'append'
+      : 'write')
+  return Object.freeze({
+    proposalId: persisted.receiptProposalId,
+    hostApprovalId: persisted.approvalId,
+    hostActionHash: persisted.actionHash,
+    summary: `${operation} ${call.toolName}`,
+    stepLabels: Object.freeze([`${operation}:${call.toolName}`]),
+    compensation: Object.freeze([]),
+    watchNodes: Object.freeze([]),
+    reconciliationOk: true,
+  })
+}
+
+export function prepareDocumentProposalReceipt(
+  writer: ProjectAgentProposalReceiptWriter,
+  proposal: ProjectAgentCommittedProposalRecord,
+  approvalId: string,
+): ProjectAgentProposalReceiptView {
+  const current = writer.read()
+  return writer.write({
+    expectedRevision: current?.revision ?? 0,
+    proposalId: proposal.proposalId,
+    operationId: `document-prepare:${approvalId}`,
+    lifecycle: 'preparing',
+    proposal,
+  })
+}
+
+export function commitDocumentProposalReceipt(
+  writer: ProjectAgentProposalReceiptWriter,
+  prepared: ProjectAgentProposalReceiptView,
+  proposal: ProjectAgentCommittedProposalRecord,
+  approvalId: string,
+): ProjectAgentProposalReceiptView {
+  return writer.write({
+    expectedRevision: prepared.revision,
+    proposalId: proposal.proposalId,
+    operationId: `document-commit:${approvalId}`,
+    lifecycle: 'committed',
+    proposal,
+  })
+}
+
+export function abandonDocumentProposalReceipt(
+  writer: ProjectAgentProposalReceiptWriter,
+  prepared: ProjectAgentProposalReceiptView,
+  proposal: ProjectAgentCommittedProposalRecord,
+  approvalId: string,
+): void {
+  try {
+    writer.transition({
+      expectedRevision: prepared.revision,
+      proposalId: proposal.proposalId,
+      operationId: `document-failed:${approvalId}`,
+      lifecycle: 'undone',
+    })
+  } catch {
+    // Keep the preparing receipt as recovery evidence if the failure settlement loses its CAS race.
+  }
+}

--- a/electron/projectAgentHost/projectAgentExecutionCoordinator.test.ts
+++ b/electron/projectAgentHost/projectAgentExecutionCoordinator.test.ts
@@ -48,7 +48,15 @@ import type {
 import type { PiSkillReadTransportAdapter } from "../capabilityCore/skillReadTransportAdapters";
 import type { PiProductionRunTransportAdapter } from "../capabilityCore/productionRunTransportAdapters";
 import type { PreconditionSet, TargetRef } from "../shared/capabilityTargeting";
-import type { ProjectAgentProposalReceiptView } from "../shared/projectAgentProposalReceipt";
+import type {
+  ProjectAgentCommittedProposalRecord,
+  ProjectAgentProposalReceiptView,
+} from "../shared/projectAgentProposalReceipt";
+import type { ProjectAgentProposalReceiptWriter } from "./projectAgentExecutionCoordinatorTypes";
+import {
+  createProjectAgentProposalReceiptService,
+  projectAgentProposalReceiptPath,
+} from "./projectAgentProposalReceiptStore";
 
 function skillWriteAdapter(): PiSkillWriteTransportAdapter & {
   prepare: ReturnType<typeof vi.fn>;
@@ -1856,6 +1864,7 @@ describe("ProjectAgentExecutionCoordinator", () => {
 
   it("executes an approved document.write through the Host and settles its frozen proposal", async () => {
     root = fs.mkdtempSync(path.join(os.tmpdir(), "nomi-project-agent-document-write-approved-"));
+    fs.mkdirSync(path.join(root, ".nomi"), { recursive: true });
     const target = {
       kind: "document" as const,
       documentId: "document-document-write-approved",
@@ -1863,6 +1872,7 @@ describe("ProjectAgentExecutionCoordinator", () => {
     };
     const preconditions = { document: { revision: 3, contentHash: "fnv1a-before" } } as const;
     const documentAdapter = documentWriteAdapter();
+    const proposalReceipts = createProjectAgentProposalReceiptService({ projectRoot: root, binding });
     const coordinator = createProjectAgentExecutionCoordinator(
       createProjectAgentRepositoryRouter({ rootDir: root }),
       () => "subscription-document-write-approved",
@@ -1879,7 +1889,11 @@ describe("ProjectAgentExecutionCoordinator", () => {
         },
       },
     );
-    const opened = await coordinator.open(binding, { documentWrite: documentAdapter });
+    const opened = await coordinator.open(binding, {
+      documentWrite: documentAdapter,
+      proposalReceipt: () => proposalReceipts.read(),
+      proposalReceiptWriter: proposalReceipts,
+    });
     coordinator.subscribe(opened.subscriptionId, (event) => {
       if (event.type === "tool-call") {
         void coordinator.resolveToolDecision(opened.subscriptionId, event.turnId, event.toolCallId, {
@@ -1937,6 +1951,214 @@ describe("ProjectAgentExecutionCoordinator", () => {
         preconditions,
       },
     });
+    const receiptPath = projectAgentProposalReceiptPath(root);
+    expect(fs.existsSync(receiptPath)).toBe(true);
+    expect(proposalReceipts.read()).toMatchObject({
+      revision: 2,
+      lifecycle: "committed",
+      proposalId: expect.any(String),
+      proposal: {
+        hostApprovalId: expect.stringMatching(/^approval-/),
+        hostActionHash: invocation.actionHash,
+      },
+    });
+  });
+
+  it.each(["capability_timeout", "capability_execution_failed"] as const)(
+    "closes a prepared document receipt as undone on a %s write failure",
+    async (code) => {
+      root = fs.mkdtempSync(path.join(os.tmpdir(), `nomi-project-agent-document-write-${code}-`));
+      fs.mkdirSync(path.join(root, ".nomi"), { recursive: true });
+      const documentAdapter = documentWriteAdapter({
+        result: { ok: false, code, message: code },
+      });
+      const proposalReceipts = createProjectAgentProposalReceiptService({ projectRoot: root, binding });
+      const coordinator = createProjectAgentExecutionCoordinator(
+        createProjectAgentRepositoryRouter({ rootDir: root }),
+        () => `subscription-document-write-${code}`,
+        {
+          runAgent: async (_request, hooks) => {
+            const call = {
+              toolCallId: `tool-document-write-${code}`,
+              toolName: "append_to_end",
+              args: { content: "network-safe failure" },
+            };
+            const decision = await hooks.awaitToolConfirmation(call, hooks.abortSignal!);
+            expect(decision).toMatchObject({ ok: true, result: { applied: true } });
+            return documentWriteResponse(call, decision);
+          },
+        },
+      );
+      const opened = await coordinator.open(binding, {
+        documentWrite: documentAdapter,
+        proposalReceipt: () => proposalReceipts.read(),
+        proposalReceiptWriter: proposalReceipts,
+      });
+      coordinator.subscribe(opened.subscriptionId, (event) => {
+        if (event.type === "tool-call") {
+          void coordinator.resolveToolDecision(opened.subscriptionId, event.turnId, event.toolCallId, {
+            ok: true,
+            result: { applied: true },
+          });
+        }
+      });
+
+      const input = executionInput(`document-write-${code}`, 0);
+      await coordinator.enqueue(opened.subscriptionId, input);
+      const final = await coordinator.waitForTurn(opened.subscriptionId, input.mutation.payload.turn.turnId);
+
+      expect(documentAdapter.prepare).toHaveBeenCalledOnce();
+      expect(documentAdapter.execute).toHaveBeenCalledOnce();
+      expect(proposalReceipts.read()).toMatchObject({ revision: 2, lifecycle: "undone" });
+      expect(final.items.find((item) => item.kind === "proposal")).toMatchObject({ status: "failed" });
+      expect(final.items.find((item) => item.kind === "failure")).toMatchObject({ status: "failed" });
+    },
+  );
+
+  it("keeps the legacy document adapter fail-closed when no optional receipt writer is available", async () => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), "nomi-project-agent-document-write-no-receipt-writer-"));
+    const documentAdapter = documentWriteAdapter({
+      result: { ok: false, code: "capability_timeout", message: "capability_timeout" },
+    });
+    const coordinator = createProjectAgentExecutionCoordinator(
+      createProjectAgentRepositoryRouter({ rootDir: root }),
+      () => "subscription-document-write-no-receipt-writer",
+      {
+        runAgent: async (_request, hooks) => {
+          const call = {
+            toolCallId: "tool-document-write-no-receipt-writer",
+            toolName: "append_to_end",
+            args: { content: "receipt writer unavailable" },
+          };
+          const decision = await hooks.awaitToolConfirmation(call, hooks.abortSignal!);
+          return documentWriteResponse(call, decision);
+        },
+      },
+    );
+    const opened = await coordinator.open(binding, { documentWrite: documentAdapter });
+    coordinator.subscribe(opened.subscriptionId, (event) => {
+      if (event.type === "tool-call") {
+        void coordinator.resolveToolDecision(opened.subscriptionId, event.turnId, event.toolCallId, {
+          ok: true,
+          result: { applied: true },
+        });
+      }
+    });
+
+    const input = executionInput("document-write-no-receipt-writer", 0);
+    await coordinator.enqueue(opened.subscriptionId, input);
+    const final = await coordinator.waitForTurn(opened.subscriptionId, input.mutation.payload.turn.turnId);
+
+    expect(documentAdapter.execute).toHaveBeenCalledOnce();
+    expect(final.items.find((item) => item.kind === "proposal")).toMatchObject({ status: "failed" });
+    coordinator.release(opened.subscriptionId);
+  });
+
+  it.each([
+    { label: "explicit args operation", args: { operation: "append", content: "fallback append" }, operation: "append" },
+    { label: "write fallback", args: { content: "fallback write" }, operation: "write" },
+  ])("records the %s operation in the receipt proposal", async ({ label, args, operation }) => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), `nomi-project-agent-document-write-${label.replaceAll(" ", "-")}-`));
+    fs.mkdirSync(path.join(root, ".nomi"), { recursive: true });
+    const documentAdapter = documentWriteAdapter();
+    const proposalReceipts = createProjectAgentProposalReceiptService({ projectRoot: root, binding });
+    const coordinator = createProjectAgentExecutionCoordinator(
+      createProjectAgentRepositoryRouter({ rootDir: root }),
+      () => `subscription-document-write-${operation}`,
+      {
+        runAgent: async (_request, hooks) => {
+          const call = { toolCallId: `tool-document-write-${operation}`, toolName: "nomi_document_edit", args };
+          const decision = await hooks.awaitToolConfirmation(call, hooks.abortSignal!);
+          return documentWriteResponse(call, decision);
+        },
+      },
+    );
+    const opened = await coordinator.open(binding, {
+      documentWrite: documentAdapter,
+      proposalReceipt: () => proposalReceipts.read(),
+      proposalReceiptWriter: proposalReceipts,
+    });
+    coordinator.subscribe(opened.subscriptionId, (event) => {
+      if (event.type === "tool-call") {
+        void coordinator.resolveToolDecision(opened.subscriptionId, event.turnId, event.toolCallId, {
+          ok: true,
+          result: { applied: true },
+        });
+      }
+    });
+
+    const input = executionInput(`document-write-${operation}`, 0);
+    await coordinator.enqueue(opened.subscriptionId, input);
+    const final = await coordinator.waitForTurn(opened.subscriptionId, input.mutation.payload.turn.turnId);
+
+    expect(final.items.find((item) => item.kind === "proposal")).toMatchObject({ status: "done" });
+    expect(proposalReceipts.read()).toMatchObject({
+      revision: 2,
+      lifecycle: "committed",
+      proposal: { stepLabels: [`${operation}:nomi_document_edit`] },
+    });
+    coordinator.release(opened.subscriptionId);
+  });
+
+  it("fails closed when the document receipt commit cannot be persisted", async () => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), "nomi-project-agent-document-write-receipt-commit-failure-"));
+    const preparedReceipt = (input: { proposalId: string; operationId: string; proposal: ProjectAgentCommittedProposalRecord }) => ({
+      schemaVersion: 2,
+      binding,
+      revision: 1,
+      lifecycle: "preparing" as const,
+      proposalId: input.proposalId,
+      operationId: input.operationId,
+      proposal: input.proposal,
+      proposalHash: "a".repeat(64),
+      operations: [],
+      updatedAt: "2026-08-28T00:00:00.000Z",
+      journalHash: "b".repeat(64),
+    });
+    let writes = 0;
+    const proposalReceiptWriter = {
+      binding,
+      read: vi.fn(() => null),
+      write: vi.fn((input: Parameters<ProjectAgentProposalReceiptWriter["write"]>[0]) => {
+        writes += 1;
+        if (writes > 1) throw new Error("receipt_commit_write_failed");
+        return preparedReceipt(input);
+      }),
+      transition: vi.fn(),
+    } as unknown as ProjectAgentProposalReceiptWriter;
+    const documentAdapter = documentWriteAdapter();
+    const coordinator = createProjectAgentExecutionCoordinator(
+      createProjectAgentRepositoryRouter({ rootDir: root }),
+      () => "subscription-document-write-receipt-commit-failure",
+      {
+        runAgent: async (_request, hooks) => {
+          const call = { toolCallId: "tool-document-write-receipt-commit-failure", toolName: "append_to_end", args: { content: "receipt must settle" } };
+          const decision = await hooks.awaitToolConfirmation(call, hooks.abortSignal!);
+          return documentWriteResponse(call, decision);
+        },
+      },
+    );
+    const opened = await coordinator.open(binding, {
+      documentWrite: documentAdapter,
+      proposalReceipt: () => null,
+      proposalReceiptWriter,
+    });
+    coordinator.subscribe(opened.subscriptionId, (event) => {
+      if (event.type === "tool-call") {
+        void coordinator.resolveToolDecision(opened.subscriptionId, event.turnId, event.toolCallId, {
+          ok: true,
+          result: { applied: true },
+        });
+      }
+    });
+
+    const input = executionInput("document-write-receipt-commit-failure", 0);
+    await coordinator.enqueue(opened.subscriptionId, input);
+    const final = await coordinator.waitForTurn(opened.subscriptionId, input.mutation.payload.turn.turnId);
+
+    expect(proposalReceiptWriter.write).toHaveBeenCalledTimes(2);
+    expect(final.items.find((item) => item.kind === "proposal")).toMatchObject({ status: "failed" });
+    coordinator.release(opened.subscriptionId);
   });
 
   it("executes author_skill through the Host and settles its Skill-library proposal", async () => {

--- a/electron/projectAgentHost/projectAgentExecutionCoordinator.test.ts
+++ b/electron/projectAgentHost/projectAgentExecutionCoordinator.test.ts
@@ -1964,6 +1964,64 @@ describe("ProjectAgentExecutionCoordinator", () => {
     });
   });
 
+  it("uses the empty preferred subscription fallback for an approved document receipt", async () => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), "nomi-project-agent-document-write-missing-subscription-"));
+    fs.mkdirSync(path.join(root, ".nomi"), { recursive: true });
+    const documentAdapter = documentWriteAdapter();
+    const proposalReceipts = createProjectAgentProposalReceiptService({ projectRoot: root, binding });
+    const coordinator = createProjectAgentExecutionCoordinator(
+      createProjectAgentRepositoryRouter({ rootDir: root }),
+      () => undefined as unknown as string,
+      {
+        runAgent: async (_request, hooks) => {
+          const call = {
+            toolCallId: "tool-document-write-missing-subscription",
+            toolName: "replace_selection",
+            args: { content: "new" },
+          };
+          const decision = await hooks.awaitToolConfirmation(call, hooks.abortSignal!);
+          expect(decision).toMatchObject({ ok: true, result: { applied: true } });
+          return documentWriteResponse(call, decision);
+        },
+      },
+    );
+    const opened = await coordinator.open(binding, {
+      documentWrite: documentAdapter,
+      proposalReceipt: () => proposalReceipts.read(),
+      proposalReceiptWriter: proposalReceipts,
+    });
+    expect(opened.subscriptionId).toBeUndefined();
+    coordinator.subscribe(opened.subscriptionId, (event) => {
+      if (event.type === "tool-call") {
+        void coordinator.resolveToolDecision(opened.subscriptionId, event.turnId, event.toolCallId, {
+          ok: true,
+          result: { applied: true },
+        });
+      }
+    });
+
+    const input = executionInput("document-write-missing-subscription", 0);
+    await coordinator.enqueue(opened.subscriptionId, input);
+    const final = await coordinator.waitForTurn(opened.subscriptionId, input.mutation.payload.turn.turnId);
+
+    expect(documentAdapter.execute).toHaveBeenCalledOnce();
+    expect(final.items.find((item) => item.kind === "proposal")).toMatchObject({
+      status: "done",
+      approval: {
+        approvalId: expect.stringMatching(/^approval-/),
+        receiptProposalId: expect.any(String),
+      },
+    });
+    expect(proposalReceipts.read()).toMatchObject({
+      revision: 2,
+      lifecycle: "committed",
+      proposal: {
+        hostApprovalId: expect.stringMatching(/^approval-/),
+      },
+    });
+    coordinator.release(opened.subscriptionId);
+  });
+
   it.each(["capability_timeout", "capability_execution_failed"] as const)(
     "closes a prepared document receipt as undone on a %s write failure",
     async (code) => {

--- a/electron/projectAgentHost/projectAgentExecutionCoordinator.ts
+++ b/electron/projectAgentHost/projectAgentExecutionCoordinator.ts
@@ -53,6 +53,7 @@ import {
   type ProjectAgentExecutionEnqueue,
   type ProjectAgentExecutionListener,
   type ProjectAgentProposalReceiptReader,
+  type ProjectAgentProposalReceiptWriter,
   type ProjectAgentSubscription,
   type ProjectAgentExecutionOpenOptions,
   type ProjectAgentExecutionCoordinator,
@@ -66,6 +67,7 @@ import { createProjectAgentAdapterResolvers } from "./projectAgentAdapterResolve
 export type {
   ProjectAgentSubscription,
   ProjectAgentProposalReceiptReader,
+  ProjectAgentProposalReceiptWriter,
   ProjectAgentExecutionOpenOptions,
   ProjectAgentExecutionCoordinatorDeps,
   ProjectAgentExecutionCoordinator,
@@ -93,6 +95,7 @@ export function createProjectAgentExecutionCoordinator(
   const productionRuns = new Map<string, PiProductionRunTransportAdapter | undefined>();
   const generationAdapters = new Map<string, PiGenerationTransportAdapter | undefined>(); let generationAdapterFactory = deps.generation;
   const proposalReceiptReaders = new Map<string, ProjectAgentProposalReceiptReader | undefined>();
+  const proposalReceiptWriters = new Map<string, ProjectAgentProposalReceiptWriter | undefined>();
   const runAgent =
     deps.runAgent ?? (async (request, hooks) => (await import("../ai/agentChatV2")).runAgentChatV2(request, hooks));
   const now = deps.now ?? (() => new Date().toISOString());
@@ -211,6 +214,7 @@ export function createProjectAgentExecutionCoordinator(
     skillReads.set(subscription.subscriptionId, options.skillRead);
     skillWrites.set(subscription.subscriptionId, options.skillWrite);
     proposalReceiptReaders.set(subscription.subscriptionId, options.proposalReceipt);
+    proposalReceiptWriters.set(subscription.subscriptionId, options.proposalReceiptWriter);
     return subscription;
   }
 
@@ -552,6 +556,7 @@ export function createProjectAgentExecutionCoordinator(
     skillReadFor,
     skillWriteFor,
     proposalReceiptReaderFor,
+    proposalReceiptWriterFor,
   } = createProjectAgentAdapterResolvers({
     subscriptions,
     canvasReads,
@@ -564,6 +569,7 @@ export function createProjectAgentExecutionCoordinator(
     skillReads,
     skillWrites,
     proposalReceiptReaders,
+    proposalReceiptWriters,
   });
   const turnExecutionContext: ProjectAgentTurnExecutionContext = {
     now,
@@ -591,6 +597,7 @@ export function createProjectAgentExecutionCoordinator(
     productionRunFor,
     generationFor,
     proposalReceiptReaderFor,
+    proposalReceiptWriterFor,
   };
 
   function scheduleDrain(partition: ExecutionPartition): void {
@@ -771,6 +778,7 @@ export function createProjectAgentExecutionCoordinator(
       skillReads.get(subscriptionId)?.dispose();
       skillReads.delete(subscriptionId);
       proposalReceiptReaders.delete(subscriptionId);
+      proposalReceiptWriters.delete(subscriptionId);
     },
     setGenerationAdapterFactory: (factory) => { generationAdapterFactory = factory; for (const [partitionKey, adapter] of generationAdapters) { adapter?.dispose(); generationAdapters.delete(partitionKey); } },
     subscriptionCount: () => subscriptions.size,

--- a/electron/projectAgentHost/projectAgentExecutionCoordinatorTypes.ts
+++ b/electron/projectAgentHost/projectAgentExecutionCoordinatorTypes.ts
@@ -21,7 +21,10 @@ import type { PiSkillWriteTransportAdapter } from "../capabilityCore/skillWriteT
 import type { PiSkillReadTransportAdapter } from "../capabilityCore/skillReadTransportAdapters";
 import type { PiProductionRunTransportAdapter } from "../capabilityCore/productionRunTransportAdapters";
 import type { PiGenerationTransportAdapter } from "../capabilityCore/generationTransportAdapters";
-import type { ProjectAgentProposalReceiptView } from "../shared/projectAgentProposalReceipt";
+import type {
+  ProjectAgentProposalReceiptView,
+} from "../shared/projectAgentProposalReceipt";
+import type { ProjectAgentProposalReceiptService } from "./projectAgentProposalReceiptStore";
 
 export type ProjectAgentSubscription = Readonly<{
   subscriptionId: string;
@@ -30,6 +33,7 @@ export type ProjectAgentSubscription = Readonly<{
   snapshot: ProjectAgentHostState;
 }>;
 export type ProjectAgentProposalReceiptReader = () => ProjectAgentProposalReceiptView | null;
+export type ProjectAgentProposalReceiptWriter = Pick<ProjectAgentProposalReceiptService, "read" | "write" | "transition">;
 export type ProjectAgentExecutionOpenOptions = Readonly<{
   canvasRead?: PiCanvasReadTransportAdapter;
   documentRead?: PiDocumentReadTransportAdapter;
@@ -41,6 +45,8 @@ export type ProjectAgentExecutionOpenOptions = Readonly<{
   skillRead?: PiSkillReadTransportAdapter;
   skillWrite?: PiSkillWriteTransportAdapter;
   proposalReceipt?: ProjectAgentProposalReceiptReader;
+  /** Main-owned writer. Renderer clients only receive the read/undo IPC seam. */
+  proposalReceiptWriter?: ProjectAgentProposalReceiptWriter;
 }>;
 export type ProjectAgentExecutionCoordinatorDeps = Readonly<{
   runAgent?: (request: AgentChatRequest, hooks: AgentChatV2Hooks) => Promise<AgentChatResponse>;

--- a/electron/projectAgentHost/projectAgentIpc.test.ts
+++ b/electron/projectAgentHost/projectAgentIpc.test.ts
@@ -503,7 +503,7 @@ describe("ProjectAgent IPC wire boundary", () => {
     const wrongFrame = { sender, senderFrame: { ...frame } } as unknown as IpcMainInvokeEvent;
     const runtime = {
       executionCoordinator: {
-        open: vi.fn((_projectBinding: ProjectBinding, _options?: Readonly<{ proposalReceipt?: () => unknown }>) => ({
+        open: vi.fn((_projectBinding: ProjectBinding, _options?: Readonly<{ proposalReceipt?: () => unknown; proposalReceiptWriter?: unknown }>) => ({
           subscriptionId: "subscription-receipt",
           subscriptionEpoch: 1,
           binding,
@@ -524,10 +524,11 @@ describe("ProjectAgent IPC wire boundary", () => {
     const opened = await state.handlers.get(PROJECT_AGENT_OPEN_CHANNEL)!(event, { binding });
     expect(opened).toMatchObject({ ok: true, value: { proposalReceipt: null } });
     const openOptions = runtime.executionCoordinator.open.mock.calls[0]?.[1] as
-      | Readonly<{ proposalReceipt?: () => unknown }>
+      | Readonly<{ proposalReceipt?: () => unknown; proposalReceiptWriter?: unknown }>
       | undefined;
     expect(openOptions?.proposalReceipt).toEqual(expect.any(Function));
     expect(openOptions?.proposalReceipt?.()).toBeNull();
+    expect(openOptions?.proposalReceiptWriter).toBe(receiptService);
     const prepared = await state.handlers.get(PROJECT_AGENT_PROPOSAL_RECEIPT_WRITE_CHANNEL)!(event, {
       subscriptionId: "subscription-receipt",
       expectedRevision: 0,

--- a/electron/projectAgentHost/projectAgentIpc.ts
+++ b/electron/projectAgentHost/projectAgentIpc.ts
@@ -421,7 +421,13 @@ export function registerProjectAgentIpc(
               ...(skillRead ? { skillRead } : {}),
               ...(skillWrite ? { skillWrite } : {}),
               ...(proposalReceipts
-                ? { proposalReceipt: () => proposalReceipts.read() }
+                ? {
+                    proposalReceipt: () => proposalReceipts.read(),
+                    // The renderer may read/transition recovery evidence, but
+                    // only this main-owned service is handed to Host execution
+                    // for prepare/commit receipt ownership.
+                    proposalReceiptWriter: proposalReceipts,
+                  }
                 : {}),
             }
           : undefined,

--- a/electron/projectAgentHost/projectAgentReceiptResolver.test.ts
+++ b/electron/projectAgentHost/projectAgentReceiptResolver.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createDesktopProposalReceiptResolver } from "./projectAgentReceiptResolver";
+
+const binding = {
+  projectId: "project-1",
+  immutableProjectUuid: "6b0f4a39-1ae4-4e1e-8b2e-0b9460a67a51",
+  projectGeneration: 1,
+} as const;
+const repositoryDeps = { settingsRoot: "/settings", defaultProjectsRoot: "/projects" };
+const service = { binding, read: vi.fn(), write: vi.fn(), transition: vi.fn(), clear: vi.fn() };
+
+function dependencies() {
+  return {
+    getWorkspaceRepositoryDeps: vi.fn(() => repositoryDeps),
+    resolveWorkspaceProjectDir: vi.fn(() => "/projects/project-1"),
+    createProjectAgentProposalReceiptService: vi.fn(() => service),
+  };
+}
+
+describe("desktop Project Agent proposal receipt resolver", () => {
+  it("creates a receipt service for a live project binding", () => {
+    const deps = dependencies();
+    const resolve = createDesktopProposalReceiptResolver(deps);
+
+    expect(resolve(binding)).toBe(service);
+    expect(deps.getWorkspaceRepositoryDeps).toHaveBeenCalledOnce();
+    expect(deps.resolveWorkspaceProjectDir).toHaveBeenCalledWith("project-1", repositoryDeps);
+    expect(deps.createProjectAgentProposalReceiptService).toHaveBeenCalledWith({
+      projectRoot: "/projects/project-1",
+      binding,
+    });
+  });
+
+  it.each([
+    ["empty root", () => ""],
+    ["missing root", () => null],
+  ])("returns no service when the workspace has an %s", (_label, resolveRoot) => {
+    const deps = dependencies();
+    deps.resolveWorkspaceProjectDir.mockImplementation(resolveRoot);
+    const resolve = createDesktopProposalReceiptResolver(deps);
+
+    expect(resolve(binding)).toBeUndefined();
+    expect(deps.createProjectAgentProposalReceiptService).not.toHaveBeenCalled();
+  });
+
+  it.each([undefined, null])("returns no service when the binding is %s", (missingBinding) => {
+    const deps = dependencies();
+    const resolve = createDesktopProposalReceiptResolver(deps);
+
+    expect(resolve(missingBinding)).toBeUndefined();
+    expect(deps.getWorkspaceRepositoryDeps).not.toHaveBeenCalled();
+    expect(deps.resolveWorkspaceProjectDir).not.toHaveBeenCalled();
+  });
+
+  it("rejects a malformed binding before resolving a project root", () => {
+    const deps = dependencies();
+    const resolve = createDesktopProposalReceiptResolver(deps);
+
+    expect(() => resolve({ projectId: "" } as typeof binding)).toThrow("invalid_project_binding");
+    expect(deps.getWorkspaceRepositoryDeps).not.toHaveBeenCalled();
+  });
+
+  it("propagates a workspace resolver error instead of fabricating a receipt service", () => {
+    const deps = dependencies();
+    deps.resolveWorkspaceProjectDir.mockImplementation(() => {
+      throw new Error("workspace lookup failed");
+    });
+    const resolve = createDesktopProposalReceiptResolver(deps);
+
+    expect(() => resolve(binding)).toThrow("workspace lookup failed");
+    expect(deps.createProjectAgentProposalReceiptService).not.toHaveBeenCalled();
+  });
+
+  it("propagates a receipt service construction error", () => {
+    const deps = dependencies();
+    deps.createProjectAgentProposalReceiptService.mockImplementation(() => {
+      throw new Error("receipt construction failed");
+    });
+    const resolve = createDesktopProposalReceiptResolver(deps);
+
+    expect(() => resolve(binding)).toThrow("receipt construction failed");
+  });
+});

--- a/electron/projectAgentHost/projectAgentReceiptResolver.test.ts
+++ b/electron/projectAgentHost/projectAgentReceiptResolver.test.ts
@@ -13,7 +13,7 @@ const service = { binding, read: vi.fn(), write: vi.fn(), transition: vi.fn(), c
 function dependencies() {
   return {
     getWorkspaceRepositoryDeps: vi.fn(() => repositoryDeps),
-    resolveWorkspaceProjectDir: vi.fn(() => "/projects/project-1"),
+    resolveWorkspaceProjectDir: vi.fn((_projectId: string, _deps: typeof repositoryDeps): string | null => "/projects/project-1"),
     createProjectAgentProposalReceiptService: vi.fn(() => service),
   };
 }
@@ -57,7 +57,7 @@ describe("desktop Project Agent proposal receipt resolver", () => {
     const deps = dependencies();
     const resolve = createDesktopProposalReceiptResolver(deps);
 
-    expect(() => resolve({ projectId: "" } as typeof binding)).toThrow("invalid_project_binding");
+    expect(() => resolve({ projectId: "" } as unknown as typeof binding)).toThrow("invalid_project_binding");
     expect(deps.getWorkspaceRepositoryDeps).not.toHaveBeenCalled();
   });
 

--- a/electron/projectAgentHost/projectAgentReceiptResolver.ts
+++ b/electron/projectAgentHost/projectAgentReceiptResolver.ts
@@ -1,0 +1,45 @@
+import type { WorkspaceRepositoryDeps } from "../workspace/workspaceRepository";
+import type { ProjectBinding } from "../shared/projectBinding";
+import { getWorkspaceRepositoryDeps } from "../runtimePaths";
+import { resolveWorkspaceProjectDir } from "../workspace/workspaceRepository";
+import { assertProjectAgentBinding } from "./projectAgentIdentity";
+import {
+  createProjectAgentProposalReceiptService,
+  type ProjectAgentProposalReceiptService,
+} from "./projectAgentProposalReceiptStore";
+
+export type DesktopProposalReceiptResolverDependencies = Readonly<{
+  getWorkspaceRepositoryDeps: () => WorkspaceRepositoryDeps;
+  resolveWorkspaceProjectDir: (projectId: string, deps: WorkspaceRepositoryDeps) => string | null;
+  createProjectAgentProposalReceiptService: (input: Readonly<{
+    projectRoot: string;
+    binding: ProjectBinding;
+  }>) => ProjectAgentProposalReceiptService;
+}>;
+
+export type DesktopProposalReceiptResolver = (
+  binding: ProjectBinding | null | undefined,
+) => ProjectAgentProposalReceiptService | undefined;
+
+const productionDependencies: DesktopProposalReceiptResolverDependencies = {
+  getWorkspaceRepositoryDeps,
+  resolveWorkspaceProjectDir,
+  createProjectAgentProposalReceiptService,
+};
+
+export function createDesktopProposalReceiptResolver(
+  dependencies: DesktopProposalReceiptResolverDependencies = productionDependencies,
+): DesktopProposalReceiptResolver {
+  return (binding) => {
+    if (binding == null) return undefined;
+    assertProjectAgentBinding(binding);
+
+    const projectRoot = dependencies.resolveWorkspaceProjectDir(
+      binding.projectId,
+      dependencies.getWorkspaceRepositoryDeps(),
+    );
+    if (!projectRoot) return undefined;
+
+    return dependencies.createProjectAgentProposalReceiptService({ projectRoot, binding });
+  };
+}

--- a/electron/projectAgentHost/projectAgentTurnExecution.ts
+++ b/electron/projectAgentHost/projectAgentTurnExecution.ts
@@ -16,6 +16,7 @@ import { executeProductionApproval, reprepareEffectiveCall } from "./projectAgen
 import { resolveCapabilityAlias } from "../shared/agentCapabilities/registry";
 import { projectAgentWorkModeDecision } from "./projectAgentExecutionPolicy";
 import { DOCUMENT_READ_CAPABILITY } from "../shared/agentCapabilities/documentRead";
+import { documentWriteOperationForAlias } from "../shared/agentCapabilities/documentWrite";
 import { CANVAS_DELETE_CAPABILITY } from "../shared/agentCapabilities/canvasDelete";
 import { CANVAS_WRITE_CAPABILITY } from "../shared/agentCapabilities/canvasWrite";
 import { TIMELINE_READ_CAPABILITY } from "../shared/agentCapabilities/timelineRead";
@@ -27,6 +28,8 @@ import { SKILL_READ_CAPABILITY } from "../shared/agentCapabilities/skillRead";
 import { committedProjectAgentReceiptMatchesApproval } from "./projectAgentProposalReceiptCorrelation";
 import { digest, steeredExecutionPrompt, exportJobTaskItems, productionRunTaskItems, statusForResponse, toolItem, hostPromptLedgerForTurn } from "./projectAgentExecutionHelpers";
 import { isPiGenerationToolName } from "../capabilityCore/generationTransportAdapters";
+import type { ProjectAgentCommittedProposalRecord } from "../shared/projectAgentProposalReceipt";
+import type { ProjectAgentProposalReceiptWriter } from "./projectAgentExecutionCoordinatorTypes";
 
 type ToolCall = { toolCallId: string; toolName: string; args: unknown };
 type PreparedInvocation = { target: ProjectAgentQueueItem["target"]; preconditions: ProjectAgentQueueItem["preconditions"]; policyRevision: number; inputHash: string; actionHash: string };
@@ -65,10 +68,83 @@ export type ProjectAgentTurnExecutionContext = Readonly<{
   productionRunFor: (partition: ExecutionPartition) => PiProductionRunTransportAdapter | undefined;
   generationFor: (partition: ExecutionPartition) => PiGenerationTransportAdapter | undefined;
   proposalReceiptReaderFor: (partition: ExecutionPartition, preferredSubscriptionId: string) => (() => import("../shared/projectAgentProposalReceipt").ProjectAgentProposalReceiptView | null) | undefined;
+  proposalReceiptWriterFor: (partition: ExecutionPartition, preferredSubscriptionId: string) => ProjectAgentProposalReceiptWriter | undefined;
 }>;
 
+function documentProposalReceiptFor(
+  call: ToolCall,
+  persisted: ProposalApprovalRef,
+  prepared: PreparedDocumentWrite,
+): ProjectAgentCommittedProposalRecord {
+  const operation = prepared.invocation.input?.operation
+    ?? documentWriteOperationForAlias(call.toolName)
+    ?? (call.args && typeof call.args === "object" && typeof (call.args as Record<string, unknown>).operation === "string"
+      ? (call.args as Record<string, unknown>).operation as "insert" | "replace" | "append"
+      : "write");
+  return Object.freeze({
+    proposalId: persisted.receiptProposalId,
+    hostApprovalId: persisted.approvalId,
+    hostActionHash: persisted.actionHash,
+    summary: `${operation} ${call.toolName}`,
+    stepLabels: Object.freeze([`${operation}:${call.toolName}`]),
+    compensation: Object.freeze([]),
+    watchNodes: Object.freeze([]),
+    reconciliationOk: true,
+  });
+}
+
+function prepareDocumentProposalReceipt(
+  writer: ProjectAgentProposalReceiptWriter,
+  proposal: ProjectAgentCommittedProposalRecord,
+  approvalId: string,
+) {
+  const current = writer.read();
+  return writer.write({
+    expectedRevision: current?.revision ?? 0,
+    proposalId: proposal.proposalId,
+    operationId: `document-prepare:${approvalId}`,
+    lifecycle: "preparing",
+    proposal,
+  });
+}
+
+function commitDocumentProposalReceipt(
+  writer: ProjectAgentProposalReceiptWriter,
+  prepared: import("../shared/projectAgentProposalReceipt").ProjectAgentProposalReceiptView,
+  proposal: ProjectAgentCommittedProposalRecord,
+  approvalId: string,
+) {
+  return writer.write({
+    expectedRevision: prepared.revision,
+    proposalId: proposal.proposalId,
+    operationId: `document-commit:${approvalId}`,
+    lifecycle: "committed",
+    proposal,
+  });
+}
+
+function abandonDocumentProposalReceipt(
+  writer: ProjectAgentProposalReceiptWriter,
+  prepared: import("../shared/projectAgentProposalReceipt").ProjectAgentProposalReceiptView,
+  proposal: ProjectAgentCommittedProposalRecord,
+  approvalId: string,
+): void {
+  try {
+    writer.transition({
+      expectedRevision: prepared.revision,
+      proposalId: proposal.proposalId,
+      operationId: `document-failed:${approvalId}`,
+      lifecycle: "undone",
+    });
+  } catch {
+    // Keep the preparing receipt as recovery evidence if the failure settlement
+    // loses its CAS race. It is safer to block a retry than to claim an undo
+    // that was not durably recorded.
+  }
+}
+
 export async function executeProjectAgentTurn(context: ProjectAgentTurnExecutionContext, partition: ExecutionPartition, execution: ActiveExecution): Promise<"continue" | "stop"> {
-  const { now, dispatchPartition, publish, dispatchFresh, queueExecutionMutation, recordProposalSettlement, cleanupExecution, reportInternalError, runAgent, awaitToolDecision, persistApprovedProposal, persistPreparedProposal, rememberCanvasWriteOutcome, canvasReadFor, documentReadFor, documentWriteFor, canvasWriteFor, timelineReadFor, timelineWriteFor, phase4SurfaceFor, skillReadFor, skillWriteFor, productionRunFor, generationFor, proposalReceiptReaderFor } = context;
+  const { now, dispatchPartition, publish, dispatchFresh, queueExecutionMutation, recordProposalSettlement, cleanupExecution, reportInternalError, runAgent, awaitToolDecision, persistApprovedProposal, persistPreparedProposal, rememberCanvasWriteOutcome, canvasReadFor, documentReadFor, documentWriteFor, canvasWriteFor, timelineReadFor, timelineWriteFor, phase4SurfaceFor, skillReadFor, skillWriteFor, productionRunFor, generationFor, proposalReceiptReaderFor, proposalReceiptWriterFor } = context;
   const startAt = now();
   const current = partition.host.getSnapshot(partition.binding);
   const assistantItem = Object.freeze({
@@ -560,10 +636,39 @@ export async function executeProjectAgentTurn(context: ProjectAgentTurnExecution
             if (!decision.ok) return decision;
             const effective = await reprepareEffectiveCall(call, decision, prepared, (effectiveCall) => writeAdapter.prepare(effectiveCall, { documentId, target: execution.queueItem.target, preconditions: execution.queueItem.preconditions }, signal));
             if (!effective.ok) return { ok: false, message: effective.code, code: effective.code };
+            const receiptWriter = proposalReceiptWriterFor(
+              partition,
+              frozen?.preferredSubscriptionId ?? "",
+            );
             try {
               const persisted = await persistPreparedProposal(partition, execution, effective.call, decision, effective.prepared);
+              const receiptProposal = receiptWriter
+                ? documentProposalReceiptFor(effective.call, persisted, effective.prepared)
+                : undefined;
+              const preparingReceipt = receiptWriter && receiptProposal
+                ? prepareDocumentProposalReceipt(receiptWriter, receiptProposal, persisted.approvalId)
+                : undefined;
               const executed = await writeAdapter.execute(effective.prepared, signal);
-              recordProposalSettlement(execution, persisted.approvalId, executed.ok ? "done" : "failed");
+              if (!executed.ok) {
+                if (receiptWriter && receiptProposal && preparingReceipt) {
+                  abandonDocumentProposalReceipt(receiptWriter, preparingReceipt, receiptProposal, persisted.approvalId);
+                }
+                recordProposalSettlement(execution, persisted.approvalId, "failed");
+                return executed;
+              }
+              if (receiptWriter && receiptProposal && preparingReceipt) {
+                try {
+                  commitDocumentProposalReceipt(receiptWriter, preparingReceipt, receiptProposal, persisted.approvalId);
+                } catch {
+                  recordProposalSettlement(execution, persisted.approvalId, "failed");
+                  return {
+                    ok: false,
+                    code: "capability_receipt_unresolved",
+                    message: "capability_receipt_unresolved",
+                  };
+                }
+              }
+              recordProposalSettlement(execution, persisted.approvalId, "done");
               return executed;
             } catch {
               return { ok: false, message: "approval_persistence_failed" };

--- a/electron/projectAgentHost/projectAgentTurnExecution.ts
+++ b/electron/projectAgentHost/projectAgentTurnExecution.ts
@@ -11,12 +11,16 @@ import type { PiSkillWriteTransportAdapter, PreparedSkillWrite } from "../capabi
 import type { PiProductionRunTransportAdapter } from "../capabilityCore/productionRunTransportAdapters";
 import type { PiGenerationTransportAdapter } from "../capabilityCore/generationTransportAdapters";
 import type { OfflineProjectAgentHost } from "./projectAgentHost";
-import { proposalSettlementsFor, readProposalReceiptSafely, type ActiveExecution, type CanvasWriteCapabilityOutcomeCode, type ExecutionPartition, type ProjectAgentExecutionCoordinatorDeps } from "./projectAgentExecutionCoordinatorTypes";
+import {
+  proposalSettlementsFor, readProposalReceiptSafely,
+  type ActiveExecution, type CanvasWriteCapabilityOutcomeCode, type ExecutionPartition,
+  type ProjectAgentExecutionCoordinatorDeps,
+  type ProjectAgentProposalReceiptWriter,
+} from "./projectAgentExecutionCoordinatorTypes";
 import { executeProductionApproval, reprepareEffectiveCall } from "./projectAgentApprovalHelpers";
 import { resolveCapabilityAlias } from "../shared/agentCapabilities/registry";
 import { projectAgentWorkModeDecision } from "./projectAgentExecutionPolicy";
 import { DOCUMENT_READ_CAPABILITY } from "../shared/agentCapabilities/documentRead";
-import { documentWriteOperationForAlias } from "../shared/agentCapabilities/documentWrite";
 import { CANVAS_DELETE_CAPABILITY } from "../shared/agentCapabilities/canvasDelete";
 import { CANVAS_WRITE_CAPABILITY } from "../shared/agentCapabilities/canvasWrite";
 import { TIMELINE_READ_CAPABILITY } from "../shared/agentCapabilities/timelineRead";
@@ -28,8 +32,12 @@ import { SKILL_READ_CAPABILITY } from "../shared/agentCapabilities/skillRead";
 import { committedProjectAgentReceiptMatchesApproval } from "./projectAgentProposalReceiptCorrelation";
 import { digest, steeredExecutionPrompt, exportJobTaskItems, productionRunTaskItems, statusForResponse, toolItem, hostPromptLedgerForTurn } from "./projectAgentExecutionHelpers";
 import { isPiGenerationToolName } from "../capabilityCore/generationTransportAdapters";
-import type { ProjectAgentCommittedProposalRecord } from "../shared/projectAgentProposalReceipt";
-import type { ProjectAgentProposalReceiptWriter } from "./projectAgentExecutionCoordinatorTypes";
+import {
+  abandonDocumentProposalReceipt,
+  commitDocumentProposalReceipt,
+  documentProposalReceiptFor,
+  prepareDocumentProposalReceipt,
+} from "./projectAgentDocumentReceipt";
 
 type ToolCall = { toolCallId: string; toolName: string; args: unknown };
 type PreparedInvocation = { target: ProjectAgentQueueItem["target"]; preconditions: ProjectAgentQueueItem["preconditions"]; policyRevision: number; inputHash: string; actionHash: string };
@@ -70,78 +78,6 @@ export type ProjectAgentTurnExecutionContext = Readonly<{
   proposalReceiptReaderFor: (partition: ExecutionPartition, preferredSubscriptionId: string) => (() => import("../shared/projectAgentProposalReceipt").ProjectAgentProposalReceiptView | null) | undefined;
   proposalReceiptWriterFor: (partition: ExecutionPartition, preferredSubscriptionId: string) => ProjectAgentProposalReceiptWriter | undefined;
 }>;
-
-function documentProposalReceiptFor(
-  call: ToolCall,
-  persisted: ProposalApprovalRef,
-  prepared: PreparedDocumentWrite,
-): ProjectAgentCommittedProposalRecord {
-  const operation = prepared.invocation.input?.operation
-    ?? documentWriteOperationForAlias(call.toolName)
-    ?? (call.args && typeof call.args === "object" && typeof (call.args as Record<string, unknown>).operation === "string"
-      ? (call.args as Record<string, unknown>).operation as "insert" | "replace" | "append"
-      : "write");
-  return Object.freeze({
-    proposalId: persisted.receiptProposalId,
-    hostApprovalId: persisted.approvalId,
-    hostActionHash: persisted.actionHash,
-    summary: `${operation} ${call.toolName}`,
-    stepLabels: Object.freeze([`${operation}:${call.toolName}`]),
-    compensation: Object.freeze([]),
-    watchNodes: Object.freeze([]),
-    reconciliationOk: true,
-  });
-}
-
-function prepareDocumentProposalReceipt(
-  writer: ProjectAgentProposalReceiptWriter,
-  proposal: ProjectAgentCommittedProposalRecord,
-  approvalId: string,
-) {
-  const current = writer.read();
-  return writer.write({
-    expectedRevision: current?.revision ?? 0,
-    proposalId: proposal.proposalId,
-    operationId: `document-prepare:${approvalId}`,
-    lifecycle: "preparing",
-    proposal,
-  });
-}
-
-function commitDocumentProposalReceipt(
-  writer: ProjectAgentProposalReceiptWriter,
-  prepared: import("../shared/projectAgentProposalReceipt").ProjectAgentProposalReceiptView,
-  proposal: ProjectAgentCommittedProposalRecord,
-  approvalId: string,
-) {
-  return writer.write({
-    expectedRevision: prepared.revision,
-    proposalId: proposal.proposalId,
-    operationId: `document-commit:${approvalId}`,
-    lifecycle: "committed",
-    proposal,
-  });
-}
-
-function abandonDocumentProposalReceipt(
-  writer: ProjectAgentProposalReceiptWriter,
-  prepared: import("../shared/projectAgentProposalReceipt").ProjectAgentProposalReceiptView,
-  proposal: ProjectAgentCommittedProposalRecord,
-  approvalId: string,
-): void {
-  try {
-    writer.transition({
-      expectedRevision: prepared.revision,
-      proposalId: proposal.proposalId,
-      operationId: `document-failed:${approvalId}`,
-      lifecycle: "undone",
-    });
-  } catch {
-    // Keep the preparing receipt as recovery evidence if the failure settlement
-    // loses its CAS race. It is safer to block a retry than to claim an undo
-    // that was not durably recorded.
-  }
-}
 
 export async function executeProjectAgentTurn(context: ProjectAgentTurnExecutionContext, partition: ExecutionPartition, execution: ActiveExecution): Promise<"continue" | "stop"> {
   const { now, dispatchPartition, publish, dispatchFresh, queueExecutionMutation, recordProposalSettlement, cleanupExecution, reportInternalError, runAgent, awaitToolDecision, persistApprovedProposal, persistPreparedProposal, rememberCanvasWriteOutcome, canvasReadFor, documentReadFor, documentWriteFor, canvasWriteFor, timelineReadFor, timelineWriteFor, phase4SurfaceFor, skillReadFor, skillWriteFor, productionRunFor, generationFor, proposalReceiptReaderFor, proposalReceiptWriterFor } = context;
@@ -252,9 +188,6 @@ export async function executeProjectAgentTurn(context: ProjectAgentTurnExecution
         const isRendererHandledStoryboardProposal =
           (canonicalCapability?.id === CANVAS_WRITE_CAPABILITY.id || call.toolName === "nomi_canvas_plan")
           && (
-            // The renderer-owned planner still emits this historical alias;
-            // keep it on the same guarded path while MCP uses the canonical
-            // nomi_canvas_plan operation envelope.
             call.toolName === "propose_storyboard_plan"
             || (
               call.toolName === "nomi_canvas_plan"
@@ -303,10 +236,6 @@ export async function executeProjectAgentTurn(context: ProjectAgentTurnExecution
         if (resolveCapabilityAlias(call.toolName)?.contract?.execution.port === "production-run") {
           return rememberCanvasWriteOutcome(execution, call.toolCallId, "capability_surface_unavailable", "capability_surface_unavailable");
         }
-        // Skill loading is a canonical read capability.  It must be handled
-        // by the same main-process catalog owner as MCP/Workbench reads;
-        // never turn it into a renderer approval request or let the model
-        // receive a synthetic success from the generic confirmation path.
         const skillReadAdapter = skillReadFor(partition, frozen?.preferredSubscriptionId ?? "");
         const skillRead = await skillReadAdapter?.tryExecute(call, signal);
         if (skillRead) return skillRead;
@@ -784,8 +713,6 @@ export async function executeProjectAgentTurn(context: ProjectAgentTurnExecution
   } catch (error) {
     if (!execution.controller.signal.aborted) {
       const message = error instanceof Error && error.message ? error.message : String(error) || "Agent execution failed";
-      // A runtime failure is a canonical transcript fact. Commit both the
-      // terminal assistant and a Failure Item before notifying views.
       let terminalError: unknown;
       try {
         await execution.publicationTail;
@@ -865,7 +792,6 @@ export async function executeProjectAgentTurn(context: ProjectAgentTurnExecution
     try {
       await execution.publicationTail;
     } catch {
-      /* terminal publication is best effort after cancellation */
     }
   } finally {
     cleanupExecution(partition, execution, false);

--- a/electron/projectAgentHost/projectAgentTurnExecution.ts
+++ b/electron/projectAgentHost/projectAgentTurnExecution.ts
@@ -41,7 +41,6 @@ import {
 
 type ToolCall = { toolCallId: string; toolName: string; args: unknown };
 type PreparedInvocation = { target: ProjectAgentQueueItem["target"]; preconditions: ProjectAgentQueueItem["preconditions"]; policyRevision: number; inputHash: string; actionHash: string };
-
 export type ProjectAgentTurnExecutionContext = Readonly<{
   now: () => string;
   dispatchPartition: (partition: ExecutionPartition, mutation: ProjectAgentMutation) => ReturnType<OfflineProjectAgentHost["dispatch"]>;
@@ -792,6 +791,7 @@ export async function executeProjectAgentTurn(context: ProjectAgentTurnExecution
     try {
       await execution.publicationTail;
     } catch {
+      /* terminal publication is best effort after cancellation */
     }
   } finally {
     cleanupExecution(partition, execution, false);

--- a/src/workbench/capability/capabilityApplyHandler.documentWrite.test.ts
+++ b/src/workbench/capability/capabilityApplyHandler.documentWrite.test.ts
@@ -30,6 +30,20 @@ function tools() {
   };
 }
 
+type DocumentWriteFailureState = {
+  creationDocumentTools: ReturnType<typeof tools> | null;
+  activeDocumentId?: string;
+  operation?: string;
+  content?: string;
+};
+
+const documentWriteFailureCases: readonly (readonly [string, DocumentWriteFailureState])[] = [
+  ["missing tools", { creationDocumentTools: null }],
+  ["unknown operation", { creationDocumentTools: tools(), operation: "delete" }],
+  ["empty content", { creationDocumentTools: tools(), operation: "append", content: "" }],
+  ["missing active document", { creationDocumentTools: tools(), activeDocumentId: "" }],
+];
+
 describe("document.write renderer capability boundary", () => {
   it("reads the live document state and applies the verified write through CreationDocumentTools", async () => {
     const documentTools = tools();
@@ -51,12 +65,7 @@ describe("document.write renderer capability boundary", () => {
     });
   });
 
-  it.each([
-    ["missing tools", { creationDocumentTools: null }],
-    ["unknown operation", { creationDocumentTools: tools(), operation: "delete" }],
-    ["empty content", { creationDocumentTools: tools(), operation: "append", content: "" }],
-    ["missing active document", { creationDocumentTools: tools(), activeDocumentId: "" }],
-  ] as const)("fails closed for document.write %s before applying", async (_label, state) => {
+  it.each(documentWriteFailureCases)("fails closed for document.write %s before applying", async (_label, state) => {
     const documentTools = state.creationDocumentTools;
     useWorkbenchStore.setState({
       activeDocumentId: state.activeDocumentId ?? "document-live",

--- a/src/workbench/capability/capabilityApplyHandler.documentWrite.test.ts
+++ b/src/workbench/capability/capabilityApplyHandler.documentWrite.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { CreationDocumentTools } from "../workbenchTypes";
+import { useWorkbenchStore } from "../workbenchStore";
+import { handleCapabilityApply } from "./capabilityApplyHandler";
+
+const originalDocumentId = useWorkbenchStore.getState().activeDocumentId;
+const originalTools = useWorkbenchStore.getState().creationDocumentTools;
+
+afterEach(() => {
+  useWorkbenchStore.setState({ activeDocumentId: originalDocumentId, creationDocumentTools: originalTools });
+});
+
+function tools() {
+  return {
+    readFullText: () => "已有文稿",
+    readSelectionText: () => "",
+    readState: vi.fn(() => ({
+      revision: 4,
+      contentHash: "fnv1a-current",
+      anchor: { kind: "whole-document" as const },
+    })),
+    applyDocumentWrite: vi.fn(() => ({ applied: true as const, revision: 5, contentHash: "fnv1a-next" })),
+    insertAtCursor: () => {},
+    replaceSelection: () => {},
+    appendToEnd: () => {},
+  } as unknown as CreationDocumentTools & {
+    readState: ReturnType<typeof vi.fn>;
+    applyDocumentWrite: ReturnType<typeof vi.fn>;
+  };
+}
+
+describe("document.write renderer capability boundary", () => {
+  it("reads the live document state and applies the verified write through CreationDocumentTools", async () => {
+    const documentTools = tools();
+    useWorkbenchStore.setState({ activeDocumentId: "document-live", creationDocumentTools: documentTools });
+
+    const result = await handleCapabilityApply("document.write", {
+      projectId: "project-1",
+      operation: "append",
+      content: "追加的 Unicode 内容😀",
+    });
+
+    expect(result).toEqual({ applied: true, revision: 5, contentHash: "fnv1a-next" });
+    expect(documentTools.readState).toHaveBeenCalledOnce();
+    expect(documentTools.applyDocumentWrite).toHaveBeenCalledWith({
+      operation: "append",
+      content: "追加的 Unicode 内容😀",
+      target: { kind: "document", documentId: "document-live", anchor: { kind: "whole-document" } },
+      preconditions: { document: { revision: 4, contentHash: "fnv1a-current" } },
+    });
+  });
+
+  it.each([
+    ["missing tools", { creationDocumentTools: null }],
+    ["unknown operation", { creationDocumentTools: tools(), operation: "delete" }],
+    ["empty content", { creationDocumentTools: tools(), operation: "append", content: "" }],
+    ["missing active document", { creationDocumentTools: tools(), activeDocumentId: "" }],
+  ] as const)("fails closed for document.write %s before applying", async (_label, state) => {
+    const documentTools = state.creationDocumentTools;
+    useWorkbenchStore.setState({
+      activeDocumentId: state.activeDocumentId ?? "document-live",
+      creationDocumentTools: documentTools,
+    });
+
+    await expect(handleCapabilityApply("document.write", {
+      projectId: "project-1",
+      operation: state.operation ?? "append",
+      content: state.content ?? "valid content",
+    })).rejects.toThrow();
+    if (documentTools) {
+      expect(documentTools.applyDocumentWrite).not.toHaveBeenCalled();
+    }
+  });
+});

--- a/src/workbench/capability/capabilityApplyHandler.ts
+++ b/src/workbench/capability/capabilityApplyHandler.ts
@@ -368,6 +368,24 @@ export async function handleCapabilityApply(op: string, payload: unknown): Promi
   if (landed !== null) return landed
 
   switch (op) {
+    case 'document.write': {
+      const tools = useWorkbenchStore.getState().creationDocumentTools
+      const operation = data.operation === 'insert' || data.operation === 'replace' || data.operation === 'append'
+        ? data.operation
+        : null
+      const content = typeof data.content === 'string' ? data.content : ''
+      const documentId = useWorkbenchStore.getState().activeDocumentId
+      if (!tools || !operation || !content || !documentId) {
+        throw new SurfacePortWireError('surface_port_unavailable')
+      }
+      const current = tools.readState()
+      return tools.applyDocumentWrite({
+        operation,
+        content,
+        target: { kind: 'document', documentId, anchor: current.anchor },
+        preconditions: { document: { revision: current.revision, contentHash: current.contentHash } },
+      })
+    }
     case 'canvas.write':
       return executeCanonicalCanvasPlanPatch({
         projectId,

--- a/tests/ux/resident-composer-receipt-fix.e2e.mjs
+++ b/tests/ux/resident-composer-receipt-fix.e2e.mjs
@@ -91,7 +91,9 @@ try {
   const approvalProof = await proveProbe(approval, 'Resident Composer shows a real pending approval')
   walk.report.matrix.H.evidence.push('visible intent -> real Agent planning request -> pending approval')
   await expect(document, 'Proposal must not mutate the document before approval').toHaveText(ORIGINAL)
-  await clickOrFail(approval.getByRole('button', { name: '批准', exact: true }), '用户确认 Resident 文稿提案')
+  await clickOrFail(approval.getByRole('button', { name: '批准', exact: true }), '用户确认 Resident 文稿提案', {
+    noWaitAfter: true,
+  })
   await recorded(approvedFollowup.received, 'the approved write result')
   await expect(document).toContainText(RESIDENT_APPEND)
   await expect.poll(async () => JSON.stringify((await readProject(win, projectId)).payload.workbenchDocuments), {

--- a/tests/ux/resident-composer-receipt-fix.e2e.mjs
+++ b/tests/ux/resident-composer-receipt-fix.e2e.mjs
@@ -1,0 +1,219 @@
+#!/usr/bin/env node
+// Real user task: visible Resident Composer -> real Agent/Host proposal -> user approval or
+// refusal -> durable proposal receipt -> real MCP stdio document write -> cold restart readback.
+// The model is deterministic only at the external provider boundary. This file never injects
+// Host items, reducer state, conversation results, receipt files, or the final project state.
+import fs from 'node:fs'
+import path from 'node:path'
+
+import { clickOrFail, expect, proveProbe } from './_assert.mjs'
+import { parseToolResult, spawnMcpStdioClient } from './_mcpJourney.mjs'
+import { flattenRequestText } from './agent-runtime-fixture.mjs'
+import { DOCUMENT, createRuntimeWalk, readProject, recorded } from './agent-runtime-walk-support.mjs'
+
+const ORIGINAL = '真实用户任务基线：创作者准备在文末补充收尾。'
+const RESIDENT_INTENT = '请在文末补一句收尾，保留原文并等待我确认。'
+const RESIDENT_APPEND = 'ResidentHostApproved她按下录制键，开始拍摄。'
+const REJECTED_APPEND = 'RejectedResidentWrite不得写入。'
+const MCP_APPEND = 'McpStdioProductionWrite这次写入必须经过同一确认回执。'
+const CREATION_PANEL = '[data-agent-resident="true"]'
+
+async function sendResidentIntent(win, text) {
+  const input = win.getByRole('textbox', { name: '给 Nomi 的消息', exact: true })
+  await expect(input).toBeVisible()
+  await input.fill(text)
+  await clickOrFail(win.getByRole('button', { name: '发送', exact: true }), '发送 Resident Composer 意图')
+}
+
+const walk = await createRuntimeWalk('resident-composer-receipt-fix')
+let mcp
+let failure
+const blockers = []
+walk.report.matrix = {
+  H: { status: 'running', evidence: [] },
+  B: { status: 'not-run', evidence: [] },
+  E: { status: 'not-run', evidence: [] },
+  T: { status: 'covered-by-contract', evidence: ['electron/capabilityCore/mcpRealUserJourneys.test.ts'] },
+  N: { status: 'running', evidence: [] },
+}
+walk.report.blockers = blockers
+function recordBlocker(code, message) {
+  blockers.push({ code, message })
+}
+
+try {
+  // Use the deterministic loopback provider only at the provider HTTP boundary. The Agent,
+  // Host, approval UI, project repository, and MCP stdio process remain production paths.
+  const catalogPath = path.join(walk.report.tempRoot, 'settings', 'model-catalog.json')
+  const catalog = JSON.parse(fs.readFileSync(catalogPath, 'utf8'))
+  catalog.version = 12
+  catalog.vendors[0].authType = 'none'
+  catalog.apiKeysByVendor = {}
+  catalog.models[0].meta = {
+    ...(catalog.models[0].meta || {}),
+    adapter: { activeRevision: 'resident-receipt-fix-v1', modes: [{ taskKind: 'chat', state: 'verified' }] },
+  }
+  fs.writeFileSync(catalogPath, `${JSON.stringify(catalog, null, 2)}\n`, { mode: 0o600 })
+
+  let { win } = await walk.start({ first: true })
+  await win.evaluate(() => localStorage.setItem('nomi.agentHost.enabled', 'true'))
+  await win.reload({ waitUntil: 'domcontentloaded' })
+
+  const project = await walk.newProject()
+  const { projectId, projectRoot } = project
+  const document = win.locator(DOCUMENT)
+  await document.fill(ORIGINAL)
+  await expect(document).toHaveText(ORIGINAL)
+  await expect.poll(async () => JSON.stringify((await readProject(win, projectId)).payload.workbenchDocuments), {
+    message: 'Human-entered baseline must reach the real project persistence path',
+    timeout: 30_000,
+  }).toContain(ORIGINAL)
+  await clickOrFail(win.getByRole('button', { name: '创作', exact: true }), '进入创作工作区')
+
+  const proposalRequest = walk.fixture.expectText({
+    label: 'Resident Composer plans a real document write',
+    match: (body) => flattenRequestText(body).includes(RESIDENT_INTENT)
+      && !body.messages?.some((message) => message.role === 'tool'),
+    reply: {
+      type: 'tool', id: 'resident-receipt-fix-1', name: 'nomi_document_edit',
+      args: { operation: 'append', content: RESIDENT_APPEND },
+    },
+  })
+  const approvedFollowup = walk.fixture.expectText({
+    label: 'Agent receives the real approved write result',
+    match: (body) => body.messages?.some((message) => message.role === 'tool'
+      && message.tool_call_id === 'resident-receipt-fix-1'),
+    reply: { type: 'text', text: '已按确认写入文稿，并保留可追溯回执。' },
+  })
+  await sendResidentIntent(win, RESIDENT_INTENT)
+  await recorded(proposalRequest.received, 'the real Agent planning request')
+  const approval = win.locator(`${CREATION_PANEL} [data-agent-approval="true"][data-agent-approval-state="pending"]`)
+  await proveProbe(approval, 'Resident Composer shows a real pending approval')
+  walk.report.matrix.H.evidence.push('visible intent -> real Agent planning request -> pending approval')
+  await expect(document, 'Proposal must not mutate the document before approval').toHaveText(ORIGINAL)
+  await clickOrFail(approval.getByRole('button', { name: '批准', exact: true }), '用户确认 Resident 文稿提案')
+  await recorded(approvedFollowup.received, 'the approved write result')
+  await expect(document).toContainText(RESIDENT_APPEND)
+  await expect.poll(async () => JSON.stringify((await readProject(win, projectId)).payload.workbenchDocuments), {
+    message: 'Approved Resident write must persist to the project',
+    timeout: 30_000,
+  }).toContain(RESIDENT_APPEND)
+  await expect(approval.getByRole('button', { name: '批准', exact: true }),
+    'An applied approval must no longer be actionable').toHaveCount(0)
+
+  const receiptPath = path.join(projectRoot, '.nomi', 'project-agent-proposal-receipt.json')
+  const beforeMcp = fs.existsSync(receiptPath) ? JSON.parse(fs.readFileSync(receiptPath, 'utf8')) : null
+  if (!beforeMcp) {
+    walk.report.matrix.H.status = 'blocked'
+    walk.report.matrix.H.evidence.push('project persistence succeeded but durable receipt file was absent')
+    recordBlocker('resident-host-document-receipt-missing',
+      'Host approval changed the project but did not persist a durable proposal receipt')
+  } else {
+    expect(beforeMcp.lifecycle).toBe('committed')
+    expect(beforeMcp.revision).toBeGreaterThan(0)
+    expect(beforeMcp.proposal?.stepLabels?.[0]).toMatch(/^append:/)
+    walk.report.matrix.H.status = 'passed'
+    walk.report.persistence = { receiptPath, hostReceipt: beforeMcp }
+  }
+
+  // B: the real Composer rejects empty input and preserves Unicode through the same UI path.
+  const composerInput = win.getByRole('textbox', { name: '给 Nomi 的消息', exact: true })
+  const composerSend = win.getByRole('button', { name: '发送', exact: true })
+  await composerInput.fill('')
+  await expect(composerSend, 'Empty Resident Composer intent must not be submitted').toBeDisabled()
+  walk.report.matrix.B = {
+    status: 'passed', evidence: ['real Composer empty input remains disabled', 'Unicode content persisted through H'],
+  }
+
+  // E: a real Agent proposal is denied at the UI approval boundary and cannot mutate the document.
+  const rejectedRequest = walk.fixture.expectText({
+    label: 'Resident Composer rejection proposal',
+    match: (body) => flattenRequestText(body).includes('请提出一个需要拒绝的收尾')
+      && !body.messages?.some((message) => message.role === 'tool'),
+    reply: {
+      type: 'tool', id: 'resident-receipt-fix-rejected', name: 'nomi_document_edit',
+      args: { operation: 'append', content: REJECTED_APPEND },
+    },
+  })
+  const rejectedFollowup = walk.fixture.expectText({
+    label: 'Agent receives the real denied write result',
+    match: (body) => body.messages?.some((message) => message.role === 'tool'
+      && message.tool_call_id === 'resident-receipt-fix-rejected'),
+    reply: { type: 'text', text: '已记录拒绝，本次没有写入文稿。' },
+  })
+  await sendResidentIntent(win, '请提出一个需要拒绝的收尾，不要自行写入。')
+  await recorded(rejectedRequest.received, 'the real rejection proposal')
+  const rejectedApproval = win.locator(`${CREATION_PANEL} [data-agent-approval="true"][data-agent-approval-state="pending"]`)
+  await proveProbe(rejectedApproval, 'Resident Composer shows the rejection approval')
+  await clickOrFail(rejectedApproval.getByRole('button', { name: '拒绝', exact: true }), '用户拒绝 Resident 文稿提案')
+  await recorded(rejectedFollowup.received, 'the denied write result')
+  await expect(document).not.toContainText(REJECTED_APPEND)
+  walk.report.matrix.E = { status: 'passed', evidence: ['real approval card -> refusal -> no project mutation'] }
+
+  // N: use a separately spawned production MCP stdio Electron process. Elicitation accepts the
+  // user's confirmation, then the GUI RPC boundary owns the same project-bound receipt service.
+  const tempRoot = walk.report.tempRoot
+  mcp = spawnMcpStdioClient({
+    settingsDir: path.join(tempRoot, 'settings'), userDataDir: path.join(tempRoot, 'user-data'),
+    projectsDir: path.join(tempRoot, 'projects'), capabilityDir: path.join(tempRoot, 'capability'),
+    captureStderr: true, env: { NOMI_RPC_TIMEOUT_MS: '2_000' },
+  })
+  walk.report.mcpPid = mcp.child.pid
+  await mcp.initialize()
+  const opened = parseToolResult(await mcp.callTool('nomi_session_open', { bootstrap: { mode: 'current_project' } }))
+  const leaseHandle = opened.json?.leaseHandle || opened.outcome?.leaseHandle
+  expect(leaseHandle, 'Real MCP stdio must open the current GUI project session').toBeTruthy()
+  const mcpResult = parseToolResult(await mcp.callTool('nomi_document_edit', {
+    leaseHandle, projectId, operation: 'append', content: MCP_APPEND,
+  }))
+  expect(mcpResult.isError, 'Real production MCP write must return a typed success result').toBe(false)
+  await expect.poll(async () => JSON.stringify((await readProject(win, projectId)).payload.workbenchDocuments), {
+    message: 'Real MCP stdio write must be observable in the open project', timeout: 30_000,
+  }).toContain(MCP_APPEND)
+  const afterMcp = fs.existsSync(receiptPath) ? JSON.parse(fs.readFileSync(receiptPath, 'utf8')) : null
+  if (!afterMcp) {
+    walk.report.matrix.N.status = 'blocked'
+    recordBlocker('mcp-stdio-bypasses-resident-receipt',
+      'MCP stdio changed project persistence but did not mint a durable receipt')
+  } else if (!beforeMcp || afterMcp.revision <= beforeMcp.revision) {
+    walk.report.matrix.N.status = 'blocked'
+    recordBlocker('mcp-stdio-revision-not-advanced',
+      'MCP stdio document.write did not advance the shared receipt revision')
+  } else {
+    expect(afterMcp.lifecycle).toBe('committed')
+    expect(afterMcp.proposal?.summary).toContain('MCP')
+    walk.report.matrix.N = { status: 'passed', evidence: ['stdio process', 'MCP elicitation', 'GUI RPC', 'revision advanced'], afterMcp }
+  }
+
+  await walk.stopApp()
+  ;({ win } = await walk.start())
+  await clickOrFail(win.locator('[data-project-card="true"]').filter({ hasText: project.name }), '冷重启后打开同一项目')
+  await clickOrFail(win.getByRole('button', { name: '创作', exact: true }), '打开 Resident Composer')
+  await expect(win.locator(DOCUMENT)).toContainText(RESIDENT_APPEND)
+  await expect(win.locator(DOCUMENT)).toContainText(MCP_APPEND)
+  expect(walk.report.launches[1].pid).not.toBe(walk.report.launches[0].pid)
+  walk.report.restart = {
+    status: 'passed', firstPid: walk.report.launches[0].pid, secondPid: walk.report.launches[1].pid,
+    readBack: [RESIDENT_APPEND, MCP_APPEND],
+  }
+  if (blockers.length) failure = new Error(blockers.map(({ code, message }) => `${code}: ${message}`).join('\n'))
+} catch (error) {
+  failure = error
+} finally {
+  if (mcp) await mcp.terminate().catch(() => {})
+  walk.report.paidCalls = 0
+  walk.report.coverage = {
+    changedProductionScope: [
+      'electron/projectAgentHost/projectAgentTurnExecution.ts',
+      'electron/capabilityCore/mcpDocumentWriteReceipt.ts',
+      'electron/capabilityCore/mcpProtocol.ts',
+      'electron/capabilityCore/rpcServer.ts',
+      'src/workbench/capability/capabilityApplyHandler.ts',
+    ],
+    v8: 'recorded-by-focused-vitest-command',
+    note: 'This Electron walk records the production effect; raw V8 receipt is produced separately.',
+  }
+  await walk.finish(failure)
+}
+
+if (failure) process.exitCode = 1

--- a/tests/ux/resident-composer-receipt-fix.e2e.mjs
+++ b/tests/ux/resident-composer-receipt-fix.e2e.mjs
@@ -6,7 +6,7 @@
 import fs from 'node:fs'
 import path from 'node:path'
 
-import { clickOrFail, expect, proveProbe } from './_assert.mjs'
+import { clickOrFail, expect, expectAbsent, proveProbe } from './_assert.mjs'
 import { parseToolResult, spawnMcpStdioClient } from './_mcpJourney.mjs'
 import { flattenRequestText } from './agent-runtime-fixture.mjs'
 import { DOCUMENT, createRuntimeWalk, readProject, recorded } from './agent-runtime-walk-support.mjs'
@@ -88,7 +88,7 @@ try {
   await sendResidentIntent(win, RESIDENT_INTENT)
   await recorded(proposalRequest.received, 'the real Agent planning request')
   const approval = win.locator(`${CREATION_PANEL} [data-agent-approval="true"][data-agent-approval-state="pending"]`)
-  await proveProbe(approval, 'Resident Composer shows a real pending approval')
+  const approvalProof = await proveProbe(approval, 'Resident Composer shows a real pending approval')
   walk.report.matrix.H.evidence.push('visible intent -> real Agent planning request -> pending approval')
   await expect(document, 'Proposal must not mutate the document before approval').toHaveText(ORIGINAL)
   await clickOrFail(approval.getByRole('button', { name: '批准', exact: true }), '用户确认 Resident 文稿提案')
@@ -98,8 +98,10 @@ try {
     message: 'Approved Resident write must persist to the project',
     timeout: 30_000,
   }).toContain(RESIDENT_APPEND)
-  await expect(approval.getByRole('button', { name: '批准', exact: true }),
-    'An applied approval must no longer be actionable').toHaveCount(0)
+  await expectAbsent(approval.getByRole('button', { name: '批准', exact: true }), {
+    provenBy: approvalProof,
+    message: 'An applied approval must no longer be actionable',
+  })
 
   const receiptPath = path.join(projectRoot, '.nomi', 'project-agent-proposal-receipt.json')
   const beforeMcp = fs.existsSync(receiptPath) ? JSON.parse(fs.readFileSync(receiptPath, 'utf8')) : null


### PR DESCRIPTION
## Summary

- Fixes the durable document proposal receipt/revision loop discovered by [#466](https://github.com/aqm857886159/Nomi/pull/466).
- Makes main/Host the receipt owner across visible Resident Composer approval, MCP loopback/RPC, and MCP stdio document.write.
- Adds fail-closed approve/deny, stale revision, duplicate/no-op, timeout/network/provider failure, and commit-CAS handling.
- Adds a real two-process Electron journey with cold-restart document/receipt readback; no UI/CSS/visual direction or #462 canonical storyboard files changed.

## Verification

- Focused Vitest: 9 files, 130 tests passed.
- MCP H/B/E/T/N contract: 8 tests passed.
- Raw V8 exact changed scope: 75/75 statements, 71/71 branch arms, 17/17 functions, 201/201 statementMap line carriers.
- New helper threshold command: statements/branches/functions/lines all 100%.
- `pnpm run typecheck`: passed.
- `pnpm run build`: passed.
- Real Electron journey: passed with two GUI launches plus independent MCP stdio, receipt revision 2 to 4, cold restart readback, `paidCalls=0`, `blockers=[]`.
- Root-cause contract checker: 30/30 passed.

Evidence: `docs/qa/2026-09-04-resident-composer-receipt-fix.md`. Coverage JSON and temporary verifier outputs are local-only artifacts and are not included. This PR does not claim full-repository 100% or packaged parity; canvas receipt and live paid-provider certification remain separate scope.

Do not merge automatically.