### PR TITLE
chore: 移出漏进 main 的 Codex 交付报告，gitignore 盘上现场文件

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -153,3 +153,7 @@ ds-bundle/
 # 由 .design-sync/support/build-css.mjs 生成（~620KB 的样式压平产物）：
 # 生成脚本进库、产物不进库。改了样式源码后重跑那个脚本即可。
 .design-sync/support/styles.generated.css
+
+# Codex/agent 盘上现场文件——只住 worktree，不进树（09-06 曾经由 #524 漏进 main）
+.codex-heartbeat
+CODEX-REPORT.md

--- a/CODEX-REPORT.md
+++ b/CODEX-REPORT.md
@@ -1,8 +1,0 @@
-# UI shell small delivery
-- 分支 `codex/ui-shell-version-dialog-node-empty-20260906` 已合并 `origin/main@4e8c342b4`。
-- 共享 `generationCommon.nodeEmpty` 已统一 whiteboard/scene3d 中英文节奏，并删除旧键。
-- 生产空态按钮增加稳定 `data-testid`；scene3d、whiteboard、remove-background 走查已改锚点。
-- Electron 走查：scene3d 7/7、whiteboard 6/6、remove-background 7/7，均无 console errors。
-- 实验室 pending 截图与 `contact.png` 已刷新，未更新 baseline。
-- `pnpm run gates`（提交 `a8bb2080d`）全绿：60/60 contracts、Vitest 11047 passed、build 通过。
-- 本分支待正常 push；未开 PR，主仓 `/Users/aoqimin/Desktop/Nomi` 未改动。


### PR DESCRIPTION
#524 把 Codex 工人的 `CODEX-REPORT.md` 带进了 main（工人把它当交付物提交，验收时漏看）。本 PR：
- `git rm CODEX-REPORT.md`；
- `.gitignore` 加 `.codex-heartbeat` / `CODEX-REPORT.md`——防线建在 git 这一层（R28），以后任何工人都提交不进来，不靠人眼。

docs/hook-only 级改动，无代码。

🤖 Generated with [Claude Code](https://claude.com/claude-code)