### PR TITLE
docs: restore PR 458 and 459 diagnoses on main

### DIFF
--- a/docs/audit/pr452-failure-diagnosis-20260904.md
+++ b/docs/audit/pr452-failure-diagnosis-20260904.md
@@ -1,0 +1,88 @@
+# PR #452 失败门诊断
+
+日期：2026-09-04  
+PR：[#452](https://github.com/aqm857886159/Nomi/pull/452)  
+审计 head：`75f8e4148ee6d539d2e54250e3c7bb5b75497f5a`  
+基线：`origin/main`=`45912ae01a155a3f6592f65368d0ce3d12fc034e`
+
+## 隔离状态
+
+诊断在独立 worktree 完成：
+
+`/Users/aoqimin/Documents/Codex/2026-09-04/pr452-usage-repair/work/Nomi-pr452-failure-gates-red`
+
+分支：`codex/pr452-failure-gates-red-20260904`。目标 head 分支仍在原 worktree，`main` 工作树的既有脏文件未触碰；本 worktree 初始干净。本轮没有改生产代码、没有推送、没有合并，也没有伪造绿灯。
+
+## CI 最早真实失败
+
+Run `33790669994` 的 `E2E Walkthroughs (Linux)` / `MCP L1 handshake journey` 执行：
+
+```text
+xvfb-run -a pnpm run test:mcp-journey
+pnpm run check:electron-install && node tests/ux/mcp-l1-handshake.e2e.mjs && node tests/ux/mcp-l2-journeys.e2e.mjs && node tests/ux/mcp-skills-integration.e2e.mjs
+```
+
+Electron 安装检查 13/13 通过；MCP L1 C1–C8 通过；C9 在真人生成确认门失败。最早真实失败是：
+
+```text
+nomi_operation_gate error= ...
+"errorCode":"receipt_invalid"
+"message":"Generation approval receipt projectRevision does not match the current scope"
+"recoveryActions":["This confirmation is no longer valid; confirm again in Nomi."]
+
+Error: nomi_operation_gate: ✗ This confirmation is no longer valid; confirm again in Nomi.
+    at tests/ux/mcp-l2-journeys.e2e.mjs:39:11
+```
+
+发生在 C9 `operation_plan`、`operation_preview` 和确认卡出现之后，点击 `[data-production-action="confirm"]` 返回 gate 结果时；供应商提交尚未发生。日志中的 DBus `Unknown address type` 是 Electron/Linux 环境噪声，不是最早失败点。
+
+Run `33790669994` 的 `Quality Gate` / `Require every validation surface` 只执行了 fail-closed 汇总：
+
+```text
+test "failure" = "success"
+```
+
+因此它不是第二个独立根因。其余该 run 的 Validation Scope、Contracts、Unit、Workers Builds 通过；Canvas、Mac Package 按 scope 跳过。
+
+## 单一根因假设
+
+假设：C9 在新项目切换并导入参考资产后，没有在发起付费 gate 前证明项目 manifest revision 已稳定；授权封存时读取的 revision 与确认回执提交时从 live project resolver 读取的 revision 不同，安全校验按设计拒绝了收据。
+
+证据链：
+
+1. C9 直接执行 `project_create` → hash 切换 → `session_open`，随后 `asset_import`，然后立即 `operation_plan` / `operation_preview` / `operation_gate`（`tests/ux/mcp-l2-journeys.e2e.mjs:220-275`）；这里没有 revision-stable 等待或 revision 取证。
+2. 生产接线在 `mcpStdioServer.ts:283-298` 以当前 `readWorkspaceProject(...).revision` 创建授权 envelope。
+3. `runOwnedGenerationGateAuthority.ts:78-92` 把该 envelope revision 写入 challenge/receipt 范围。
+4. `productionRunApprovalReceipt.ts:24-39` 在 gate decide 时重新读取 live project revision，并要求 receipt revision 完全相等；不相等即 `ReceiptScopeError`，再由 MCP 层映射为 `receipt_invalid`。
+5. 另一个多镜真实旅程已有同类时序说明：新项目建好后 board 初始化会继续改 revision，必须等 digest 稳定后再开 session。PR #452 的生产 diff 只涉及 Host usage 字段、状态校验和 resident projection，没有修改 generation gate、project revision 或 receipt 代码；因此当前失败不能归因于 usage ledger 的直接逻辑改动。
+
+这只是已被 CI 日志和代码路径支持的最小假设；本轮未声称已通过一次本地真实 Electron 重跑。
+
+## PR #452 已有改动（现状，不是本轮新增）
+
+- `electron/projectAgentHost/projectAgentExecutionCoordinator.test.ts`：新增 terminal usage 写入并 reopen 恢复的协调器测试。
+- `electron/projectAgentHost/projectAgentReducer.ts`：async result 接受并校验 usage，再写入 terminal turn。
+- `electron/projectAgentHost/projectAgentState.ts`、`projectAgentStateValidationPrimitives.ts`：snapshot usage schema 与整数校验。
+- `electron/projectAgentHost/projectAgentTurnExecution.ts`、`electron/shared/projectAgentContracts.ts`：Host async result/envelope/turn 类型携带 usage。
+- `src/workbench/ai/ProjectAgentResidentShell.tsx`：优先从 Host snapshot 投影当前线程的累计/最近 usage，legacy 时回退旧 store。
+
+这些改动没有在本轮修改，也没有宣称它们已通过失败的 C9 gate。
+
+## 最小修复范围建议
+
+优先修复测试/真实 harness 的时序，不放宽 receipt revision 安全边界：在 C9 的 asset import 和/或 session open 后，通过真实项目读取边界等待 project revision 连续稳定，再进行 plan/preview/gate；若需要共享 helper，范围应限于 `tests/ux/mcp-l2-journeys.e2e.mjs` 及其 journey helper。
+
+只有在能用真实 app harness 重现“项目无用户写入却在 gate 确认期间继续 revision 漂移”后，才考虑生产层修复；候选 seam 是 `electron/capabilityCore/mcpStdioServer.ts` 的授权快照与 `electron/productionRun/productionRunApprovalReceipt.ts` 的校验，但不得简单删除或放宽 `projectRevision` 比较。
+
+本轮没有足够证据证明需要生产改动，因此没有新增红测或生产修复代码。
+
+## 后续绿测最低要求
+
+修复后必须重新取得真实证据：
+
+- Host async result boundary：terminal response 的 usage 进入 durable Host snapshot；非法 usage 被拒绝。
+- 磁盘持久化：关闭/重新创建 coordinator 后 snapshot 中仍保留 usage，格式通过 state validator。
+- coordinator reopen/restore：恢复的是同一 turn/thread 的 Host 状态，不是 renderer store 的假数据。
+- renderer resident UI：真实 Electron UI 从 Host snapshot 投影累计与最近 usage，并覆盖 legacy fallback。
+- C9 真实 app harness：真实项目、asset import、operation plan/preview、确认卡、receipt decide 全链路通过，且供应商 fixture hit 仍为零额度/仅预期调用。
+- Quality Gate：必须由真实 E2E 成功驱动汇总绿灯；不能用 `test "failure" = "success"` 的汇总日志替代。

--- a/docs/qa/2026-09-04-pr456-failure-gate-diagnosis.md
+++ b/docs/qa/2026-09-04-pr456-failure-gate-diagnosis.md
@@ -1,0 +1,98 @@
+# PR #456 failure-gate diagnosis
+
+Date: 2026-09-04
+
+PR: https://github.com/aqm857886159/Nomi/pull/456  
+Head: `codex/main-typecheck-repair-20260904@9ab34aafcefd3c52e5809a337a9124797e410d3a`  
+Base: `main@45912ae01a155a3f6592f65368d0ce3d12fc034e`
+
+## Status
+
+No product fix is included in this report. The long local E2E was stopped at the user's request. No check is being claimed green.
+
+## Actual PR checks
+
+From the PR's Quality Gate run `33825807233`:
+
+| Check | Result | Evidence |
+| --- | --- | --- |
+| Validation Scope | success | completed before the failure |
+| Contracts | success | completed before the failure |
+| Unit | success | completed before the failure |
+| E2E Walkthroughs (Linux) | failure | job `100878159148` |
+| Quality Gate | failure | job `100880090686` |
+| Workers Builds: nomi | success | completed |
+
+The Quality Gate log is a downstream failure, not the first business failure. Its CI annotation step reported:
+
+```text
+CI annotation hygiene failed; inspect outputs/ci-hygiene/ci-annotations.json
+CI annotation hygiene: 11 annotations, 10 delegated, 0 allowed, 1 unexpected
+Process completed with exit code 1.
+```
+
+The one unexpected annotation is the E2E job failure annotation at `.github:109` with `Process completed with exit code 1`. The ten Contracts warnings were already delegated to the existing lint warning budget.
+
+## E2E failure
+
+The Linux E2E log reaches the C9b Phase A baseline and then fails when the new elicitation client opens a session:
+
+```text
+C9b Phase A 基线成立：非 elicitation 客户端 → GUI 生成确认卡浮出（探针活，expectAbsent 有意义）
+nomi_session_open error= ...
+  "errorCode": "lease_invalid",
+  "message": "Project session lease is invalid",
+  "nextAction": "Open a new project session and retry"
+Error: nomi_session_open: ✗ The project connection expired; select the current project again.
+    at tests/ux/mcp-l2-journeys.e2e.mjs:39:11
+    at tests/ux/mcp-l2-journeys.e2e.mjs:361:28
+```
+
+The preceding C9b Phase A steps pass. The failing call is the Phase B call at `tests/ux/mcp-l2-journeys.e2e.mjs:361`.
+
+## Root-cause judgment
+
+High-confidence root cause: the fixture replays a connection-bound selection handle across two MCP transports.
+
+1. The main `mcp` client creates the C9b project and receives `c9bSelectionHandle`.
+2. That handle is then passed to a newly spawned `c9bClient`:
+
+   ```js
+   c9bClient.callTool('nomi_session_open', {
+     projectSelectionHandle: c9bSelectionHandle,
+   })
+   ```
+
+3. `ProjectSessionAuthority` verifies the selection handle against the receiving connection before issuing a lease.
+4. The project-lease contract binds selection handles to the issuing transport's principal/session/nonce. The existing `electron/capabilityCore/projectSessionAuthority.test.ts` test explicitly covers that a created-project selection handle is valid only on the issuing connection.
+
+This is a test/fixture lifecycle error, not evidence that the lease store randomly expired. PR #456 itself changes only `src/workbench/generationCanvas/nodes/useNodeModelAutoSelect.ts` (using hydrated metadata for the provider-switch notice); it does not change project-session or lease code.
+
+## Local verification boundary
+
+The first local attempt failed before the E2E because the fresh worktree had no `dist-electron` output:
+
+```text
+Error: Cannot find module .../dist-electron/capabilityCore/nodeKindDomain.js
+```
+
+After `pnpm install --frozen-lockfile` and `pnpm run build`, the original E2E reached C7/C8/C9 and was manually stopped before C9b. Therefore the local run did not independently reproduce the CI lease failure; the CI log above is the authoritative failure evidence for this diagnosis.
+
+## Smallest candidate repair (not implemented)
+
+Keep the GUI on the C9b project, but let the new `c9bClient` bootstrap its own current-project selection/lease:
+
+```js
+await call(c9bClient, 'nomi_session_open', {
+  bootstrap: { mode: 'current_project' },
+})
+```
+
+An alternative is to create the project through `c9bClient` itself and use the handle returned to that same connection. Either candidate still requires a fresh red/green run; neither is claimed as verified here.
+
+## Required next verification
+
+1. Apply one candidate fixture change only.
+2. Run `node tests/ux/mcp-l2-journeys.e2e.mjs` and record the C9b result.
+3. Run the relevant Quality Gate workflow checks again.
+4. Keep the existing connection-replay unit test green and verify no other journey regresses.


### PR DESCRIPTION
Documentation-only recovery of two diagnosis documents absent from current origin/main. PR #458 was merged with base codex/main-typecheck-repair-20260904; PR #459 was merged with base codex/agent-usage-ledger-followup-20260904. The extracted documents retain their historical evidence boundaries and do not claim product fixes or green gates. Only docs/qa/2026-09-04-pr456-failure-gate-diagnosis.md and docs/audit/pr452-failure-diagnosis-20260904.md are included; no old-base code or other changes are included. Verified from origin/main 2c4eeb5a83202a173452c7e7a2146e24ed9fc5f0 with check:docs-index, check:doc-status, check:root-cause-contracts, test:system:contracts PASS (1/1), lint:ci 0 errors/82 threshold warnings, typecheck, and check:test-types. Do not merge automatically.