### PR TITLE
fix(storyboard): storyboardPlan.ts 拆模块回到 800 行内（main 热修）

### DIFF
--- a/src/workbench/creation/storyboard/exec/storyboardRowActions.ts
+++ b/src/workbench/creation/storyboard/exec/storyboardRowActions.ts
@@ -1,10 +1,10 @@
 import type { GenerationCanvasNode } from '../../../generationCanvas/model/generationCanvasTypes'
 import type { ArchetypeMode } from '../../../../config/modelArchetypes/types'
 import type { PlanAnchor, PlanShot, StoryboardPlan } from '../../../generationCanvas/agent/storyboardPlan'
+import { buildAnchorSheetPrompt } from '../../../generationCanvas/agent/storyboardPromptCompiler'
 import {
   renderShotKeyframePrompt,
   renderShotNodePrompt,
-  buildAnchorSheetPrompt,
   effectiveShotDurationSec,
   stableShotId,
   storyboardAnchorToCreateNodesArgs,

--- a/src/workbench/creation/storyboard/exec/storyboardRowStatus.ts
+++ b/src/workbench/creation/storyboard/exec/storyboardRowStatus.ts
@@ -2,7 +2,7 @@ import type { GenerationCanvasNode } from '../../../generationCanvas/model/gener
 import type { ArchetypeMode, ArchetypeReferenceSlot } from '../../../../config/modelArchetypes/types'
 import type { ModelOption } from '../../../../config/models'
 import type { PlanAnchor, PlanShot, StoryboardPlan } from '../../../generationCanvas/agent/storyboardPlan'
-import { isVisualAnchor } from '../../../generationCanvas/agent/storyboardPlan'
+import { isVisualAnchor } from '../../../generationCanvas/agent/storyboardPromptCompiler'
 import { isAnchorFrozen } from '../../../generationCanvas/model/anchorBibleKeys'
 import { hasUsableResult } from '../../../generationCanvas/runner/dependencyWaves'
 import { missingRequiredSlots, referencedVisualAnchors, resolveShotArchetypeMode } from '../shotRow/shotRowModel'

--- a/src/workbench/generationCanvas/agent/storyboardPlan.test.ts
+++ b/src/workbench/generationCanvas/agent/storyboardPlan.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
-import { buildAnchorSheetPrompt, effectiveShotDurationSec, storyboardPlanToCreateNodesArgs, type StoryboardPlan } from './storyboardPlan'
+import { effectiveShotDurationSec, storyboardPlanToCreateNodesArgs, type StoryboardPlan } from './storyboardPlan'
+import { buildAnchorSheetPrompt } from './storyboardPromptCompiler'
 import { parseStoryboardPlan, storyboardPlanSchema } from './storyboardPlanSchema'
 import { storyboardProfileForKey } from './storyboardProfiles'
 

--- a/src/workbench/generationCanvas/agent/storyboardPlan.ts
+++ b/src/workbench/generationCanvas/agent/storyboardPlan.ts
@@ -1,7 +1,13 @@
 import type { BuiltinCanvasCategoryId, GenerationCanvasEdgeMode } from '../model/generationCanvasTypes'
 import { DEFAULT_IMAGE_SECONDS } from '../model/buildClipFromGenerationNode'
 import i18n from '../../../i18n'
-import { parsePromptSegments } from '../../assets/promptMentions'
+import {
+  buildAnchorSheetPrompt,
+  buildKeyframePrompt,
+  buildShotPrompt,
+  isVisualAnchor,
+  referenceOrderForShot,
+} from './storyboardPromptCompiler'
 
 /**
  * 「分镜方案」中间表示（IR）—— 剧本→方案文档→确认→落画布 主链路的中枢。
@@ -330,17 +336,6 @@ export type StoryboardPlanToArgsOptions = {
   storyboardDesignId?: string
 }
 
-const VISUAL_KINDS: ReadonlySet<PlanAnchorKind> = new Set(['character', 'scene', 'prop'])
-
-/**
- * 「这把锚会生成参考图卡」的唯一谓词（materialize / 连边 / 分镜表卡面与等待判定共用）：
- * carrier=visual 且 kind 在可出图集合（style 恒文本语义，即使 carrier 被手动翻成 visual
- * 也不建节点——materialize 同一判定，卡面「生成」按钮与等待判定不得与它分裂）。
- */
-export function isVisualAnchor(anchor: Pick<PlanAnchor, 'carrier' | 'kind'>): boolean {
-  return anchor.carrier === 'visual' && VISUAL_KINDS.has(anchor.kind)
-}
-
 /** 锚类型 → 该锚连到镜头的参考边语义。 */
 function edgeModeForAnchor(kind: PlanAnchorKind): GenerationCanvasEdgeMode {
   if (kind === 'character') return 'character_ref'
@@ -410,128 +405,6 @@ function storyboardShotMetadata(
   if (typeof shot.camIdx === 'number' && Number.isInteger(shot.camIdx) && shot.camIdx >= 0) metadata.camIdx = shot.camIdx
   if (shot.continuity !== undefined) metadata.continuity = shot.continuity
   return metadata
-}
-
-/**
- * 定妆卡/场景卡提示词构造（R6 调研落地：把图当「版面/网格」描述，先锁身份再列视图，
- * 中性背景+平光+小标签，多视图+多变体集中一张图，整张喂参考视频）。GPT Image 2 尤擅此类多面板版面。
- * 视觉锚（character/scene/prop）→ 卡片大图；变体（成年/童年、白天/夜晚…）拼进「变体行」。
- */
-/**
- * 锚的「身份描述段」：W2 圣经优先用 static（身份 DNA）+ dynamic（服装/状态）分区拼——身份 DNA 先锁、
- * 服装状态另起一行，让身份与可变层在卡片 prompt 里就分开（对齐 ViMax：身份只看 static）。二者都空时
- * 退化到旧 description（旧草稿无新字段时向后兼容）。
- */
-function anchorIdentityBody(anchor: PlanAnchor): string {
-  const staticFeatures = (anchor.staticFeatures || '').trim()
-  const dynamicFeatures = (anchor.dynamicFeatures || '').trim()
-  if (staticFeatures || dynamicFeatures) {
-    return [
-      staticFeatures ? `身份特征（跨镜保持一致）：${staticFeatures}` : '',
-      dynamicFeatures ? `服装与状态：${dynamicFeatures}` : '',
-    ].filter(Boolean).join('\n')
-  }
-  return anchor.description.trim()
-}
-
-export function buildAnchorSheetPrompt(anchor: PlanAnchor): string {
-  const name = anchor.name.trim()
-  const desc = anchorIdentityBody(anchor)
-  const variantLine =
-    anchor.variants && anchor.variants.length
-      ? `\nVariants: ${anchor.variants.map((v) => v.trim()).filter(Boolean).join(', ')} (show each variant in its own labeled panel).`
-      : ''
-  if (anchor.kind === 'scene') {
-    return [
-      'Environment reference sheet. Landscape layout, clearly separated panels, small labels below each panel, consistent color palette and lighting.',
-      `The same location "${name}": ${desc}`,
-      'Views: 1) distant establishing view 2) close-up detail 3) overhead view 4) three-quarter view.' + variantLine,
-      'Requirements: keep the same location and visual style consistent across panels; avoid people, style drift, and merged panels.',
-    ].join('\n')
-  }
-  if (anchor.kind === 'prop') {
-    return [
-      'Prop reference sheet. White neutral background, flat lighting, clearly separated panels, small labels below each panel.',
-      `The same object "${name}": ${desc}`,
-      'Views: 1) front 2) side 3) close-up detail.' + variantLine,
-      'Requirements: keep the same object consistent across panels; avoid scene backgrounds, style drift, and merged panels.',
-    ].join('\n')
-  }
-  // character（默认）
-  return [
-    'Character reference sheet. White neutral background, flat lighting, landscape layout, clearly separated panels, small labels below each panel.',
-    `The same character "${name}" must keep the same face shape, hairstyle, clothing, and identifying features across all panels: ${desc}`,
-    'Views: 1) full-body front A-pose 2) side 3) back 4) three-quarter side 5) expression row (neutral / smiling / angry).' + variantLine,
-    'Requirements: keep facial features and clothing consistent across panels; avoid merged panels, cross-panel drift, and scene backgrounds.',
-  ].join('\n')
-}
-
-/**
- * 引用锚要拼进镜头 prompt 的那几段。两类锚、两种拼法，**唯一一处**（两个 build*Prompt 共用，别再各抄一份）：
- *
- *  · 文本锚（style 等，carrier='text'）：整段 description。它本来就不建节点，只能靠 prompt 说清。
- *  · 视觉锚（角色/场景/道具 = 定妆卡）：只拼 `staticFeatures`（身份 DNA），**绝不拼 dynamicFeatures**。
- *    档案本来就把这两层分开了：static 是「同一个人」的定义（脸/眼/疤/年龄性别），跨镜不变；
- *    dynamic 是服装与状态，跨镜本来就该变——拼进去会跟这一镜的画面打架（这一镜她刚从水里爬出来，
- *    卡上却写着「穿黄油布外套」）。
- *
- * 为什么视觉锚除了连参考图还要**再给一段字**（2026-09-02 实测才敢加，不是拍脑袋）：
- * Seedream 4.5 i2i、同一张参考图、同一段镜头文字，只有「拼不拼 static」一个变量，shot3 各跑 4 次——
- *   · 只给图：**0/4** 拿到要求的「脸部特写」（都退回全身/中景站位）
- *   · 图 + static：**3/4** 拿到特写
- * 身份本身两臂都没崩（参考图 i2i 已经锁得住），所以这段字的收益在**构图遵循度**：
- * 只给图时模型不知道这一镜的重点是谁，就退回最安全的全身；给了身份文字它才照着「特写谁的脸」去构图。
- *
- * 顺带解决黑盒：拼在这里 = 这段字进 `node.prompt`，用户在提示词框里**看得见也改得动**，
- * 而不是躺在 meta 里没人知道它存不存在。
- */
-function anchorPromptBits(shot: PlanShot, anchorById: Map<string, PlanAnchor>): string[] {
-  return shot.anchorIds
-    .map((id) => anchorById.get(id))
-    .filter((anchor): anchor is PlanAnchor => Boolean(anchor))
-    .map((anchor) => {
-      if (anchor.carrier === 'text') return `${anchor.name}：${anchor.description}`.trim()
-      const staticFeatures = (anchor.staticFeatures || '').trim()
-      return staticFeatures ? `${anchor.name}·身份特征（跨镜保持一致）：${staticFeatures}` : ''
-    })
-    .filter(Boolean)
-}
-
-/** 视觉参考的边顺序：先按提示词 @ 的出现顺序，再接没有 @ 的旧绑定，保持兼容。 */
-function referenceOrderForShot(shot: PlanShot, anchorById: Map<string, PlanAnchor>): Map<string, number> {
-  const byUrl = new Map<string, string>()
-  for (const anchor of anchorById.values()) {
-    if (anchor.referenceUrl) byUrl.set(anchor.referenceUrl, anchor.id)
-  }
-  const ordered = new Set<string>()
-  for (const segment of parsePromptSegments(shot.prompt)) {
-    if (segment.type !== 'mention') continue
-    const anchorId = byUrl.get(segment.url)
-    if (anchorId && shot.anchorIds.includes(anchorId)) ordered.add(anchorId)
-  }
-  for (const anchorId of shot.anchorIds) {
-    const anchor = anchorById.get(anchorId)
-    if (anchor && isVisualAnchor(anchor)) ordered.add(anchorId)
-  }
-  return new Map([...ordered].map((anchorId, index) => [anchorId, index]))
-}
-
-/** 镜头 prompt = 镜头本体 + 引用锚的描述段（文本锚整段 / 视觉锚只给身份 DNA）。 */
-function buildShotPrompt(shot: PlanShot, anchorById: Map<string, PlanAnchor>): string {
-  const bits = anchorPromptBits(shot, anchorById)
-  const base = shot.prompt.trim()
-  return bits.length ? [base, ...bits].filter(Boolean).join('\n') : base
-}
-
-function buildKeyframePrompt(shot: PlanShot, anchorById: Map<string, PlanAnchor>): string {
-  // 优先级：用户在编辑器手改的 keyframe.prompt > planner 的静态首帧分解 ffDesc > 镜头 prompt（今天的兜底）。
-  // 为什么 ffDesc 排在 shot.prompt 前：shot.prompt 写的是「运动」（推进/摇移/动作演进），拿它当首帧图
-  // 提示词会让静态首帧被运动词污染（director-shot-translation 的污染词铁律）；ffDesc 才是那一帧的快照。
-  const keyframePrompt = typeof shot.keyframe?.prompt === 'string' && shot.keyframe.prompt.trim()
-    ? shot.keyframe.prompt.trim()
-    : (typeof shot.ffDesc === 'string' && shot.ffDesc.trim() ? shot.ffDesc.trim() : shot.prompt.trim())
-  const bits = anchorPromptBits(shot, anchorById)
-  return bits.length ? [keyframePrompt, ...bits].filter(Boolean).join('\n') : keyframePrompt
 }
 
 /** 视觉锚 → 定妆卡/场景卡节点（clientId = anchor.id）。整方案落画布与单锚按需 materialize（B）共用。 */

--- a/src/workbench/generationCanvas/agent/storyboardPromptCompiler.ts
+++ b/src/workbench/generationCanvas/agent/storyboardPromptCompiler.ts
@@ -1,0 +1,147 @@
+import { parsePromptSegments } from '../../assets/promptMentions'
+import type { PlanAnchor, PlanAnchorKind, PlanShot } from './storyboardPlan'
+
+/**
+ * 分镜方案的**提示词编译层**：把 `StoryboardPlan` 的锚/镜头结构编译成真正下发给模型的文字
+ * （定妆卡 prompt、镜头 prompt、首帧 prompt），外加同样由 prompt 派生的视觉参考顺序。
+ *
+ * 为什么单独一层：这些全是**纯函数**——只读 plan、只吐字符串，不碰节点/边/落画布参数。
+ * 它们和 `storyboardPlan.ts` 里的「结构 → create_canvas_nodes 参数」是两件事，混住会让
+ * 「改一句提示词措辞」和「改落画布结构」挤在同一个文件里（R9 分层）。
+ *
+ * 依赖方向：本文件只**按类型**回引 `storyboardPlan.ts`（`import type`，无运行期环）；
+ * `storyboardPlan.ts` 反过来按值 import 这里的编译函数。
+ */
+
+const VISUAL_KINDS: ReadonlySet<PlanAnchorKind> = new Set(['character', 'scene', 'prop'])
+
+/**
+ * 「这把锚会生成参考图卡」的唯一谓词（materialize / 连边 / 分镜表卡面与等待判定共用）：
+ * carrier=visual 且 kind 在可出图集合（style 恒文本语义，即使 carrier 被手动翻成 visual
+ * 也不建节点——materialize 同一判定，卡面「生成」按钮与等待判定不得与它分裂）。
+ */
+export function isVisualAnchor(anchor: Pick<PlanAnchor, 'carrier' | 'kind'>): boolean {
+  return anchor.carrier === 'visual' && VISUAL_KINDS.has(anchor.kind)
+}
+
+/**
+ * 定妆卡/场景卡提示词构造（R6 调研落地：把图当「版面/网格」描述，先锁身份再列视图，
+ * 中性背景+平光+小标签，多视图+多变体集中一张图，整张喂参考视频）。GPT Image 2 尤擅此类多面板版面。
+ * 视觉锚（character/scene/prop）→ 卡片大图；变体（成年/童年、白天/夜晚…）拼进「变体行」。
+ */
+/**
+ * 锚的「身份描述段」：W2 圣经优先用 static（身份 DNA）+ dynamic（服装/状态）分区拼——身份 DNA 先锁、
+ * 服装状态另起一行，让身份与可变层在卡片 prompt 里就分开（对齐 ViMax：身份只看 static）。二者都空时
+ * 退化到旧 description（旧草稿无新字段时向后兼容）。
+ */
+function anchorIdentityBody(anchor: PlanAnchor): string {
+  const staticFeatures = (anchor.staticFeatures || '').trim()
+  const dynamicFeatures = (anchor.dynamicFeatures || '').trim()
+  if (staticFeatures || dynamicFeatures) {
+    return [
+      staticFeatures ? `身份特征（跨镜保持一致）：${staticFeatures}` : '',
+      dynamicFeatures ? `服装与状态：${dynamicFeatures}` : '',
+    ].filter(Boolean).join('\n')
+  }
+  return anchor.description.trim()
+}
+
+export function buildAnchorSheetPrompt(anchor: PlanAnchor): string {
+  const name = anchor.name.trim()
+  const desc = anchorIdentityBody(anchor)
+  const variantLine =
+    anchor.variants && anchor.variants.length
+      ? `\nVariants: ${anchor.variants.map((v) => v.trim()).filter(Boolean).join(', ')} (show each variant in its own labeled panel).`
+      : ''
+  if (anchor.kind === 'scene') {
+    return [
+      'Environment reference sheet. Landscape layout, clearly separated panels, small labels below each panel, consistent color palette and lighting.',
+      `The same location "${name}": ${desc}`,
+      'Views: 1) distant establishing view 2) close-up detail 3) overhead view 4) three-quarter view.' + variantLine,
+      'Requirements: keep the same location and visual style consistent across panels; avoid people, style drift, and merged panels.',
+    ].join('\n')
+  }
+  if (anchor.kind === 'prop') {
+    return [
+      'Prop reference sheet. White neutral background, flat lighting, clearly separated panels, small labels below each panel.',
+      `The same object "${name}": ${desc}`,
+      'Views: 1) front 2) side 3) close-up detail.' + variantLine,
+      'Requirements: keep the same object consistent across panels; avoid scene backgrounds, style drift, and merged panels.',
+    ].join('\n')
+  }
+  // character（默认）
+  return [
+    'Character reference sheet. White neutral background, flat lighting, landscape layout, clearly separated panels, small labels below each panel.',
+    `The same character "${name}" must keep the same face shape, hairstyle, clothing, and identifying features across all panels: ${desc}`,
+    'Views: 1) full-body front A-pose 2) side 3) back 4) three-quarter side 5) expression row (neutral / smiling / angry).' + variantLine,
+    'Requirements: keep facial features and clothing consistent across panels; avoid merged panels, cross-panel drift, and scene backgrounds.',
+  ].join('\n')
+}
+
+/**
+ * 引用锚要拼进镜头 prompt 的那几段。两类锚、两种拼法，**唯一一处**（两个 build*Prompt 共用，别再各抄一份）：
+ *
+ *  · 文本锚（style 等，carrier='text'）：整段 description。它本来就不建节点，只能靠 prompt 说清。
+ *  · 视觉锚（角色/场景/道具 = 定妆卡）：只拼 `staticFeatures`（身份 DNA），**绝不拼 dynamicFeatures**。
+ *    档案本来就把这两层分开了：static 是「同一个人」的定义（脸/眼/疤/年龄性别），跨镜不变；
+ *    dynamic 是服装与状态，跨镜本来就该变——拼进去会跟这一镜的画面打架（这一镜她刚从水里爬出来，
+ *    卡上却写着「穿黄油布外套」）。
+ *
+ * 为什么视觉锚除了连参考图还要**再给一段字**（2026-09-02 实测才敢加，不是拍脑袋）：
+ * Seedream 4.5 i2i、同一张参考图、同一段镜头文字，只有「拼不拼 static」一个变量，shot3 各跑 4 次——
+ *   · 只给图：**0/4** 拿到要求的「脸部特写」（都退回全身/中景站位）
+ *   · 图 + static：**3/4** 拿到特写
+ * 身份本身两臂都没崩（参考图 i2i 已经锁得住），所以这段字的收益在**构图遵循度**：
+ * 只给图时模型不知道这一镜的重点是谁，就退回最安全的全身；给了身份文字它才照着「特写谁的脸」去构图。
+ *
+ * 顺带解决黑盒：拼在这里 = 这段字进 `node.prompt`，用户在提示词框里**看得见也改得动**，
+ * 而不是躺在 meta 里没人知道它存不存在。
+ */
+function anchorPromptBits(shot: PlanShot, anchorById: Map<string, PlanAnchor>): string[] {
+  return shot.anchorIds
+    .map((id) => anchorById.get(id))
+    .filter((anchor): anchor is PlanAnchor => Boolean(anchor))
+    .map((anchor) => {
+      if (anchor.carrier === 'text') return `${anchor.name}：${anchor.description}`.trim()
+      const staticFeatures = (anchor.staticFeatures || '').trim()
+      return staticFeatures ? `${anchor.name}·身份特征（跨镜保持一致）：${staticFeatures}` : ''
+    })
+    .filter(Boolean)
+}
+
+/** 视觉参考的边顺序：先按提示词 @ 的出现顺序，再接没有 @ 的旧绑定，保持兼容。 */
+export function referenceOrderForShot(shot: PlanShot, anchorById: Map<string, PlanAnchor>): Map<string, number> {
+  const byUrl = new Map<string, string>()
+  for (const anchor of anchorById.values()) {
+    if (anchor.referenceUrl) byUrl.set(anchor.referenceUrl, anchor.id)
+  }
+  const ordered = new Set<string>()
+  for (const segment of parsePromptSegments(shot.prompt)) {
+    if (segment.type !== 'mention') continue
+    const anchorId = byUrl.get(segment.url)
+    if (anchorId && shot.anchorIds.includes(anchorId)) ordered.add(anchorId)
+  }
+  for (const anchorId of shot.anchorIds) {
+    const anchor = anchorById.get(anchorId)
+    if (anchor && isVisualAnchor(anchor)) ordered.add(anchorId)
+  }
+  return new Map([...ordered].map((anchorId, index) => [anchorId, index]))
+}
+
+/** 镜头 prompt = 镜头本体 + 引用锚的描述段（文本锚整段 / 视觉锚只给身份 DNA）。 */
+export function buildShotPrompt(shot: PlanShot, anchorById: Map<string, PlanAnchor>): string {
+  const bits = anchorPromptBits(shot, anchorById)
+  const base = shot.prompt.trim()
+  return bits.length ? [base, ...bits].filter(Boolean).join('\n') : base
+}
+
+export function buildKeyframePrompt(shot: PlanShot, anchorById: Map<string, PlanAnchor>): string {
+  // 优先级：用户在编辑器手改的 keyframe.prompt > planner 的静态首帧分解 ffDesc > 镜头 prompt（今天的兜底）。
+  // 为什么 ffDesc 排在 shot.prompt 前：shot.prompt 写的是「运动」（推进/摇移/动作演进），拿它当首帧图
+  // 提示词会让静态首帧被运动词污染（director-shot-translation 的污染词铁律）；ffDesc 才是那一帧的快照。
+  const keyframePrompt = typeof shot.keyframe?.prompt === 'string' && shot.keyframe.prompt.trim()
+    ? shot.keyframe.prompt.trim()
+    : (typeof shot.ffDesc === 'string' && shot.ffDesc.trim() ? shot.ffDesc.trim() : shot.prompt.trim())
+  const bits = anchorPromptBits(shot, anchorById)
+  return bits.length ? [keyframePrompt, ...bits].filter(Boolean).join('\n') : keyframePrompt
+}


### PR DESCRIPTION
## 根因：两个 PR 各自绿，合起来红

`check:filesize` 在 `main` 上红：`src/workbench/generationCanvas/agent/storyboardPlan.ts` 818 行 > 上限 800。

- PR #492 把这个文件停在**正正好 800 行**——它自己那条分支上门岗是绿的（`<=` 上限）。
- PR #494 在同一文件上又加了 18 行——它以自己的 base 算也是绿的。
- 两条合进 `main` 之后叠成 818 行，门岗才第一次看见越界。

也就是说没有任何一次「改坏了」，是**行数预算被两条分支各花一半**。按 R9 拆模块修，不加 ALLOWLIST、不删注释凑行数。

## 拆了什么

新文件 `src/workbench/generationCanvas/agent/storyboardPromptCompiler.ts`（147 行）= 分镜方案的**提示词编译层**，全是纯函数（只读 plan、只吐字符串，不碰节点/边/落画布参数）：

| 搬过去的 | 作用 |
|---|---|
| `buildAnchorSheetPrompt` / `anchorIdentityBody` | 定妆卡 / 场景卡 / 道具卡的版面提示词 |
| `buildShotPrompt` / `buildKeyframePrompt` / `anchorPromptBits` | 镜头提示词与首帧提示词，及二者共用的锚描述段 |
| `referenceOrderForShot` | 由 prompt 里 `@` 出现顺序派生的视觉参考顺序 |
| `isVisualAnchor` + `VISUAL_KINDS` | 上面几个函数共用的谓词，跟着一起走以免留下反向依赖 |

留在 `storyboardPlan.ts` 的还是原来的职责：IR 类型定义 + 「结构 → `create_canvas_nodes` 参数」的转换。

**行为零改动**：整块逐字搬移，没有改写、没有留并行实现、没有回退壳（P1）。原文件按值 import 新模块；新模块只用 `import type` 回引类型，`import type` 不算静态环，`check:boundaries` 绿。

三个外部使用方直接改成从新家 import（不留 re-export 兼容壳）：
- `src/workbench/creation/storyboard/exec/storyboardRowActions.ts`（`buildAnchorSheetPrompt`）
- `src/workbench/creation/storyboard/exec/storyboardRowStatus.ts`（`isVisualAnchor`）
- `src/workbench/generationCanvas/agent/storyboardPlan.test.ts`（`buildAnchorSheetPrompt`，断言一条没删）

## 行数前后

| 文件 | 前 | 后 |
|---|---|---|
| `storyboardPlan.ts` | 818（超限 18） | **685**（离上限还有 115 行余量） |
| `storyboardPromptCompiler.ts` | — | **147** |

## 验证

`pnpm run gates` 全绿（contracts 56 项含 `check:filesize` / `check:boundaries` / `check:vocabularies` / `lint:ci` / `typecheck` / `check:test-types`，加 `pnpm run test` 与 `pnpm build`），在提交后的 HEAD `5143f2e9` 上重跑并盖戳。零付费调用。纯代码位置搬移，无用户可见改动，未做走查。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
