### PR TITLE
test: add real-user long-video journey contract

### DIFF
--- a/docs/qa/2026-09-04-real-user-long-video-task.md
+++ b/docs/qa/2026-09-04-real-user-long-video-task.md
@@ -1,0 +1,69 @@
+# 真实用户长视频创作任务骨架
+
+## 当前结论
+
+本分支只新增 manifest、runner、provider preflight、Electron/UI boundary harness、测试和本文档；没有修改 #468/#469 或设计稿相关文件。
+
+截至 2026-09-04，本机检查结果是：
+
+- 合法长视频样本：`marketing/assets/demo.mp4`，仓库已跟踪，`ffprobe` 时长 60.096 秒；它是 fixture，不是假装 live provider 产物。
+- 最小 live profile：provider `apimart`，model `gemini-3.5-flash`，类型为 text-vision。仓库的 APIMart 档案包含 `supportsImageInput`，视频拆解只需要参考帧视觉分析，不调用视频生成模型。
+- 本机 Nomi model catalog 存在 APIMart vendor、目标 model 和加密 credential record；检查只输出 record 是否存在，不输出任何 secret 值。这个 record 的可解密/可用性不能由磁盘 JSON 单独证明。
+- 当前 shell 没有 `APIMART_API_KEY`、`NOMI_LONG_VIDEO_PATH`、`NOMI_LONG_VIDEO_LIVE_CANARY=1` 或预算确认值，因此 live canary 状态是 `blocked-live`。
+- 本次没有运行任何 live API call，也没有产生 provider 费用。loopback 走查若显式运行，只能证明本地 UI/bridge 路径，费用证据为 0 USD，不能证明 live 成功。
+
+## 红 → 绿证据
+
+先加入的红测是 `real-user-long-video.boundary.test.mjs`：它给 runner 一个暴露 `injectStore` 的 driver，必须失败并返回 `ui_boundary_required`；在 runner 尚不存在时，首轮失败为 module-not-found。补齐 runner 后，红测和顺序/证据测试通过。
+
+当前 focused 绿测命令：
+
+```bash
+pnpm exec vitest run tests/ux/real-user-long-video.boundary.test.mjs tests/ux/real-user-long-video.runner.test.mjs
+```
+
+它验证：动作顺序、直接 store 注入拒绝、`pass + blocked-live` 拒绝、blocked 后不继续执行、缺少 live gate/credential/sample 时只返回 blocked。
+
+## Electron/UI boundary 路径
+
+显式 loopback 走查通过用户可见边界开始：进入 Nomi → 新建项目已通过；随后在 Agent 菜单查找 `workbench.storyboard.planner` 时发现当前 UI 不暴露它，因此走查在 Skill 步骤诚实返回 `blocked-live`，后续步骤为 `blocked_by:load-skill`。它不访问 `window.__nomiCanvasStore` 或任何 Zustand store；项目 readback（若到达该步）使用公开 Electron project bridge。
+
+当前 build 还没有独立的 deconstruction “批准/拒绝”控件，预览也没有稳定的统一 selector。因此即使 Skill 暴露，harness 也会在 `approve-result` 返回 `blocked-live`，不会把结果可见误判为用户批准；其后的审批拒绝、重启回读、重复幂等和失败回滚保持 blocked-by 证据。这是当前真实缺口，不是伪造 pass。
+
+已执行的 loopback 命令实际结果：`enter-nomi=pass (loopback)`；`load-skill=blocked-live (skill_not_exposed_in_current_agent_menu)`；没有向 loopback provider 发起模型请求，live provider 请求数仍为 0。
+
+## live canary profile
+
+文件 `tests/ux/real-user-long-video.live-canary.json` 要求同时满足：
+
+```bash
+NOMI_LONG_VIDEO_UI_E2E=1 \
+NOMI_LONG_VIDEO_LIVE_CANARY=1 \
+NOMI_LONG_VIDEO_BUDGET_CONFIRM=I_UNDERSTAND_ONE_REQUEST \
+APIMART_API_KEY='(secret, do not print)' \
+NOMI_LONG_VIDEO_PATH=/absolute/path/to/long-video.mp4 \
+node tests/ux/real-user-long-video.e2e.mjs --live
+```
+
+profile 限定单次、单并发、每镜头一帧、不生成视频、不重试、隔离 userData、只清理 runner 自有临时目录；请求 ID 与费用/额度证据是硬要求。缺任一项只能是 `blocked-live`。当前由于环境变量不齐，上述命令不会启动 provider 请求。
+
+## 证据状态定义
+
+manifest 对每一步标注 H/B/E/T/N：Human、Behavior、Evidence、Technical boundary、Negative path；并区分 `loopback`、`recorded`、`blocked-live`。loopback/recorded 只能证明本地或磁盘事实，不能升级成 live provider 成功。
+
+## 独立检查命令
+
+```bash
+node tests/ux/real-user-long-video.provider-check.mjs
+node tests/ux/real-user-long-video.runner.mjs
+NOMI_LONG_VIDEO_UI_E2E=1 node tests/ux/real-user-long-video.e2e.mjs --loopback
+```
+
+Electron 走查要求先有最新构建产物：
+
+```bash
+pnpm run build
+NOMI_LONG_VIDEO_UI_E2E=1 node tests/ux/real-user-long-video.e2e.mjs --loopback
+```
+
+该 PR 不合并、不发布；live canary 仍需后续补齐审批/拒绝 UI、稳定预览边界、请求 ID/费用 receipt 出口后，才有资格产生 live 证据。

--- a/tests/ux/real-user-long-video.boundary.test.mjs
+++ b/tests/ux/real-user-long-video.boundary.test.mjs
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import { describe, it } from "vitest";
+import { runRealUserLongVideoJourney } from "./real-user-long-video.runner.mjs";
+
+describe("real user long-video journey boundary", () => {
+  it("rejects direct store injection before any journey step can pass", async () => {
+    const events = [];
+    const unsafeDriver = {
+      async injectStore() {
+        events.push("store-injected");
+      },
+    };
+
+    await assert.rejects(
+      () => runRealUserLongVideoJourney({ driver: unsafeDriver, record: (event) => events.push(event) }),
+      /ui_boundary_required/,
+    );
+    assert.deepEqual(events, []);
+  });
+});

--- a/tests/ux/real-user-long-video.e2e.mjs
+++ b/tests/ux/real-user-long-video.e2e.mjs
@@ -1,0 +1,350 @@
+// 真实用户长视频任务的 Electron/UI boundary harness。
+//
+// 约束：动作只能通过可见 DOM/真实 Electron bridge 完成；不导入、不读取、不调用任何
+// Zustand/canvas store。默认不执行，loopback 也必须显式 opt-in；live 还要经过 runner
+// 的独立 gate。当前 deconstruction panel 没有用户审批/拒绝控件，所以该边界会诚实停在
+// approve-result=blocked-live，不把前面的 loopback 结果伪装成完整任务通过。
+import fs from 'node:fs'
+import http from 'node:http'
+import os from 'node:os'
+import path from 'node:path'
+import { execFileSync } from 'node:child_process'
+import { launchNomiApp, repoRoot } from './_launchApp.mjs'
+import { enableAgentHostThroughSettings } from './agent-runtime-walk-support.mjs'
+import {
+  REAL_USER_LONG_VIDEO_MANIFEST,
+  blockedLiveReport,
+  liveCanaryReadiness,
+  runRealUserLongVideoJourney,
+} from './real-user-long-video.runner.mjs'
+
+const FIXTURE_VIDEO = path.join(repoRoot, REAL_USER_LONG_VIDEO_MANIFEST.sample.path)
+const FIXTURE_VENDOR = 'real-user-loopback-vision'
+const FIXTURE_MODEL = 'real-user-loopback-model'
+const FIXTURE_SKILL = 'workbench.storyboard.planner'
+const NOW = '2026-09-04T00:00:00.000Z'
+
+function json(res, status, value) {
+  res.statusCode = status
+  res.setHeader('Content-Type', 'application/json')
+  res.end(JSON.stringify(value))
+}
+
+function listen(server) {
+  return new Promise((resolve, reject) => {
+    const onError = (error) => { server.off('listening', onListening); reject(error) }
+    const onListening = () => { server.off('error', onError); resolve(`http://127.0.0.1:${server.address().port}`) }
+    server.once('error', onError)
+    server.once('listening', onListening)
+    server.listen(0, '127.0.0.1')
+  })
+}
+
+function streamCompletion(res) {
+  const content = JSON.stringify({
+    shotSize: '中景',
+    mood: '明快',
+    visual: '本地 loopback fixture 视频中的主体完成连续动作，构图与光线保持稳定。',
+    onScreenText: 'LOCAL LOOPBACK',
+    imagePrompt: '本地 loopback 主体，中景构图，稳定光线，真实视频分析',
+    motionPrompt: '主体完成连续动作，镜头平稳跟随',
+  })
+  res.statusCode = 200
+  res.setHeader('Content-Type', 'text/event-stream')
+  res.setHeader('Cache-Control', 'no-cache')
+  res.setHeader('Connection', 'keep-alive')
+  const frame = (delta, finishReason = null) => `data: ${JSON.stringify({
+    id: 'real-user-loopback-request', object: 'chat.completion.chunk', created: 1,
+    model: FIXTURE_MODEL, choices: [{ index: 0, delta, finish_reason: finishReason }],
+  })}\n\n`
+  res.write(frame({ role: 'assistant', content: '' }))
+  res.write(frame({ content }))
+  res.write(frame({}, 'stop'))
+  res.end('data: [DONE]\n\n')
+}
+
+async function startLoopbackProvider() {
+  const requests = []
+  const server = http.createServer((req, res) => {
+    if (req.method !== 'POST' || !req.url?.endsWith('/chat/completions')) return json(res, 404, { error: 'route not found' })
+    requests.push({ method: req.method, url: req.url })
+    streamCompletion(res)
+  })
+  const origin = await listen(server)
+  return {
+    origin,
+    requests,
+    close: () => new Promise((resolve) => server.close(resolve)),
+  }
+}
+
+function writeLoopbackCatalog(settingsDir, baseUrl) {
+  fs.writeFileSync(path.join(settingsDir, 'model-catalog.json'), `${JSON.stringify({
+    version: 12,
+    vendors: [{
+      key: FIXTURE_VENDOR, name: 'Local long-video loopback', enabled: true,
+      baseUrlHint: baseUrl, authType: 'none', providerKind: 'openai-compatible',
+      assetIngestion: { strategy: 'inline-base64', accepts: ['image'] },
+      createdAt: NOW, updatedAt: NOW,
+    }],
+    models: [{
+      vendorKey: FIXTURE_VENDOR, modelKey: FIXTURE_MODEL, labelZh: '本地长视频视觉 fixture',
+      kind: 'text', enabled: true, published: true,
+      meta: { supportsImageInput: true, supportsToolCalls: true },
+      createdAt: NOW, updatedAt: NOW,
+    }, {
+      vendorKey: FIXTURE_VENDOR, modelKey: 'real-user-loopback-image-model', labelZh: '本地图像 fixture',
+      kind: 'image', enabled: true, published: true,
+      meta: { supportsToolCalls: true, adapter: { activeRevision: 'loopback', modes: [{ taskKind: 'text_to_image', state: 'verified' }] } },
+      createdAt: NOW, updatedAt: NOW,
+    }],
+    mappings: [], apiKeysByVendor: {},
+  }, null, 2)}\n`, 'utf8')
+}
+
+function sampleDurationSeconds(samplePath) {
+  const raw = execFileSync('ffprobe', [
+    '-v', 'error', '-show_entries', 'format=duration', '-of', 'default=noprint_wrappers=1:nokey=1', samplePath,
+  ], { encoding: 'utf8' }).trim()
+  const duration = Number(raw)
+  if (!Number.isFinite(duration) || duration <= 0) throw new Error(`invalid video duration: ${samplePath}`)
+  return duration
+}
+
+async function dismissChrome(win) {
+  await win.evaluate(() => {
+    for (const key of ['nomi:splash:v1', 'nomi:journey-tour:v1', 'nomi:canvas-gesture-hint:v1', 'nomi-onboarding-checklist:v1']) localStorage.setItem(key, 'seen')
+    localStorage.setItem('__nomiE2E', '1')
+  })
+  await win.reload()
+  await win.waitForLoadState('domcontentloaded')
+}
+
+async function enterProject(win) {
+  await dismissChrome(win)
+  const create = win.getByText('新建空白项目', { exact: true }).first()
+  await create.waitFor({ state: 'visible', timeout: 15_000 })
+  await create.click()
+  await win.waitForFunction(() => /projectId=/.test(location.href), undefined, { timeout: 15_000 })
+  const projectId = /[?#&]projectId=([^&#]+)/.exec(win.url())?.[1] || null
+  if (!projectId) throw new Error('project id was not created through the library UI')
+  await win.getByRole('button', { name: '生成', exact: true }).click().catch(async () => {
+    await win.locator('[data-mode="generation"]').click()
+  })
+  await win.locator('.generation-canvas-v2-toolbar').waitFor({ state: 'visible', timeout: 15_000 })
+  return projectId
+}
+
+async function openAgent(win) {
+  const collapsed = win.locator('[data-agent-resident-collapsed="true"]').first()
+  if (await collapsed.isVisible().catch(() => false)) await collapsed.click()
+  let panel = win.locator('[data-agent-panel="true"][data-agent-surface="generation"]').first()
+  if (!(await panel.isVisible().catch(() => false))) {
+    // Agent Host is product-level opt-in. Enable it through the visible Settings UI,
+    // never by mutating a workbench store or local storage preference.
+    await enableAgentHostThroughSettings(win)
+    const nextCollapsed = win.locator('[data-agent-resident-collapsed="true"]').first()
+    if (await nextCollapsed.isVisible().catch(() => false)) await nextCollapsed.click()
+    panel = win.locator('[data-agent-panel="true"][data-agent-surface="generation"]').first()
+  }
+  await panel.waitFor({ state: 'visible', timeout: 10_000 })
+  return panel
+}
+
+function buildUiDriver({ appRef, winRef, profile, samplePath, loopback }) {
+  let projectId = null
+  let videoNodeCountBeforeImport = 0
+  let sourceNode = null
+  let selectedSkill = null
+  let selectedModel = null
+  let persistedBeforeRestart = null
+  let restartReadback = null
+
+  const perform = async (step) => {
+    const win = winRef()
+    if (!win && step.action !== 'restartReadback') return { status: 'blocked', evidenceState: 'blocked-live', detail: 'electron_window_unavailable' }
+
+    if (step.action === 'enterNomi') {
+      projectId = await enterProject(win)
+      await openAgent(win)
+      return { status: 'pass', evidenceState: 'loopback', detail: 'created project through library UI', evidence: { projectId } }
+    }
+
+    if (step.action === 'loadSkill') {
+      const panel = await openAgent(win)
+      await panel.locator('[data-agent-composer-mode="true"]').click()
+      const item = win.locator(`[data-agent-menu-item="${FIXTURE_SKILL}"]`).first()
+      if (!(await item.isVisible().catch(() => false))) {
+        return {
+          status: 'blocked', evidenceState: 'blocked-live',
+          detail: 'skill_not_exposed_in_current_agent_menu: workbench.storyboard.planner is filtered from the visible Skill list; refusing hidden/internal injection',
+          evidence: { requestedSkill: FIXTURE_SKILL },
+        }
+      }
+      await item.click()
+      await win.locator(`[data-agent-reference="skill:${FIXTURE_SKILL}"]`).waitFor({ state: 'visible', timeout: 10_000 })
+      selectedSkill = FIXTURE_SKILL
+      return { status: 'pass', evidenceState: 'loopback', detail: 'Skill selected from visible Agent menu', evidence: { skill: selectedSkill } }
+    }
+
+    if (step.action === 'selectModel') {
+      const panel = await openAgent(win)
+      await panel.locator('[data-agent-composer-model="true"]').click()
+      const identity = loopback ? `${FIXTURE_VENDOR}/${FIXTURE_MODEL}` : 'apimart/gemini-3.5-flash'
+      const item = win.locator(`[data-agent-menu-item="${identity}"]`).first()
+      await item.waitFor({ state: 'visible', timeout: 10_000 })
+      await item.click()
+      selectedModel = identity
+      return { status: 'pass', evidenceState: loopback ? 'loopback' : 'blocked-live', detail: 'model selected from visible Agent menu', evidence: { model: selectedModel, provider: profile.provider } }
+    }
+
+    if (step.action === 'importVideo') {
+      videoNodeCountBeforeImport = await win.locator('.generation-canvas-v2-node').count()
+      const library = win.getByRole('button', { name: '素材库', exact: true }).first()
+      await library.click()
+      const picker = win.locator('input[aria-label="素材文件选择器"]').first()
+      await picker.setInputFiles(samplePath)
+      await win.waitForFunction((before) => document.querySelectorAll('.generation-canvas-v2-node').length > before, videoNodeCountBeforeImport, { timeout: 30_000 })
+      sourceNode = win.locator('.generation-canvas-v2-node').last()
+      await sourceNode.waitFor({ state: 'visible', timeout: 10_000 })
+      return { status: 'pass', evidenceState: 'recorded', detail: 'video entered through Asset Library file picker and became a canvas node', evidence: { samplePath, durationSeconds: sampleDurationSeconds(samplePath), nodeCount: await win.locator('.generation-canvas-v2-node').count() } }
+    }
+
+    if (step.action === 'deconstructVideo') {
+      if (!sourceNode) return { status: 'blocked', evidenceState: 'blocked-live', detail: 'video_node_missing' }
+      await sourceNode.hover()
+      const deconstruct = win.getByRole('button', { name: '拆解', exact: true }).first()
+      await deconstruct.waitFor({ state: 'visible', timeout: 10_000 })
+      await deconstruct.click()
+      const panel = win.locator('[data-deconstruct-panel]').last()
+      await panel.locator('[data-deconstruct-start="true"]').click()
+      await panel.locator('[data-deconstruct-shots="true"]').waitFor({ state: 'visible', timeout: 180_000 })
+      const shots = await panel.locator('[data-deconstruct-shot]').count()
+      return { status: shots > 0 ? 'pass' : 'blocked', evidenceState: loopback ? 'loopback' : 'blocked-live', detail: 'visible deconstruction panel produced storyboard rows', evidence: { shotCount: shots, loopbackRequests: loopback?.requests.length || 0 } }
+    }
+
+    if (step.action === 'produceStoryboard') {
+      const shots = await win.locator('[data-deconstruct-shots="true"] [data-deconstruct-shot]').count()
+      return shots > 0
+        ? { status: 'pass', evidenceState: loopback ? 'loopback' : 'blocked-live', detail: 'storyboard rows are visible in the deconstruction result', evidence: { shotCount: shots } }
+        : { status: 'blocked', evidenceState: 'blocked-live', detail: 'storyboard_rows_missing' }
+    }
+
+    if (step.action === 'sendToCanvas') {
+      const add = win.locator('[data-deconstruct-add-to-canvas="true"]').last()
+      const before = await win.locator('.generation-canvas-v2-node').count()
+      await add.click()
+      await win.waitForFunction((count) => document.querySelectorAll('.generation-canvas-v2-node').length > count, before, { timeout: 30_000 })
+      const count = await win.locator('.generation-canvas-v2-node').count()
+      return { status: count > videoNodeCountBeforeImport + 1 ? 'pass' : 'blocked', evidenceState: loopback ? 'loopback' : 'blocked-live', detail: 'visible add-to-canvas action completed', evidence: { nodeCount: count } }
+    }
+
+    if (step.action === 'openPreview') {
+      const preview = win.getByRole('button', { name: '预览', exact: true }).first()
+      await preview.click()
+      await win.locator('[data-workspace-mode="preview"], .workbench-preview, [data-preview-workspace]').first().waitFor({ state: 'visible', timeout: 15_000 }).catch(() => {})
+      return { status: 'blocked', evidenceState: 'blocked-live', detail: 'preview entry was clicked but a stable preview boundary selector is not exposed by this build' }
+    }
+
+    if (step.action === 'approveResult' || step.action === 'rejectResult') {
+      return { status: 'blocked', evidenceState: 'blocked-live', detail: 'deconstruction panel exposes no user approval/rejection control; refusing to infer approval from result visibility' }
+    }
+
+    if (step.action === 'verifyPersistence') {
+      const persisted = await win.evaluate((id) => window.nomiDesktop?.projects?.readAsync(id), projectId)
+      persistedBeforeRestart = persisted
+      const payload = persisted?.payload || persisted
+      return { status: payload ? 'pass' : 'blocked', evidenceState: 'recorded', detail: 'project read through public Electron project bridge', evidence: { projectId, hasPayload: Boolean(payload) } }
+    }
+
+    if (step.action === 'restartReadback') {
+      if (!projectId) return { status: 'blocked', evidenceState: 'blocked-live', detail: 'project_id_missing' }
+      await appRef().close().catch(() => {})
+      const launched = await launchNomiApp({
+        name: 'real-user-long-video-cold-readback',
+        userDataDir: profile.userDataDir, settingsDir: profile.settingsDir, projectsDir: profile.projectsDir,
+        syntheticCredentialStorage: loopback,
+        env: { NODE_ENV: 'production' }, settleMs: 0,
+      })
+      profile.replace(launched)
+      await dismissChrome(launched.win)
+      restartReadback = await launched.win.evaluate((id) => window.nomiDesktop?.projects?.readAsync(id), projectId)
+      return { status: restartReadback ? 'pass' : 'blocked', evidenceState: 'recorded', detail: 'cold restart readback through public Electron project bridge', evidence: { projectId, hasReadback: Boolean(restartReadback), hadPriorReadback: Boolean(persistedBeforeRestart) } }
+    }
+
+    if (step.action === 'repeatIdempotently') {
+      return { status: 'blocked', evidenceState: 'blocked-live', detail: 'not reached until approval boundary is implemented' }
+    }
+
+    if (step.action === 'failureRollback') {
+      return { status: 'blocked', evidenceState: 'blocked-live', detail: 'not reached until approval/rejection and failure injection boundaries are implemented' }
+    }
+
+    return { status: 'blocked', evidenceState: 'blocked-live', detail: `unsupported_action:${step.action}` }
+  }
+
+  return { perform }
+}
+
+async function run(mode) {
+  const live = mode === 'live'
+  const readiness = liveCanaryReadiness()
+  if (live && !readiness.ready) {
+    console.log(JSON.stringify(blockedLiveReport('live_canary_prerequisites_missing', { readiness }), null, 2))
+    return 0
+  }
+  if (!fs.existsSync(FIXTURE_VIDEO)) throw new Error(`missing repository fixture: ${FIXTURE_VIDEO}`)
+  const samplePath = live ? path.resolve(process.env.NOMI_LONG_VIDEO_PATH) : FIXTURE_VIDEO
+  const durationSeconds = sampleDurationSeconds(samplePath)
+  if (durationSeconds < REAL_USER_LONG_VIDEO_MANIFEST.sample.minimumDurationSeconds) throw new Error(`sample is shorter than ${REAL_USER_LONG_VIDEO_MANIFEST.sample.minimumDurationSeconds}s`)
+
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'nomi-real-user-long-video-'))
+  const profile = {
+    userDataDir: path.join(tempRoot, 'user-data'), settingsDir: path.join(tempRoot, 'settings'), projectsDir: path.join(tempRoot, 'projects'),
+    current: null, replace(next) { this.current = next },
+  }
+  for (const dir of [profile.userDataDir, profile.settingsDir, profile.projectsDir]) fs.mkdirSync(dir, { recursive: true })
+  let loopback = null
+  try {
+    if (!live) {
+      loopback = await startLoopbackProvider()
+      writeLoopbackCatalog(profile.settingsDir, loopback.origin)
+    }
+    const launched = await launchNomiApp({
+      name: live ? 'real-user-long-video-live' : 'real-user-long-video-loopback',
+      userDataDir: profile.userDataDir, settingsDir: profile.settingsDir, projectsDir: profile.projectsDir,
+      syntheticCredentialStorage: !live,
+      env: { NODE_ENV: 'production' }, settleMs: 0,
+    })
+    profile.replace(launched)
+    const driver = buildUiDriver({ appRef: () => profile.current.app, winRef: () => profile.current.win, profile, samplePath, loopback })
+    const report = await runRealUserLongVideoJourney({ driver, record: (step) => console.log(JSON.stringify(step)) })
+    console.log(JSON.stringify({
+      mode, provider: live ? readiness.provider : 'loopback', model: live ? readiness.model : FIXTURE_MODEL,
+      skill: FIXTURE_SKILL, videoDurationSeconds: durationSeconds,
+      requestIds: live ? [] : loopback.requests.map(() => 'real-user-loopback-request'),
+      costEvidence: live ? null : { type: 'loopback', amount: 0, currency: 'USD', liveProvider: false },
+      report,
+    }, null, 2))
+    await profile.current.app.close().catch(() => {})
+    return report.terminalStatus === 'pass' ? 0 : 0
+  } finally {
+    await profile.current?.app?.close().catch(() => {})
+    await loopback?.close().catch(() => {})
+    fs.rmSync(tempRoot, { recursive: true, force: true })
+  }
+}
+
+const args = new Set(process.argv.slice(2))
+if (!process.env.NOMI_LONG_VIDEO_UI_E2E) {
+  console.log(JSON.stringify({ status: 'skipped', evidenceState: 'blocked-live', detail: 'set NOMI_LONG_VIDEO_UI_E2E=1 to opt in; CI default is off' }, null, 2))
+  process.exit(0)
+}
+if (!args.has('--loopback') && !args.has('--live')) {
+  console.log(JSON.stringify({ status: 'blocked', evidenceState: 'blocked-live', detail: 'choose --loopback or --live explicitly' }, null, 2))
+  process.exit(0)
+}
+run(args.has('--live') ? 'live' : 'loopback').catch((error) => {
+  console.error(error.stack || error.message)
+  process.exit(2)
+})

--- a/tests/ux/real-user-long-video.live-canary.json
+++ b/tests/ux/real-user-long-video.live-canary.json
@@ -1,0 +1,34 @@
+{
+  "profileVersion": 1,
+  "id": "nomi.real-user.long-video.live-canary.apimart-gemini-3-5-flash",
+  "provider": "apimart",
+  "model": "gemini-3.5-flash",
+  "modelKind": "text-vision",
+  "selectionReason": "仓库已有 APIMart OpenAI-compatible 文本档案，并明确声明 gemini-3.5-flash 支持 image input；视频拆解只需文本视觉分析，不应额外调用视频生成模型。",
+  "credentialEnv": "APIMART_API_KEY",
+  "samplePathEnv": "NOMI_LONG_VIDEO_PATH",
+  "explicitGates": {
+    "liveCanaryEnv": "NOMI_LONG_VIDEO_LIVE_CANARY=1",
+    "budgetConfirmationEnv": "NOMI_LONG_VIDEO_BUDGET_CONFIRM=I_UNDERSTAND_ONE_REQUEST"
+  },
+  "requestBudget": {
+    "maxCanaryRuns": 1,
+    "framesPerShot": 1,
+    "concurrency": 1,
+    "noVideoGeneration": true,
+    "noRetry": true,
+    "costEvidenceRequired": true,
+    "requestIdEvidenceRequired": true
+  },
+  "rollback": {
+    "isolateUserData": true,
+    "deleteOnlyOwnedTempProfile": true,
+    "doNotModifyExistingCatalog": true,
+    "doNotPublishOrMerge": true
+  },
+  "truthRules": [
+    "缺 APIMART_API_KEY、NOMI_LONG_VIDEO_PATH、请求 ID 或费用/额度证据时只能是 blocked-live。",
+    "仓库 fixture、loopback server 和 recorded output 不能证明 live provider 成功。",
+    "API key 只能进入应用配置 bridge；日志和报告只记录存在性，不记录 secret 值。"
+  ]
+}

--- a/tests/ux/real-user-long-video.manifest.json
+++ b/tests/ux/real-user-long-video.manifest.json
@@ -1,0 +1,40 @@
+{
+  "schemaVersion": 1,
+  "id": "nomi.real-user.long-video-creation",
+  "title": "真实用户长视频创作任务",
+  "purpose": "验证用户从进入 Nomi 到视频拆解、分镜表、画布/预览、审批、持久化和失败回滚的真实顺序；不把内部 store 注入当作用户路径。",
+  "defaultExecution": "contract-only",
+  "evidenceStates": ["loopback", "recorded", "blocked-live"],
+  "classifications": {
+    "H": "Human action: 用户可见的进入、点击、选择、导入和审批动作",
+    "B": "Behavior: Skill、模型和产物在用户动作后的可观察行为",
+    "E": "Evidence: 磁盘、重启、请求和费用/额度证据",
+    "T": "Technical boundary: Electron/UI/preload/本地持久化边界",
+    "N": "Negative path: 拒绝、失败、回滚和阻断必须诚实返回"
+  },
+  "sample": {
+    "path": "marketing/assets/demo.mp4",
+    "kind": "repository-tracked-fixture",
+    "licenseEvidence": "仓库已跟踪的 marketing demo 素材；runner 只读取，不宣称是真实 provider 生成",
+    "minimumDurationSeconds": 30,
+    "measuredDurationSeconds": 60.096,
+    "liveOverrideEnv": "NOMI_LONG_VIDEO_PATH"
+  },
+  "liveCanaryProfile": "tests/ux/real-user-long-video.live-canary.json",
+  "steps": [
+    { "id": "enter-nomi", "action": "enterNomi", "classification": "H", "evidenceMode": "loopback", "required": true },
+    { "id": "load-skill", "action": "loadSkill", "classification": "B", "evidenceMode": "loopback", "required": true },
+    { "id": "select-model", "action": "selectModel", "classification": "H", "evidenceMode": "loopback", "required": true },
+    { "id": "import-video", "action": "importVideo", "classification": "H", "evidenceMode": "recorded", "required": true },
+    { "id": "deconstruct-video", "action": "deconstructVideo", "classification": "B", "evidenceMode": "blocked-live", "required": true },
+    { "id": "produce-storyboard", "action": "produceStoryboard", "classification": "B", "evidenceMode": "blocked-live", "required": true },
+    { "id": "send-to-canvas", "action": "sendToCanvas", "classification": "H", "evidenceMode": "blocked-live", "required": true },
+    { "id": "open-preview", "action": "openPreview", "classification": "H", "evidenceMode": "blocked-live", "required": true },
+    { "id": "approve-result", "action": "approveResult", "classification": "H", "evidenceMode": "blocked-live", "required": true },
+    { "id": "reject-result", "action": "rejectResult", "classification": "N", "evidenceMode": "blocked-live", "required": true },
+    { "id": "verify-persistence", "action": "verifyPersistence", "classification": "E", "evidenceMode": "recorded", "required": true },
+    { "id": "restart-readback", "action": "restartReadback", "classification": "T", "evidenceMode": "recorded", "required": true },
+    { "id": "repeat-idempotently", "action": "repeatIdempotently", "classification": "E", "evidenceMode": "recorded", "required": true },
+    { "id": "failure-rollback", "action": "failureRollback", "classification": "N", "evidenceMode": "blocked-live", "required": true }
+  ]
+}

--- a/tests/ux/real-user-long-video.provider-check.mjs
+++ b/tests/ux/real-user-long-video.provider-check.mjs
@@ -1,0 +1,28 @@
+// Redacted provider/config preflight. It reports presence and public catalog metadata only;
+// never prints API-key plaintext, ciphertext, token, or environment values.
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { liveCanaryReadiness } from './real-user-long-video.runner.mjs'
+
+const catalogPath = path.join(os.homedir(), 'Library', 'Application Support', 'Nomi', 'model-catalog.json')
+const result = {
+  providerProfile: { provider: 'apimart', model: 'gemini-3.5-flash', credentialEnv: 'APIMART_API_KEY' },
+  environment: liveCanaryReadiness(),
+  catalog: { path: catalogPath, present: false, apimartVendor: null, targetModel: null, encryptedCredentialRecordPresent: false },
+}
+if (fs.existsSync(catalogPath)) {
+  try {
+    const catalog = JSON.parse(fs.readFileSync(catalogPath, 'utf8'))
+    const vendor = catalog.vendors?.find((row) => row.key === 'apimart')
+    const model = catalog.models?.find((row) => row.vendorKey === 'apimart' && row.modelKey === 'gemini-3.5-flash')
+    const keyRecord = catalog.apiKeysByVendor?.apimart
+    result.catalog.present = true
+    result.catalog.apimartVendor = vendor ? { enabled: vendor.enabled, providerKind: vendor.providerKind, authType: vendor.authType, baseUrlHint: vendor.baseUrlHint } : null
+    result.catalog.targetModel = model ? { kind: model.kind, enabled: model.enabled, supportsImageInput: model.meta?.supportsImageInput === true } : null
+    result.catalog.encryptedCredentialRecordPresent = Boolean(keyRecord && typeof keyRecord === 'object' && (keyRecord.enc || keyRecord.ciphertext || keyRecord.encryptedValue))
+  } catch (error) {
+    result.catalog.parseError = error instanceof Error ? error.message : String(error)
+  }
+}
+console.log(JSON.stringify(result, null, 2))

--- a/tests/ux/real-user-long-video.runner.mjs
+++ b/tests/ux/real-user-long-video.runner.mjs
@@ -1,0 +1,131 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const MANIFEST_PATH = path.join(HERE, "real-user-long-video.manifest.json");
+export const REAL_USER_LONG_VIDEO_MANIFEST = JSON.parse(fs.readFileSync(MANIFEST_PATH, "utf8"));
+
+const FORBIDDEN_DRIVER_KEYS = /(^|[^a-z])(inject|set|get|read|use|dispatch).*(store|zustand|state)|store|zustand/i;
+const VALID_EVIDENCE_STATES = new Set(["loopback", "recorded", "blocked-live"]);
+
+function uiBoundaryRequired(driver) {
+  if (!driver || typeof driver.perform !== "function") return true;
+  return Object.keys(driver).some((key) => FORBIDDEN_DRIVER_KEYS.test(key));
+}
+
+function assertUiBoundaryDriver(driver) {
+  if (uiBoundaryRequired(driver)) {
+    throw new Error("ui_boundary_required: journey drivers may only expose visible UI boundary actions");
+  }
+}
+
+function normalizeResult(step, result) {
+  const normalized = result && typeof result === "object" ? result : {};
+  const status = normalized.status === "pass" || normalized.status === "blocked" ? normalized.status : "blocked";
+  const evidenceState = VALID_EVIDENCE_STATES.has(normalized.evidenceState)
+    ? normalized.evidenceState
+    : "blocked-live";
+  if (status === "pass" && evidenceState === "blocked-live") {
+    throw new Error(`invalid_evidence: ${step.id} cannot pass with blocked-live evidence`);
+  }
+  return {
+    stepId: step.id,
+    action: step.action,
+    classification: step.classification,
+    status,
+    evidenceState,
+    detail: typeof normalized.detail === "string" ? normalized.detail : "",
+    evidence: normalized.evidence && typeof normalized.evidence === "object" ? normalized.evidence : {},
+  };
+}
+
+export async function runRealUserLongVideoJourney({ driver, record = () => {} } = {}) {
+  assertUiBoundaryDriver(driver);
+  const steps = [];
+  let blockedBy = null;
+
+  for (const step of REAL_USER_LONG_VIDEO_MANIFEST.steps) {
+    if (blockedBy) {
+      const skipped = {
+        stepId: step.id,
+        action: step.action,
+        classification: step.classification,
+        status: "blocked",
+        evidenceState: "blocked-live",
+        detail: `blocked_by:${blockedBy}`,
+        evidence: {},
+      };
+      steps.push(skipped);
+      record(skipped);
+      continue;
+    }
+    const result = normalizeResult(step, await driver.perform({ ...step }));
+    steps.push(result);
+    record(result);
+    if (result.status === "blocked") blockedBy = step.id;
+  }
+
+  return {
+    manifestId: REAL_USER_LONG_VIDEO_MANIFEST.id,
+    terminalStatus: blockedBy ? "blocked" : "pass",
+    blockedBy,
+    steps,
+  };
+}
+
+export function liveCanaryReadiness(env = process.env) {
+  const profile = JSON.parse(fs.readFileSync(path.join(HERE, "real-user-long-video.live-canary.json"), "utf8"));
+  const has = (name) => typeof env[name] === "string" && env[name].trim().length > 0;
+  const ready = env["NOMI_LONG_VIDEO_LIVE_CANARY"] === "1"
+    && env["NOMI_LONG_VIDEO_BUDGET_CONFIRM"] === "I_UNDERSTAND_ONE_REQUEST"
+    && has(profile.credentialEnv)
+    && has(profile.samplePathEnv);
+  return {
+    ready,
+    provider: profile.provider,
+    model: profile.model,
+    credentialEnv: profile.credentialEnv,
+    credentialPresent: has(profile.credentialEnv),
+    samplePathEnv: profile.samplePathEnv,
+    samplePathPresent: has(profile.samplePathEnv),
+    liveCanaryEnabled: env.NOMI_LONG_VIDEO_LIVE_CANARY === "1",
+    budgetConfirmed: env.NOMI_LONG_VIDEO_BUDGET_CONFIRM === "I_UNDERSTAND_ONE_REQUEST",
+  };
+}
+
+export function blockedLiveReport(reason, extra = {}) {
+  return {
+    manifestId: REAL_USER_LONG_VIDEO_MANIFEST.id,
+    terminalStatus: "blocked",
+    blockedBy: null,
+    steps: REAL_USER_LONG_VIDEO_MANIFEST.steps.map((step) => ({
+      stepId: step.id,
+      action: step.action,
+      classification: step.classification,
+      status: "blocked",
+      evidenceState: "blocked-live",
+      detail: reason,
+      evidence: {},
+    })),
+    ...extra,
+  };
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const args = new Set(process.argv.slice(2));
+  if (!args.has("--execute")) {
+    console.log(JSON.stringify(blockedLiveReport("contract-only: pass --execute to run an explicit UI walk"), null, 2));
+    process.exit(0);
+  }
+  if (args.has("--live")) {
+    const readiness = liveCanaryReadiness();
+    console.log(JSON.stringify({ mode: "live", readiness }, null, 2));
+    if (!readiness.ready) {
+      console.log(JSON.stringify(blockedLiveReport("live_canary_prerequisites_missing", { readiness }), null, 2));
+      process.exit(0);
+    }
+  }
+  console.error("UI driver not attached: use real-user-long-video.e2e.mjs for the Electron boundary walk");
+  process.exit(2);
+}

--- a/tests/ux/real-user-long-video.runner.test.mjs
+++ b/tests/ux/real-user-long-video.runner.test.mjs
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import { describe, it } from "vitest";
+import {
+  REAL_USER_LONG_VIDEO_MANIFEST,
+  liveCanaryReadiness,
+  runRealUserLongVideoJourney,
+} from "./real-user-long-video.runner.mjs";
+
+describe("real user long-video runner contract", () => {
+  it("keeps the user-visible action order in the manifest", () => {
+    assert.deepEqual(
+      REAL_USER_LONG_VIDEO_MANIFEST.steps.map((step) => step.action),
+      [
+        "enterNomi", "loadSkill", "selectModel", "importVideo", "deconstructVideo",
+        "produceStoryboard", "sendToCanvas", "openPreview", "approveResult", "rejectResult",
+        "verifyPersistence", "restartReadback", "repeatIdempotently", "failureRollback",
+      ],
+    );
+  });
+
+  it("does not allow a blocked-live result to be reported as pass", async () => {
+    await assert.rejects(
+      () => runRealUserLongVideoJourney({
+        driver: { perform: async () => ({ status: "pass", evidenceState: "blocked-live" }) },
+      }),
+      /invalid_evidence/,
+    );
+  });
+
+  it("stops executing after the first real UI boundary blocker", async () => {
+    const executed = [];
+    const report = await runRealUserLongVideoJourney({
+      driver: {
+        perform: async ({ action }) => {
+          executed.push(action);
+          return action === "deconstructVideo"
+            ? { status: "blocked", evidenceState: "blocked-live", detail: "no live provider" }
+            : { status: "pass", evidenceState: "loopback", detail: "visible UI action" };
+        },
+      },
+    });
+    assert.deepEqual(executed, ["enterNomi", "loadSkill", "selectModel", "importVideo", "deconstructVideo"]);
+    assert.equal(report.terminalStatus, "blocked");
+    assert.equal(report.steps.at(-1).detail, "blocked_by:deconstruct-video");
+  });
+
+  it("requires explicit live flag, budget confirmation, provider key, and real sample path", () => {
+    const base = {
+      NOMI_LONG_VIDEO_LIVE_CANARY: "1",
+      NOMI_LONG_VIDEO_BUDGET_CONFIRM: "I_UNDERSTAND_ONE_REQUEST",
+      APIMART_API_KEY: "redacted-placeholder-for-test",
+      NOMI_LONG_VIDEO_PATH: "/tmp/user-video.mp4",
+    };
+    assert.equal(liveCanaryReadiness(base).ready, true);
+    assert.equal(liveCanaryReadiness({ ...base, APIMART_API_KEY: "" }).ready, false);
+    assert.equal(liveCanaryReadiness({ ...base, NOMI_LONG_VIDEO_BUDGET_CONFIRM: "yes" }).ready, false);
+    assert.equal(liveCanaryReadiness(base).credentialPresent, true);
+  });
+});


### PR DESCRIPTION
## Summary

- Add a manifest and sequential runner for the real-user long-video creation journey.
- Add a red-first boundary test that rejects direct store injection, plus focused contract tests.
- Add an opt-in Electron/UI boundary harness and a redacted provider preflight.
- Add an APIMart `gemini-3.5-flash` live-canary profile with explicit credential/sample/budget gates and one-call limits.

## Evidence and limits

- Repository fixture: `marketing/assets/demo.mp4`, ffprobe duration 60.096s.
- Current environment: `APIMART_API_KEY` missing; `NOMI_LONG_VIDEO_PATH` missing; live flag missing; budget confirmation missing.
- Live canary: not run; zero provider requests and zero provider cost.
- Explicit loopback Electron walk reached `enter-nomi=pass`, then blocked at visible Skill selection because `workbench.storyboard.planner` is not exposed in the current Agent menu. No model request was made.
- Approval/rejection controls, stable preview selector, and post-approval persistence/idempotency/rollback evidence remain honestly blocked; no success is inferred from store/result visibility.

## Verification

- `pnpm exec vitest run tests/ux/real-user-long-video.boundary.test.mjs tests/ux/real-user-long-video.runner.test.mjs`
- `pnpm run check:secrets`
- `pnpm run check:mjs-parse`
- `pnpm run check:docs-index`
- `pnpm run check:doc-status`
- `pnpm run check:test-waits`
- `pnpm run check:git-delivery`
- `pnpm run build`
- `NOMI_LONG_VIDEO_UI_E2E=1 node tests/ux/real-user-long-video.e2e.mjs --loopback` (blocked at visible Skill boundary, as documented)
- `NOMI_LONG_VIDEO_UI_E2E=1 node tests/ux/real-user-long-video.e2e.mjs --live` (blocked before provider request by missing gates)

Do not merge this PR. It is a test contract and gap report, not live certification.
