### PR TITLE
test: add Agent M0-M5 vertical-spine red contract

### DIFF
--- a/docs/plan/2026-09-05-m0-m5-vertical-spine-status.md
+++ b/docs/plan/2026-09-05-m0-m5-vertical-spine-status.md
@@ -1,0 +1,75 @@
+# Nomi M0-M5 Agent vertical-spine status ledger
+
+> 唯一状态台账：本文件是本交付的持久化状态真源。后续每个未完成项必须拆成独立 PR，并在对应单元格补入命令、SHA、PR 或明确的 blocked reason；状态不得只留在对话中。
+
+## Goal
+
+完成 Nomi 当前主线收敛：以 Agent 的 M0-M5 真实端到端闭环为最高优先级，贯通真实 Electron 用户任务、MCP 调用、最新版分镜表、画布写入、approval、receipt、项目持久化、关闭重启恢复、视觉走查和 packaged 验证。持续盘点并安全收敛所有 PR/分支/worktree/计划；当前 red-stage 只是本总目标的第一阶段，不缩小、不替代总目标。
+
+第一代表任务固定为：新建隔离项目 → 选择分镜行 → 选择 Skill 与模型 → Agent 读取上下文 → `nomi_canvas_plan` → `patch_shots` → 批准/拒绝 → 真实写入项目 → durable receipt/revision → Agent/分镜表/画布一致 → 关闭重启回读/reconcile → packaged 重复。
+
+## Non-goals
+
+本阶段不做 UI redesign，也不修改生产实现。TikHub、APIMart、视频解析、字幕、视频分镜后置；provider spend 只允许在受控 canary 中发生，凭据只走本机环境变量。静态检查、fixture、loopback、CI green 或预写项目不能单独证明真实用户任务完成；不得调用 fake store、生产 handler 或 legacy bare `patch_shots` 作为最终证据。
+
+## Current phase
+
+`red-stage / M1-B first real seam recorded / production untouched`
+
+| Field | Value |
+|---|---|
+| Base | `origin/main@163bddf157b613bde1d8291098b8813cea2bc80b` |
+| Branch | `codex/agent-vertical-spine-m0-m5-red-20260905` |
+| Worktree | `/Users/aoqimin/Desktop/Nomi-agent-vertical-spine-m0-m5-red-20260905` |
+| First representative task | real Electron isolated project → storyboard row 2 → Skill/model identity → right Agent context → `nomi_canvas_plan(operation=patch_shots)` → approval/decline → durable write/receipt/revision → three projections → cold restart/reconcile → same-SHA packaged repeat |
+| Current first failure | `M1.select-storyboard-row`, dimension `B`: new real project exposes only `新建分镜方案`; `[data-storyboard-editor="true"]` never becomes visible |
+| Evidence contract | `tests/system/agent-vertical-spine-m0-m5.contract.json` |
+| Red runner | `tests/ux/agent-vertical-spine-m0-m5.red.e2e.mjs` |
+| Evidence report | `docs/qa/2026-09-05-agent-vertical-spine-m0-m5-red.md` |
+| Conflict boundary | No existing total-plan link was changed; this disjoint ledger avoids the active #476 change surface. |
+
+## Definition of done
+
+代表任务必须模拟真实用户的连续多轮 Agent 协作，而非一次性请求；覆盖从零开始、补充/否定/改口、只改一镜、先预览后确认、分步生成、部分生成、生成后微调、关闭重启后继续追问；每轮记录自然用户话术、Agent 上下文、M0-M5 断言、approval/receipt/revision/persistence 状态，并按未开始→红测→实现→绿测→真实 Electron→持久化/重启→视觉→packaged→合入 main 追踪。
+
+完成 Nomi 当前主线的 Definition of Done：每个 M0-M5 与其对应 PR 都必须记录状态、SHA、证据命令、阻塞原因和下一步；每阶段依次完成红测 → 最小实现 → 同断言绿测 → 真实用户任务 → 持久化/重启 → 视觉走查 → packaged → 合入 main。全量目标完成前，不能把静态/fixture/CI green 当作真实完成。
+
+The total goal is done only when every M0-M5 row reaches every stage below with evidence from the same real user task: visible Electron actions, preload/public MCP production call shape, durable project/receipt/revision readback, approval and decline semantics, Agent/storyboard/canvas projection agreement, cold restart/reconcile, and a repeat from the packaged app built from the current SHA. `main 合入` requires a reviewed PR and explicit merge evidence; this red-stage branch must not be merged or described as production completion.
+
+Stage vocabulary is fixed and ordered: `未开始 → 红测 → 实现 → 绿测 → 真实用户任务 → 持久化/重启 → 视觉走查 → packaged → main 合入`.
+
+## M0-M5 status
+
+Every cell is an evidence pointer or a blocked reason. `absorbed` means existing coverage was retained as context but does not satisfy this same-task completion gate.
+
+### Natural multi-round transcript and internal ledger
+
+The canonical transcript is stored in `tests/system/agent-vertical-spine-m0-m5.contract.json` under `multiRoundProtocol.transcript`; the runner must enter each turn through the visible Agent composer. User-facing text contains no operation/tool/id/fixture/API parameter. The internal record for every turn has M0-M5 assertion, status, receipt, revision, and context fields. The current red run stops before R1 at M1/B, so each downstream turn is explicitly blocked rather than presented as complete.
+
+| Round | Natural user turn | Required internal status/evidence in this red stage |
+|---|---|---|
+| R1 | “我想做一个30秒竖屏短片，先理顺故事和分镜，不要一上来生成。” | M0 project route/disk read is passed; M1-M5 are blocked by `M1.select-storyboard-row` / `B`; no approval, receipt, or revision advance. |
+| R2 | “先不要生成，只改第三个镜头：让人物站在门口犹豫两秒，其他镜头和内容都不要动。” | Must preserve same project and map natural “第三个镜头” to row 2; current status blocked before selection; receipt/revision remain unchanged. |
+| R3 | “我改主意了，先告诉我具体会改哪些，再让我确认；现在不要生成，也不要碰其他镜头。” | Must produce a readable preview without mutation; current status not reached; approval remains pending and no receipt is allowed. |
+| R4 | “确认这次修改。先执行这一个镜头的改动，但只生成前三个镜头，后面的先别动。” | Must record one approval, one scoped write and a durable revision/receipt; current status not reached and no write is claimed. |
+| R5 | “刚才第三个镜头的犹豫再短一点，门外的雨声保留，其他已经完成的镜头不要改；先预览这个小改动。” | Must carry prior context/receipt/revision into a second proposal and keep it reversible; current status not reached. |
+| R6 | “我重新打开项目了，刚才做到哪里？请接着之前的工作，先告诉我现在的状态和下一步，不要直接生成。” | Must reconcile fresh-process project, Agent, storyboard and canvas projections without duplicate write, then await confirmation; current status not reached. |
+
+| Milestone | 未开始 | 红测 | 实现 | 绿测 | 真实用户任务 | 持久化/重启 | 视觉走查 | packaged | main 合入 |
+|---|---|---|---|---|---|---|---|---|---|
+| **M0** real Electron isolated project | N/A — current delivery has entered red stage; SHA `163bddf157b613bde1d8291098b8813cea2bc80b` | PASS — `pnpm run build && node tests/ux/agent-vertical-spine-m0-m5.red.e2e.mjs`; real Electron created project and disk `.nomi/project.json`; SHA `163bddf157b613bde1d8291098b8813cea2bc80b` | BLOCKED — no production implementation is in scope for this red-stage PR | BLOCKED — M1 first failure stops the same-task green gate; rerun command above required | PASS for M0 slice only — visible `新建空白项目` click plus preload route/read; not full M0-M5 completion; evidence in `docs/qa/2026-09-05-agent-vertical-spine-m0-m5-red.md` | BLOCKED — full durable revision/restart proof belongs to M5 and was not reached | BLOCKED — no visual acceptance claim in red stage; UI redesign excluded | PASS for M0 slice only — `pnpm run dist:mac:dir` + packaged red runner opened packaged Electron and created isolated project; no full packaged closure claim; report linked above | BLOCKED — no PR merged; user explicitly requires no merge |
+| **M1** storyboard row 2 selection | N/A — red contract is active; SHA `163bddf157b613bde1d8291098b8813cea2bc80b` | FAILED — `pnpm run build && node tests/ux/agent-vertical-spine-m0-m5.red.e2e.mjs`; first failure `M1.select-storyboard-row`, `locator.waitFor: Timeout 10000ms exceeded` on `[data-storyboard-editor="true"]`; body had only `新建分镜方案`; dimension `B`; report linked above | BLOCKED — no production implementation in this delivery | BLOCKED — editor/row seam must be repaired before green rerun; command above is the gate | BLOCKED — visible row selection was not reached in the real newly-created project | BLOCKED — no selection revision could be persisted or restarted | BLOCKED — visual walk requires reachable existing storyboard table, not a redesign | FAILED — `pnpm run dist:mac:dir` + packaged runner opened packaged Electron, then failed at the same `M1.select-storyboard-row` / `B` assertion; evidence linked above | BLOCKED — no PR merged; red-stage only |
+| **M2** canonical `nomi_canvas_plan` / `patch_shots` | N/A — red contract is active; SHA `163bddf157b613bde1d8291098b8813cea2bc80b` | BLOCKED — runner stops at M1/B before canonical call; existing `tests/ux/storyboard-agent-canonical-patch.e2e.mjs` is absorbed, not this journey | BLOCKED — no production implementation in this delivery | BLOCKED — requires M1 green then canonical public MCP call with `operation=patch_shots` | BLOCKED — no same-task proposal for row 2; static/fixture/loopback evidence is insufficient | BLOCKED — untouched fields, revision, receipt and restart not reached | BLOCKED — projection visual gate not reached | BLOCKED — packaged canonical call is downstream of M1/B | BLOCKED — no PR merged; a separate M2 repair PR is required |
+| **M3** Skill/model identity + Agent context | N/A — red contract is active; SHA `163bddf157b613bde1d8291098b8813cea2bc80b` | BLOCKED — runner stops before Skill/model/context; existing `tests/ux/mcp-skills-integration.e2e.mjs` and resident tests are absorbed, not same-task proof | BLOCKED — no production implementation in this delivery | BLOCKED — requires M1 and M2 seams first | BLOCKED — no visible Skill/model selection or right Agent read reached | BLOCKED — request identity/revision cannot be read back yet | BLOCKED — no visual acceptance claim in red stage | BLOCKED — packaged repeat is downstream of M3 identity/context | BLOCKED — no PR merged; a separate M3 repair PR is required |
+| **M4** approval/decline + durable write | N/A — red contract is active; SHA `163bddf157b613bde1d8291098b8813cea2bc80b` | BLOCKED — runner stops before approval; existing canonical approval/receipt coverage is absorbed but lacks this UI approve/decline pair | BLOCKED — no production implementation in this delivery | BLOCKED — requires canonical proposal and real elicitation accept/decline | BLOCKED — no one-approve/one-decline same-task evidence | BLOCKED — no write-once, no-op decline, receipt or revision evidence reached | BLOCKED — approval UI was not traversed | BLOCKED — packaged approval/decline is downstream of M4 | BLOCKED — no PR merged; a separate M4 repair PR is required |
+| **M5** projections + cold restart/reconcile + packaged | N/A — red contract is active; SHA `163bddf157b613bde1d8291098b8813cea2bc80b` | BLOCKED — runner stops before projection, restart and packaged assertions | BLOCKED — no production implementation in this delivery | BLOCKED — requires M0-M4 green evidence in order | BLOCKED — Agent/storyboard/canvas agreement was not reached | BLOCKED — cold restart/reconcile and duplicate-write checks were not reached | BLOCKED — real visual walk and projection comparison were not reached | BLOCKED — required command: `pnpm run dist:mac:dir && NOMI_VERTICAL_SPINE_PACKAGED_APP=release/mac-arm64/Nomi.app node tests/ux/agent-vertical-spine-m0-m5.red.e2e.mjs --packaged`; no current packaged certification | BLOCKED — no PR merged; packaged evidence and a reviewed PR are required before any main merge |
+
+## Evidence and next PR split
+
+- M0-M1 current repair boundary: make the existing storyboard editor reachable after a real new project and bind row 2 to the canonical Agent context. This is the next repair PR; it must rerun the unchanged red runner and update this ledger.
+- M2: canonical public `nomi_canvas_plan` proposal must prove selected-row-only patch and untouched fields.
+- M3: visible Skill/model/vendor identity must travel with the same project, selection, and revision into the right Agent request.
+- M4: one real approval writes once; one real decline leaves project, receipt, and revision unchanged.
+- M5: Agent/storyboard/canvas projections, durable readback, cold restart/reconcile, and current-SHA packaged repeat must all be evidenced; each unfinished item remains a separate PR.
+- Retained evidence: MCP boundary, new storyboard table boundary, and canvas/receipt tests are recorded as `absorbed` where they overlap, but they do not substitute for this vertical spine.
+- Deferred scope: TikHub and video remain explicitly post-M5.

--- a/docs/qa/2026-09-05-agent-vertical-spine-m0-m5-red.md
+++ b/docs/qa/2026-09-05-agent-vertical-spine-m0-m5-red.md
@@ -1,0 +1,109 @@
+# M0-M5 Agent vertical-spine red-stage evidence
+
+状态：`red / first seam recorded / production implementation intentionally untouched`
+
+## Scope
+
+本交付只验证一条真实用户任务的生产调用形状；代表任务必须是连续多轮 Agent 协作，不是一次性 prompt：
+
+`Electron 新建隔离项目 → 选择分镜行 → 选择 Skill 与模型身份 → 右侧 Agent 读取上下文 → nomi_canvas_plan(operation=patch_shots) → approval/decline → 真实项目写入 → durable receipt/revision → Agent/分镜/画布一致 → 关闭重启并回读/reconcile → 当前 SHA packaged 重复`
+
+明确不含视频、TikHub、Skill Hub、UI redesign 或 provider spend。此次只新增合同、runner 和证据文档；不修改生产实现，也不把 loopback 结果当最终证据。
+
+自然用户 transcript（R1–R6）从零开始覆盖补充/否定/改口、只改第三镜、先预览后确认、分步/部分生成、生成后微调、关闭重启后继续追问。用户话术不出现 operation/tool/id/fixture/API 参数；canonical tool/id 只在内部 assertion、MCP trace、receipt 和 revision evidence 中记录。完整视频生成仍保留在总目标；当前核心 spine 只推进到可验证的生成提案/真实项目写入边界，后续再用 APIMart/TikHub 做受控真实媒体 canary。
+
+## Base and isolation
+
+```text
+fetch: git fetch origin main
+base: origin/main@163bddf157b613bde1d8291098b8813cea2bc80b
+branch: codex/agent-vertical-spine-m0-m5-red-20260905
+worktree: /Users/aoqimin/Desktop/Nomi-agent-vertical-spine-m0-m5-red-20260905
+preflight: passed; clean; same-commit with origin/main
+```
+
+Runner:
+
+- Contract: `tests/system/agent-vertical-spine-m0-m5.contract.json`
+- Real Electron red journey: `tests/ux/agent-vertical-spine-m0-m5.red.e2e.mjs`
+- Command: `pnpm run build && node tests/ux/agent-vertical-spine-m0-m5.red.e2e.mjs`
+- Packaged repeat: `NOMI_VERTICAL_SPINE_PACKAGED_APP=release/mac-arm64/Nomi.app node tests/ux/agent-vertical-spine-m0-m5.red.e2e.mjs --packaged`
+
+The runner creates the project by clicking the visible `新建空白项目` action and verifies the resulting project through the real preload read and isolated `.nomi/project.json`. It does not seed a project payload, inject Zustand/store state, invoke a production handler, call a legacy bare `patch_shots` tool, or start a loopback provider.
+
+## Absorbed existing coverage
+
+The following mainline coverage was inspected and registered as absorbed rather than duplicated:
+
+| Existing evidence | Absorbed boundary | Not sufficient for this spine |
+|---|---|---|
+| `tests/ux/storyboard-agent-canonical-patch.e2e.mjs` | Real Electron + MCP stdio + `nomi_canvas_plan(operation=patch_shots)` + disk receipt + cold restart | Starts from a prewritten storyboard project; no UI row selection, visible Skill/model identity, right Agent context, approve/decline pair, or Agent/table/canvas agreement |
+| `tests/ux/mcp-skills-integration.e2e.mjs` | MCP Skill resource/list/read boundary | No same-project storyboard selection or durable canvas write |
+| `tests/ux/agent-runtime-provider.walk.mjs` and Agent shell structure tests | Resident Agent/runtime and visible menu seams | No canonical storyboard write and no persistence/restart chain |
+| `src/workbench/ai/resident/residentReferences.test.ts` | Pure storyboard reference and canonical selection-injection shape | No real Electron UI selection or production Host/MCP execution |
+| `tests/ux/real-user-long-video.e2e.mjs` | Real Electron project creation and explicit blocked-live honesty | Out of scope video/TikHub task and not the requested canonical storyboard vertical spine |
+
+## First real failure
+
+The first runner setup error (assuming the project directory basename was the project id) was corrected before treating product output as evidence. The following is the exact fresh real-Electron result after that correction. The first failure is the first unmet seam, not a fabricated unit red test; later steps remain `not-reached` until this seam is repaired.
+
+```text
+command: pnpm run build && node tests/ux/agent-vertical-spine-m0-m5.red.e2e.mjs
+firstFailure.phase: development
+firstFailure.step: M1.select-storyboard-row
+firstFailure.dimension: B
+firstFailure.message: locator.waitFor: Timeout 10000ms exceeded; waiting for locator('[data-storyboard-editor="true"]').first() to be visible
+firstFailure.url: file:///Users/aoqimin/Desktop/Nomi-agent-vertical-spine-m0-m5-red-20260905/dist/index.html?step=create#/studio?projectId=project-1788546985278-4m25d8
+firstFailure.bodyText: Nomi / 项目库 / › / 未命名项目 09/05 02:36 / 创作 / 生成 / 预览 / 0/4 / 创作内容 / 原稿 · 1 篇 / 未命名项目 / 新建分镜方案
+firstFailure.observation: storyboardEditorCount=0; storyboardRow2Count=0
+evidenceRoot: /var/folders/f4/vz86j5nd0_sf56qdhzrmbbvw0000gn/T/nomi-agent-vertical-spine-red-3JfqRu
+```
+
+The current-SHA packaged repeat was also executed after normalizing the `.app` input to its executable. Packaged Electron opened and created an isolated project, then stopped at the same first product seam:
+
+```text
+command: pnpm run dist:mac:dir && NOMI_VERTICAL_SPINE_PACKAGED_APP=release/mac-arm64/Nomi.app node tests/ux/agent-vertical-spine-m0-m5.red.e2e.mjs --packaged
+packaged firstFailure.step: M1.select-storyboard-row
+packaged firstFailure.dimension: B
+packaged firstFailure.message: locator.waitFor: Timeout 10000ms exceeded; waiting for locator('[data-storyboard-editor="true"]').first() to be visible
+packaged firstFailure.url: file:///Users/aoqimin/Desktop/Nomi-agent-vertical-spine-m0-m5-red-20260905/release/mac-arm64/Nomi.app/Contents/Resources/app.asar/dist/index.html?step=create#/studio?projectId=project-1788547326987-j7otsj
+packaged firstFailure.observation: storyboardEditorCount=0; storyboardRow2Count=0; body had only 新建分镜方案
+packaged evidenceRoot: /var/folders/f4/vz86j5nd0_sf56qdhzrmbbvw0000gn/T/nomi-agent-vertical-spine-red-ZAjLWf
+```
+
+The earlier packaged `spawn ... Nomi.app EACCES` was a runner input-shape error and was corrected; it is not counted as product evidence. `pnpm run dist:mac:dir` completed, including the repository packaged MCP smoke (`24 tools`, `34 resources`, unsigned generic writes rejected).
+
+After adding the six-turn natural-language contract and transcript assertions, the development runner was rerun. It preserved the same first failure (fresh project and temp paths for this run):
+
+```text
+command: node tests/ux/agent-vertical-spine-m0-m5.red.e2e.mjs
+firstFailure.phase: development
+firstFailure.step: M1.select-storyboard-row
+firstFailure.dimension: B
+firstFailure.message: locator.waitFor: Timeout 10000ms exceeded; waiting for locator('[data-storyboard-editor="true"]').first() to be visible
+firstFailure.url: file:///Users/aoqimin/Desktop/Nomi-agent-vertical-spine-m0-m5-red-20260905/dist/index.html?step=create#/studio?projectId=project-1788547646495-91af3e
+firstFailure.observation: storyboardEditorCount=0; storyboardRow2Count=0; body had only 新建分镜方案
+evidenceRoot: /var/folders/f4/vz86j5nd0_sf56qdhzrmbbvw0000gn/T/nomi-agent-vertical-spine-red-jUVtnC
+```
+
+Expected classification at this red stage is the M1/B boundary if the blank-project UI cannot expose a `data-storyboard-editor="true"` with a selectable `data-storyboard-row="2"`. If the current build fails earlier, preserve the earlier observed failure and do not relabel it.
+
+## H/B/E/T/N gap ledger
+
+| Dimension | Red-stage status | Gap to next layer |
+|---|---|---|
+| H | not reached or first failure | Real user-visible storyboard row selection and later Skill/model/approval actions are not yet traversed by one task |
+| B | not reached or first failure | Bind row selection to Agent context and canonical `select.indexes`, then assert only row 2 changes |
+| E | not reached | Need project payload, revision, approval/decline outcome, durable receipt, and duplicate-write count from disk |
+| T | not reached | Need renderer → preload → Host/public MCP → owner store → persistence → fresh process → packaged path evidence |
+| N | not reached | Need stale revision, wrong project, empty selection, decline, duplicate confirmation, and reconcile mismatch fail-closed cases |
+
+## Next-layer repair recommendation
+
+Repair the earliest shared boundary exposed by the first failure: make the existing storyboard editor reachable from a real newly-created project and make row selection produce the canonical storyboard reference/context handle consumed by the resident Agent. Then rerun this same runner before touching any later M2-M5 implementation. Once M1 is green, the next red assertion should be the first missing link among Skill/model identity, Host context, public `nomi_canvas_plan`, approval/decline, receipt/revision, projection agreement, restart/reconcile, and packaged repeat.
+
+This branch intentionally stops at the red contract. It is not a production completion claim and must not be merged as feature delivery.
+
+## Persistent status ledger
+
+The durable single source of milestone status is [`docs/plan/2026-09-05-m0-m5-vertical-spine-status.md`](../plan/2026-09-05-m0-m5-vertical-spine-status.md). It keeps the full goal intact—全量盘点与安全收敛、Agent 核心 M0-M5 真实 `patch_shots` 闭环、MCP/新版分镜表/画布证据保留、TikHub/视频后置—even though this branch only records the first red seam.

--- a/tests/system/agent-vertical-spine-m0-m5.contract.json
+++ b/tests/system/agent-vertical-spine-m0-m5.contract.json
@@ -1,0 +1,183 @@
+{
+  "schemaVersion": 1,
+  "id": "nomi.agent.vertical-spine.m0-m5",
+  "title": "M0-M5 Agent vertical spine red contract",
+  "baseRef": "origin/main",
+  "userTask": "我想做一个30秒竖屏短片，先理顺故事和分镜，不要一上来生成；第三个镜头改为站门口犹豫两秒，其他镜头不动；先告诉我改哪些，确认后再生成",
+  "userSurfaceRule": "用户层只出现上述自然语言与可读的 Skill、模型、分镜和审批文案；不得出现 API 参数、工具名、operation、patch_shots、leaseHandle 或内部 id。",
+  "generationBoundary": "当前核心 spine 先跑到可验证的生成提案/真实项目写入边界；完整视频生成仍属于总目标，待 M0-M5 闭环后用 APIMart/TikHub 做真实媒体 canary。",
+  "multiRoundProtocol": {
+    "rule": "同一真实项目、同一 Agent thread、同一用户任务必须经历补充、否定、改口、单镜头范围、预览后确认、分步生成、生成后微调、关闭重启后追问并继续；不得把整段压成一条 prompt。",
+    "technicalBoundary": "用户话术不得出现 operation、tool、id、fixture 或 API 参数；canonical tool/id 只允许出现在内部 assertion、MCP trace、receipt 和 revision evidence。",
+    "transcript": [
+      {
+        "turn": "R1",
+        "when": "新建项目后",
+        "user": "我想做一个30秒竖屏短片，先理顺故事和分镜，不要一上来生成。",
+        "internal": {
+          "M0": { "assertion": "real isolated project is current project", "status": "pending-red-gate", "receipt": "none before approval", "revision": "read durable project revision", "context": "project identity from route and disk" },
+          "M1": { "assertion": "storyboard surface is visible", "status": "blocked-by-current-M1-B", "receipt": "not applicable", "revision": "selection revision not available", "context": "no row context yet" },
+          "M2": { "assertion": "no write is proposed before user asks", "status": "not-reached", "receipt": "none", "revision": "unchanged", "context": "natural planning request only" },
+          "M3": { "assertion": "Agent reads current project and storyboard context", "status": "not-reached", "receipt": "none", "revision": "same current revision", "context": "right Agent thread" },
+          "M4": { "assertion": "no approval card or write before confirmation", "status": "not-reached", "receipt": "none", "revision": "unchanged", "context": "waiting for plan" },
+          "M5": { "assertion": "thread and durable state remain resumable", "status": "not-reached", "receipt": "none", "revision": "readback pending", "context": "same project after restart" }
+        }
+      },
+      {
+        "turn": "R2",
+        "when": "Agent asks what to change",
+        "user": "先不要生成，只改第三个镜头：让人物站在门口犹豫两秒，其他镜头和内容都不要动。",
+        "internal": {
+          "M0": { "assertion": "same real project, no project switch", "status": "pending-red-gate", "receipt": "none", "revision": "same as R1", "context": "same project" },
+          "M1": { "assertion": "‘第三个镜头’ maps to visible row 2 index only", "status": "blocked-by-current-M1-B", "receipt": "not applicable", "revision": "selection revision pending", "context": "selected storyboard row 2" },
+          "M2": { "assertion": "proposal diff contains only the third shot", "status": "not-reached", "receipt": "proposal only", "revision": "must not advance", "context": "selection handle from R2" },
+          "M3": { "assertion": "Agent repeats requested scope and untouched-shot constraint", "status": "not-reached", "receipt": "none", "revision": "same selection revision", "context": "third-shot reference" },
+          "M4": { "assertion": "preview is shown without mutation", "status": "not-reached", "receipt": "none", "revision": "unchanged", "context": "approval still pending" },
+          "M5": { "assertion": "preview state is durable/resumable without write", "status": "not-reached", "receipt": "none", "revision": "unchanged after readback", "context": "same Agent thread" }
+        }
+      },
+      {
+        "turn": "R3",
+        "when": "用户否定并改口，要求先看改动",
+        "user": "我改主意了，先告诉我具体会改哪些，再让我确认；现在不要生成，也不要碰其他镜头。",
+        "internal": {
+          "M0": { "assertion": "same project remains bound", "status": "pending-red-gate", "receipt": "none", "revision": "same as R2", "context": "project unchanged" },
+          "M1": { "assertion": "selection remains only the third storyboard row", "status": "blocked-by-current-M1-B", "receipt": "not applicable", "revision": "selection revision pending", "context": "same row context" },
+          "M2": { "assertion": "proposal preview is explainable in user language", "status": "not-reached", "receipt": "proposal not committed", "revision": "must not advance", "context": "one-shot diff" },
+          "M3": { "assertion": "Agent acknowledges changed instruction and preserves scope", "status": "not-reached", "receipt": "none", "revision": "same revision", "context": "same thread plus third-shot handle" },
+          "M4": { "assertion": "no write until explicit confirmation", "status": "not-reached", "receipt": "none", "revision": "unchanged", "context": "approval gate visible" },
+          "M5": { "assertion": "uncommitted preview can be reconciled", "status": "not-reached", "receipt": "none", "revision": "readback unchanged", "context": "resume-safe draft" }
+        }
+      },
+      {
+        "turn": "R4",
+        "when": "确认后只执行部分范围",
+        "user": "确认这次修改。先执行这一个镜头的改动，但只生成前三个镜头，后面的先别动。",
+        "internal": {
+          "M0": { "assertion": "same project is the write target", "status": "pending-red-gate", "receipt": "one receipt target", "revision": "current revision precondition", "context": "same project" },
+          "M1": { "assertion": "third-shot selection is preserved", "status": "blocked-by-current-M1-B", "receipt": "not applicable", "revision": "selected revision pending", "context": "row 2 only" },
+          "M2": { "assertion": "canonical semantic proposal encodes only selected patch", "status": "not-reached", "receipt": "proposal id internal only", "revision": "pre-write revision", "context": "patch scope row 2" },
+          "M3": { "assertion": "Skill/model/context identity travels with request", "status": "not-reached", "receipt": "none", "revision": "pre-write revision", "context": "Agent + third-shot + first-three generation range" },
+          "M4": { "assertion": "approval writes once and exposes readable diff", "status": "not-reached", "receipt": "durable receipt required", "revision": "must advance exactly once", "context": "approved proposal" },
+          "M5": { "assertion": "partial generation boundary is durable and resumable", "status": "not-reached", "receipt": "receipt survives restart", "revision": "readback equals approved revision", "context": "first three shots only" }
+        }
+      },
+      {
+        "turn": "R5",
+        "when": "生成后继续微调",
+        "user": "刚才第三个镜头的犹豫再短一点，门外的雨声保留，其他已经完成的镜头不要改；先预览这个小改动。",
+        "internal": {
+          "M0": { "assertion": "same project and completed partial generation", "status": "pending-red-gate", "receipt": "prior receipt must be readable", "revision": "post-R4 revision", "context": "same project" },
+          "M1": { "assertion": "same third-shot row remains selected", "status": "blocked-by-current-M1-B", "receipt": "prior receipt only", "revision": "post-R4 selection revision", "context": "row 2" },
+          "M2": { "assertion": "second proposal changes only the third shot detail", "status": "not-reached", "receipt": "new preview receipt pending", "revision": "must not advance before approval", "context": "delta from post-R4" },
+          "M3": { "assertion": "Agent carries prior receipt/revision and current context", "status": "not-reached", "receipt": "prior receipt id internal", "revision": "post-R4 revision", "context": "same thread and row" },
+          "M4": { "assertion": "preview remains reversible until next approval", "status": "not-reached", "receipt": "no new committed receipt yet", "revision": "unchanged", "context": "second approval gate" },
+          "M5": { "assertion": "micro-adjustment is resumable without duplicate write", "status": "not-reached", "receipt": "duplicate check pending", "revision": "readback pending", "context": "same project after restart" }
+        }
+      },
+      {
+        "turn": "R6",
+        "when": "关闭重启后追问并继续",
+        "user": "我重新打开项目了，刚才做到哪里？请接着之前的工作，先告诉我现在的状态和下一步，不要直接生成。",
+        "internal": {
+          "M0": { "assertion": "fresh process reads the same project", "status": "pending-red-gate", "receipt": "prior receipt readback", "revision": "durable current revision", "context": "same project after restart" },
+          "M1": { "assertion": "storyboard row and selection reconcile", "status": "blocked-by-current-M1-B", "receipt": "prior receipt reference", "revision": "reconciled revision", "context": "third-shot row" },
+          "M2": { "assertion": "next proposal uses reconciled selection, not stale state", "status": "not-reached", "receipt": "new receipt only after approval", "revision": "reconciled precondition", "context": "canonical semantic plan internally" },
+          "M3": { "assertion": "Agent explains durable progress and resumes context", "status": "not-reached", "receipt": "prior receipt visible internally", "revision": "reconciled revision", "context": "fresh Agent process/thread projection" },
+          "M4": { "assertion": "no action is executed before renewed confirmation", "status": "not-reached", "receipt": "none for this turn", "revision": "unchanged", "context": "approval remains explicit" },
+          "M5": { "assertion": "restart/reconcile has no duplicate write and supports continuation", "status": "not-reached", "receipt": "duplicate-free durable receipt", "revision": "same as disk readback", "context": "same task continuation" }
+        }
+      }
+    ]
+  },
+  "scope": {
+    "include": [
+      "real Electron project creation",
+      "storyboard row selection",
+      "visible Skill and model identity selection",
+      "right-side Agent context read",
+      "nomi_canvas_plan with operation=patch_shots",
+      "approval and decline",
+      "durable project write, receipt, and revision",
+      "Agent/storyboard/canvas projection agreement",
+      "cold restart and reconcile",
+      "current-SHA packaged repeat"
+    ],
+    "exclude": ["video canary in this red stage", "TikHub canary in this red stage", "Skill Hub", "UI redesign", "provider spend"]
+  },
+  "evidencePolicy": {
+    "required": [
+      "real Electron window",
+      "visible DOM user actions",
+      "preload bridge and public MCP stdio",
+      "production semantic tool name nomi_canvas_plan",
+      "disk-backed project and receipt readback",
+      "cold Electron restart",
+      "packaged app repeat from the same SHA"
+    ],
+    "forbidden": [
+      "fake store injection",
+      "direct production handler invocation",
+      "loopback as final evidence",
+      "legacy bare patch_shots MCP tool",
+      "static DOM-only completion claim"
+    ]
+  },
+  "productionCallShape": {
+    "tool": "nomi_canvas_plan",
+    "args": {
+      "projectId": "<real project id>",
+      "leaseHandle": "<verified current-project lease>",
+      "operation": "patch_shots",
+      "select": { "kind": "indexes", "indexes": [2] },
+      "patch": { "promptAppend": "夜雨反光", "aspectRatio": "9:16" }
+    },
+    "approval": "one real approval before the write and one real decline with no mutation"
+  },
+  "milestones": [
+    {
+      "id": "M0",
+      "entry": "Create one isolated project through the real Electron library UI",
+      "exit": "projectId is visible in the route and the project record is readable from disk"
+    },
+    {
+      "id": "M1",
+      "entry": "Select storyboard row 2 through the visible storyboard editor",
+      "exit": "the selection is observable and bound to the same project revision"
+    },
+    {
+      "id": "M2",
+      "entry": "Use the canonical semantic canvas plan call shape",
+      "exit": "only selected row 2 is proposed and unmentioned fields remain unchanged"
+    },
+    {
+      "id": "M3",
+      "entry": "Choose a visible Skill and model/vendor identity, then let the right Agent read the selection",
+      "exit": "the Agent request carries project, selection, Skill, model/vendor, and revision identity"
+    },
+    {
+      "id": "M4",
+      "entry": "Approve one proposal and decline a second proposal",
+      "exit": "approval writes once; decline creates no project mutation or receipt"
+    },
+    {
+      "id": "M5",
+      "entry": "Read project, receipt, revision, and projections, then cold restart and repeat from the packaged app",
+      "exit": "fresh process reconciles the same durable state without duplicate write or receipt"
+    }
+  ],
+  "dimensions": {
+    "H": "User-visible creation, row selection, Skill/model selection, Agent read, approval, decline, restart",
+    "B": "Selection injection, context propagation, canonical operation, and three-surface projection",
+    "E": "Project payload, revision, receipt, approval/decline outcome, and duplicate-write evidence",
+    "T": "Electron renderer → preload → Host/MCP → project owner → persistence → fresh process → packaged app",
+    "N": "Missing surface, stale revision, wrong project, empty selection, decline, duplicate confirmation, and reconcile mismatch"
+  },
+  "naturalTaskVariants": {
+    "H": "用户只表达短片目标、故事/分镜优先、第三镜头的自然修改和先确认后生成；观察可见 Skill/model、Agent 上下文与 approval 文案是否可理解。",
+    "B": "用户说‘第三个镜头’，内部必须解析为同一项目的第 3 行；仅该行进入提案，其他镜头和未提及字段保持不动，三面投影一致。",
+    "E": "用户先看‘改哪些’再确认；批准只写一次并留下 receipt/revision，拒绝不改项目、不写 receipt。",
+    "T": "自然语言从真实 Electron composer 经 preload/Host 到公共 MCP 语义调用，再落盘、重启回读并在 packaged app 重复；canonical tool/id 只在技术 assertion/receipt 中出现。",
+    "N": "同一自然任务覆盖空白项目无分镜、歧义‘第三个镜头’、错项目/旧 revision、空选择、拒绝、重复确认和重启 reconcile 不一致，并 fail closed。"
+  }
+}

--- a/tests/ux/agent-vertical-spine-m0-m5.red.e2e.mjs
+++ b/tests/ux/agent-vertical-spine-m0-m5.red.e2e.mjs
@@ -1,0 +1,244 @@
+// M0-M5 red-stage vertical spine.
+//
+// This runner intentionally stops at the first unmet production seam. It starts
+// a real isolated Electron app, creates a project through the visible library UI,
+// and only then attempts the storyboard → Agent → MCP → durable write path.
+// It does not seed a project, inject a Zustand/store state, call a handler, or use
+// a loopback provider. A future green implementation must make every later step
+// execute through the same real UI/preload/public-MCP path.
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import { launchNomiApp, closeNomiApp } from './_launchApp.mjs'
+import { makeIsolatedDirs, parseToolResult, spawnMcpStdioClient } from './_mcpJourney.mjs'
+
+const contractPath = path.resolve('tests/system/agent-vertical-spine-m0-m5.contract.json')
+const contract = JSON.parse(fs.readFileSync(contractPath, 'utf8'))
+const transcript = contract.multiRoundProtocol?.transcript || []
+const forbiddenUserTokens = /\b(operation|tool|id|fixture|patch_shots|leaseHandle|nomi_canvas_plan)\b/i
+if (transcript.length < 6) throw new Error('natural multi-round transcript must contain at least six turns')
+for (const turn of transcript) {
+  if (!turn.user || forbiddenUserTokens.test(turn.user)) throw new Error(`user transcript leaks technical vocabulary: ${turn.turn}`)
+  for (const milestone of ['M0', 'M1', 'M2', 'M3', 'M4', 'M5']) {
+    const internal = turn.internal?.[milestone]
+    if (!internal || !internal.assertion || !internal.status || !('receipt' in internal) || !('revision' in internal) || !('context' in internal)) {
+      throw new Error(`incomplete internal assertion for ${turn.turn}/${milestone}`)
+    }
+  }
+}
+const packagedInput = process.env.NOMI_VERTICAL_SPINE_PACKAGED_APP || null
+const packagedApp = packagedInput
+  ? path.resolve(packagedInput.endsWith('.app') ? path.join(packagedInput, 'Contents', 'MacOS', 'Nomi') : packagedInput)
+  : null
+const requestedPhase = process.argv.includes('--packaged') ? 'packaged' : 'development'
+const evidenceRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'nomi-agent-vertical-spine-red-'))
+
+const gaps = {
+  H: { status: 'not-reached', reason: 'later user-visible actions are blocked by the first failed seam', next: 'make the real storyboard surface and row selection reachable after project creation' },
+  B: { status: 'not-reached', reason: 'canonical selection/context/write behavior was not reached', next: 'bind row 2 selection to the Agent context snapshot and canonical operation args' },
+  E: { status: 'not-reached', reason: 'no write, receipt, or revision may be claimed before a real proposal executes', next: 'persist one approved write and one declined no-op with receipt/revision evidence' },
+  T: { status: 'not-reached', reason: 'the UI-to-preload-to-Host-to-owner chain was not traversed beyond project creation', next: 'connect the real renderer selection to the public MCP/Host owner and fresh-process readback' },
+  N: { status: 'not-reached', reason: 'negative cases must run after the canonical entry is reachable', next: 'exercise stale/wrong-project/empty/decline/duplicate/reconcile cases and fail closed' },
+}
+
+function projectIdFromUrl(url) {
+  return new URL(url).hash.split('?')[1] ? new URLSearchParams(new URL(url).hash.split('?')[1]).get('projectId') : null
+}
+
+function projectDirFor(dirs, projectId) {
+  const candidates = fs.existsSync(dirs.projectsDir) ? fs.readdirSync(dirs.projectsDir) : []
+  const match = candidates.find((name) => {
+    const file = path.join(dirs.projectsDir, name, '.nomi', 'project.json')
+    if (!fs.existsSync(file)) return false
+    try { return JSON.parse(fs.readFileSync(file, 'utf8')).id === projectId } catch { return false }
+  })
+  return match ? path.join(dirs.projectsDir, match) : null
+}
+
+function readProject(projectDir) {
+  return JSON.parse(fs.readFileSync(path.join(projectDir, '.nomi', 'project.json'), 'utf8'))
+}
+
+async function failureContext(win, step, error) {
+  return {
+    step,
+    message: error?.message || String(error),
+    url: win?.url?.() || null,
+    bodyText: win ? await win.locator('body').innerText().catch(() => '') : '',
+    storyboardEditorCount: win ? await win.locator('[data-storyboard-editor="true"]').count().catch(() => 0) : 0,
+    storyboardRow2Count: win ? await win.locator('[data-storyboard-editor="true"] [data-storyboard-row="2"]').count().catch(() => 0) : 0,
+  }
+}
+
+async function dismissSplash(win) {
+  const skip = win.locator('[data-splash-skip="true"]').first()
+  if (await skip.count()) {
+    await skip.click({ timeout: 5_000 })
+    await win.locator('.nomi-splash').waitFor({ state: 'detached', timeout: 5_000 }).catch(() => undefined)
+  }
+}
+
+async function runPhase(phase, executablePath = undefined) {
+  const dirs = makeIsolatedDirs(`nomi-agent-vertical-spine-${phase}-`)
+  let app = null
+  let win = null
+  let mcp = null
+  let decline = null
+  const steps = []
+  let firstFailure = null
+  let currentStep = 'M0.start-electron'
+  try {
+    const instance = await launchNomiApp({
+      name: `agent-vertical-spine-${phase}`,
+      executablePath,
+      userDataDir: dirs.userDataDir,
+      settingsDir: dirs.settingsDir,
+      projectsDir: dirs.projectsDir,
+      capabilityDir: dirs.capabilityDir,
+      args: ['--disable-gpu', '--disable-software-rasterizer', '--no-proxy-server'],
+      settleMs: 0,
+    })
+    app = instance.app
+    win = instance.win
+    steps.push({ id: 'M0.start-electron', status: 'passed', evidence: 'real Electron window opened' })
+
+    await dismissSplash(win)
+    const create = win.getByText('新建空白项目', { exact: true }).first()
+    await create.waitFor({ state: 'visible', timeout: 15_000 })
+    await create.click()
+    await win.waitForFunction(() => /projectId=/.test(location.href), undefined, { timeout: 15_000 })
+    const projectId = projectIdFromUrl(win.url())
+    if (!projectId) throw new Error('M0 project creation did not produce a projectId route')
+    await win.waitForFunction(async (id) => {
+      const record = await window.nomiDesktop?.projects?.readAsync?.(id)
+      return Boolean(record?.id === id && record?.payload)
+    }, projectId, { timeout: 15_000 })
+    const projectDir = projectDirFor(dirs, projectId)
+    if (!projectDir) throw new Error(`M0 project ${projectId} was not readable from the isolated project root`)
+    const initial = readProject(projectDir)
+    steps.push({ id: 'M0.create-isolated-project', status: 'passed', evidence: { projectId, revision: initial.revision, projectDir } })
+
+    currentStep = 'M1.select-storyboard-row'
+    await win.getByRole('button', { name: '创作', exact: true }).first().click().catch(() => undefined)
+    const storyboardEditor = win.locator('[data-storyboard-editor="true"]').first()
+    await storyboardEditor.waitFor({ state: 'visible', timeout: 10_000 })
+    const row = storyboardEditor.locator('[data-storyboard-row="2"]').first()
+    await row.waitFor({ state: 'visible', timeout: 10_000 })
+    await row.click()
+    await storyboardEditor.locator('[data-storyboard-row="2"][data-selected="true"], [data-storyboard-row="2"] [aria-selected="true"]').first().waitFor({ state: 'visible', timeout: 5_000 })
+    steps.push({ id: 'M1.select-storyboard-row', status: 'passed', evidence: 'row 2 selected through visible storyboard DOM' })
+
+    currentStep = 'M3.select-skill-and-model'
+    const collapsed = win.locator('[data-agent-resident-collapsed="true"]').first()
+    if (await collapsed.isVisible().catch(() => false)) await collapsed.click()
+    const panel = win.locator('[data-agent-panel="true"]').first()
+    await panel.waitFor({ state: 'visible', timeout: 10_000 })
+    await panel.locator('[data-agent-composer-mode="true"]').click()
+    const skill = win.locator('[data-agent-menu-item="workbench.storyboard.planner"]').first()
+    await skill.waitFor({ state: 'visible', timeout: 10_000 })
+    await skill.click()
+    await panel.locator('[data-agent-reference="skill:workbench.storyboard.planner"]').waitFor({ state: 'visible', timeout: 5_000 })
+    await panel.locator('[data-agent-composer-model="true"]').click()
+    const model = win.locator('button[data-agent-menu-item*="/"]').first()
+    await model.waitFor({ state: 'visible', timeout: 10_000 })
+    const modelIdentity = await model.getAttribute('data-agent-menu-item')
+    await model.click()
+    steps.push({ id: 'M3.select-skill-and-model', status: 'passed', evidence: { skill: 'workbench.storyboard.planner', modelIdentity } })
+
+    currentStep = 'M3.agent-reads-selection-context'
+    await panel.locator('[data-agent-reference="storyboard:shot:2"]').waitFor({ state: 'visible', timeout: 10_000 })
+    steps.push({ id: 'M3.agent-reads-selection-context', status: 'passed', evidence: 'Agent reference is bound to storyboard shot 2' })
+
+    currentStep = 'M3.natural-language-multi-round-transcript'
+    const input = panel.locator('[data-agent-input="true"]').first()
+    const send = panel.locator('[data-agent-composer-send="true"]').first()
+    await input.waitFor({ state: 'visible', timeout: 10_000 })
+    for (const turn of transcript.slice(0, 5)) {
+      if (forbiddenUserTokens.test(turn.user)) throw new Error(`${turn.turn} user text contains a technical token`)
+      const before = await panel.locator('[data-agent-item-kind]').count()
+      await input.fill(turn.user)
+      await send.click()
+      await panel.locator('[data-agent-item-kind="user"]').filter({ hasText: turn.user }).last().waitFor({ state: 'visible', timeout: 10_000 })
+      await panel.locator('[data-agent-item-kind="assistant"], [data-agent-item-kind="failure"], [data-agent-item-kind="approval"]').nth(Math.max(0, before)).waitFor({ state: 'visible', timeout: 30_000 }).catch(() => undefined)
+      steps.push({ id: `M3.${turn.turn}.natural-user-turn`, status: 'passed', evidence: { user: turn.user, internalAssertions: ['M0', 'M1', 'M2', 'M3', 'M4', 'M5'] } })
+    }
+
+    currentStep = 'M2.canonical-patch-shots'
+    mcp = spawnMcpStdioClient({ ...dirs, clientInfo: { name: 'agent-vertical-spine-red', version: '1' }, capabilities: { elicitation: {} }, captureStderr: true })
+    await mcp.initialize()
+    const opened = parseToolResult(await mcp.callTool('nomi_session_open', { bootstrap: { mode: 'current_project' } }))
+    const leaseHandle = opened.json?.leaseHandle || opened.outcome?.leaseHandle
+    if (!leaseHandle) throw new Error('M2 current-project session did not return a verified lease')
+    const canonicalArgs = { ...contract.productionCallShape.args, projectId, leaseHandle, select: { kind: 'indexes', indexes: [2] } }
+    const approved = parseToolResult(await mcp.callToolOrThrow(contract.productionCallShape.tool, canonicalArgs))
+    if (approved.json?.operation !== 'patch_shots' && approved.outcome?.operation !== 'patch_shots') throw new Error('M2 canonical result did not identify patch_shots')
+    steps.push({ id: 'M2.canonical-patch-shots', status: 'passed', evidence: { tool: contract.productionCallShape.tool, operation: 'patch_shots' } })
+
+    currentStep = 'M4.approved-write-receipt-revision'
+    const changed = readProject(projectDir)
+    if (changed.revision <= initial.revision) throw new Error('M4 approved canonical patch did not advance the durable project revision')
+    const receiptPath = path.join(projectDir, '.nomi', 'project-agent-proposal-receipt.json')
+    if (!fs.existsSync(receiptPath)) throw new Error('M4 approved canonical patch has no durable proposal receipt')
+    steps.push({ id: 'M4.approved-write-receipt-revision', status: 'passed', evidence: { revision: changed.revision, projectDir } })
+
+    const beforeDecline = JSON.stringify(readProject(projectDir))
+    decline = spawnMcpStdioClient({
+      ...dirs,
+      clientInfo: { name: 'agent-vertical-spine-red-decline', version: '1' },
+      capabilities: { elicitation: {} },
+      elicitationAction: 'decline',
+      captureStderr: true,
+    })
+    await decline.initialize()
+    const declineOpened = parseToolResult(await decline.callTool('nomi_session_open', { bootstrap: { mode: 'current_project' } }))
+    const declineLease = declineOpened.json?.leaseHandle || declineOpened.outcome?.leaseHandle
+    const declined = await decline.callTool(contract.productionCallShape.tool, { ...canonicalArgs, leaseHandle: declineLease, patch: { promptAppend: '拒绝后不应落盘' } })
+    if (!declined.isError && !/denied|declin|approval/i.test(declined.text)) throw new Error('M4 declined canonical proposal did not return a denial-shaped result')
+    if (JSON.stringify(readProject(projectDir)) !== beforeDecline) throw new Error('M4 declined canonical proposal mutated the project')
+    await decline.terminate()
+    decline = null
+    steps.push({ id: 'M4.declined-write-is-noop', status: 'passed', evidence: 'real MCP elicitation decline returned without project mutation' })
+
+    await mcp.terminate()
+    mcp = null
+    await closeNomiApp(app)
+    app = null
+    currentStep = 'M5.cold-restart-reconcile'
+    const restarted = await launchNomiApp({ name: `agent-vertical-spine-${phase}-restart`, executablePath, userDataDir: dirs.userDataDir, settingsDir: dirs.settingsDir, projectsDir: dirs.projectsDir, capabilityDir: dirs.capabilityDir, args: ['--disable-gpu', '--disable-software-rasterizer', '--no-proxy-server'], settleMs: 0 })
+    app = restarted.app
+    win = restarted.win
+    const readback = readProject(projectDir)
+    const restartedPanel = win.locator('[data-agent-panel="true"]').first()
+    await restartedPanel.waitFor({ state: 'visible', timeout: 10_000 })
+    const resumeInput = restartedPanel.locator('[data-agent-input="true"]').first()
+    const resumeSend = restartedPanel.locator('[data-agent-composer-send="true"]').first()
+    const resumeTurn = transcript.find((turn) => turn.turn === 'R6')
+    await resumeInput.fill(resumeTurn.user)
+    await resumeSend.click()
+    await restartedPanel.locator('[data-agent-item-kind="user"]').filter({ hasText: resumeTurn.user }).last().waitFor({ state: 'visible', timeout: 10_000 })
+    steps.push({ id: 'M5.cold-restart-reconcile', status: 'passed', evidence: { revision: readback.revision, projectId, resumedTurn: resumeTurn.turn, internalAssertions: ['M0', 'M1', 'M2', 'M3', 'M4', 'M5'] } })
+    return { phase, status: 'passed', steps, firstFailure: null, gaps, evidenceRoot, dirs }
+  } catch (error) {
+    firstFailure = await failureContext(win, currentStep, error)
+    const failedDimension = currentStep.startsWith('M1') ? 'B' : currentStep.startsWith('M2') ? 'T' : currentStep.startsWith('M3') ? 'H' : currentStep.startsWith('M4') ? 'E' : 'T'
+    gaps[failedDimension] = { status: 'failed', reason: firstFailure.message, next: gaps[failedDimension].next }
+    return { phase, status: 'failed', steps, firstFailure: { ...firstFailure, dimension: failedDimension }, gaps, evidenceRoot, dirs }
+  } finally {
+    if (mcp) await mcp.terminate().catch(() => undefined)
+    if (decline) await decline.terminate().catch(() => undefined)
+    if (app) await closeNomiApp(app)
+  }
+}
+
+const phases = []
+if (requestedPhase === 'packaged' && !packagedApp) {
+  phases.push({ phase: 'packaged', status: 'blocked', reason: 'NOMI_VERTICAL_SPINE_PACKAGED_APP is required for the packaged repeat' })
+} else {
+  phases.push(await runPhase(requestedPhase, requestedPhase === 'packaged' ? packagedApp : undefined))
+}
+const result = { schemaVersion: 1, contract: contract.id, requestedPhase, phases, evidenceRoot }
+fs.writeFileSync(path.join(evidenceRoot, 'summary.json'), JSON.stringify(result, null, 2))
+console.log(JSON.stringify(result, null, 2))
+if (phases.some((phase) => phase.status === 'failed')) process.exitCode = 1
+if (phases.some((phase) => phase.status === 'blocked')) process.exitCode = 2


### PR DESCRIPTION
## Red-stage only

This PR adds the persistent M0-M5 Agent vertical-spine contract, natural multi-round transcript, red Electron runner, and status/evidence ledger. It intentionally does not modify production implementation and must not be merged as feature completion.

## Scope

- Highest-priority mainline convergence: Agent M0-M5 real end-to-end spine.
- Natural user task from a real isolated Electron project, with R1-R6 multi-round collaboration: no generation first, single third-shot edit, preview/confirmation, partial generation, post-generation micro-adjustment, and restart/resume question.
- Internal assertions cover M0-M5, H/B/E/T/N, approval, receipt, revision, persistence/restart, projection agreement, and packaged repeat.
- MCP/new storyboard table/canvas evidence is retained; TikHub/APIMart/video media canaries remain later scope.

## Evidence

- Base: `origin/main@163bddf157b613bde1d8291098b8813cea2bc80b`
- Development red run reaches real Electron project creation, then fails at `M1.select-storyboard-row` / `B`: `[data-storyboard-editor="true"]` never becomes visible; body has only `新建分镜方案`.
- Current-SHA packaged repeat opens packaged Electron and fails at the same M1/B seam.
- `pnpm run dist:mac:dir` and packaged MCP smoke passed; this is not vertical-spine completion evidence.
- `pnpm run check:mjs-parse` passed (597 files).

## Follow-up

Next repair PR: make the existing storyboard editor reachable after real project creation and bind row 2 selection to Agent context, then rerun the unchanged runner. Do not merge this red-stage PR.