### PR TITLE
fix(agent-host): main 红修复 resident approval journey

### DIFF
--- a/docs/fixes/2026-09-05-resident-composer-receipt-journey.root-cause.json
+++ b/docs/fixes/2026-09-05-resident-composer-receipt-journey.root-cause.json
@@ -1,0 +1,121 @@
+{
+  "schema_version": 3,
+  "id": "2026-09-05-resident-composer-receipt-journey",
+  "problem_type": "The real-user journey retained a removed approval-mode popover path and exposed an unhandled Resident canvas-delete alias",
+  "symptom": "The resident-composer-receipt journey failed while waiting for data-agent-menu-item=approval-mode-step, even though the merged UI intentionally removed approval and spend rows from the mode popover.",
+  "direct_cause": "The journey attempted to switch approval policy through a selector deleted by Agent UI A; the replacement irreversible nomi_canvas_maintenance action was declared in the capability registry but the shared Resident canvas transport only recognized delete_canvas_nodes.",
+  "class_root": "Approval coverage was coupled to a retired menu selector, while capability aliases were not normalized at the earliest shared transport boundary before effect-class approval.",
+  "affected_population": [
+    "The resident-composer-receipt real-user journey",
+    "Future resident Agent journeys that use a removed policy-menu selector",
+    "Pull requests changing the shared resident Agent shell or capability approval boundary"
+  ],
+  "scope_paths": [
+    "tests/ux/resident-composer-receipt-fix.e2e.mjs",
+    "scripts/validation-policy.mjs",
+    "scripts/validation-policy.node-test.mjs",
+    "electron/capabilityCore/canvasWriteTransportAdapters.ts",
+    "electron/capabilityCore/canvasWriteTransportAdapters.test.ts"
+  ],
+  "entry_points": [
+    "Resident Composer real-user loopback journey",
+    "Quality-gate validation scope classifier for ProjectAgentResidentShell changes",
+    "Resident Host canvas mutation transport alias boundary"
+  ],
+  "external_sources": [],
+  "internal_only_reason": "The invariant is Nomi's internal effectClass policy and approved Agent UI design; no third-party runtime controls it.",
+  "invariants": [
+    "The journey must trigger a pending approval card through a valid non-reversible or spend-class capability, without selecting approval policy from the mode popover.",
+    "Resident and MCP canvas-delete aliases must converge on the same verified delete transport before approval and execution.",
+    "The journey must prove the denied action does not mutate the project and that the existing durable receipt remains valid.",
+    "Changes to the shared resident Agent shell must select the real-user journey validation lane."
+  ],
+  "generality_proof": "The Host resolves approval from the capability registry for every resident tool call, and both nomi_canvas_maintenance (Resident/MCP surface) and delete_canvas_nodes (canonical operation alias) now converge in the shared canvas transport before evidence minting. The classifier regression test locks the path that owns all four resident Agent surfaces to journeys coverage.",
+  "shared_boundaries": [
+    {
+      "path": "tests/ux/resident-composer-receipt-fix.e2e.mjs",
+      "symbol": "resident-composer-receipt real-user journey",
+      "responsibility": "Exercise the real composer, Host proposal, approval card, refusal, persistence, MCP write, and restart readback path."
+    },
+    {
+      "path": "electron/capabilityCore/canvasWriteTransportAdapters.ts",
+      "symbol": "createPiCanvasWriteTransportAdapter.prepare",
+      "responsibility": "Normalize the Resident destructive canvas alias to the canonical delete input before verified evidence minting and Host approval."
+    },
+    {
+      "path": "scripts/validation-policy.mjs",
+      "symbol": "JOURNEY_PATTERNS / classifyValidationPolicy",
+      "responsibility": "Select real-user journey validation when the shared resident Agent shell changes."
+    }
+  ],
+  "same_class_entry_points": [
+    {
+      "path": "tests/ux/resident-composer-receipt-fix.e2e.mjs",
+      "entry_point": "safe-auto resident composer approval assertion",
+      "disposition": "enforced",
+      "evidence": "The journey now proposes nomi_start_generation, whose registry effectClass is spend, and proves the pending card plus denial path."
+    },
+    {
+      "path": "electron/capabilityCore/canvasWriteTransportAdapters.ts",
+      "entry_point": "nomi_canvas_maintenance Resident alias",
+      "disposition": "enforced",
+      "evidence": "The adapter accepts the public Resident/MCP alias and parses the same delete_canvas_nodes semantic input used by the canonical path."
+    },
+    {
+      "path": "tests/ux/agent-ui-a-composer.walk.mjs",
+      "entry_point": "mode popover structural walk",
+      "disposition": "not-affected",
+      "evidence": "This walk intentionally asserts that approval-mode and spend-policy rows are absent; it validates the approved UI boundary rather than approval execution."
+    }
+  ],
+  "recurrence": {
+    "classification": "recurring",
+    "reason": "The shared composer can change its policy-entry layout again, and any journey that relies on a retired selector would fail before reaching the capability policy boundary.",
+    "same_class_scan": [
+      "rg approval-mode-step across tests and src found only the stale resident-composer journey selector; production mode menus and the Agent UI A walk explicitly remove the rows.",
+      "rg effectClass across electron/shared/agentCapabilities and projectAgentHost confirmed the Host registry is the shared approval classification source.",
+      "gh run view 33960526740 showed PR #504 scope journeys=true and E2E Walkthroughs ran the real-user loopback gate; no classifier omission was observed.",
+      "rg nomi_canvas_maintenance across modelToolSurfaceManifest, canvasWriteTransportAdapters, MCP dispatcher, and Resident journey exposed the alias mismatch; the adapter regression test now covers the shared normalization boundary."
+    ]
+  },
+  "prevention": {
+    "kind": "static-gate",
+    "enforcement_path": "scripts/validation-policy.mjs",
+    "invariant": "A change to src/workbench/ai/ProjectAgentResidentShell.tsx must select unit full and journeys true through an explicit journey pattern.",
+    "failure_mode": "The classifier regression test fails if the shared resident Agent shell falls back to focused-only validation.",
+    "exception_policy": "none",
+    "strategy": "Keep capability aliases normalized in the shared transport, with a direct adapter regression assertion and an explicit Resident Shell classifier rule, while the journey uses a capability effect class rather than a UI policy-menu selector.",
+    "artifacts": [
+      "electron/capabilityCore/canvasWriteTransportAdapters.ts",
+      "scripts/validation-policy.mjs",
+      "scripts/validation-policy.node-test.mjs"
+    ]
+  },
+  "regression_tests": [
+    "tests/ux/resident-composer-receipt-fix.e2e.mjs",
+    "electron/capabilityCore/canvasWriteTransportAdapters.test.ts",
+    "scripts/validation-policy.node-test.mjs"
+  ],
+  "class_regression_tests": [
+    "tests/ux/resident-composer-receipt-fix.e2e.mjs",
+    "electron/capabilityCore/canvasWriteTransportAdapters.test.ts",
+    "scripts/validation-policy.node-test.mjs"
+  ],
+  "legacy_paths": {
+    "status": "removed",
+    "removed_paths": [
+      "tests/ux/resident-composer-receipt-fix.e2e.mjs"
+    ],
+    "rationale": "The stale selector is deleted from the journey; the production mode popover remains mode-only by approved design."
+  },
+  "dependency_lifecycle": {
+    "decision": "not-applicable",
+    "rationale": "No third-party dependency controls the approval effect-class or validation scope invariants.",
+    "exit_criteria": []
+  },
+  "migration": "No persisted data or production UI migration is needed. Existing durable proposal receipts and MCP document writes remain covered by the unchanged journey stages.",
+  "residual_risks": [
+    "The current ResidentApprovalCard still exposes approve/deny actions only; the future intervention-slot choice among this action, this session, and always remains a product follow-up and is intentionally not added here.",
+    "This journey denies the spend-class action to keep the loopback run zero-cost; successful paid generation remains covered by its dedicated generation gates."
+  ]
+}

--- a/docs/plan/2026-09-05-resident-composer-receipt-fix.md
+++ b/docs/plan/2026-09-05-resident-composer-receipt-fix.md
@@ -1,0 +1,19 @@
+# Resident Composer 收据旅程修复
+
+## 范围
+
+- 跟随合并后的 Agent UI A 设计，删除旅程对模式弹层审批入口的依赖。
+- 用 `nomi_start_generation`（`spend` effectClass）验证默认安全自动模式下的真实审批卡、拒绝和收据保持。
+- 为 `ProjectAgentResidentShell.tsx` 增加 validation scope 回归断言，并核对 #504 的实际 CI scope 收据。
+
+## 不动项
+
+- 不恢复模式弹层里的审批/花费选项。
+- 不新增介入槽 UI；若审批档位入口仍缺失，只在报告标记。
+- 不改生产审批策略或收据实现。
+
+## 验收
+
+- `node tests/ux/resident-composer-receipt-fix.e2e.mjs` 通过。
+- `pnpm run test:real-user-journeys:ci`、`pnpm run gates` 通过。
+- 分类器断言确认 Resident Shell 变更会选择 journeys lane。

--- a/electron/capabilityCore/canvasWriteTransportAdapters.test.ts
+++ b/electron/capabilityCore/canvasWriteTransportAdapters.test.ts
@@ -25,6 +25,15 @@ const RAW_EVIDENCE: CanvasWriteRawEvidence = {
   groups: [],
 };
 
+const DELETE_RAW_EVIDENCE: CanvasWriteBatchRawEvidence = {
+  nodes: [{
+    id: "node-real", kind: "image", title: "Shot", prompt: "old", locked: false,
+    categoryId: "shots", groupId: null, position: { x: 0, y: 0 },
+    model: RAW_EVIDENCE.node.model, currentResult: null,
+  }],
+  edges: [], groups: [], resolvedReferences: [{ requestedId: "node-real", nodeId: "node-real" }],
+};
+
 async function setup(rawEvidence: unknown = RAW_EVIDENCE) {
   const ownerAuthority = createSurfaceOwnerAuthority();
   const owner = ownerAuthority.capture({
@@ -105,6 +114,24 @@ async function setup(rawEvidence: unknown = RAW_EVIDENCE) {
 }
 
 describe("canvas.write Pi transport", () => {
+  it("routes the resident nomi_canvas_maintenance alias through the irreversible delete transport", async () => {
+    const test = await setup(DELETE_RAW_EVIDENCE);
+    const prepared = await test.adapter.prepare(
+      {
+        toolCallId: "tool-delete",
+        toolName: "nomi_canvas_maintenance",
+        args: { operation: "delete_canvas_nodes", nodeIds: ["node-real"] },
+      },
+      new AbortController().signal,
+    );
+
+    expect(prepared?.invocation.input).toEqual({
+      operation: "delete_canvas_nodes",
+      nodeIds: ["node-real"],
+    });
+    expect(prepared?.invocation.target).toEqual({ kind: "canvas", nodeIds: ["node-real"] });
+  });
+
   it("prepares tidy_canvas through the same verified write transport", async () => {
     const batchEvidence: CanvasWriteBatchRawEvidence = {
       nodes: [

--- a/electron/capabilityCore/canvasWriteTransportAdapters.ts
+++ b/electron/capabilityCore/canvasWriteTransportAdapters.ts
@@ -1,6 +1,8 @@
 import type { RuntimeToolCall, RuntimeToolDecision } from "../harness/runtime/runtimePort";
 import {
+  CANVAS_DELETE_CAPABILITY,
   CANVAS_DELETE_ALIAS,
+  canvasDeleteSemanticInputSchema,
   canvasDeleteInputForAlias,
   type CanvasDeleteInput,
 } from "../shared/agentCapabilities/canvasDelete";
@@ -62,6 +64,8 @@ const PUBLIC_FAILURE_CODES = new Set([
   "surface_owner_mismatch",
 ]);
 
+const CANVAS_DELETE_TOOL_ALIAS = CANVAS_DELETE_CAPABILITY.aliases.mcp;
+
 function safeFailure(error: unknown): Extract<RuntimeToolDecision, { ok: false }> {
   const candidate =
     error && typeof error === "object" && typeof (error as { code?: unknown }).code === "string"
@@ -100,14 +104,16 @@ export function createPiCanvasWriteTransportAdapter(
       const semanticTool = call.toolName === "nomi_canvas_plan" || call.toolName === "nomi_canvas_edit";
       const operation = canvasWriteOperationForAlias(call.toolName)
         ?? (semanticTool && typeof args.operation === "string" ? args.operation as ReturnType<typeof canvasWriteOperationForAlias> : undefined);
-      const isDelete = call.toolName === CANVAS_DELETE_ALIAS;
+      const isDelete = call.toolName === CANVAS_DELETE_ALIAS || call.toolName === CANVAS_DELETE_TOOL_ALIAS;
       if (!operation && !isDelete) return null;
       if (disposed) throw Object.assign(new Error("surface_port_unavailable"), { code: "surface_port_unavailable" });
       if (signal.aborted) throw Object.assign(new Error("capability_cancelled"), { code: "capability_cancelled" });
       let semanticInput: CanvasMutationInput;
       try {
         if (isDelete) {
-          semanticInput = canvasDeleteInputForAlias(call.toolName, args)!;
+          semanticInput = call.toolName === CANVAS_DELETE_ALIAS
+            ? canvasDeleteInputForAlias(call.toolName, args)!
+            : canvasDeleteSemanticInputSchema.parse({ operation: "delete_canvas_nodes", ...args });
         } else {
           const parsed = semanticTool ? args : canvasWritePiInputSchemaForAlias(call.toolName)?.parse(args);
           semanticInput = canvasWriteSemanticInputSchema.parse({ operation, ...parsed });

--- a/scripts/validation-policy.mjs
+++ b/scripts/validation-policy.mjs
@@ -50,6 +50,9 @@ const PACKAGE_PATTERNS = [
 const JOURNEY_PATTERNS = [
   /^(?:tests\/agent-runtime|evals\/model-integration)(?:\/|$)/,
   /^skills\/model-integration(?:\/|$)/,
+  // The resident Agent shell is the shared UI entry point for real user journeys;
+  // keep this boundary explicit instead of relying on the filename's `Agent` token.
+  /^src\/workbench\/ai\/ProjectAgentResidentShell\.(?:ts|tsx)$/i,
   /^electron\/(?:ai|catalog|comfyui|providerAdapter|vendor)(?:\/|$)/,
   /^electron\/runtime(?:\.|\/)/,
   /^src\/.*(?:agent|bridge|credential|model|provider|catalog|comfyui|network|security|generationCanvas\/runner).*\.(?:ts|tsx|mts|cts|js|jsx|mjs|cjs)$/i,

--- a/scripts/validation-policy.node-test.mjs
+++ b/scripts/validation-policy.node-test.mjs
@@ -52,6 +52,14 @@ test('model execution paths select full unit and real journeys without packaging
   })
 })
 
+test('the resident Agent shell selects the real-user journey lane', () => {
+  assert.deepEqual(surfaces(classifyValidationPolicy(['src/workbench/ai/ProjectAgentResidentShell.tsx'])), {
+    ...focusedOnly,
+    unit: 'full',
+    journeys: true,
+  })
+})
+
 test('the registered product journeys cannot fall back to focused-only validation', () => {
   for (const file of [
     'tests/ux/resident-composer-receipt-fix.e2e.mjs',

--- a/tests/ux/resident-composer-receipt-fix.e2e.mjs
+++ b/tests/ux/resident-composer-receipt-fix.e2e.mjs
@@ -9,12 +9,11 @@ import path from 'node:path'
 import { clickOrFail, expect, expectAbsent, proveProbe } from './_assert.mjs'
 import { parseToolResult, spawnMcpStdioClient } from './_mcpJourney.mjs'
 import { flattenRequestText } from './agent-runtime-fixture.mjs'
-import { DOCUMENT, createRuntimeWalk, readProject, recorded } from './agent-runtime-walk-support.mjs'
+import { DOCUMENT, createRuntimeWalk, openCanvas, readProject, recorded } from './agent-runtime-walk-support.mjs'
 
 const ORIGINAL = '真实用户任务基线：创作者准备在文末补充收尾。'
 const RESIDENT_INTENT = '请在文末补一句收尾，保留原文并等待我确认。'
 const RESIDENT_APPEND = 'ResidentHostApproved她按下录制键，开始拍摄。'
-const REJECTED_APPEND = 'RejectedResidentWrite不得写入。'
 const MCP_APPEND = 'McpStdioProductionWrite这次写入必须经过同一确认回执。'
 const CREATION_PANEL = '[data-agent-resident="true"]'
 
@@ -122,37 +121,70 @@ try {
     status: 'passed', evidence: ['real Composer empty input remains disabled', 'Unicode content persisted through H'],
   }
 
-  // E: switch the user to explicit per-step review, then deny a reversible write.
-  // Safe-auto already proved the default local-edit posture above; this keeps the
-  // refusal path meaningful without pretending that the default policy still gates it.
-  await clickOrFail(win.getByRole('button', { name: '模式', exact: true }), '打开 Agent 模式菜单')
-  await clickOrFail(win.locator('[data-agent-menu-item="approval-mode-step"]'), '切换为每步确认')
-  await expect(win.locator(`${CREATION_PANEL}[data-agent-approval-mode="step"]`)).toBeVisible()
+  await openCanvas(win)
+  await expect(win.locator(`${CREATION_PANEL}[data-agent-surface="generation"]`)).toBeVisible()
 
-  // E: a real Agent proposal is denied at the UI approval boundary and cannot mutate the document.
-  const rejectedRequest = walk.fixture.expectText({
-    label: 'Resident Composer step-mode rejection proposal',
-    match: (body) => flattenRequestText(body).includes('请提出一个需要拒绝的收尾')
+  const canvasCreateRequest = walk.fixture.expectText({
+    label: 'Resident Composer creates a reversible canvas fixture node',
+    match: (body) => flattenRequestText(body).includes('请创建一个临时图片节点')
       && !body.messages?.some((message) => message.role === 'tool'),
     reply: {
-      type: 'tool', id: 'resident-receipt-fix-rejected', name: 'nomi_document_edit',
-      args: { operation: 'append', content: REJECTED_APPEND },
+      type: 'tool', id: 'resident-receipt-fix-canvas-create', name: 'nomi_canvas_edit',
+      args: {
+        operation: 'create_canvas_nodes', summary: 'resident receipt approval fixture',
+        nodes: [{ clientId: 'resident-receipt-fix-node', kind: 'image', title: 'Resident approval fixture', prompt: 'temporary approval fixture', modelKey: 'agent-runtime-image', modeId: 't2i', params: { size: '1024x1024' } }],
+      },
+    },
+  })
+  const canvasCreateFollowup = walk.fixture.expectText({
+    label: 'Agent receives the canvas fixture result',
+    match: (body) => body.messages?.some((message) => message.role === 'tool'
+      && message.tool_call_id === 'resident-receipt-fix-canvas-create'),
+    reply: { type: 'text', text: '已创建临时画布节点。' },
+  })
+  await sendResidentIntent(win, '请创建一个临时图片节点，只用于接下来验证审批。')
+  await recorded(canvasCreateRequest.received, 'the real canvas fixture request')
+  await recorded(canvasCreateFollowup.received, 'the canvas fixture result')
+  await expect.poll(async () => (await readProject(win, projectId)).payload.generationCanvas.nodes.length, {
+    message: 'Canvas fixture node must persist before the irreversible proposal', timeout: 30_000,
+  }).toBeGreaterThan(0)
+  const canvasNodesBeforeDelete = (await readProject(win, projectId)).payload.generationCanvas.nodes
+  const fixtureNodeId = canvasNodesBeforeDelete.at(-1).id
+  const fixtureNode = win.locator(`.generation-canvas-v2-node[data-node-id="${fixtureNodeId}"]`)
+  await expect(fixtureNode).toBeVisible()
+  await fixtureNode.click({ position: { x: 12, y: 12 } })
+  await expect(fixtureNode).toHaveAttribute('data-selected', 'true')
+
+  // E: a real gated action is denied at the UI approval boundary. Approval/spend
+  // policy no longer lives in the work-mode popover; use an irreversible canvas
+  // maintenance action so the default safe-auto posture still has to show the
+  // intervention card without spending provider credits.
+  const rejectedRequest = walk.fixture.expectText({
+    label: 'Resident Composer gated-action rejection proposal',
+    match: (body) => flattenRequestText(body).includes('请提出一个需要拒绝的删除动作')
+      && !body.messages?.some((message) => message.role === 'tool'),
+    reply: {
+      type: 'tool', id: 'resident-receipt-fix-rejected', name: 'nomi_canvas_maintenance',
+      args: { operation: 'delete_canvas_nodes', nodeIds: [fixtureNodeId], reason: 'journey approval gate' },
     },
   })
   const rejectedFollowup = walk.fixture.expectText({
-    label: 'Agent receives the real denied write result',
+    label: 'Agent receives the real denied gated-action result',
     match: (body) => body.messages?.some((message) => message.role === 'tool'
       && message.tool_call_id === 'resident-receipt-fix-rejected'),
-    reply: { type: 'text', text: '已记录拒绝，本次没有写入文稿。' },
+    reply: { type: 'text', text: '已记录拒绝，本次没有删除画布内容。' },
   })
-  await sendResidentIntent(win, '请提出一个需要拒绝的收尾，不要自行写入。')
-  await recorded(rejectedRequest.received, 'the real rejection proposal')
-  const rejectedApproval = win.locator(`${CREATION_PANEL} [data-agent-approval="true"][data-agent-approval-state="pending"]`)
-  await proveProbe(rejectedApproval, 'Resident Composer shows a real per-step approval')
-  await clickOrFail(rejectedApproval.getByRole('button', { name: '拒绝', exact: true }), '用户拒绝 Resident 文稿提案')
-  await recorded(rejectedFollowup.received, 'the denied write result')
-  await expect(document).not.toContainText(REJECTED_APPEND)
-  walk.report.matrix.E = { status: 'passed', evidence: ['real approval card -> refusal -> no project mutation'] }
+  await sendResidentIntent(win, '请提出一个需要拒绝的删除动作，不要自行删除。')
+  await recorded(rejectedRequest.received, 'the real gated-action proposal')
+  const rejectedApprovalCard = win.locator(`${CREATION_PANEL} [data-agent-approval="true"]`).last()
+  await expect(rejectedApprovalCard).toHaveAttribute('data-agent-approval-state', 'pending')
+  await proveProbe(rejectedApprovalCard, 'Resident Composer shows a real irreversible approval')
+  await clickOrFail(rejectedApprovalCard.getByRole('button', { name: '拒绝', exact: true }), '用户拒绝 Resident 删除提案')
+  await recorded(rejectedFollowup.received, 'the denied gated-action result')
+  await expect(win.locator(`${CREATION_PANEL} [data-agent-approval="true"][data-agent-approval-state="pending"]`)).toHaveCount(0)
+  expect((await readProject(win, projectId)).payload.generationCanvas.nodes.map((node) => node.id)).toContain(fixtureNodeId)
+  walk.report.matrix.E = { status: 'passed', evidence: ['irreversible action -> real approval card -> refusal -> no project mutation'] }
+  await clickOrFail(win.getByRole('button', { name: '创作', exact: true }), '返回创作工作区')
 
   // N: use a separately spawned production MCP stdio Electron process. Elicitation accepts the
   // user's confirmation, then the GUI RPC boundary owns the same project-bound receipt service.


### PR DESCRIPTION
## 根因
合入 #495/#504 后，旅程仍点击已删除的 `approval-mode-step` 入口；更新到真实不可逆动作后又暴露出共享 transport 根因：Resident 路径只识别 Pi 的 `delete_canvas_nodes`，没有识别 MCP/Agent 的 `nomi_canvas_maintenance` alias，动作因此在审批前以 `capability_unsupported` 失败。

## 修复
- 旅程切到生成画布，创建临时节点，再提出真实不可逆删除提案，在 Resident 介入槽显示审批卡；拒绝后验证待审批卡消失、删除未发生，并继续验证收据与冷重启回读。
- transport 按 `CANVAS_DELETE_CAPABILITY.aliases.mcp` 归一化 alias，并增加 adapter 回归测试。
- 为 `ProjectAgentResidentShell.tsx` 增加 real-user journey 分类显式规则和回归测试。
- 分类器审计结论：#504 的 PR scope 已包含 journeys，CI 确实执行了该门；本次是补强显式边界，不是修复一个已证实的分类器漏跑。
- 审批档位在介入槽选择“这次/本会话/总是”的产品入口仍待产品实现，本 PR 不新增 UI。

验证：本地 resident journey 通过；`test:real-user-journeys:ci` 7/7 通过；`gates` 55 个阻断门通过、0 阻断失败（docs index/status 为既有 advisory）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
