### PR TITLE
fix: expose storyboard planner in Agent Skill picker

### DIFF
--- a/docs/fixes/2026-09-04-workbench-skill-picker.root-cause.json
+++ b/docs/fixes/2026-09-04-workbench-skill-picker.root-cause.json
@@ -1,0 +1,127 @@
+{
+  "schema_version": 3,
+  "id": "2026-09-04-workbench-skill-picker",
+  "problem_type": "Workbench Agent Skill discoverability and selection boundary",
+  "symptom": "The real Agent Skill menu does not show or allow selecting workbench.storyboard.planner even though the canonical Skill catalog discovers its package.",
+  "direct_cause": "The renderer-facing Skill IPC list keeps user Skills and built-in Skills with stages, so the valid single-stage storyboard planner is filtered out before the menu renders it.",
+  "class_root": "The shared Skill catalog has no explicit Workbench-selectability invariant; a presentation-specific stages heuristic is used as a proxy and silently drops valid single-stage Workbench Skills.",
+  "affected_population": [
+    "Users opening the Agent Skill menu in creation, generation, or preview surfaces",
+    "Built-in single-stage Workbench Skills, especially workbench.storyboard.planner",
+    "Instances with missing providers, malformed manifests, or unavailable catalog health"
+  ],
+  "scope_paths": [
+    "electron/skills/skillManifestSchema.ts",
+    "electron/skills/skillStore.ts",
+    "electron/skills/skillIpc.ts",
+    "skills/workbench-storyboard-planner/skill.json",
+    "src/workbench/ai/ProjectAgentResidentShell.tsx",
+    "tests/ux/real-user-long-video.e2e.mjs"
+  ],
+  "entry_points": [
+    "ProjectAgentResidentShell Skill menu",
+    "CreationPromptPicker Skill section",
+    "Skill Library reload and card projection",
+    "ProjectAgent Host skill.read execution"
+  ],
+  "external_sources": [],
+  "internal_only_reason": "This invariant is Nomi's internal canonical catalog-to-Workbench contract; no third-party runtime decides which installed Skill is user-selectable.",
+  "invariants": [
+    "A built-in Skill enters the Workbench picker only when its validated manifest explicitly declares selectableInWorkbench or it is an existing multi-stage playbook; internal routing Skills remain hidden.",
+    "User Skills remain visible even when their optional manifest is missing or invalid, while their manifestError remains observable in the DTO.",
+    "Workbench picker visibility is independent of MCP audience and provider health; missing text/image/video providers mark capability gaps but do not silently remove the Skill.",
+    "A selected menu item preserves the canonical Skill name and is passed as skillKey through the existing resident Agent request path."
+  ],
+  "generality_proof": "The Agent resident shell, CreationPromptPicker, and Skill Library all consume the renderer-facing skill.list DTO, while Pi/MCP discovery continues to use the same Skill records. Centralizing Workbench selectability on the validated record prevents a single-stage or future explicitly selectable built-in from being dropped by any renderer caller, without widening MCP visibility or routing-only resources.",
+  "shared_boundaries": [
+    {
+      "path": "electron/skills/skillStore.ts",
+      "symbol": "isSkillSelectableInWorkbench",
+      "responsibility": "Own the canonical Workbench selection invariant from validated Skill origin, manifest declaration, and existing playbook shape."
+    },
+    {
+      "path": "electron/skills/skillIpc.ts",
+      "symbol": "listSkillsForRenderer",
+      "responsibility": "Project only canonical selectable records into the DTO consumed by every Workbench picker."
+    },
+    {
+      "path": "src/workbench/ai/ProjectAgentResidentShell.tsx",
+      "symbol": "ProjectAgentResidentShell",
+      "responsibility": "Render the DTO and preserve the selected canonical Skill identity in the existing store-to-Agent request path."
+    }
+  ],
+  "same_class_entry_points": [
+    {
+      "path": "src/workbench/ai/ProjectAgentResidentShell.tsx",
+      "entry_point": "ProjectAgentResidentShell({ surface }) Skill menu",
+      "disposition": "enforced",
+      "evidence": "The resident menu reads listWorkbenchSkills, which is backed by nomi:skill:list and therefore the shared listSkillsForRenderer boundary."
+    },
+    {
+      "path": "src/workbench/ai/CreationPromptPicker.tsx",
+      "entry_point": "CreationPromptPicker Skill section",
+      "disposition": "enforced",
+      "evidence": "The creation picker calls the same listWorkbenchSkills API and renders its returned DTO without a second catalog filter."
+    },
+    {
+      "path": "src/workbench/skillLibrary/useWorkbenchSkills.ts",
+      "entry_point": "useWorkbenchSkills Skill Library",
+      "disposition": "enforced",
+      "evidence": "The library reload path calls the same listWorkbenchSkills API, so the canonical IPC projection is shared with management UI."
+    },
+    {
+      "path": "electron/harness/runtime/pi/nomiSkillResources.mts",
+      "entry_point": "createNomiSkillResourceCatalog",
+      "disposition": "not-affected",
+      "evidence": "Pi loads the full canonical resource catalog for model-facing progressive disclosure; it must not apply the user-facing Workbench picker filter."
+    }
+  ],
+  "recurrence": {
+    "classification": "recurring",
+    "reason": "Any future built-in Skill without stages, or any caller that copies the stages-only heuristic, can reproduce the same silent omission.",
+    "same_class_scan": [
+      "rg listWorkbenchSkills across src/workbench: resident Agent, CreationPromptPicker, and Skill Library all converge on one API.",
+      "rg listSkillsForRenderer and isSkillSelectableInWorkbench across electron: the IPC projection and policy are the shared production boundary.",
+      "rg workbench.storyboard.planner and stages across skills, electron/skills, and tests: the reported package is single-stage while routing Skills are separately identified."
+    ]
+  },
+  "prevention": {
+    "kind": "centralized-boundary",
+    "enforcement_path": "electron/skills/skillStore.ts",
+    "invariant": "Only validated built-in Skills explicitly selectable for Workbench or existing multi-stage playbooks, plus all user Skills, enter the Workbench DTO; provider health and MCP audience do not alter this visibility decision.",
+    "failure_mode": "Missing or invalid built-in manifests fail closed and stay out of the picker; missing provider/network health leaves a valid Skill visible with a capability warning; malformed user packages remain observable with manifestError under the existing user-origin policy.",
+    "exception_policy": "none",
+    "strategy": "Declare user-facing Workbench intent in the canonical manifest, evaluate it once at the Skill record boundary, and remove the duplicated stages-only IPC heuristic.",
+    "artifacts": [
+      "electron/skills/skillManifestSchema.ts",
+      "electron/skills/skillStore.ts",
+      "electron/skills/skillIpc.ts",
+      "skills/workbench-storyboard-planner/skill.json"
+    ]
+  },
+  "regression_tests": [
+    "electron/skills/skillStore.test.ts",
+    "electron/skills/skillIpc.test.ts",
+    "electron/skills/skillManifestSchema.test.ts",
+    "tests/ux/real-user-long-video.e2e.mjs"
+  ],
+  "class_regression_tests": [
+    "electron/skills/skillStore.test.ts",
+    "electron/skills/skillIpc.test.ts"
+  ],
+  "legacy_paths": {
+    "status": "not-applicable",
+    "removed_paths": [],
+    "rationale": "The old stages-only branch was an inline predicate, not a standalone path; it is removed from listSkillsForRenderer and replaced by the shared Workbench selectability boundary. No parallel list or hidden injection path is retained."
+  },
+  "dependency_lifecycle": {
+    "decision": "not-applicable",
+    "rationale": "The defect is caused by Nomi's catalog projection policy, not a third-party dependency.",
+    "exit_criteria": []
+  },
+  "migration": "No persisted data migration is needed. The new manifest field is optional, existing user Skills remain selectable, existing multi-stage playbooks retain their behavior, and the selected Skill continues through the current ephemeral composer state and Host request contract.",
+  "residual_risks": [
+    "A live provider canary requires user-supplied credentials and a real sample; it must remain blocked when those prerequisites are absent.",
+    "The existing long-video journey has later approval/rejection boundaries outside this picker fix; those remain explicitly blocked rather than inferred from screenshots or result visibility."
+  ]
+}

--- a/docs/plan/2026-09-04-workbench-skill-picker-fix.md
+++ b/docs/plan/2026-09-04-workbench-skill-picker-fix.md
@@ -1,5 +1,7 @@
 # Workbench Skill picker 修复
 
+> 状态：✅ 已交付
+
 ## 目标
 
 让合法的 `workbench.storyboard.planner` 从 canonical Skill catalog 经真实

--- a/docs/plan/2026-09-04-workbench-skill-picker-fix.md
+++ b/docs/plan/2026-09-04-workbench-skill-picker-fix.md
@@ -1,0 +1,32 @@
+# Workbench Skill picker 修复
+
+## 目标
+
+让合法的 `workbench.storyboard.planner` 从 canonical Skill catalog 经真实
+`nomi:skill:list` IPC 进入 Agent Skill 菜单，并且点击后的 `{ key, name }`
+继续走现有 `creationActiveSkill` → `runWorkbenchAgent({ skillKey })` 链路。
+
+## 根因与边界
+
+- 根因：renderer-facing Skill 列表把“内置 playbook（有 stages）”误当成全部可选内置 Skill，漏掉合法的单阶段 storyboard planner。
+- 共享边界：`electron/skills/skillStore.ts` 负责可选性策略；`electron/skills/skillIpc.ts` 负责把该策略投影成 renderer DTO。
+- 保留：用户 Skill 仍可见；已有多阶段内置 playbook 仍可见；MCP audience 仍与 Workbench picker 独立。
+- 不动：PR #454 的 storyboard 规划/画布样张、Agent runner、生成 provider 与既有审批链。
+
+## 实施
+
+1. 红测覆盖 happy、单阶段合法 Skill、内部 routing Skill、缺失/坏 manifest、用户 Skill、错误 audience 与 provider 缺失时仍可选择。
+2. 在 Skill manifest 增加显式 `selectableInWorkbench` 声明；storyboard planner 标记该声明。
+3. 删除 IPC 内重复的 stages-only 过滤，改用 `isSkillSelectableInWorkbench` 共享策略。
+4. 通过真实 Electron loopback journey：从 Agent 菜单看到并点击 Skill，检查 chip 与发送请求的 `skillKey`，再走公开项目读回/冷启动边界。
+
+## 验收
+
+- `pnpm exec vitest run electron/skills/skillIpc.test.ts electron/skills/skillStore.test.ts electron/skills/skillManifestSchema.test.ts`
+- `pnpm run check:root-cause-contracts`
+- 受影响的 focused/unit/contracts、typecheck、build 与真实 Electron loopback journey。
+- live provider canary 只有在 UI journey 绿后才尝试；无凭据时记录 blocked，不伪造成功。
+
+## 回滚
+
+回滚本分支提交即可；无用户数据迁移。新 manifest 字段为可选字段，旧 Skill 包继续按原有用户/多阶段规则处理。

--- a/docs/plan/INDEX.md
+++ b/docs/plan/INDEX.md
@@ -13,6 +13,7 @@
 |---|---|---|
 | [2026-09-04-nomi-convergence-execution-plan.md](2026-09-04-nomi-convergence-execution-plan.md) | **Nomi 收敛总执行方案**：以 M0–M5 为主轴，统一 Agent/MCP/分镜表/画布/视频/TikHub/真实 Provider/持久化/重启/视觉和 PR 收敛门槛；以 current `origin/main` 为基线 | 🚧 |
 | [2026-09-04-main-convergence-follow-ups.md](2026-09-04-main-convergence-follow-ups.md) | Main 收敛后续明细；历史执行拆解，状态以总方案和 current-main 审计为准 | 📎 |
+| [2026-09-04-workbench-skill-picker-fix.md](2026-09-04-workbench-skill-picker-fix.md) | Workbench Agent Skill 选择器共享可选性边界修复：恢复 storyboard planner 的真实菜单选择与 Host 请求链路 | ✅ |
 | [2026-09-03-open-work-ledger.md](2026-09-03-open-work-ledger.md) | 全量开工账本历史快照；只用于追溯，不覆盖总方案的当前状态 | 📎 |
 
 ## 模型接入 / Onboarding（最大簇）

--- a/docs/skill-pack-format.md
+++ b/docs/skill-pack-format.md
@@ -43,6 +43,10 @@ skills/
   "version": "1.0.0",                       // SemVer
   "description": "把一段故事文本拆成 6-12 个镜头节点 + 时序连边",
 
+  // 可选：允许内置单阶段 Skill 出现在 Workbench Agent Skill 选择器。
+  // 不填时，内置多阶段流程包仍按兼容规则显示；内部 routing Skill 默认隐藏。
+  "selectableInWorkbench": true,
+
   // 工具白名单：LLM 仅能调用这里列出的工具
   // 如果省略或为空数组，等同于"允许所有内置工具"
   "tools": [
@@ -51,7 +55,7 @@ skills/
   ],
 
   // 必需的 provider 能力。runtime 会检查模型目录里是否至少有一个
-  // enabled 的对应 kind 模型；缺少时 skill 不可用。
+  // enabled 的对应 kind 模型；缺少时选择器保留该 Skill，但标出能力缺口。
   "requiredProviders": ["text"],            // 子集: "text" | "image" | "video"
 
   // 权限边界。Agent 调用受限工具前 UI 会做对应确认。

--- a/electron/skills/builtinSkills.test.ts
+++ b/electron/skills/builtinSkills.test.ts
@@ -56,6 +56,13 @@ describe("built-in skill packs", () => {
     ]);
   });
 
+  it("marks the storyboard planner as a user-selectable Workbench Skill", () => {
+    const raw = JSON.parse(fs.readFileSync(path.join(SKILLS_DIR, "workbench-storyboard-planner", "skill.json"), "utf8"));
+    const parsed = parseSkillManifest(raw);
+    expect(parsed.ok).toBe(true);
+    if (parsed.ok) expect(parsed.manifest.selectableInWorkbench).toBe(true);
+  });
+
   it("release-media-pack is an evidence-first 7-stage playbook with an honest handoff", () => {
     const raw = JSON.parse(fs.readFileSync(path.join(SKILLS_DIR, "release-media-pack", "skill.json"), "utf8"));
     const parsed = parseSkillManifest(raw);

--- a/electron/skills/skillIpc.test.ts
+++ b/electron/skills/skillIpc.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { SkillManifest } from "./skillManifestSchema";
+import type { SkillRecord } from "./skillStore";
+import { listSkillsForRenderer } from "./skillIpc";
+
+const manifest = (partial: Partial<SkillManifest>): SkillManifest => ({
+  name: "test.skill",
+  version: "1.0.0",
+  description: "Test skill",
+  tools: [],
+  requiredProviders: [],
+  permissions: [],
+  ...partial,
+});
+
+const record = (partial: Partial<SkillRecord>): SkillRecord => ({
+  name: "test.skill",
+  directoryName: "test-skill",
+  filePath: "/tmp/test-skill/SKILL.md",
+  description: "Test skill",
+  body: "Use the test skill.",
+  manifest: manifest({ name: "test.skill" }),
+  origin: "builtin",
+  audience: "internal",
+  packageVersion: "1",
+  contentHash: "a".repeat(64),
+  ...partial,
+});
+
+vi.mock("./skillStore", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./skillStore")>();
+  return { ...actual, readSkillRecords: vi.fn() };
+});
+
+describe("listSkillsForRenderer", () => {
+  it("projects an explicitly selectable single-stage storyboard Skill into the real renderer DTO", async () => {
+    const { readSkillRecords } = await import("./skillStore");
+    vi.mocked(readSkillRecords).mockReturnValue([
+      record({
+        name: "workbench.storyboard.planner",
+        directoryName: "workbench-storyboard-planner",
+        manifest: manifest({ name: "workbench.storyboard.planner", selectableInWorkbench: true }),
+      }),
+      record({
+        name: "workbench.generation.canvas-planner",
+        directoryName: "workbench-generation",
+        manifest: manifest({ name: "workbench.generation.canvas-planner" }),
+      }),
+    ]);
+
+    expect(listSkillsForRenderer().map((skill) => skill.name)).toEqual([
+      "workbench.storyboard.planner",
+    ]);
+  });
+
+  it("keeps user Skills and existing playbooks visible while excluding malformed or routing-only built-ins", async () => {
+    const { readSkillRecords } = await import("./skillStore");
+    vi.mocked(readSkillRecords).mockReturnValue([
+      record({ name: "brand.promo", manifest: manifest({ name: "brand.promo", stages: [{ id: "script", goal: "Write", tools: [] }] }) }),
+      record({ name: "workbench.broken", manifest: null, manifestError: "invalid manifest" }),
+      record({ name: "workbench.routing", manifest: manifest({ name: "workbench.routing" }) }),
+      record({ name: "user.skill", origin: "user", manifest: null, manifestError: "invalid manifest" }),
+      record({ name: "wrong.scope", manifest: manifest({ name: "wrong.scope", audience: "mcp" }) }),
+    ]);
+
+    expect(listSkillsForRenderer().map((skill) => skill.name)).toEqual([
+      "brand.promo",
+      "user.skill",
+    ]);
+    expect(listSkillsForRenderer().find((skill) => skill.name === "user.skill")).toMatchObject({
+      origin: "user",
+      manifestError: "invalid manifest",
+    });
+  });
+});

--- a/electron/skills/skillIpc.test.ts
+++ b/electron/skills/skillIpc.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 import type { SkillManifest } from "./skillManifestSchema";
+import { SKILL_PACKAGE_VERSION } from "./skillPackage";
 import type { SkillRecord } from "./skillStore";
 import { listSkillsForRenderer } from "./skillIpc";
 
@@ -23,7 +24,7 @@ const record = (partial: Partial<SkillRecord>): SkillRecord => ({
   manifest: manifest({ name: "test.skill" }),
   origin: "builtin",
   audience: "internal",
-  packageVersion: "1",
+  packageVersion: SKILL_PACKAGE_VERSION,
   contentHash: "a".repeat(64),
   ...partial,
 });

--- a/electron/skills/skillIpc.ts
+++ b/electron/skills/skillIpc.ts
@@ -4,7 +4,7 @@ import { deriveSkillNeeds } from "./skillCapability";
 import { ipcMain } from "electron";
 import { assertTrustedSender } from "../ipcSenderGuard";
 import type { SkillProviderKind } from "./skillManifestSchema";
-import { readSkillRecords } from "./skillStore";
+import { isSkillSelectableInWorkbench, readSkillRecords } from "./skillStore";
 import {
   importSkillPackageToUserDir,
   exportSkillPackageByName,
@@ -37,11 +37,9 @@ export type SkillListItem = {
 
 export function listSkillsForRenderer(): SkillListItem[] {
   return readSkillRecords()
-    // 库只露「用户会浏览、挑来用」的：用户目录的（自己导入/建的，永远显示）∪ 内置 playbook（有 stages，
-    // 如品牌宣传片）。藏掉两类不该出现在用户库里的：① 外来工程技能（superpowers 的 brainstorming 等，
-    // 无 manifest）；② 幕后管线技能（creation-edit / skill-author / workbench.* 助手，自动路由或按钮触发，
-    // 不是浏览挑选项）。口径与创作区技能下拉（ActiveSkillChip 的 isPlaybook 过滤）一致。
-    .filter((r) => r.origin === "user" || (r.manifest?.stages?.length ?? 0) > 0)
+    // The canonical record policy owns picker visibility. Do not recreate a
+    // stages-only heuristic here: single-stage built-ins may explicitly opt in.
+    .filter(isSkillSelectableInWorkbench)
     .map((r) => {
     const needs = r.manifest ? deriveSkillNeeds(r.manifest) : null;
     return {

--- a/electron/skills/skillManifestSchema.test.ts
+++ b/electron/skills/skillManifestSchema.test.ts
@@ -29,6 +29,20 @@ describe("skillManifestSchema", () => {
     expect(result.ok).toBe(true);
   });
 
+  it("accepts an explicit Workbench picker visibility declaration", () => {
+    const result = parseSkillManifest({
+      name: "workbench.storyboard.planner",
+      version: "1.0.0",
+      description: "Storyboard planner",
+      selectableInWorkbench: true,
+      tools: ["propose_storyboard_plan"],
+      requiredProviders: ["text", "image"],
+      permissions: ["create"],
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.manifest.selectableInWorkbench).toBe(true);
+  });
+
   it("rejects unknown permission values", () => {
     const result = parseSkillManifest({
       name: "x",

--- a/electron/skills/skillManifestSchema.ts
+++ b/electron/skills/skillManifestSchema.ts
@@ -97,6 +97,8 @@ export const skillManifestSchema = z.object({
   description: z.string().min(1),
   /** Visibility request. User-imported Skills are still forced internal by origin policy. */
   audience: skillAudienceSchema.optional(),
+  /** Explicitly allow a built-in Skill to appear in the Workbench picker. */
+  selectableInWorkbench: z.boolean().optional(),
   /** Canonical requests can only shrink the Host-owned capability ceiling. */
   requestedCapabilities: z.array(skillRequestedCapabilitySchema).max(64)
     .refine((items) => new Set(items).size === items.length, "must not contain duplicate capability ids")

--- a/electron/skills/skillStore.test.ts
+++ b/electron/skills/skillStore.test.ts
@@ -1,9 +1,34 @@
 import { describe, expect, it } from "vitest";
 
+import type { SkillManifest } from "./skillManifestSchema";
+import { SKILL_PACKAGE_VERSION } from "./skillPackage";
 import { findSkillRecord, isSkillSelectableInWorkbench, normalizeSkillLookupKey, type SkillRecord } from "./skillStore";
 
+function manifest(partial: Partial<SkillManifest>): SkillManifest {
+  return {
+    name: "test.skill",
+    version: "1.0.0",
+    description: "Test skill",
+    tools: [],
+    requiredProviders: [],
+    permissions: [],
+    ...partial,
+  };
+}
+
 function record(name: string, directoryName: string): SkillRecord {
-  return { name, directoryName, filePath: `${directoryName}/SKILL.md`, body: "x", manifest: null, origin: "builtin" };
+  return {
+    name,
+    directoryName,
+    filePath: `${directoryName}/SKILL.md`,
+    description: "Test skill",
+    body: "x",
+    manifest: null,
+    origin: "builtin",
+    audience: "internal",
+    packageVersion: SKILL_PACKAGE_VERSION,
+    contentHash: "a".repeat(64),
+  };
 }
 
 const records: SkillRecord[] = [
@@ -43,18 +68,18 @@ describe("isSkillSelectableInWorkbench", () => {
   it("requires explicit opt-in for a built-in single-stage Skill", () => {
     expect(isSkillSelectableInWorkbench({
       ...record("workbench.storyboard.planner", "workbench-storyboard-planner"),
-      manifest: { selectableInWorkbench: true } as SkillRecord["manifest"],
+      manifest: manifest({ selectableInWorkbench: true }),
     })).toBe(true);
     expect(isSkillSelectableInWorkbench({
       ...record("workbench.generation.canvas-planner", "workbench-generation"),
-      manifest: { selectableInWorkbench: false } as SkillRecord["manifest"],
+      manifest: manifest({ selectableInWorkbench: false }),
     })).toBe(false);
   });
 
   it("keeps user Skills and existing multi-stage playbooks selectable, independent of MCP audience", () => {
     expect(isSkillSelectableInWorkbench({
       ...record("brand.promo", "brand-promo"),
-      manifest: { stages: [{ id: "script", goal: "Write", tools: [] }] } as SkillRecord["manifest"],
+      manifest: manifest({ stages: [{ id: "script", goal: "Write", tools: [] }] }),
     })).toBe(true);
     expect(isSkillSelectableInWorkbench({
       ...record("user.skill", "user-skill"),
@@ -63,7 +88,7 @@ describe("isSkillSelectableInWorkbench", () => {
     })).toBe(true);
     expect(isSkillSelectableInWorkbench({
       ...record("mcp.only", "mcp-only"),
-      manifest: { audience: "mcp" } as SkillRecord["manifest"],
+      manifest: manifest({ audience: "mcp" }),
     })).toBe(false);
   });
 });

--- a/electron/skills/skillStore.test.ts
+++ b/electron/skills/skillStore.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { findSkillRecord, normalizeSkillLookupKey, type SkillRecord } from "./skillStore";
+import { findSkillRecord, isSkillSelectableInWorkbench, normalizeSkillLookupKey, type SkillRecord } from "./skillStore";
 
 function record(name: string, directoryName: string): SkillRecord {
   return { name, directoryName, filePath: `${directoryName}/SKILL.md`, body: "x", manifest: null, origin: "builtin" };
@@ -36,5 +36,34 @@ describe("findSkillRecord", () => {
 
   it("returns null when nothing matches", () => {
     expect(findSkillRecord("does.not.exist", "nope", records)).toBeNull();
+  });
+});
+
+describe("isSkillSelectableInWorkbench", () => {
+  it("requires explicit opt-in for a built-in single-stage Skill", () => {
+    expect(isSkillSelectableInWorkbench({
+      ...record("workbench.storyboard.planner", "workbench-storyboard-planner"),
+      manifest: { selectableInWorkbench: true } as SkillRecord["manifest"],
+    })).toBe(true);
+    expect(isSkillSelectableInWorkbench({
+      ...record("workbench.generation.canvas-planner", "workbench-generation"),
+      manifest: { selectableInWorkbench: false } as SkillRecord["manifest"],
+    })).toBe(false);
+  });
+
+  it("keeps user Skills and existing multi-stage playbooks selectable, independent of MCP audience", () => {
+    expect(isSkillSelectableInWorkbench({
+      ...record("brand.promo", "brand-promo"),
+      manifest: { stages: [{ id: "script", goal: "Write", tools: [] }] } as SkillRecord["manifest"],
+    })).toBe(true);
+    expect(isSkillSelectableInWorkbench({
+      ...record("user.skill", "user-skill"),
+      origin: "user",
+      manifest: null,
+    })).toBe(true);
+    expect(isSkillSelectableInWorkbench({
+      ...record("mcp.only", "mcp-only"),
+      manifest: { audience: "mcp" } as SkillRecord["manifest"],
+    })).toBe(false);
   });
 });

--- a/electron/skills/skillStore.ts
+++ b/electron/skills/skillStore.ts
@@ -263,13 +263,15 @@ export function isSkillVisibleToMcp(record: SkillRecord, access: SkillMcpAccess 
 }
 
 /**
- * Workbench picker visibility is separate from MCP audience visibility. Creative
- * built-ins and every user skill are selectable; workbench implementation skills
- * remain internal routing resources and must not clutter the picker.
+ * Workbench picker visibility is separate from MCP audience visibility. User
+ * Skills and existing playbooks remain selectable; a built-in single-stage
+ * Skill must opt in explicitly so routing resources do not leak into the UI.
  */
-export function isSkillSelectableInWorkbench(record: Pick<SkillRecord, "name" | "origin">): boolean {
+export function isSkillSelectableInWorkbench(
+  record: Pick<SkillRecord, "name" | "origin" | "manifest">,
+): boolean {
   if (record.origin === "user") return true;
-  return !record.name.startsWith("workbench.") && record.name !== "creation-edit";
+  return record.manifest?.selectableInWorkbench === true || Boolean(record.manifest?.stages?.length);
 }
 
 export type SkillSummary = {

--- a/skills/workbench-storyboard-planner/skill.json
+++ b/skills/workbench-storyboard-planner/skill.json
@@ -2,6 +2,7 @@
   "name": "workbench.storyboard.planner",
   "version": "1.0.0",
   "description": "Decompose a 200–500 character story into 6–12 ordered storyboard shots and lay them out on the generation canvas with linear edges.",
+  "selectableInWorkbench": true,
   "tools": [
     "read_canvas_state",
     "create_canvas_nodes",

--- a/tests/ux/real-user-long-video.e2e.mjs
+++ b/tests/ux/real-user-long-video.e2e.mjs
@@ -40,6 +40,13 @@ function listen(server) {
   })
 }
 
+async function readJsonBody(req) {
+  const chunks = []
+  for await (const chunk of req) chunks.push(Buffer.from(chunk))
+  const raw = Buffer.concat(chunks).toString('utf8')
+  return raw ? JSON.parse(raw) : null
+}
+
 function streamCompletion(res) {
   const content = JSON.stringify({
     shotSize: '中景',
@@ -65,9 +72,10 @@ function streamCompletion(res) {
 
 async function startLoopbackProvider() {
   const requests = []
-  const server = http.createServer((req, res) => {
+  const server = http.createServer(async (req, res) => {
     if (req.method !== 'POST' || !req.url?.endsWith('/chat/completions')) return json(res, 404, { error: 'route not found' })
-    requests.push({ method: req.method, url: req.url })
+    const body = await readJsonBody(req)
+    requests.push({ method: req.method, url: req.url, body })
     streamCompletion(res)
   })
   const origin = await listen(server)
@@ -112,12 +120,11 @@ function sampleDurationSeconds(samplePath) {
 }
 
 async function dismissChrome(win) {
-  await win.evaluate(() => {
-    for (const key of ['nomi:splash:v1', 'nomi:journey-tour:v1', 'nomi:canvas-gesture-hint:v1', 'nomi-onboarding-checklist:v1']) localStorage.setItem(key, 'seen')
-    localStorage.setItem('__nomiE2E', '1')
-  })
-  await win.reload()
-  await win.waitForLoadState('domcontentloaded')
+  const splashSkip = win.locator('[data-splash-skip="true"]').first()
+  if (await splashSkip.count()) {
+    await splashSkip.click()
+    await splashSkip.waitFor({ state: 'detached', timeout: 5_000 })
+  }
 }
 
 async function enterProject(win) {
@@ -196,6 +203,29 @@ function buildUiDriver({ appRef, winRef, profile, samplePath, loopback }) {
       await item.click()
       selectedModel = identity
       return { status: 'pass', evidenceState: loopback ? 'loopback' : 'blocked-live', detail: 'model selected from visible Agent menu', evidence: { model: selectedModel, provider: profile.provider } }
+    }
+
+    if (step.action === 'applySkill') {
+      const panel = await openAgent(win)
+      const beforeRequests = loopback?.requests.length || 0
+      await panel.locator('[data-agent-input="true"]').fill('请用当前选择的 Skill 做一次只读规划，只回复已加载。')
+      await panel.locator('[data-agent-composer-send="true"]').click()
+      // A selected Skill is loaded as the canonical turn's prompt layer. It
+      // does not necessarily produce a model `load_skill` tool item (and the
+      // UI correctly reserves that row for actual Host skill.read calls).
+      // Wait for the real turn result, then inspect the provider request.
+      const terminalItem = panel.locator('[data-agent-item-kind="assistant"][data-agent-status="done"], [data-agent-item-kind="failure"]').last()
+      await terminalItem.waitFor({ state: 'visible', timeout: 30_000 })
+      const terminalKind = await terminalItem.getAttribute('data-agent-item-kind')
+      if (terminalKind !== 'assistant') {
+        return { status: 'blocked', evidenceState: 'blocked-live', detail: 'selected_skill_turn_failed_before_provider_result', evidence: { requestedSkill: FIXTURE_SKILL, failure: await terminalItem.textContent(), requestCount: loopback?.requests.length || 0 } }
+      }
+      const captured = loopback?.requests.slice(beforeRequests).find((request) => request.body)
+      const requestText = JSON.stringify(captured?.body || '')
+      if (!requestText.includes(FIXTURE_SKILL)) {
+        return { status: 'blocked', evidenceState: 'blocked-live', detail: 'selected_skill_not_carried_into_agent_request', evidence: { requestedSkill: FIXTURE_SKILL, requestCount: loopback?.requests.length || 0 } }
+      }
+      return { status: 'pass', evidenceState: 'loopback', detail: 'selected Skill loaded through Host and carried into the provider request', evidence: { skill: FIXTURE_SKILL, terminal: await terminalItem.textContent(), requestCount: loopback?.requests.length || 0 } }
     }
 
     if (step.action === 'importVideo') {

--- a/tests/ux/real-user-long-video.manifest.json
+++ b/tests/ux/real-user-long-video.manifest.json
@@ -25,6 +25,7 @@
     { "id": "enter-nomi", "action": "enterNomi", "classification": "H", "evidenceMode": "loopback", "required": true },
     { "id": "load-skill", "action": "loadSkill", "classification": "B", "evidenceMode": "loopback", "required": true },
     { "id": "select-model", "action": "selectModel", "classification": "H", "evidenceMode": "loopback", "required": true },
+    { "id": "apply-skill", "action": "applySkill", "classification": "B", "evidenceMode": "loopback", "required": true },
     { "id": "import-video", "action": "importVideo", "classification": "H", "evidenceMode": "recorded", "required": true },
     { "id": "deconstruct-video", "action": "deconstructVideo", "classification": "B", "evidenceMode": "blocked-live", "required": true },
     { "id": "produce-storyboard", "action": "produceStoryboard", "classification": "B", "evidenceMode": "blocked-live", "required": true },

--- a/tests/ux/real-user-long-video.runner.test.mjs
+++ b/tests/ux/real-user-long-video.runner.test.mjs
@@ -11,7 +11,7 @@ describe("real user long-video runner contract", () => {
     assert.deepEqual(
       REAL_USER_LONG_VIDEO_MANIFEST.steps.map((step) => step.action),
       [
-        "enterNomi", "loadSkill", "selectModel", "importVideo", "deconstructVideo",
+        "enterNomi", "loadSkill", "selectModel", "applySkill", "importVideo", "deconstructVideo",
         "produceStoryboard", "sendToCanvas", "openPreview", "approveResult", "rejectResult",
         "verifyPersistence", "restartReadback", "repeatIdempotently", "failureRollback",
       ],
@@ -39,7 +39,7 @@ describe("real user long-video runner contract", () => {
         },
       },
     });
-    assert.deepEqual(executed, ["enterNomi", "loadSkill", "selectModel", "importVideo", "deconstructVideo"]);
+    assert.deepEqual(executed, ["enterNomi", "loadSkill", "selectModel", "applySkill", "importVideo", "deconstructVideo"]);
     assert.equal(report.terminalStatus, "blocked");
     assert.equal(report.steps.at(-1).detail, "blocked_by:deconstruct-video");
   });


### PR DESCRIPTION
## Summary
- add an explicit canonical `selectableInWorkbench` manifest contract for built-in Skills
- expose `workbench.storyboard.planner` through the shared Workbench Skill visibility boundary
- remove the duplicate stages-only IPC filter and cover renderer DTO, malformed/user/audience cases
- extend the real Electron loopback journey to select the Skill visibly and verify its Host/provider request path

## Verification
- focused Skill tests: 36/36
- `pnpm run check:root-cause-contracts`
- `pnpm run check:docs-index`
- `pnpm run check:test-waits`
- `pnpm run check:boundaries`
- `pnpm run check:mjs-parse`
- `pnpm run check:secrets`
- `pnpm run lint:ci` (0 errors, baseline 82 warnings)
- `pnpm run typecheck && pnpm run build`
- real Electron loopback: visible Skill selection + Host/provider request carried `workbench.storyboard.planner`

## Honest boundaries
- live provider canary is blocked because no credential, real sample, live enablement, or budget confirmation was provided
- the existing long-video journey remains separately blocked at its pre-existing `send-to-canvas` boundary (node count 0); no success is inferred from that result
