### PR TITLE
fix(ci): ancestry-aware merged receipts and protected docs autosync

### DIFF
--- a/.github/workflows/docs-autosync.yml
+++ b/.github/workflows/docs-autosync.yml
@@ -23,6 +23,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 # 不取消在途：每个 merge 都要补自己那一份，取消上一班会漏账（补齐是幂等的，串行跑最省心）。
 concurrency:
@@ -34,7 +35,7 @@ jobs:
     name: Docs Gate Autosync
     runs-on: ubuntu-latest
     steps:
-      # ref: main 而不是触发 SHA —— 要 push 回去就必须站在分支上，不能是 detached HEAD。
+      # ref: main 保证修复基于触发时的受保护主线快照；提交由 create-pull-request 创建独立分支。
       - uses: actions/checkout@v7
         with:
           ref: main
@@ -56,25 +57,20 @@ jobs:
           pnpm run check:doc-status
           pnpm run check:ledger
 
-      - name: Commit the repair back to main
-        run: |
-          if git diff --quiet -- docs; then
-            echo "无补齐 diff，跳过提交。"
-            exit 0
-          fi
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add -- docs
-          # [skip ci] 防自触发：这个 commit 不含任何代码，没有任何门岗需要重跑。
-          git commit -m "chore(docs-gates): auto-sync 索引/状态/账本 [skip ci]"
-          # 合并高峰里别人可能已经推了新的 main；rebase 重试而不是 force——
-          # 补齐是幂等的，rebase 后内容仍然正确。
-          for attempt in 1 2 3; do
-            if git push origin HEAD:main; then
-              exit 0
-            fi
-            echo "push 被拒（第 $attempt 次），拉取后重试"
-            git pull --rebase origin main
-          done
-          echo "::error::docs-autosync 连续三次 push 失败，请手动跑 node scripts/repair-doc-gates.mjs"
-          exit 1
+      # R17 证据：run 33967545325（2026-09-05）三次直推均收到 GH006，
+      # 明确要求通过 pull request 且缺少 2 个 required checks。受保护 main 只能走 PR。
+      # [skip ci] 放在 bot commit message 中，避免合并回 main 后再次触发门岗链。
+      - name: Open a docs repair pull request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          base: main
+          branch: docs/autosync-${{ github.sha }}
+          delete-branch: true
+          add-paths: docs
+          commit-message: "chore(docs-gates): auto-sync 索引/状态/账本 [skip ci]"
+          title: "chore(docs-gates): auto-sync 索引/状态/账本"
+          body: |
+            Automated repair for the three advisory docs gates after `${{ github.sha }}`.
+
+            [skip ci]

--- a/docs/engineering-rules.md
+++ b/docs/engineering-rules.md
@@ -541,7 +541,7 @@ pnpm run delivery:verify-merged -- --expected-sha <merge-commit-sha>
 
 **分支定性先算 merge-base（2026-09-01 一日三撞的「落后假象」固化）**：评审、对账或打捞任何分支前，先 `git merge-base origin/main <branch>`；真实 authored delta = `MB..branch`。直接对 main tip 的两点视图里出现的大片删除或陌生文件，**第一假设是「main 在分支落后期间前进了」**，不是分支真要删它们；GitHub 页面的 +/- 数字与 behind 红字同理不可直接采信（实例：某评估把三点视图 +1416 当真实贡献，两点实测是 272 文件混合物；另一分支两点视图「删 14.6 万行」实为落后 1500+ commit 的反转幻影）。远落后分支的并线一律 `gh pr update-branch` 服务端做——本地 merge 后 push 的追平 diff 会撞 R25 的评审上限（15-88MB 实测）。
 
-最终交付不再本地跑第三遍：在真实 merged-main SHA 上运行 `pnpm run delivery:verify-merged -- --expected-sha <SHA>`。命令仍用有界 Git fetch 证明 `HEAD`、远端主线和 expected SHA/tree 身份，然后等待该 exact SHA 的 `Quality Gate` 与 `Mac Package` check run。GitHub required-check 语义中的 success/skipped/neutral 可写入 Git common dir 的 per-SHA `ci-evidence.json`；missing、pending、failure 或错误 SHA 都不能生成成功收据。同一 SHA 再调用直接复用收据，不启动 repository tests。
+最终交付不再本地跑第三遍：在真实 merged-main SHA 上运行 `pnpm run delivery:verify-merged -- --expected-sha <SHA>`。命令用有界 Git fetch 确认 expected SHA 对象存在且属于当前远端主线 tip 的祖先，然后等待该 exact SHA 的 `Quality Gate` 与 `Mac Package` check run；即使 main 已继续合入提交，也不需要 checkout。GitHub required-check 语义中的 success/skipped/neutral 可写入 Git common dir 的 per-SHA `ci-evidence.json`，并记录当前 `tip` 与 `relation`；missing、pending、failure、非祖先或错误 SHA 都不能生成成功收据。同一 SHA 在 tip 未变化时直接复用收据，不启动 repository tests。
 
 ## R23 React Flow 生成画布单内核与迁移等价
 

--- a/docs/fixes/2026-09-05-delivery-receipts-docs-autosync.root-cause.json
+++ b/docs/fixes/2026-09-05-delivery-receipts-docs-autosync.root-cause.json
@@ -1,0 +1,101 @@
+{
+  "schema_version": 3,
+  "id": "2026-09-05-delivery-receipts-docs-autosync",
+  "problem_type": "Merged-main CI receipt ancestry and protected-branch docs autosync",
+  "symptom": "Merged verification rejected a valid earlier merge SHA after main advanced, while Docs Gate Autosync failed three times with GH006 when trying to push generated docs directly to protected main.",
+  "direct_cause": "verify-merged required HEAD and origin/main to equal expectedSha and keyed receipts to HEAD; the workflow committed on main and retried a forbidden direct push without a pull-request path.",
+  "class_root": "The delivery boundary did not distinguish an exact checked commit from the current main tip, and the autosync boundary had no protected-branch-safe write protocol.",
+  "affected_population": [
+    "Consecutive merged pull requests verified after origin/main advances",
+    "Any docs gate autosync run that finds generated changes on protected main",
+    "Maintainers relying on durable per-SHA CI evidence"
+  ],
+  "scope_paths": [
+    "scripts/git-delivery.mjs",
+    ".github/workflows/docs-autosync.yml"
+  ],
+  "entry_points": [
+    "verify-merged delivery command",
+    "Docs Gate Autosync workflow after a main push"
+  ],
+  "external_sources": [],
+  "internal_only_reason": "The missing invariants are repository-specific delivery and workflow policies; the captured GitHub run log and repository tests directly establish the failure and fix.",
+  "invariants": [
+    "The expected commit must exist locally and be an ancestor of the freshly fetched origin/main tip; checks are fetched for that exact commit.",
+    "Every receipt records the checked commit, current main tip, and tip/ancestor relation.",
+    "Docs repairs targeting protected main are committed on docs/autosync-<sha> and proposed through a pull request with [skip ci]."
+  ],
+  "generality_proof": "All merged verification calls converge on verifyMergedDelivery and its Git ancestry assertion, while the only docs autosync writer is this workflow. The shared checks therefore cover both the current-tip case and every earlier ancestor without requiring checkout, and replace every protected-main direct push attempt with the same pull-request action.",
+  "shared_boundaries": [
+    {
+      "path": "scripts/git-delivery.mjs",
+      "symbol": "verifyMergedDelivery",
+      "responsibility": "Fetch the authoritative remote tip, validate expected commit existence and ancestry, query exact-SHA checks, and write an idempotent receipt."
+    },
+    {
+      "path": ".github/workflows/docs-autosync.yml",
+      "symbol": "Open a docs repair pull request",
+      "responsibility": "Publish repaired docs through a bot branch and pull request so protected main is never written directly."
+    }
+  ],
+  "same_class_entry_points": [
+    {
+      "path": "scripts/git-delivery.mjs",
+      "entry_point": "verifyMergedDelivery",
+      "disposition": "enforced",
+      "evidence": "The command is the sole merged-main verifier and now enforces cat-file existence plus merge-base ancestry before exact-SHA checks."
+    },
+    {
+      "path": ".github/workflows/docs-autosync.yml",
+      "entry_point": "autosync job",
+      "disposition": "enforced",
+      "evidence": "The workflow is the sole writer for generated docs and now delegates branch creation and PR submission to create-pull-request."
+    }
+  ],
+  "recurrence": {
+    "classification": "recurring",
+    "reason": "Main can advance between any two merged PR validations, and every future autosync run executes against a protected branch with the same required checks.",
+    "same_class_scan": [
+      "Searched scripts/git-delivery.mjs and scripts/git-delivery.node-test.mjs for HEAD, remote main, expected SHA, receipt, and check-runs handling.",
+      "Searched all .github/workflows files for docs autosync writers, direct main pushes, and existing create-pull-request usage.",
+      "Inspected run 33967545325 logs: all three direct pushes were rejected with GH006 requiring a pull request and two required checks."
+    ]
+  },
+  "prevention": {
+    "kind": "centralized-boundary",
+    "enforcement_path": "scripts/git-delivery.mjs",
+    "invariant": "An explicit expected SHA is valid only when its Git object exists and it is an ancestor of the freshly fetched origin/main tip; the receipt names both identities and the relation.",
+    "failure_mode": "The command exits with missing_expected_sha or expected_sha_not_ancestor before querying checks or writing a receipt.",
+    "exception_policy": "none",
+    "strategy": "Move identity validation from equality with the caller's checkout to the earliest shared Git object boundary, and make the workflow use a protected-branch-safe PR writer.",
+    "artifacts": [
+      "scripts/git-delivery.mjs",
+      ".github/workflows/docs-autosync.yml"
+    ]
+  },
+  "regression_tests": [
+    "scripts/git-delivery.node-test.mjs",
+    "scripts/run-gates-contracts.node-test.mjs"
+  ],
+  "class_regression_tests": [
+    "scripts/git-delivery.node-test.mjs",
+    "scripts/run-gates-contracts.node-test.mjs"
+  ],
+  "legacy_paths": {
+    "status": "removed",
+    "removed_paths": [
+      ".github/workflows/docs-autosync.yml"
+    ],
+    "rationale": "The workflow's direct commit and push-to-main implementation was removed and replaced by the pull-request action."
+  },
+  "dependency_lifecycle": {
+    "decision": "not-applicable",
+    "rationale": "The defect was a repository identity and branch-protection invariant; GitHub Actions and Git CLI versions do not control that policy.",
+    "exit_criteria": []
+  },
+  "migration": "Existing v2 receipts are ignored and regenerated with schema v3 when the checked SHA is verified again. No branch or commit rewrite is needed; future docs repairs appear as ordinary pull requests.",
+  "residual_risks": [
+    "A required-check run may still remain pending or fail on the exact ancestor SHA; verification continues to fail closed until checks complete successfully.",
+    "A docs repair PR still requires the repository's normal required checks and merge policy before it changes main."
+  ]
+}

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -26,6 +26,8 @@ pnpm run test:journeys
 
 推送任务分支并创建 PR。禁止直接推送 `main`。
 
+PR 合入后运行 `pnpm run delivery:verify-merged -- --expected-sha <SHA>`：它按该 SHA 拉取 checks，即使 `origin/main` 已前进也会记录当前 `tip` 与 `relation=ancestor`；文档门岗补齐则由 `Docs Gate Autosync` 另开 PR 回写，禁止直推受保护主线。
+
 ## 2. 生成可安装的开发预览版
 
 在 PR 上添加 `desktop-preview` label，或者手动运行 GitHub Actions 的 `Desktop Preview` 工作流并填写分支名。

--- a/scripts/git-delivery.mjs
+++ b/scripts/git-delivery.mjs
@@ -238,7 +238,7 @@ export function assertPreflightState(state, { protectedBranches = ['main', 'mast
   return state
 }
 
-export function assertMergedState(state, { expectedSha } = {}) {
+export function assertMergedState(state, { expectedSha, cwd = state.repoRoot } = {}) {
   if (!SHA_PATTERN.test(String(expectedSha || ''))) {
     throw new DeliveryError(
       'invalid_expected_sha',
@@ -248,28 +248,34 @@ export function assertMergedState(state, { expectedSha } = {}) {
   if (!state.clean) {
     throw new DeliveryError('dirty_worktree', 'Merged verification requires a clean worktree', state)
   }
-  if (state.headCommit !== expectedSha) {
+  const expectedCommit = gitStatus(cwd, ['cat-file', '-e', `${expectedSha}^{commit}`])
+  if (expectedCommit.exitCode !== 0) {
     throw new DeliveryError(
-      'unexpected_head',
-      `HEAD is not the expected merged commit: expected ${expectedSha}, observed ${state.headCommit}`,
-      state,
+      'missing_expected_sha',
+      `Expected merged commit is not available locally: ${expectedSha}`,
+      { ...state, expectedSha, expectedCommit },
     )
   }
-  if (state.remoteCommit !== expectedSha) {
+  const ancestry = gitStatus(cwd, ['merge-base', '--is-ancestor', expectedSha, state.remoteRef])
+  if (![0, 1].includes(ancestry.exitCode)) {
     throw new DeliveryError(
-      'remote_main_moved',
-      `${state.remoteRef} is not the expected merged commit: expected ${expectedSha}, observed ${state.remoteCommit}`,
-      state,
+      'git_state_failed',
+      `Cannot compare expected merged commit with ${state.remoteRef}`,
+      { ...state, expectedSha, ancestry },
     )
   }
-  if (state.relation !== 'same-commit') {
+  if (ancestry.exitCode !== 0) {
     throw new DeliveryError(
-      'merged_identity_diverged',
-      `Merged identity relation must be same-commit, observed ${state.relation}`,
-      state,
+      'expected_sha_not_ancestor',
+      `${state.remoteRef} does not contain expected merged commit ${expectedSha}; observed tip ${state.remoteCommit}`,
+      { ...state, expectedSha, ancestry },
     )
   }
-  return state
+  return {
+    ...state,
+    expectedSha,
+    verificationRelation: state.remoteCommit === expectedSha ? 'tip' : 'ancestor',
+  }
 }
 
 export async function preflightDelivery({
@@ -410,15 +416,15 @@ export async function waitForRequiredChecks({
   }
 }
 
-function receiptPathFor(state) {
-  return path.join(state.commonDir, 'nomi-delivery', 'merged-main', state.headCommit, 'ci-evidence.json')
+function receiptPathFor(state, commitSha = state.expectedSha || state.headCommit) {
+  return path.join(state.commonDir, 'nomi-delivery', 'merged-main', commitSha, 'ci-evidence.json')
 }
 
 function readReceipt(receiptPath) {
   if (!fs.existsSync(receiptPath)) return null
   try {
     const receipt = JSON.parse(fs.readFileSync(receiptPath, 'utf8'))
-    return receipt?.schemaVersion === 2 && receipt?.kind === 'exact-sha-ci-evidence' && Array.isArray(receipt.checks)
+    return receipt?.schemaVersion === 3 && receipt?.kind === 'exact-sha-ci-evidence' && Array.isArray(receipt.checks)
       ? receipt
       : null
   } catch (error) {
@@ -495,10 +501,17 @@ export async function verifyMergedDelivery({
   sleep,
 } = {}) {
   await fetchRemote({ cwd, remote, base, timeoutMs })
-  const state = assertMergedState(inspectDeliveryState({ cwd, remote, base }), { expectedSha })
-  const receiptPath = receiptPathFor(state)
+  const state = assertMergedState(inspectDeliveryState({ cwd, remote, base }), { expectedSha, cwd })
+  const receiptPath = receiptPathFor(state, expectedSha)
   const existing = readReceipt(receiptPath)
-  if (existing && evaluateRequiredChecks(existing.checks).state === 'passed') {
+  if (
+    existing &&
+    existing.commitSha === expectedSha &&
+    existing.tip === state.remoteCommit &&
+    existing.relation === state.verificationRelation &&
+    existing.treeSha === gitOutput(cwd, ['rev-parse', `${expectedSha}^{tree}`]) &&
+    evaluateRequiredChecks(existing.checks).state === 'passed'
+  ) {
     return { state, receiptPath, receipt: existing, reused: true }
   }
 
@@ -515,11 +528,13 @@ export async function verifyMergedDelivery({
       ...(sleep ? { sleep } : {}),
     })
     const receipt = {
-      schemaVersion: 2,
+      schemaVersion: 3,
       kind: 'exact-sha-ci-evidence',
-      commitSha: state.headCommit,
-      treeSha: state.headTree,
+      commitSha: expectedSha,
+      treeSha: gitOutput(cwd, ['rev-parse', `${expectedSha}^{tree}`]),
       remoteRef: state.remoteRef,
+      tip: state.remoteCommit,
+      relation: state.verificationRelation,
       repository: resolvedRepository,
       observedAt: now().toISOString(),
       requiredChecks: [...REQUIRED_MERGED_CHECKS],

--- a/scripts/git-delivery.node-test.mjs
+++ b/scripts/git-delivery.node-test.mjs
@@ -154,7 +154,7 @@ test('preflight fails closed on protected, dirty, and stale task branches', asyn
   )
 })
 
-test('merged verification accepts only the exact fetched main commit, not an equivalent-tree task commit', async (t) => {
+test('merged verification accepts the current origin/main tip', async (t) => {
   const f = fixture()
   t.after(f.cleanup)
   const expectedSha = git(f.work, ['rev-parse', 'origin/main'])
@@ -162,12 +162,43 @@ test('merged verification accepts only the exact fetched main commit, not an equ
   git(f.work, ['switch', '--detach', expectedSha])
   const mergedState = inspectDeliveryState({ cwd: f.work })
   assert.doesNotThrow(() => assertMergedState(mergedState, { expectedSha }))
+  assert.equal(assertMergedState(mergedState, { expectedSha }).verificationRelation, 'tip')
+})
 
-  git(f.work, ['switch', '-c', 'codex/equivalent-tree'])
-  git(f.work, ['commit', '--allow-empty', '-m', 'metadata only'])
-  const taskState = inspectDeliveryState({ cwd: f.work })
-  assert.equal(taskState.relation, 'same-tree-different-commit')
-  assert.throws(() => assertMergedState(taskState, { expectedSha }), /HEAD is not the expected merged commit/)
+test('merged verification accepts an expected SHA that is an ancestor of the current tip', async (t) => {
+  const f = fixture()
+  t.after(f.cleanup)
+  const expectedSha = git(f.work, ['rev-parse', 'origin/main'])
+  commit(f.seed, 'remote advances', 'remote\n')
+  git(f.seed, ['push', 'origin', 'main'])
+  git(f.work, ['switch', '--detach', expectedSha])
+
+  const result = await verifyMergedDelivery({
+    cwd: f.work,
+    expectedSha,
+    repository: 'example/nomi',
+    listCheckRuns: async () => passedChecks(),
+  })
+  assert.equal(result.receipt.commitSha, expectedSha)
+  assert.equal(result.receipt.tip, git(f.work, ['rev-parse', 'origin/main']))
+  assert.equal(result.receipt.relation, 'ancestor')
+})
+
+test('merged verification rejects an expected SHA outside the fetched main ancestry', async (t) => {
+  const f = fixture()
+  t.after(f.cleanup)
+  git(f.work, ['switch', '--detach', 'origin/main'])
+  const expectedSha = commit(f.work, 'unmerged task commit', 'task\n')
+  await assert.rejects(
+    verifyMergedDelivery({
+      cwd: f.work,
+      expectedSha,
+      repository: 'example/nomi',
+      fetchRemote: async () => {},
+      listCheckRuns: async () => passedChecks(),
+    }),
+    (error) => error instanceof DeliveryError && error.code === 'expected_sha_not_ancestor',
+  )
 })
 
 function checkRun(name, conclusion, overrides = {}) {
@@ -303,6 +334,30 @@ test('merged verification waits for missing checks and never converts a failed c
     (error) => error instanceof DeliveryError && error.code === 'required_checks_failed',
   )
   assert.equal(fs.existsSync(waiting.receiptPath), false)
+})
+
+test('merged verification fails closed when required checks remain incomplete', async (t) => {
+  const f = fixture()
+  t.after(f.cleanup)
+  const expectedSha = git(f.work, ['rev-parse', 'origin/main'])
+  git(f.work, ['switch', '--detach', expectedSha])
+
+  await assert.rejects(
+    verifyMergedDelivery({
+      cwd: f.work,
+      expectedSha,
+      repository: 'example/nomi',
+      fetchRemote: async () => {},
+      listCheckRuns: async () => [
+        checkRun('Quality Gate', null, { status: 'in_progress' }),
+        checkRun('Mac Package', 'skipped'),
+      ],
+      ciTimeoutMs: 1,
+      pollIntervalMs: 1,
+      sleep: async () => {},
+    }),
+    (error) => error instanceof DeliveryError && error.code === 'required_checks_timeout',
+  )
 })
 
 test('evidence lock prevents concurrent collectors for one merged SHA', async (t) => {

--- a/scripts/run-gates-contracts.node-test.mjs
+++ b/scripts/run-gates-contracts.node-test.mjs
@@ -163,3 +163,15 @@ test('package.json 的 gates:contracts 就是这个 runner，且 advisory 只限
     assert.match(autosync, new RegExp(name.replace(':', '[:-]')), `${name} 必须由 docs-autosync 验收补齐结果`)
   }
 })
+
+test('Docs Gate Autosync never writes protected main directly and opens a SHA-scoped PR', async () => {
+  const { default: fs } = await import('node:fs')
+  const { default: path } = await import('node:path')
+  const { fileURLToPath } = await import('node:url')
+  const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+  const autosync = fs.readFileSync(path.join(repoRoot, '.github/workflows/docs-autosync.yml'), 'utf8')
+  assert.match(autosync, /peter-evans\/create-pull-request@v7/)
+  assert.match(autosync, /branch:\s*docs\/autosync-\$\{\{ github\.sha \}\}/)
+  assert.match(autosync, /commit-message:.*\[skip ci\]/)
+  assert.doesNotMatch(autosync, /git push[^\n]*HEAD:main/)
+})


### PR DESCRIPTION
## 根因

- `verify-merged` 把调用方 HEAD、`origin/main` 和 `--expected-sha` 强制要求为同一提交。连续合入后，较早 merge SHA 虽仍是 main 祖先，却被错误判为 `unexpected_head` / `remote_main_moved`，导致 exact-SHA checks 收据丢失。
- Docs Gate Autosync 在受保护 main 上直接 push。run `33967545325`（2026-09-05）日志复现三次 GH006：必须通过 pull request，且缺少 2 个 required checks。

## 改法

- fetched `origin/main` 作为当前 tip；用 `git cat-file -e <sha>^{commit}` 和 `git merge-base --is-ancestor <sha> origin/main` 验证 expected SHA，无需 checkout。
- checks 仍通过 `gh api /repos/{owner}/{repo}/commits/{sha}/check-runs` 精确拉取；schema v3 收据按 expected SHA 保存并记录 `tip`、`relation`（`tip` / `ancestor`）和 expected tree，tip 未变化时复用。
- Docs Gate Autosync 改用 `peter-evans/create-pull-request@v7`，分支为 `docs/autosync-${{ github.sha }}`，commit message 带 `[skip ci]`，不再写入 `main`。
- 新增 tip / ancestor / 非祖先 / checks 未完成测试，以及 workflow 结构回归测试和 schema-v3 根因合同。

## 不动项

- 不改变 required checks 名称、成功结论集合、GitHub checks API 或 REST compare 禁止策略。
- 不改变文档门岗的 advisory 语义、修复脚本内容或其他发布/工作流。
- 不合并 PR，不直接推送受保护 main。

验证：`pnpm run gates`（55 个阻断门通过；2 个既有 advisory 文档门按设计报告）、全量 Vitest 10,966 项通过、构建和 typecheck 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
