### PR TITLE
feat(gates): 控件契约门岗认第三种说谎——点了失败、用户看不到

### DIFF
--- a/docs/fixes/2026-09-06-silent-discarded-host-command.root-cause.json
+++ b/docs/fixes/2026-09-06-silent-discarded-host-command.root-cause.json
@@ -1,0 +1,130 @@
+{
+  "schema_version": 3,
+  "id": "2026-09-06-silent-discarded-host-command",
+  "problem_type": "控件把跨进程命令的拒绝丢掉（点了失败，界面一个字不说）",
+  "symptom": "常驻 Agent 面板的会话列表里，每一行（含当前正看着的那一行）都有删除钮。删当前会话时 Host 拒绝，按钮点下去弹窗不关、行还在、面板顶上的错误条一个字都不显示——用户只能反复点。#519 已修掉这一处，但当时只修了这一处。",
+  "direct_cause": "src/workbench/ai/ProjectAgentResidentShell.tsx 的会话行写的是 onClick={() => void removeProjectAgentThread(thread.threadId)}；electron/projectAgentHost/projectAgentThreadReduction.ts 对当前会话回 thread_read_only，projectAgentUiCommands.ts 的 dispatch 把它抛成 ProjectAgentClientError，而裸 `void` 让这个拒绝变成 unhandled rejection，没有任何人把它送进面板既有的错误条。",
+  "class_root": "「渲染层把一个会被主进程拒绝的 Promise 丢掉、且没人把拒绝翻译给用户」这件事在本仓没有任何执行边界拦得住：本仓 lint 没开 no-floating-promises（需要类型信息），而唯一管「控件说谎」的门岗 scripts/check-control-contract.mjs 只认客户端短路守卫（handler 里 if 住了不做事）和空 handler 两种形状——它看的是「handler 没做事」，看不见「做了事、事失败了、用户什么都看不到」。于是同一句合同（设计系统 §4.1 C1「可点即有效」）下有一整类失效从门岗底下走过去。",
+  "migration": "判据这一层新增 scripts/control-contract-discarded-commands.mjs，由既有门岗 scripts/check-control-contract.mjs import 后与前两条规则合并报告——**不另开门岗**，「控件说谎」仍然只有一个 owner、一条命令（check:controls）。规则抓出的 5 处按 P1 就地修掉，没有加任何排除名单（ALLOWLIST 仍是 0 条）。",
+  "affected_population": [
+    "在画布助手记忆卡里改一条记忆文本、置顶或删除的用户：主进程写记忆失败时输入框照样收起、文字弹回原样，没有任何东西说没保存上（src/workbench/generationCanvas/components/MemoryFold.tsx 四处）",
+    "在任务中心点「取消导出」的用户：IPC 拒绝时行照样在跑、按钮照样在那儿，没有解释（src/workbench/taskCenter/TaskCenterPanel.tsx）",
+    "在时间轴收起条点「+ 配乐」挑一首曲子的用户：时长探不出来时函数返回 null，弹窗关了、轴上什么都没多、一声不吭（src/workbench/timeline/TimelineSecondaryAddRow.tsx）",
+    "任何未来在 JSX handler 里 void 掉、async 掉或裸飘一个 Host 命令的开发路径"
+  ],
+  "scope_paths": [
+    "scripts/check-control-contract.mjs",
+    "scripts/control-contract-discarded-commands.mjs",
+    "scripts/check-control-contract.test.mjs",
+    "src/workbench/generationCanvas/components/MemoryFold.tsx",
+    "src/workbench/taskCenter/TaskCenterPanel.tsx",
+    "src/workbench/timeline/TimelineSecondaryAddRow.tsx",
+    "src/i18n/locales/generationCommon.ts",
+    "src/i18n/resources.ts"
+  ],
+  "entry_points": [
+    "src/workbench/generationCanvas/components/MemoryFold.tsx:76 onBlur → commitEdit → updateProjectMemoryFact（桥的 memory.update 裸 await，无 catch）",
+    "src/workbench/generationCanvas/components/MemoryFold.tsx:77 onKeyDown → commitEdit → updateProjectMemoryFact（同上，Enter 提交那条路）",
+    "src/workbench/generationCanvas/components/MemoryFold.tsx:106 onClick → updateProjectMemoryFact（置顶，async handler 直接 setFacts(await …)）",
+    "src/workbench/generationCanvas/components/MemoryFold.tsx:117 onClick → removeProjectMemoryFact（删除，同上）",
+    "src/workbench/taskCenter/TaskCenterPanel.tsx:202 onAction → runAction → getDesktopBridge()?.exports.cancel(jobId)（裸 await 的 IPC）",
+    "src/workbench/ai/ProjectAgentResidentShell.tsx 会话行删除钮（#519 已修，本次用它做门岗的红证明 fixture）"
+  ],
+  "invariants": [
+    "JSX 的 on* handler 里，任何会被主进程拒绝的命令 Promise 都必须有人接住并把失败讲给用户；三种拼法（void f()、async handler 里 await、裸飘 f()）一视同仁，改拼法不能绕过。",
+    "「控件说谎」这条合同只有一个门岗 owner：check:controls。规则三与规则一二同进同出、同一条命令、同一份报告。",
+    "门岗对 #519 修前那一行必须报红、对 #519 的修法（把命令包进接住拒绝的 runThreadCommand）必须放行——由 scripts/check-control-contract.test.mjs 的头两条用例长期钉住。"
+  ],
+  "regression_tests": [
+    "scripts/check-control-contract.test.mjs"
+  ],
+  "residual_risks": [
+    "命令 reject 了、上层也 catch 了，但 catch 里只 console.warn 没告诉用户——语法上看不出「有没有告诉用户」，这一档仍然只能靠 R13 走查。",
+    "「成功地什么也没做」（命令 resolve 出 null/false 表示没做成、调用方不看）不是 Promise 拒绝，门岗测不到；本次 TimelineSecondaryAddRow 的配乐钮就是这一种，靠人读代码发现的。",
+    "命令经 props 传下去好几层才被丢掉的，需要跨组件数据流，门岗追不到。",
+    "canReject 顺着 await 往下追时，追不到声明的（注入依赖、第三方）一律当作不会 reject——这是为压掉 runPasteShareLinkImport 那类误报付的代价，可能漏掉真的会 reject 的注入依赖。"
+  ],
+  "external_sources": [],
+  "internal_only_reason": "纯内部结构问题：判据全部来自本仓自己的模块图（渲染层到主进程只有 src/desktop/bridge.ts 一个闸口，由 R26 的 check:boundaries 保证）与本仓真实代码的逐条核查，不依赖任何第三方行为。",
+  "recurrence": {
+    "classification": "recurring",
+    "reason": "「控件说谎」这一族在本仓至少第 6 次（门岗自己的 header 记了前 5 次：剪辑页显示下拉、3D 空态启动器、连线参考图、死的 + 图标、确认落画布，加上 2026-09-06 转场按钮的空 handler）。本次是这族里门岗没覆盖的一支：不是「没做事」而是「做了事没人管失败」。只要 JSX handler 还能把命令 Promise 丢掉，任何新按钮都能再造一次，而 lint、单测、五门都不响。",
+    "same_class_scan": [
+      "AST 实扫全仓 .tsx 的 on* handler 里被丢弃的调用：共 121 处。",
+      "逐层核查后：10 处调用链摸得到主进程桥；其中 9 处被调函数是 async/返回 Promise（clipNodeSourceFromAsset 是同步纯映射，出局）；其中 5 处那个 Promise 真的会 reject。",
+      "被筛掉的每一条都独立核查过并记在 scripts/control-contract-discarded-commands.mjs 的 header 里：recoverTaskActions.ts 的 recoverNodeResult 与 extractShotCutsToNodes 自己 try/catch 完把失败写回节点状态；productionRunStore.ts 的 navigateTo 只 await 一个全程 try/catch 的 loadRun；design/confirmDialogStore.ts 的 confirmDialog 是 new Promise(resolve=>…) 没有 reject 这条路；pasteShareLinkImport.ts 的 runPasteShareLinkImport 每个 IPC 都 try/catch 了；StoryboardPlanEditor.tsx 的 void runAction(() => generateAnchorCard(…)) 由 runAction 的 try/catch 兜住。",
+      "扩到具名 handler（onClick={handleThing}）后又核查 3 处：CustomVendorManage 的 handleDeleteVendor 与 AssetLibraryPanel 的 handlePasteLink 经核查是误报（前者被桶文件再导出挡住解析，后者只剩注入对话框裸 await），据此收窄了判据；NodeGenerationComposer 的 handleGenerate 走 confirmAndRunNodeVariants，追 await 追不到会 reject 的路径。"
+    ]
+  },
+  "generality_proof": "拦在「JSX 的 on* handler ↔ 跨进程命令」这道边界上，而不是逐个按钮打补丁：全仓渲染层通往主进程只有 src/desktop/bridge.ts 一个闸口（R26 的 check:boundaries 保证没有第二条），所以「这个调用会不会被主进程拒绝」等价于「它的模块 import 得到 bridge.ts 吗」，是个可判定的静态问题；而「用户会不会知道」等价于「这条拒绝有没有人接」。两者都在同一个 AST 扫描里判完，任何新写的按钮、任何新的命令模块、以及把 void 改成 async 或裸飘这两种改拼法的绕法，都会在同一次 check:controls 里被同样地拦住，不需要谁记得再加一条规则。",
+  "shared_boundaries": [
+    {
+      "path": "scripts/control-contract-discarded-commands.mjs",
+      "symbol": "discardedCommandOffenders",
+      "responsibility": "扫出 JSX handler 里被丢弃、且没人把失败讲给用户的跨进程命令；顺着模块图判「会不会被主进程拒绝」，顺着 try/catch/.catch/包装函数判「有没有人接住」。"
+    },
+    {
+      "path": "scripts/check-control-contract.mjs",
+      "symbol": "check:controls",
+      "responsibility": "「控件说谎」这条合同的唯一门岗 owner：把三条规则（目标守卫、空 handler、被丢弃的命令）合并成一次判定、一份报告。"
+    }
+  ],
+  "same_class_entry_points": [
+    {
+      "path": "src/workbench/generationCanvas/components/MemoryFold.tsx",
+      "entry_point": "commitEdit / 置顶钮 / 删除钮",
+      "disposition": "enforced",
+      "evidence": "三处原本各自把 memory.update / memory.remove 的 Promise 丢掉（两处 void、两处 async handler）。改为统一走 runMemoryCommand：失败时 toast generationCommon.memory.changeFailed 并把列表拉回真相。门岗对修前那棵树报这 4 行，对修后放行。"
+    },
+    {
+      "path": "src/workbench/taskCenter/TaskCenterPanel.tsx",
+      "entry_point": "runAction",
+      "disposition": "enforced",
+      "evidence": "原本 await confirmAndRunNode 与 await getDesktopBridge()?.exports.cancel(jobId) 都裸着，整个 Promise 被 void 掉。加 try/catch + toast taskCenter.actionFailed 后门岗放行。"
+    },
+    {
+      "path": "src/workbench/ai/ProjectAgentResidentShell.tsx",
+      "entry_point": "runThreadCommand（#519 的修法）",
+      "disposition": "enforced",
+      "evidence": "#519 已把三个会话命令包进 runThreadCommand（void command().catch(…) → setError）。门岗对这个形状放行，对它修之前那一行报红——两条都写死在 scripts/check-control-contract.test.mjs 的头两条用例里。"
+    },
+    {
+      "path": "src/workbench/creation/storyboard/StoryboardPlanEditor.tsx",
+      "entry_point": "onGenerateAnchor / onRegenerateAnchor",
+      "disposition": "not-affected",
+      "evidence": "形状是 void runAction(() => generateAnchorCard(…))，命令写在回调里，而 runAction 自己 try/catch 完 toast 了——回调是在它的 try 里跑的。早一版判据会顺着回调找进去误报它，据此加了「交给一个自己 catch 的函数去跑」这条放行，并写成回归用例。"
+    },
+    {
+      "path": "src/workbench/generationCanvas/runner/recoverTaskActions.ts",
+      "entry_point": "recoverNodeResult",
+      "disposition": "not-affected",
+      "evidence": "它自己 try/catch 完，把失败写回节点状态（setNodeStatus(id,'error',message)）告诉用户，所以 void 它不会静默——门岗据此不报，且把这个形状写成「命令自己报失败就放行」的回归用例。"
+    }
+  ],
+  "prevention": {
+    "kind": "static-gate",
+    "enforcement_path": "scripts/control-contract-discarded-commands.mjs",
+    "invariant": "JSX 的 on* handler 不得丢弃一个会被主进程拒绝、且没人把失败讲给用户的命令 Promise。",
+    "failure_mode": "check:controls 退出码 1，逐条列出 file:line、handler 名、被丢掉的调用、追到的命令与它所在模块，并给两条修法（在这里 catch 进既有错误条／让命令自己报失败）。gates:contracts 因此红，push 闸拦住。",
+    "exception_policy": "none",
+    "strategy": "把「点了失败没人说」做成与「点了不做事」同一道门岗的第三条规则，判据照着 121 处真实代码收窄到零误报，不留排除名单。",
+    "artifacts": [
+      "scripts/control-contract-discarded-commands.mjs",
+      "scripts/check-control-contract.mjs",
+      "scripts/check-control-contract.test.mjs"
+    ]
+  },
+  "class_regression_tests": [
+    "scripts/check-control-contract.test.mjs"
+  ],
+  "legacy_paths": {
+    "status": "not-applicable",
+    "removed_paths": [],
+    "rationale": "本次是给既有门岗补一条它看不见的规则，没有被替换掉的旧实现——规则一二原样保留，ALLOWLIST 仍是 0 条；被修的三个组件是把丢弃改成接住，不存在并行的旧路径。"
+  },
+  "dependency_lifecycle": {
+    "decision": "not-applicable",
+    "rationale": "没有引入或升级任何依赖：分析全部用仓库已有的 typescript 编译器 API 做纯语法扫描。",
+    "exit_criteria": []
+  }
+}

--- a/scripts/check-control-contract.mjs
+++ b/scripts/check-control-contract.mjs
@@ -28,6 +28,11 @@
 // 用户点半天以为坏了。判据只有一条、零解释空间：handler 是箭头函数，body 是空块或
 // undefined/null 字面量。真要占位就别渲染这个控件，或者 disabled + 说明为什么。
 //
+// 规则三（2026-09-06 加）：**被静默丢弃的命令**。前两条看的是「handler 没做事」，这条看的是
+// 「做了事、事失败了、用户什么都看不到」——`onClick={() => void someHostCommand(id)}`，命令被
+// Host 拒绝，裸 `void` 把拒绝丢进 unhandled rejection，界面一个字都不说。判据和它是怎么从
+// 121 处 `void` 收窄到个位数真问题的，都写在 control-contract-discarded-commands.mjs 里。
+//
 // 抓不到的（诚实标注，别把它当万能）：
 //   · 守卫藏在具名函数里、JSX 上只写 onClick={handler} → 需要跨函数数据流，留给 R13 走查断言
 //   · disabled 了但没说明原因（契约 C4）→ 全仓 100+ 处 disabled={readOnly} 语境自明，做成硬门必成噪音
@@ -36,6 +41,7 @@ import fs from 'node:fs'
 import path from 'node:path'
 import { createRequire } from 'node:module'
 import { fileURLToPath } from 'node:url'
+import { discardedCommandOffenders } from './control-contract-discarded-commands.mjs'
 
 const require = createRequire(import.meta.url)
 const ts = require('typescript')
@@ -166,8 +172,9 @@ function isEmptyHandler(fn) {
     || (ts.isVoidExpression(body) && ts.isNumericLiteral(body.expression))
 }
 
+const SCANNED = sourceFiles(SRC)
 const offenders = []
-for (const file of sourceFiles(SRC)) {
+for (const file of SCANNED) {
   const text = fs.readFileSync(file, 'utf8')
   const sf = ts.createSourceFile(file, text, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX)
   const rel = path.relative(ROOT, file)
@@ -209,14 +216,30 @@ for (const file of sourceFiles(SRC)) {
   visit(sf)
 }
 
-if (offenders.length > 0) {
+// 规则三：被静默丢弃的命令。判据和缘起住在 control-contract-discarded-commands.mjs，
+// 那份分析要走模块图和 Promise 数据流，塞进本文件会把两种完全不同的判断搅在一起。
+const discarded = discardedCommandOffenders({ root: ROOT, files: SCANNED })
+
+if (offenders.length > 0 || discarded.length > 0) {
   console.error('✗ 控件交互契约门岗未通过（设计系统 §4.1 C1）：')
-  console.error('  下面这些控件点下去会静默失效：handler 里有目标守卫、或 handler 根本是空的，控件却没有 disabled。')
-  console.error('  修法：守卫为假时给控件 disabled，并用 title 说清「为什么现在点不了」。')
-  console.error('  禁用的 <button> 自身不触发 title，要用外层 <span title={原因} style={{display:"contents"}}> 包住')
-  console.error('  （既有范式见 NodeGenerationComposer.tsx 的生成钮）。\n')
-  for (const o of offenders) console.error(`  · ${o.where}  ${o.handler} 守卫: ${o.guard}`)
+  if (offenders.length > 0) {
+    console.error('\n【点了不做事】handler 里有目标守卫、或 handler 根本是空的，控件却没有 disabled。')
+    console.error('  修法：守卫为假时给控件 disabled，并用 title 说清「为什么现在点不了」。')
+    console.error('  禁用的 <button> 自身不触发 title，要用外层 <span title={原因} style={{display:"contents"}}> 包住')
+    console.error('  （既有范式见 NodeGenerationComposer.tsx 的生成钮）。\n')
+    for (const o of offenders) console.error(`  · ${o.where}  ${o.handler} 守卫: ${o.guard}`)
+  }
+  if (discarded.length > 0) {
+    console.error('\n【点了失败但用户看不到】handler 丢掉了一个会被拒绝的跨进程命令的 Promise，')
+    console.error('  拒绝变成 unhandled rejection：控件像是生效了，实际什么都没发生，界面也不解释。')
+    console.error('  修法二选一：① 在这里接住并告诉用户（`.catch(…)` 走本面板既有的错误条／toast，')
+    console.error('  范式见 ProjectAgentResidentShell.tsx 的 runThreadCommand）；② 让命令自己把失败')
+    console.error('  报给用户（像 recoverTaskActions.ts 那样 catch 完写回节点状态），此时它就不再 reject。\n')
+    for (const d of discarded) console.error(`  · ${d.where}  ${d.handler}={() => void ${d.discarded}}  → ${d.command}（${d.module}）`)
+  }
   process.exit(1)
 }
 
-console.log(`✓ 控件交互契约门岗通过：无「点了没反应」的控件（例外 ${ALLOWLIST.size} 条，均已写明理由）。`)
+console.log(
+  `✓ 控件交互契约门岗通过：无「点了没反应」「点了失败没人说」的控件（例外 ${ALLOWLIST.size} 条，均已写明理由）。`,
+)

--- a/scripts/check-control-contract.test.mjs
+++ b/scripts/check-control-contract.test.mjs
@@ -1,0 +1,257 @@
+// 规则三（被静默丢弃的命令）的红/绿证明。
+//
+// R17 要求「加规则必须先验它会红」，而且这个红要**留得住**——所以红证明不是一次手工跑，
+// 是下面第一条用例：它复刻 #519 修之前那一行真实代码（常驻 Agent 面板里每个会话行的删除钮
+// `onClick={() => void removeProjectAgentThread(thread.threadId)}`，Host 对当前会话拒绝
+// `thread.remove`，裸 void 把拒绝丢掉、面板的错误条什么都不显示），断言门岗抓得到它。
+// 第二条用例是 #519 的修法（runThreadCommand 包一层 .catch），断言门岗放行。
+// 谁哪天把规则改窄到抓不住这个 bug，这两条会一起翻红。
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, expect, it } from 'vitest'
+import { discardedCommandOffenders } from './control-contract-discarded-commands.mjs'
+
+const roots = []
+
+afterEach(() => {
+  while (roots.length > 0) fs.rmSync(roots.pop(), { recursive: true, force: true })
+})
+
+/** 造一棵最小仓库：真闸口 src/desktop/bridge.ts + 若干模块 + 一个组件。 */
+function fixture(files) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'nomi-control-contract-'))
+  roots.push(root)
+  const write = (rel, text) => {
+    const full = path.join(root, rel)
+    fs.mkdirSync(path.dirname(full), { recursive: true })
+    fs.writeFileSync(full, text)
+  }
+  write('src/desktop/bridge.ts', 'export function getDesktopBridge() { return globalThis.nomi }\n')
+  for (const [rel, text] of Object.entries(files)) write(rel, text)
+  return root
+}
+
+function scan(root, componentRel = 'src/ui/Panel.tsx') {
+  return discardedCommandOffenders({ root, files: [path.join(root, componentRel)] })
+}
+
+/** #519 那个命令模块：dispatch 会因为 Host 拒绝而抛，removeThread 把它原样往外抛。 */
+const HOST_COMMANDS = `import { getDesktopBridge } from '../desktop/bridge'
+async function dispatch(type: string, payload: unknown) {
+  const result = await getDesktopBridge().command({ type, payload })
+  if (!result.ok) throw new Error(result.error.code)
+  return result.value
+}
+export async function removeProjectAgentThread(threadId: string) {
+  return dispatch('thread.remove', { threadId })
+}
+`
+
+it('抓得到 #519 修之前那行：裸 void 掉一个会被 Host 拒绝的命令', () => {
+  const root = fixture({
+    'src/ui/hostCommands.ts': HOST_COMMANDS,
+    'src/ui/Panel.tsx': `import { removeProjectAgentThread } from './hostCommands'
+export function Panel({ threads }: { threads: { threadId: string }[] }) {
+  return <div>{threads.map((thread) => (
+    <button key={thread.threadId} onClick={() => void removeProjectAgentThread(thread.threadId)}>删除</button>
+  ))}</div>
+}
+`,
+  })
+  const offenders = scan(root)
+  expect(offenders).toHaveLength(1)
+  expect(offenders[0].handler).toBe('onClick')
+  expect(offenders[0].command).toBe('removeProjectAgentThread')
+})
+
+it('放行 #519 的修法：包一层把拒绝送进错误条', () => {
+  const root = fixture({
+    'src/ui/hostCommands.ts': HOST_COMMANDS,
+    'src/ui/Panel.tsx': `import { removeProjectAgentThread } from './hostCommands'
+export function Panel({ threads, setError }: { threads: { threadId: string }[]; setError: (m: string) => void }) {
+  const runThreadCommand = (command: () => Promise<unknown>) => { void command().catch((caught) => setError(String(caught))) }
+  return <div>{threads.map((thread) => (
+    <button key={thread.threadId} onClick={() => runThreadCommand(() => removeProjectAgentThread(thread.threadId))}>删除</button>
+  ))}</div>
+}
+`,
+  })
+  expect(scan(root)).toEqual([])
+})
+
+it('隔着一层本地包装照样抓得到，包装自己 try/catch 了就放行', () => {
+  const component = (wrapper) => `import { removeProjectAgentThread } from './hostCommands'
+export function Panel({ threadId }: { threadId: string }) {
+  ${wrapper}
+  return <button onClick={() => void commit()}>删除</button>
+}
+`
+  const bare = fixture({
+    'src/ui/hostCommands.ts': HOST_COMMANDS,
+    'src/ui/Panel.tsx': component('const commit = async () => { await removeProjectAgentThread(threadId) }'),
+  })
+  expect(scan(bare)).toHaveLength(1)
+
+  const guarded = fixture({
+    'src/ui/hostCommands.ts': HOST_COMMANDS,
+    'src/ui/Panel.tsx': component(
+      'const commit = async () => { try { await removeProjectAgentThread(threadId) } catch (error) { alert(String(error)) } }',
+    ),
+  })
+  expect(scan(guarded)).toEqual([])
+})
+
+it('三种拼法都算丢弃：void、async handler、飘着的 Promise', () => {
+  for (const handler of [
+    '() => void removeProjectAgentThread(threadId)',
+    'async () => { await removeProjectAgentThread(threadId) }',
+    '() => { removeProjectAgentThread(threadId) }',
+  ]) {
+    const root = fixture({
+      'src/ui/hostCommands.ts': HOST_COMMANDS,
+      'src/ui/Panel.tsx': `import { removeProjectAgentThread } from './hostCommands'
+export function Panel({ threadId }: { threadId: string }) {
+  return <button onClick={${handler}}>删除</button>
+}
+`,
+    })
+    expect(scan(root), handler).toHaveLength(1)
+  }
+})
+
+it('命令写在一个自己 try/catch 的函数的回调里 → 放行（回调是在它的 try 里跑的）', () => {
+  // StoryboardPlanEditor 的 `void runAction(() => generateAnchorCard(…))` 就是这个形状：
+  // runAction 里 try/catch 完 toast 了。早一版规则会顺着回调找进去误报它。
+  const root = fixture({
+    'src/ui/hostCommands.ts': HOST_COMMANDS,
+    'src/ui/Panel.tsx': `import { removeProjectAgentThread } from './hostCommands'
+export function Panel({ threadId }: { threadId: string }) {
+  const runAction = async (action: () => Promise<void>) => {
+    try { await action() } catch (error) { toast(String(error), 'error') }
+  }
+  return <button onClick={() => void runAction(() => removeProjectAgentThread(threadId))}>删除</button>
+}
+`,
+  })
+  expect(scan(root)).toEqual([])
+})
+
+it('命令自己把失败报给用户（catch 完写状态、不再 reject）就放行', () => {
+  const root = fixture({
+    'src/ui/hostCommands.ts': `import { getDesktopBridge } from '../desktop/bridge'
+export async function recoverResult(id: string) {
+  try {
+    await getDesktopBridge().recover(id)
+  } catch (error) {
+    setNodeStatus(id, 'error', String(error))
+  }
+}
+`,
+    'src/ui/Panel.tsx': `import { recoverResult } from './hostCommands'
+export function Panel({ id }: { id: string }) {
+  return <button onClick={() => void recoverResult(id)}>找回</button>
+}
+`,
+  })
+  expect(scan(root)).toEqual([])
+})
+
+it('直接调桥上的方法也算命令，但 getDesktopBridge() 这句本身不算（它同步返回对象）', () => {
+  const root = fixture({
+    'src/ui/Panel.tsx': `import { getDesktopBridge } from '../desktop/bridge'
+export function Panel({ jobId }: { jobId: string }) {
+  return <div>
+    <button onClick={() => void getDesktopBridge()?.exports.cancel(jobId)}>取消导出</button>
+    <button onClick={() => { const bridge = getDesktopBridge(); bridge?.exports.reveal(jobId) }}>打开</button>
+  </div>
+}
+`,
+  })
+  const offenders = scan(root)
+  expect(offenders).toHaveLength(1)
+  expect(offenders[0].command).toContain('cancel')
+})
+
+it('注入进来的依赖不算「会 reject」——看不见的东西不硬说', () => {
+  // runPasteShareLinkImport 的形状：每个 IPC 都 try/catch 了，只剩一个注入的对话框裸 await。
+  const root = fixture({
+    'src/ui/hostCommands.ts': `import { getDesktopBridge } from '../desktop/bridge'
+export async function runImport(deps: { prompt: () => Promise<string | null> }) {
+  const url = await deps.prompt()
+  if (!url) return
+  try {
+    await getDesktopBridge()?.connector.import(url)
+  } catch {
+    toast('failed', 'error')
+  }
+}
+`,
+    'src/ui/Panel.tsx': `import { runImport } from './hostCommands'
+export function Panel({ prompt }: { prompt: () => Promise<string | null> }) {
+  return <button onClick={() => void runImport({ prompt })}>导入</button>
+}
+`,
+  })
+  expect(scan(root)).toEqual([])
+})
+
+it('桶文件里再导出的函数要追得过去（追不过去会把它当成会 reject）', () => {
+  const root = fixture({
+    'src/design/confirmDialogStore.ts': `export function confirmDialog(options: { title: string }): Promise<boolean> {
+  return new Promise((resolve) => submit({ ...options, resolve }))
+}
+`,
+    'src/design/index.ts': "export { confirmDialog } from './confirmDialogStore'\n",
+    'src/ui/hostCommands.ts': `import { getDesktopBridge } from '../desktop/bridge'
+import { confirmDialog } from '../design'
+export async function confirmAndDelete(key: string): Promise<{ deleted: boolean }> {
+  const ok = await confirmDialog({ title: 'delete' })
+  if (!ok) return { deleted: false }
+  try {
+    getDesktopBridge().modelCatalog.deleteVendor(key)
+    return { deleted: true }
+  } catch {
+    return { deleted: false }
+  }
+}
+`,
+    'src/ui/Panel.tsx': `import { confirmAndDelete } from './hostCommands'
+export function Panel({ vendorKey }: { vendorKey: string }) {
+  const handleDelete = async () => { await confirmAndDelete(vendorKey) }
+  return <button onClick={handleDelete}>删除</button>
+}
+`,
+  })
+  expect(scan(root)).toEqual([])
+})
+
+it('不碰主进程的、以及同步的调用都不算——这条规则只管跨进程命令', () => {
+  const root = fixture({
+    'src/ui/pure.ts': 'export function copyLabel(text: string) { return text.trim() }\n',
+    'src/ui/Panel.tsx': `import { copyLabel } from './pure'
+export function Panel({ text }: { text: string }) {
+  return <div>
+    <button onClick={() => void navigator.clipboard.writeText(text)}>复制</button>
+    <button onClick={() => void copyLabel(text)}>标签</button>
+  </div>
+}
+`,
+  })
+  expect(scan(root)).toEqual([])
+})
+
+it('全仓没有被静默丢弃的命令', async () => {
+  const root = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..')
+  const src = path.join(root, 'src')
+  const files = []
+  const walk = (dir) => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name)
+      if (entry.isDirectory()) walk(full)
+      else if (entry.name.endsWith('.tsx') && !/\.(test|spec)\.tsx$/.test(entry.name)) files.push(full)
+    }
+  }
+  walk(src)
+  expect(discardedCommandOffenders({ root, files })).toEqual([])
+})

--- a/scripts/control-contract-discarded-commands.mjs
+++ b/scripts/control-contract-discarded-commands.mjs
@@ -1,0 +1,583 @@
+// 控件交互契约 · 规则三：**被静默丢弃的命令**。check-control-contract.mjs 的一块，不是第二道门岗
+// （「控件说谎」只能有一个 owner）。规则一二看的是 handler 里**没做事**；这条看的是 handler
+// **做了事、事失败了、用户什么都看不到**——落在同一句合同（设计系统 §4.1 C1）上。
+//
+// 缘起（2026-09-06，#519）：常驻 Agent 面板的会话列表给每一行都渲染删除钮，包括当前会话，
+//     onClick={() => void removeProjectAgentThread(thread.threadId)}
+// 而 Host 对当前会话拒绝 `thread.remove`（projectAgentThreadReduction.ts 的 `thread_read_only`）。
+// 裸 `void` 把这个拒绝丢进 unhandled rejection，面板顶上的错误条一个字都不显示：用户点删除、
+// 弹窗不关、行还在、没有任何解释。修法（#519）是把命令包进 `runThreadCommand`，让拒绝走
+// 和别的命令同一条错误条。
+//
+// **规则是照着证据收出来的，不是先定的。** 每收窄一次，都是拿真实误报换来的：
+//
+//   全仓 .tsx 里 `on*` handler 中被丢掉的调用          121 处
+//    → 调用链摸得到主进程桥的                            10 处（其余是剪贴板、事件派发、纯本地状态）
+//    → 被调的是 async / 返回 Promise 的                   9 处（clipNodeSourceFromAsset 是同步纯映射）
+//    → 那个 Promise 真的会 reject 的                      5 处
+//
+// 被这四道筛掉的都是**长得像 bug 的好代码**，一条条记在这儿，免得谁再把规则放宽回去：
+//   · recoverNodeResult / extractShotCutsToNodes：自己 try/catch 完，把失败写回节点状态告诉用户了
+//   · productionRunStore.navigateTo：只 await 一个全程 try/catch 的 loadRun，压根 reject 不了
+//   · confirmDialog：`new Promise(resolve => …)`，没有 reject 这条路（它从 src/design 桶文件
+//     再导出，不跟着 `export … from` 追过去就会解析失败，而「解析失败」曾被当成「会 reject」）
+//   · runPasteShareLinkImport：每个 IPC 都 try/catch 了，只剩一个**注入进来的**对话框裸 await——
+//     看不见的东西不能硬说它会 reject，所以「解析不到」的默认答案是「不会」
+//   · StoryboardPlanEditor 的 `void runAction(() => generateAnchorCard(…))`：命令写在回调里，
+//     而 runAction 自己 try/catch 完 toast 了——回调是在它的 try 里跑的
+//   · `getDesktopBridge()` 这句调用本身：同步返回一个对象，不是 Promise（不加这条，设置页
+//     一口气误报十几处）
+//
+// 硬零 121 会是纯噪音，48 条不解释的棘轮同样是噪音——门岗自己的 header 写着「会瞎叫的门岗不如
+// 没有」，上一版正则对真实代码报的 11 条全是误报。所以宁可漏，也不瞎叫；漏掉的写在最后。
+//
+// 判据（四条同时成立）：
+//   1. JSX 上 `on*` 的值是内联箭头/函数，**或**本文件里定义的一个具名函数
+//      （`onClick={handleThing}` 也要看，否则「把箭头体抽成具名 const」就是消音门岗的办法）
+//   2. 里面有个调用的 Promise 没人要——`void f(…)`、`async () => await f(…)`、
+//      以及裸飘着的 `f(…)` 都算（三种拼法同一个 bug；只盯 `void`，改成 async 就绕过去了）
+//   3. 没人接住这个拒绝：不在带 catch 的 try 里，不挂在 `.catch` / `.then` 上，
+//      也不是交给一个自己 try/catch 的函数去跑的回调。中间可以隔若干层同文件内的本地包装，
+//      但那些包装自己也不能 try/catch——一 catch，拒绝就有人管了
+//   4. 被调的是**会拒绝的跨进程命令**，两种认法：
+//      a. 直接调桥上的方法：`getDesktopBridge()?.exports.cancel(jobId)`——主进程说不就是 reject
+//      b. 声明在能（传递地）import 到 `src/desktop/bridge.ts` 的模块里、声明为 async 或返回
+//         Promise、**且真的会 reject**：顺着 await 往下追（有界），追到某处 throw、或追到桥上
+//         （桥的方法都是 `return invoke(…)` 的薄壳，主进程的拒绝正是从那儿回来的）才算；
+//         追不到声明的（注入的依赖、第三方）当作不会 reject——见上面 runPasteShareLinkImport
+//
+// 抓不到的（诚实标注，别把它当万能）：
+//   · 命令 reject 了、上层也 catch 了，但 catch 里只 console.warn 没告诉用户 → 语法上看不出
+//     「有没有告诉用户」，留给 R13 走查
+//   · 「成功地什么也没做」——命令 resolve 出 null / false 表示没做成，调用方不看
+//     （TimelineSecondaryAddRow 的配乐钮就踩过：探测不出时长就返回 null，一声不吭）。
+//     这是同一句合同下的另一种失效，但它不是 Promise 拒绝，靠类型和走查管
+//   · 通过 props 传下去好几层才丢掉的 → 需要跨组件数据流
+//   · 动态取到的命令（`handlers[kind]()`）→ 名字不是静态的
+import fs from 'node:fs'
+import path from 'node:path'
+import { createRequire } from 'node:module'
+
+const require = createRequire(import.meta.url)
+const ts = require('typescript')
+
+/** 顺着 await 往下追的层数上限。追不动就当「会 reject」（宁可多问一句，也别放过）。 */
+const MAX_AWAIT_DEPTH = 6
+
+/**
+ * 一次扫描的全部状态。做成实例而不是模块级 Map，测试才能对着临时目录的 fixture 反复跑，
+ * 不会被上一次扫描的缓存串味。
+ */
+class Scanner {
+  constructor(root) {
+    this.root = root
+    this.src = path.join(root, 'src')
+    // 渲染层通往主进程的**唯一**闸口（R26 的 check:boundaries 保证没有第二条）。
+    // 「这个模块碰不碰主进程」就等于「它 import 得到这个文件吗」。
+    this.bridge = path.join(this.src, 'desktop', 'bridge.ts')
+    this.sources = new Map()
+    this.imports = new Map()
+    this.deps = new Map()
+    this.reaches = new Map()
+    this.decls = new Map()
+    this.rejects = new Map()
+  }
+
+  sourceFile(file) {
+    if (!this.sources.has(file)) {
+      const text = fs.existsSync(file) ? fs.readFileSync(file, 'utf8') : ''
+      this.sources.set(
+        file,
+        ts.createSourceFile(file, text, ts.ScriptTarget.Latest, true, file.endsWith('.tsx') ? ts.ScriptKind.TSX : ts.ScriptKind.TS),
+      )
+    }
+    return this.sources.get(file)
+  }
+
+  /** 只解析相对路径 import；包名和 alias 不是本仓内部模块，追不到也不该追。 */
+  resolveSpecifier(fromFile, spec) {
+    if (!spec.startsWith('.')) return null
+    const base = path.resolve(path.dirname(fromFile), spec)
+    for (const candidate of [`${base}.ts`, `${base}.tsx`, path.join(base, 'index.ts'), path.join(base, 'index.tsx')]) {
+      if (fs.existsSync(candidate)) return candidate
+    }
+    return null
+  }
+
+  moduleDeps(file) {
+    if (this.deps.has(file)) return this.deps.get(file)
+    const set = new Set()
+    this.deps.set(file, set)
+    if (!fs.existsSync(file)) return set
+    for (const statement of this.sourceFile(file).statements) {
+      const specifier = statement.moduleSpecifier
+      if (!specifier || !ts.isStringLiteral(specifier)) continue
+      // `import type` 不产生运行时依赖：只带类型的模块碰不到主进程。
+      if (ts.isImportDeclaration(statement) && statement.importClause?.isTypeOnly) continue
+      const resolved = this.resolveSpecifier(file, specifier.text)
+      if (resolved) set.add(resolved)
+    }
+    return set
+  }
+
+  reachesBridge(file) {
+    if (this.reaches.has(file)) return this.reaches.get(file)
+    this.reaches.set(file, false) // 环保护：循环 import 时先当「够不着」，由别的边定胜负
+    if (file === this.bridge) {
+      this.reaches.set(file, true)
+      return true
+    }
+    let hit = false
+    for (const dep of this.moduleDeps(file)) {
+      if (this.reachesBridge(dep)) {
+        hit = true
+        break
+      }
+    }
+    this.reaches.set(file, hit)
+    return hit
+  }
+
+  /** 这个文件里，每个 import 进来的名字来自哪个模块（值 import；类型 import 不算）。 */
+  importedNames(file) {
+    if (this.imports.has(file)) return this.imports.get(file)
+    const map = new Map()
+    this.imports.set(file, map)
+    if (!fs.existsSync(file)) return map
+    for (const statement of this.sourceFile(file).statements) {
+      if (!ts.isImportDeclaration(statement) || !ts.isStringLiteral(statement.moduleSpecifier)) continue
+      const clause = statement.importClause
+      if (!clause || clause.isTypeOnly) continue
+      const target = this.resolveSpecifier(file, statement.moduleSpecifier.text)
+      if (clause.name) map.set(clause.name.text, target)
+      if (!clause.namedBindings) continue
+      if (ts.isNamedImports(clause.namedBindings)) {
+        for (const element of clause.namedBindings.elements) if (!element.isTypeOnly) map.set(element.name.text, target)
+      } else {
+        map.set(clause.namedBindings.name.text, target)
+      }
+    }
+    return map
+  }
+
+  /**
+   * 在一个模块里按名字找函数声明。四种写法都认：函数声明、类方法、
+   * `const f = () => …`、对象字面量的 `f: async () => …`（zustand store 就长这样）。
+   */
+  findFunction(file, name, seen = new Set()) {
+    const key = `${file}#${name}`
+    if (this.decls.has(key)) return this.decls.get(key)
+    let found = null
+    if (fs.existsSync(file)) {
+      const nameOf = (node) => (node && ts.isIdentifier(node) ? node.text : null)
+      const walk = (node) => {
+        if (found) return
+        if (ts.isFunctionDeclaration(node) && node.name?.text === name && node.body) {
+          found = node
+          return
+        }
+        if (ts.isMethodDeclaration(node) && nameOf(node.name) === name) {
+          found = node
+          return
+        }
+        if ((ts.isVariableDeclaration(node) || ts.isPropertyAssignment(node)) && nameOf(node.name) === name) {
+          const fn = unwrapFunction(node.initializer)
+          if (fn) {
+            found = fn
+            return
+          }
+        }
+        node.forEachChild(walk)
+      }
+      walk(this.sourceFile(file))
+      // 桶文件：`export { confirmDialog } from './confirmDialogStore'`。不跟过去的话，
+      // 凡是从 src/design 这类 index.ts 引进来的函数都解析不到，而「解析不到」在
+      // canReject 里是按「会 reject」算的——那就会把一堆永不 reject 的东西报成违规。
+      if (!found) found = this.findReExported(file, name, seen)
+    }
+    this.decls.set(key, found)
+    return found
+  }
+
+  findReExported(file, name, seen = new Set()) {
+    if (seen.has(file)) return null
+    seen.add(file)
+    for (const statement of this.sourceFile(file).statements) {
+      if (!ts.isExportDeclaration(statement) || !statement.moduleSpecifier || !ts.isStringLiteral(statement.moduleSpecifier)) continue
+      if (statement.isTypeOnly) continue
+      const target = this.resolveSpecifier(file, statement.moduleSpecifier.text)
+      if (!target) continue
+      const clause = statement.exportClause
+      if (clause && ts.isNamedExports(clause)) {
+        const element = clause.elements.find((entry) => entry.name.text === name)
+        if (!element) continue
+        const original = (element.propertyName ?? element.name).text
+        const fn = this.findFunction(target, original)
+        if (fn) return fn
+        continue
+      }
+      // `export * from './x'`
+      const fn = this.findFunction(target, name)
+      if (fn) return fn
+    }
+    return null
+  }
+
+  /**
+   * 把一个调用表达式解析到它的声明。`f(…)` 看 import 表；`store.getState().navigateTo(…)`
+   * 取链尾的方法名，根名字是 import 就去那个模块找，否则在本文件里找。
+   */
+  resolveCall(callExpr, file) {
+    const { root, member } = callTarget(callExpr.expression)
+    if (!member) return null
+    const imports = this.importedNames(file)
+    if (root && imports.has(root)) {
+      const module = imports.get(root)
+      if (!module) return null
+      const fn = this.findFunction(module, member)
+      return fn ? { file: module, fn } : null
+    }
+    const fn = this.findFunction(file, member)
+    return fn ? { file, fn } : null
+  }
+
+  /**
+   * 这个函数的 Promise 会 reject 到调用方吗？
+   *
+   * 会：函数体里存在**没被 try(带 catch) 罩住**的 throw、await、或 `return <调用>`，
+   * 且被 await/return 的那个东西自己也会 reject（顺着往下追，最多 MAX_AWAIT_DEPTH 层）。
+   * catch 子句里的代码不算被罩住——`catch { … throw error }` 就是要往外抛。
+   * 追不到声明（第三方、动态、超深）就当会 reject：这条规则宁可让人多写一个 catch，
+   * 也不该悄悄放过一个真会静默失败的按钮。
+   */
+  canReject(fn, file, depth = 0, stack = new Set()) {
+    if (!fn?.body) return true
+    const key = `${file}#${fn.pos}`
+    if (stack.has(key)) return false // 递归：这一支不额外贡献 reject
+    if (this.rejects.has(key)) return this.rejects.get(key)
+    stack.add(key)
+
+    const settles = (expr) => {
+      if (depth >= MAX_AWAIT_DEPTH) return true
+      if (!ts.isCallExpression(expr)) return true
+      if (ts.isPropertyAccessExpression(expr.expression) && (expr.expression.name.text === 'catch' || expr.expression.name.text === 'then')) {
+        return false
+      }
+      const target = this.resolveCall(expr, file)
+      // 追到桥本身就停：桥的方法都是 `return invoke(…)` 这种薄壳，语法上看不出会不会抛，
+      // 而**主进程的拒绝正是从这儿回来的**——#519 的 `thread_read_only` 就走这条路。
+      // 再往里追只会追进 ipc 壳里，得出「不会 reject」的错结论。
+      if (target?.file === this.bridge) return true
+      if (target) return this.canReject(target.fn, target.file, depth + 1, stack)
+      // 解析不到声明的两种情况，答案相反，不能一刀切：
+      //   `await api.update(…)`（api 来自 getDesktopBridge()）= 走 IPC，主进程说不就是 reject
+      //   `await deps.prompt(…)`（注入进来的对话框）= 我们看不见它是什么，不能凭空说它会 reject
+      // 早一版把两者都当「会 reject」，于是 runPasteShareLinkImport 这种把每个 IPC 都
+      // try/catch 完、只剩一个注入对话框裸 await 的函数被报成违规——典型的瞎叫。
+      return this.callCrossesBridge(expr, file)
+    }
+
+    let hit = false
+    const walk = (node, guarded) => {
+      if (hit) return
+      // 不跨进嵌套函数：回调有自己的 Promise 身世。
+      if (node !== fn && (ts.isArrowFunction(node) || ts.isFunctionExpression(node) || ts.isFunctionDeclaration(node))) return
+      if (ts.isTryStatement(node)) {
+        walk(node.tryBlock, guarded || Boolean(node.catchClause))
+        if (node.catchClause) walk(node.catchClause, guarded)
+        if (node.finallyBlock) walk(node.finallyBlock, guarded)
+        return
+      }
+      if (!guarded) {
+        if (ts.isThrowStatement(node)) {
+          hit = true
+          return
+        }
+        if (ts.isAwaitExpression(node) && settles(node.expression)) {
+          hit = true
+          return
+        }
+        if (ts.isReturnStatement(node) && node.expression && ts.isCallExpression(node.expression) && settles(node.expression)) {
+          hit = true
+          return
+        }
+      }
+      node.forEachChild((child) => walk(child, guarded))
+    }
+
+    if (ts.isBlock(fn.body)) walk(fn.body, false)
+    else hit = ts.isCallExpression(fn.body) ? settles(fn.body) : false
+
+    stack.delete(key)
+    this.rejects.set(key, hit)
+    return hit
+  }
+
+  /**
+   * 调的是**桥上的一个方法**：`getDesktopBridge()?.exports.cancel(jobId)`。
+   * 注意不能只问「这句里有没有提到桥」——`getDesktopBridge()` 自己就提到了，可它同步返回一个
+   * 对象，压根不是 Promise，把它当命令会在设置页一口气误报十几处。必须是「桥.某方法(…)」。
+   */
+  callNamesBridge(callExpr, file) {
+    const callee = callExpr.expression
+    if (!ts.isPropertyAccessExpression(callee)) return false
+    return this.bridgeMention(file)(callee.expression)
+  }
+
+  /** 本文件里哪些名字是从桥那个模块 import 进来的；返回一个「这棵子树提到桥了吗」的判定。 */
+  bridgeMention(file) {
+    const bridgeNames = new Set()
+    for (const [name, module] of this.importedNames(file)) if (module === this.bridge) bridgeNames.add(name)
+    return (node) => {
+      if (bridgeNames.size === 0) return false
+      let hit = false
+      const walk = (current) => {
+        if (hit) return
+        if (ts.isIdentifier(current) && bridgeNames.has(current.text)) {
+          hit = true
+          return
+        }
+        current.forEachChild(walk)
+      }
+      walk(node)
+      return hit
+    }
+  }
+
+  /**
+   * 比 callNamesBridge 松一档：根名字是个本地变量、而它的初始化式里用到了桥也算
+   * （`const api = getDesktopBridge()?.memory` 之后的 `await api.update(…)`）。
+   * 只给 canReject 用——那里问的是「这个 await 会不会抛」，外层的 try/catch 已经算过了。
+   */
+  callCrossesBridge(callExpr, file) {
+    const mentionsBridge = this.bridgeMention(file)
+    if (mentionsBridge(callExpr.expression)) return true
+    const { root } = callTarget(callExpr.expression)
+    if (!root) return false
+    let initializer = null
+    const find = (node) => {
+      if (initializer) return
+      if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.name.text === root && node.initializer) {
+        initializer = node.initializer
+        return
+      }
+      node.forEachChild(find)
+    }
+    find(this.sourceFile(file))
+    return Boolean(initializer && mentionsBridge(initializer))
+  }
+
+  /** 被调的是不是「会拒绝的跨进程命令」。 */
+  commandFor(callExpr, file) {
+    const { root, member } = callTarget(callExpr.expression)
+    if (!root || !member) return null
+    // 直接捅 IPC：`getDesktopBridge()?.exports.cancel(jobId)`。这是本类 bug 最赤裸的形状——
+    // 主进程说不，Promise 就 reject，没人接就没人知道。桥上的方法在 bridge.ts 里是薄壳，
+    // 按名字未必找得到声明，所以不走下面的「找声明 + 判 async」那条路。
+    if (this.callNamesBridge(callExpr, file)) {
+      return { command: `${root}(…).${member}`, module: relative(this.root, this.bridge) }
+    }
+    const module = this.importedNames(file).get(root)
+    if (!module || !this.reachesBridge(module)) return null
+    const decl = this.findFunction(module, member)
+    if (!decl || !isAsyncish(decl, this.sourceFile(module))) return null
+    if (!this.canReject(decl, module)) return null
+    return { command: member, module: relative(this.root, module) }
+  }
+
+  /**
+   * 在一段代码里找**没人接住**的命令调用。
+   *
+   * 三种写法是同一个 bug，所以一起看，不然「把 void 改成 async」就成了绕过门岗的逃生口：
+   *   onClick={() => void hostCommand(id)}            裸 void 丢掉
+   *   onClick={async () => { await hostCommand(id) }} React 不 await handler 的返回值
+   *   onClick={() => { hostCommand(id) }}             飘着的 Promise（本仓 lint 没开
+   *                                                   no-floating-promises，它需要类型信息）
+   *
+   * 三种情况算「有人接住」，整棵子树跳过：
+   *   · 外面套着带 catch 的 try
+   *   · 这个调用挂在 `.catch(…)` / `.then(…)` 上
+   *   · 调的是一个**自己 try/catch 的函数**——它收下的回调是在它的 try 里跑的。
+   *     StoryboardPlanEditor 的 `void runAction(() => generateAnchorCard(…))` 就靠这条放行：
+   *     runAction 里 try/catch 完 toast 了，命令写在它的回调里不等于没人管。
+   *
+   * 不跨进嵌套函数（除了上面那条回调规则）——回调有自己的 Promise 身世。
+   * handler 直接调本文件里的包装函数时往里追，包装可以再套包装。
+   */
+  unhandledCommands(node, file, locals, options = {}) {
+    const { prefix = '', seen = new Set() } = options
+    const found = []
+    const walk = (current, guarded) => {
+      if (found.length > 0 && prefix) return // 包装里找到一个就够了，不必列举
+      if (current !== node && (ts.isArrowFunction(current) || ts.isFunctionExpression(current) || ts.isFunctionDeclaration(current))) return
+      if (ts.isTryStatement(current)) {
+        walk(current.tryBlock, guarded || Boolean(current.catchClause))
+        if (current.catchClause) walk(current.catchClause, guarded)
+        if (current.finallyBlock) walk(current.finallyBlock, guarded)
+        return
+      }
+      if (ts.isCallExpression(current)) {
+        const callee = current.expression
+        if (ts.isPropertyAccessExpression(callee) && (callee.name.text === 'catch' || callee.name.text === 'then')) {
+          current.forEachChild((child) => walk(child, true))
+          return
+        }
+        const command = guarded ? null : this.commandFor(current, file)
+        if (command) {
+          found.push({ call: current, command: `${prefix}${command.command}`, module: command.module })
+          return
+        }
+        const { root } = callTarget(callee)
+        const wrapper = root && !this.importedNames(file).has(root) ? locals.get(root) : this.resolveCall(current, file)?.fn
+        if (wrapper?.body) {
+          // 包装自己接住了拒绝 → 它和它收下的回调都不算丢弃。
+          if (handlesRejection(wrapper.body)) {
+            current.forEachChild((child) => walk(child, true))
+            return
+          }
+          if (!guarded && root && locals.has(root) && !seen.has(root)) {
+            seen.add(root)
+            const deeper = this.unhandledCommands(wrapper.body, file, locals, { prefix: `${prefix}${root} → `, seen })
+            if (deeper.length > 0) {
+              found.push({ call: current, command: deeper[0].command, module: deeper[0].module })
+              return
+            }
+          }
+        }
+      }
+      current.forEachChild((child) => walk(child, guarded))
+    }
+    const body = ts.isArrowFunction(node) || ts.isFunctionExpression(node) || ts.isFunctionDeclaration(node) ? node.body : node
+    if (body) walk(body, false)
+    return found
+  }
+}
+
+function unwrapFunction(node) {
+  let candidate = node
+  // React.useCallback(fn, deps) / useMemo(() => fn) 之类：真正的函数是第一个实参。
+  if (
+    candidate &&
+    ts.isCallExpression(candidate) &&
+    candidate.arguments.length > 0 &&
+    (ts.isArrowFunction(candidate.arguments[0]) || ts.isFunctionExpression(candidate.arguments[0]))
+  ) {
+    candidate = candidate.arguments[0]
+  }
+  return candidate && (ts.isArrowFunction(candidate) || ts.isFunctionExpression(candidate)) ? candidate : null
+}
+
+function isAsyncish(fn, sourceFile) {
+  if (!fn) return false
+  if (fn.modifiers?.some((modifier) => modifier.kind === ts.SyntaxKind.AsyncKeyword)) return true
+  return Boolean(fn.type && /^Promise\b/.test(fn.type.getText(sourceFile)))
+}
+
+/** `a.b().c(…)` → { root: 'a', member: 'c' }；`f(…)` → { root: 'f', member: 'f' }。 */
+function callTarget(expr) {
+  let node = expr
+  let member = null
+  for (;;) {
+    if (ts.isPropertyAccessExpression(node)) {
+      if (!member) member = node.name.text
+      node = node.expression
+      continue
+    }
+    if (ts.isCallExpression(node)) {
+      node = node.expression
+      continue
+    }
+    if (ts.isNonNullExpression(node) || ts.isParenthesizedExpression(node)) {
+      node = node.expression
+      continue
+    }
+    break
+  }
+  const root = ts.isIdentifier(node) ? node.text : null
+  return { root, member: member ?? root }
+}
+
+/** 这段代码里有没有人接住拒绝：try、`.catch`、`.then`（两参形式也算表态了）。 */
+function handlesRejection(node) {
+  let hit = false
+  const walk = (current) => {
+    if (hit) return
+    if (ts.isTryStatement(current)) {
+      hit = true
+      return
+    }
+    if (ts.isPropertyAccessExpression(current) && (current.name.text === 'catch' || current.name.text === 'then')) {
+      hit = true
+      return
+    }
+    current.forEachChild(walk)
+  }
+  walk(node)
+  return hit
+}
+
+function localFunctions(scanner, file) {
+  const map = new Map()
+  const walk = (node) => {
+    if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name)) {
+      const fn = unwrapFunction(node.initializer)
+      if (fn) map.set(node.name.text, fn)
+    }
+    if (ts.isFunctionDeclaration(node) && node.name) map.set(node.name.text, node)
+    node.forEachChild(walk)
+  }
+  walk(scanner.sourceFile(file))
+  return map
+}
+
+function relative(root, file) {
+  return path.relative(root, file).replaceAll(path.sep, '/')
+}
+
+/**
+ * 扫出所有「点了会失败、失败了没人说」的控件。
+ * @param {{ root: string, files: readonly string[] }} input 仓库根 + 要扫的 .tsx 绝对路径
+ * @returns {{ where: string, handler: string, discarded: string, command: string, module: string }[]}
+ */
+export function discardedCommandOffenders({ root, files }) {
+  const scanner = new Scanner(root)
+  const offenders = []
+  for (const file of files) {
+    const sourceFile = scanner.sourceFile(file)
+    const locals = localFunctions(scanner, file)
+    const rel = relative(root, file)
+    const visit = (node) => {
+      if (
+        ts.isJsxAttribute(node) &&
+        /^on[A-Z]/.test(node.name.getText()) &&
+        node.initializer &&
+        ts.isJsxExpression(node.initializer) &&
+        node.initializer.expression
+      ) {
+        // 内联箭头，或 `onClick={handleThing}` 这种指名道姓（本文件里定义的那个函数）。
+        // 后者必须一起看：否则「把箭头体抽成一个具名 const」就成了消音门岗的办法。
+        const inline = node.initializer.expression
+        const handler = ts.isArrowFunction(inline) || ts.isFunctionExpression(inline)
+          ? inline
+          : ts.isIdentifier(inline) && !scanner.importedNames(file).has(inline.text)
+            ? locals.get(inline.text)
+            : undefined
+        if (handler) {
+          const prefix = handler === inline ? '' : `${inline.getText(sourceFile)} → `
+          for (const hit of scanner.unhandledCommands(handler, file, locals, { prefix })) {
+            offenders.push({
+              where: `${rel}:${sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile)).line + 1}`,
+              handler: node.name.getText(),
+              discarded: hit.call.getText(sourceFile).replace(/\s+/g, ' ').slice(0, 60),
+              command: hit.command,
+              module: hit.module,
+            })
+          }
+        }
+      }
+      node.forEachChild(visit)
+    }
+    visit(sourceFile)
+  }
+  return offenders
+}

--- a/src/i18n/locales/generationCommon.ts
+++ b/src/i18n/locales/generationCommon.ts
@@ -1023,6 +1023,7 @@ export const zhGenerationCommon = {
     unpin: '取消置顶',
     pin: '置顶（优先注入）',
     delete: '删除这条记忆',
+    changeFailed: '记忆没改动成，请再试一次',
   },
   reconcile: {
     fields: {
@@ -2484,6 +2485,7 @@ export const enGenerationCommon = {
     unpin: 'Unpin',
     pin: 'Pin for priority context',
     delete: 'Delete this memory',
+    changeFailed: 'The memory was not changed. Try again.',
   },
   reconcile: {
     fields: {

--- a/src/i18n/resources.ts
+++ b/src/i18n/resources.ts
@@ -93,6 +93,7 @@ export const zhCN = {
     freeToCancel: '取消不产生费用',
     cancelQueued: '取消排队的 {{count}} 个',
     retryFailed: '重试失败的 {{count}} 个',
+    actionFailed: '这个操作没执行成，请再试一次',
     sections: {
       running: '进行中 {{count}}',
       queued: '排队中 {{count}}',
@@ -475,6 +476,7 @@ export const en = {
     freeToCancel: 'free to cancel',
     cancelQueued: 'Cancel {{count}} queued',
     retryFailed: 'Retry {{count}} failed',
+    actionFailed: 'That action did not go through. Try again.',
     sections: {
       running: 'Running {{count}}',
       queued: 'Queued {{count}}',

--- a/src/workbench/generationCanvas/components/MemoryFold.tsx
+++ b/src/workbench/generationCanvas/components/MemoryFold.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { IconBrain, IconChevronDown, IconPin, IconPinFilled, IconX } from '@tabler/icons-react'
 import { cn } from '../../../utils/cn'
 import { useTranslation } from 'react-i18next'
+import { toast } from '../../../ui/toast'
 import {
   fetchProjectMemoryFacts,
   removeProjectMemoryFact,
@@ -34,11 +35,27 @@ export function MemoryFold({ refreshKey }: { refreshKey: number }): JSX.Element 
 
   if (facts.length === 0) return null
 
-  const commitEdit = async (fact: MemoryFactView) => {
+  /**
+   * 三颗记忆按钮（改文本 / 置顶 / 删）走的都是主进程的记忆接口，它会失败（读写记忆文件、
+   * 项目已切走）。此前三处各自把 Promise 丢掉：用户改完一条记忆按回车，输入框收起来了，
+   * 文字弹回原样，没有任何东西说改失败了——他会以为自己没保存上（设计系统 §4.1 C1）。
+   * 一个包装管三处：成功了刷新列表，失败了说一句、并把列表拉回真相（乐观显示不留假象）。
+   */
+  const runMemoryCommand = (command: () => Promise<MemoryFactView[]>): void => {
+    void command()
+      .then(setFacts)
+      .catch((error: unknown) => {
+        console.error('project memory command failed', error)
+        toast(t('generationCommon.memory.changeFailed'), 'error')
+        void fetchProjectMemoryFacts().then(setFacts).catch(() => undefined)
+      })
+  }
+
+  const commitEdit = (fact: MemoryFactView): void => {
     setEditingId(null)
     const text = draft.trim()
     if (!text || text === fact.text) return
-    setFacts(await updateProjectMemoryFact(fact.id, { text }))
+    runMemoryCommand(() => updateProjectMemoryFact(fact.id, { text }))
   }
 
   return (
@@ -73,9 +90,9 @@ export function MemoryFold({ refreshKey }: { refreshKey: number }): JSX.Element 
                   value={draft}
                   autoFocus
                   onChange={(event) => setDraft(event.target.value)}
-                  onBlur={() => void commitEdit(fact)}
+                  onBlur={() => commitEdit(fact)}
                   onKeyDown={(event) => {
-                    if (event.key === 'Enter') void commitEdit(fact)
+                    if (event.key === 'Enter') commitEdit(fact)
                     if (event.key === 'Escape') setEditingId(null)
                   }}
                 />
@@ -103,7 +120,7 @@ export function MemoryFold({ refreshKey }: { refreshKey: number }): JSX.Element 
                     : 'text-nomi-ink-30 opacity-0 group-hover:opacity-100 hover:text-nomi-ink-60',
                 )}
                 aria-label={fact.pinned ? t('generationCommon.memory.unpin') : t('generationCommon.memory.pin')}
-                onClick={async () => setFacts(await updateProjectMemoryFact(fact.id, { pinned: !fact.pinned }))}
+                onClick={() => runMemoryCommand(() => updateProjectMemoryFact(fact.id, { pinned: !fact.pinned }))}
               >
                 {fact.pinned ? <IconPinFilled size={12} /> : <IconPin size={12} stroke={1.8} />}
               </button>
@@ -114,7 +131,7 @@ export function MemoryFold({ refreshKey }: { refreshKey: number }): JSX.Element 
                   'text-nomi-ink-30 opacity-0 group-hover:opacity-100 hover:text-nomi-ink-60',
                 )}
                 aria-label={t('generationCommon.memory.delete')}
-                onClick={async () => setFacts(await removeProjectMemoryFact(fact.id))}
+                onClick={() => runMemoryCommand(() => removeProjectMemoryFact(fact.id))}
               >
                 <IconX size={12} stroke={1.8} />
               </button>

--- a/src/workbench/taskCenter/TaskCenterPanel.tsx
+++ b/src/workbench/taskCenter/TaskCenterPanel.tsx
@@ -17,6 +17,7 @@ import { confirmAndRunNode } from '../generationCanvas/runner/generationRunContr
 import { confirmAndRunPlan } from '../generationCanvas/components/batchPlanPreview'
 import { buildDependencyWaves } from '../generationCanvas/runner/dependencyWaves'
 import { buildTaskCenterView, formatElapsed, type TaskCenterRow } from './taskCenterEntries'
+import { toast } from '../../ui/toast'
 import { currentWorkbenchFloatingTopOffset } from '../../ui/app-shell/windowChrome'
 import type { ProductionRunSummary } from '../../../electron/productionRun/productionRunTypes'
 import type { TaskCenterProjection } from './taskCenterProjection'
@@ -202,13 +203,23 @@ export function TaskCenterPanel({ opened, onClose, productionRuns, exportJobs, o
     return <TaskRow key={row.id} row={row} onReveal={reveal} onAction={() => void runAction(row)} />
   }
 
+  /**
+   * 行上那颗操作钮（取消 / 中断 / 重试 / 取消导出）里有两条通到主进程，会失败。
+   * 此前整个 Promise 被裸 `void` 丢掉：用户点「取消导出」，行还在跑、按钮还在那儿、
+   * 一个字的解释也没有（设计系统 §4.1 C1）。失败就说一句，别让人对着不动的行猜。
+   */
   const runAction = async (row: TaskCenterProjection): Promise<void> => {
     const action = row.action
     if (!action) return
-    if (action.kind === 'cancel_generation_queue') cancelQueued(row as TaskCenterRow)
-    else if (action.kind === 'interrupt_generation') interruptRunning(row as TaskCenterRow)
-    else if (action.kind === 'retry_generation') await confirmAndRunNode(action.nodeId)
-    else if (action.kind === 'cancel_export_job') await getDesktopBridge()?.exports.cancel(action.jobId)
+    try {
+      if (action.kind === 'cancel_generation_queue') cancelQueued(row as TaskCenterRow)
+      else if (action.kind === 'interrupt_generation') interruptRunning(row as TaskCenterRow)
+      else if (action.kind === 'retry_generation') await confirmAndRunNode(action.nodeId)
+      else if (action.kind === 'cancel_export_job') await getDesktopBridge()?.exports.cancel(action.jobId)
+    } catch (error) {
+      console.error('task center action failed', error)
+      toast(t('taskCenter.actionFailed'), 'error')
+    }
   }
 
   return (

--- a/src/workbench/timeline/TimelineSecondaryAddRow.tsx
+++ b/src/workbench/timeline/TimelineSecondaryAddRow.tsx
@@ -80,7 +80,19 @@ export function TimelineSecondaryAddRow({
               // 拖它或拖素材过来，两条路都在。
               const state = useWorkbenchStore.getState()
               const audioTrackEmpty = state.timeline.tracks.every((track) => track.type !== 'audio' || track.clips.length === 0)
+              // 加不进去时它**成功地返回 null**（时长探不出来、素材类型落不了轨），此前整个
+              // Promise 被裸 `void` 丢掉：用户挑了首曲子，弹窗关了，轴上什么都没多，一个字的
+              // 解释也没有（设计系统 §4.1 C1）。这不是拒绝、是「静悄悄地没做成」，所以要看返回值，
+              // 光加 catch 没用；catch 是给同步抛出的意外留的，说的是同一句话。
+              // 「轴保持原样」是真的：失败都发生在写轴之前。
               void addAssetToTimeline(asset, { fps, startFrame: audioTrackEmpty ? 0 : state.timeline.playheadFrame })
+                .then((clip) => {
+                  if (!clip) toast(t('timelineEditor.adoption.failedRecovered'), 'error')
+                })
+                .catch((error: unknown) => {
+                  console.error('add music to timeline failed', error)
+                  toast(t('timelineEditor.adoption.failedRecovered'), 'error')
+                })
               setMusicPickerOpen(false)
             }}
             onUpload={() => {}}


### PR DESCRIPTION
## 为什么

#519 修掉了常驻 Agent 面板「删当前会话」那一处：Host 对当前会话拒绝 `thread.remove`
（`projectAgentThreadReduction.ts` 的 `thread_read_only`），而按钮写的是
`onClick={() => void removeProjectAgentThread(thread.threadId)}` —— 裸 `void` 把拒绝丢进
unhandled rejection，弹窗不关、行还在、面板顶上的错误条一个字都不显示。

**但当时只修了那一处。** `check:controls`（设计系统 §4.1 C1「可点即有效」）只认两种形状：
handler 里的目标守卫、空 handler —— 它看的是「handler **没做事**」，看不见「**做了事、
事失败了、用户什么都看不到**」。本仓 lint 也没开 `no-floating-promises`（需要类型信息）。
于是同一句合同下有一整类失效从门岗底下走过去。

## 规则是照着证据收出来的，不是先定的

```
全仓 .tsx 的 on* handler 里被丢弃的调用        121 处
 → 调用链摸得到主进程桥的                        10 处   （其余是剪贴板、事件派发、纯本地状态）
 → 被调函数是 async / 返回 Promise 的             9 处   （clipNodeSourceFromAsset 是同步纯映射）
 → 那个 Promise 真的会 reject 的                  5 处
```

硬零 121 是纯噪音，48 条不解释的棘轮同样是噪音 —— 门岗自己的 header 写着「会瞎叫的门岗
不如没有」，并记着上一版正则对真实代码报的 11 条**全是误报**。

**每一次收窄都是拿一条真误报换来的**，被筛掉的好代码逐条记在
`scripts/control-contract-discarded-commands.mjs` 的 header 里，免得谁再把规则放宽回去：

| 被筛掉的 | 为什么它不是 bug |
|---|---|
| `recoverNodeResult` / `extractShotCutsToNodes` | 自己 try/catch 完，把失败写回节点状态告诉用户了 |
| `productionRunStore.navigateTo` | 只 await 一个全程 try/catch 的 `loadRun`，压根 reject 不了 |
| `confirmDialog` | `new Promise(resolve => …)`，没有 reject 这条路（从 `src/design` 桶文件再导出，不跟着 `export … from` 追过去就会误判） |
| `runPasteShareLinkImport` | 每个 IPC 都 try/catch 了，只剩一个**注入进来的**对话框裸 await |
| `void runAction(() => generateAnchorCard(…))` | 命令写在回调里，而 `runAction` 自己 try/catch 完 toast 了 |
| `getDesktopBridge()` 这句调用本身 | 同步返回一个对象，不是 Promise（不加这条，设置页一口气误报十几处） |

**三种拼法一视同仁**（`void f()` / `async` handler 里 await / 裸飘的 `f()`），**具名 handler
也看**（`onClick={handleThing}`）—— 否则「改个拼法」或「抽成具名 const」就是消音门岗的办法。

## 一个 owner，不另开门岗

判据住在新模块 `scripts/control-contract-discarded-commands.mjs`，由既有门岗
`check-control-contract.mjs` import 后与前两条规则**合并成一次判定、一份报告**。
「控件说谎」仍然只有一个 owner、一条命令（`check:controls`）。

## R17 的红证明留得住

不是一次手工跑，是 `scripts/check-control-contract.test.mjs` 的头两条用例：复刻 #519 修**之前**
那一行（必须红）与 #519 的修法（`runThreadCommand` 包一层 `.catch`，必须绿）。谁哪天把规则
改窄到抓不住这个 bug，这两条会一起翻红。另有 9 条钉住每一次收窄换来的放行，以及全仓恒无
违规一条，共 11 条。

## 抓出的 5 处按 P1 就地修掉（ALLOWLIST 仍是 0 条，没加任何排除名单）

- **`MemoryFold`** 改文本 / 置顶 / 删三颗钮（4 处）—— 改完一条记忆按回车，输入框收起、
  文字弹回原样，没有任何东西说没保存上。统一走 `runMemoryCommand`：失败说一句，并把列表
  拉回真相（乐观显示不留假象）。
- **`TaskCenterPanel` 的 `runAction`** —— 点「取消导出」失败时行还在跑、按钮还在那儿、
  没有解释。加 try/catch + toast。
- **`TimelineSecondaryAddRow`「+ 配乐」** —— 这颗是另一种失效：加不进去时它**成功地返回
  `null`**（时长探不出来），弹窗关了、轴上什么都没多、一声不吭。看返回值才拦得住，光加
  catch 没用。这一种门岗看不见，是读代码发现的，已记进残余风险。

新增两条文案（zh-CN / en 同步）：`generationCommon.memory.changeFailed`、`taskCenter.actionFailed`。

## 诚实标注：抓不到的

- 命令 reject 了、上层也 catch 了，但 catch 里只 `console.warn` 没告诉用户 —— 语法上看不出
  「有没有告诉用户」，留给 R13 走查。
- 「成功地什么也没做」（resolve 出 `null`/`false`）不是 Promise 拒绝，门岗测不到。
- 命令经 props 传下去好几层才被丢掉的 —— 需要跨组件数据流。
- `canReject` 追不到声明的（注入依赖、第三方）一律当作不会 reject —— 这是为压掉
  `runPasteShareLinkImport` 那类误报付的代价。

## 验证

- `pnpm run gates` 全绿（含 `check:controls`、`check:root-cause-contracts`、`check:i18n`）
- `scripts/check-control-contract.test.mjs` 11 条全过
- 门岗耗时 ~0.7s，不拖慢 contracts
- R21 的 schema-v3 根因合同：`docs/fixes/2026-09-06-silent-discarded-host-command.root-cause.json`
  （classification: `recurring`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
