### PR TITLE
fix(skill-ipc): expose storyboard planner in Agent menu

### DIFF
--- a/electron/skills/skillIpc.test.ts
+++ b/electron/skills/skillIpc.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+
+import { listSkillsForRenderer } from "./skillIpc";
+import { readSkillRecords } from "./skillStore";
+
+describe("renderer Skill catalog projection", () => {
+  it("exposes the built-in storyboard planner in the Agent Skill menu DTO", () => {
+    const record = readSkillRecords().find((skill) => skill.name === "workbench.storyboard.planner");
+    expect(record?.origin).toBe("builtin");
+    expect(record?.name).toBe("workbench.storyboard.planner");
+
+    const visible = listSkillsForRenderer();
+    expect(visible.map((skill) => skill.name)).toContain("workbench.storyboard.planner");
+  });
+});

--- a/electron/skills/skillIpc.ts
+++ b/electron/skills/skillIpc.ts
@@ -41,7 +41,18 @@ export function listSkillsForRenderer(): SkillListItem[] {
     // 如品牌宣传片）。藏掉两类不该出现在用户库里的：① 外来工程技能（superpowers 的 brainstorming 等，
     // 无 manifest）；② 幕后管线技能（creation-edit / skill-author / workbench.* 助手，自动路由或按钮触发，
     // 不是浏览挑选项）。口径与创作区技能下拉（ActiveSkillChip 的 isPlaybook 过滤）一致。
-    .filter((r) => r.origin === "user" || (r.manifest?.stages?.length ?? 0) > 0)
+    // storyboard planner 是内置的单段 legacy skill：它用 storyboardProfile，不声明 stages，
+    // 但仍是 Agent 菜单的合法选择项。放行必须保持在精确身份、合法 manifest、启用且 internal scope 内。
+    .filter((r) => r.origin === "user" || (
+      !r.manifestError &&
+      !r.disableModelInvocation &&
+      r.audience === "internal" &&
+      ((r.manifest?.stages?.length ?? 0) > 0 || (
+        r.name === "workbench.storyboard.planner" &&
+        r.manifest !== null &&
+        "storyboardProfile" in r.manifest
+      ))
+    ))
     .map((r) => {
     const needs = r.manifest ? deriveSkillNeeds(r.manifest) : null;
     return {

--- a/electron/skills/skillManifestSchema.ts
+++ b/electron/skills/skillManifestSchema.ts
@@ -49,6 +49,21 @@ export const skillExampleSchema = z.object({
 });
 export type SkillExample = z.infer<typeof skillExampleSchema>;
 
+const storyboardProfileSchema = z.object({
+  default: z.string().min(1),
+  templates: z.array(z.object({
+    key: z.string().min(1),
+    aspect: z.string().min(1),
+    dialogue: z.boolean(),
+    promptSkeleton: z.array(z.object({
+      key: z.string().min(1),
+      label: z.string().min(1),
+      kind: z.string().min(1),
+      options: z.array(z.string().min(1)),
+    }).strict()),
+  }).strict()),
+}).strict();
+
 /**
  * 阶段级模型偏好 —— **只声明能力身份（kind + 可选 family），绝不绑 vendor 专属 archetypeId，
  * 也不写死参数**（参数合法区间交模型档案给）。这是「通用第一（P4）」+「分享出去不绑死」的硬约束：
@@ -111,6 +126,8 @@ export const skillManifestSchema = z.object({
   inputs: z.array(skillInputSchema).optional(),
   /** Sample prompts shown in onboarding or the skill picker (optional). */
   examples: z.array(skillExampleSchema).optional(),
+  /** Legacy storyboard planner metadata for the single-stage Agent menu skill. */
+  storyboardProfile: storyboardProfileSchema.optional(),
   /**
    * Multi-stage playbook skeleton (optional). Absent ⇒ legacy single-stage pack
    * (current 5 built-ins are unaffected — full back-compat). Present ⇒ the


### PR DESCRIPTION
## Summary
- preserve the built-in `storyboardProfile` metadata in the Skill manifest schema
- expose the valid enabled internal `workbench.storyboard.planner` in the renderer Skill DTO
- add a real renderer-filter regression test

## Verification
- `pnpm exec tsc -p electron/tsconfig.json --noEmit`
- focused Vitest: 26 passed
- `pnpm run check:skill-ipc-coverage`
- `git diff --check`
- real Electron walk attempted; blocked because required `dist-electron` artifacts are absent and launcher requires `pnpm run build`

No external model/API calls were made. Not merged.