### PR TITLE
fix(ux-walk): production-mcp 旅程按身份选项目卡——终结「任务卡 10s 超时」这族抖动 + positional-project-open 门岗

### DIFF
--- a/docs/fixes/2026-09-06-production-mcp-taskcard-timeout.root-cause.json
+++ b/docs/fixes/2026-09-06-production-mcp-taskcard-timeout.root-cause.json
@@ -1,0 +1,128 @@
+{
+  "schema_version": 3,
+  "id": "2026-09-06-production-mcp-taskcard-timeout",
+  "problem_type": "走查按**位置**认对象（.first()），而那个位置是派生排序——多了一个兄弟就变成掷硬币",
+  "symptom": "CI「Real user loopback journey gate」里 production-mcp 旅程在 2026-09-05 晚间两个不同 PR 上各红一次（run 33991470467 首跑红重跑绿、run 33993567585 首跑红），main 同一条恒绿。报错固定是 tests/ux/production-mcp-journey.e2e.mjs:109 `locator.waitFor: Timeout 10000ms exceeded. waiting for locator('[data-production-task-card]') to be visible`，位置是重启后那次 openRunFromTaskCenter（调用点 :315）；它前面 15 条断言（含「approved storyboard materializes through the external MCP seam with eight planned jobs」）全过。",
+  "direct_cause": "重启后那步用 `gui.window.locator('[data-project-card=\"true\"]').first().click()` 打开项目。自 c73db10ef（2026-09-04，test(mcp): cover semantic document and canvas journeys）起，这条旅程在同一个隔离项目库里有**两个**项目：GUI 建的制作项目，和 MCP `nomi_project_create` 建的语义夹具「MCP semantic production fixture」。库卡顺序由 src/workbench/library/libraryDiscovery.ts 的 sortByLibraryUsage 按最近使用/updatedAt 倒序派生，两者的时间戳落在同一秒内，`.first()` 于是在两个项目之间掷硬币。点中语义项目那次，任务中心正常打开但里面是空的（面板文案「没有在跑的任务」），制作卡自然永不出现，10s 后超时。",
+  "class_root": "走查用**位置**指认对象，而位置是别处推导出来的量（这里是「最近用过」排序）。这类锚点在只有一个候选时百分之百正确，等到某天多出一个兄弟，它既不会报错也不会变红，而是安静地指向另一个东西；失败随后出现在**下游**，以一条完全无关的名字（「制作卡 10s 没出现」）报出来，把排查一路引向「等太短 / 卡不渲染 / 机器慢」。加大超时永远修不好它——点错项目等一万秒也等不到那张卡。",
+  "migration": "旅程里那两行位置式打开（`.first().click()` + 只验 `hash.includes('projectId=')` 的宽松等待）在同 commit 删除，换成唯一的 openProjectFromLibrary(window, wantedProjectId)：按 `[data-project-id]` 选身份、并等 hash 里出现**那个具体的** projectId。不留并行版，旅程里再无位置式开项目的写法。",
+  "affected_population": [
+    "CI 上跑 production-mcp 旅程的每一个 PR：约一半概率在重启步骤假红，且报错名字指错方向（两次已实测：run 33991470467、run 33993567585）",
+    "任何未来在同一隔离库里建第二个项目、又沿用位置式项目卡锚点的走查",
+    "无用户影响：产品侧的项目库排序与任务中心行为都正确，缺的是 DOM 上一个可按身份选中的锚点"
+  ],
+  "scope_paths": [
+    "tests/ux/production-mcp-journey.e2e.mjs",
+    "src/workbench/library/ProjectLibraryPage.tsx",
+    "scripts/check-walkthroughs.mjs",
+    "scripts/check-walkthroughs.node-test.mjs",
+    "scripts/lib/positionalProjectOpen.mjs",
+    "scripts/walkthrough-baseline.json"
+  ],
+  "entry_points": [
+    "tests/ux/production-mcp-journey.e2e.mjs:312 重启后打开项目（多项目 × 位置选择 → 本次红）",
+    "tests/ux/scene3d-ux-shots.walk.mjs / scene3d-exit-flush-recording.walk.mjs / scene3d-camera-follow.walk.mjs / scene3d-pose-toggle-and-drive-keys.walk.mjs / smoke.e2e.mjs / golden-path.e2e.mjs / design-fidelity.e2e.mjs 的 `[data-project-card].first()`（库里只有一个项目，位置=身份，不在本族）",
+    "tests/ux/custom-prompt-realtask.walk.mjs / selection-toolbar-vendor.walk.mjs / library-cover-imported-video.walk.mjs / agent-ui-d-lossless-history.walk.mjs / rich-editor-p1.walk.mjs / canvas-card-stack.walk.mjs / agent-runtime-editing.walk.mjs 已经按 hasText/filter 选身份（正确写法，本仓既有习惯）"
+  ],
+  "invariants": [
+    "走查打开项目库里的某个项目时，必须按项目身份（data-project-id）选中，不得按位置（.first()/.nth()/.last()）。",
+    "打开之后必须证明进的就是那个项目：等 location.hash 里出现**具体的** projectId，而不是只等 `projectId=` 这个前缀。",
+    "项目库卡在 DOM 上始终带 data-project-id，使身份选择在结构上可用。"
+  ],
+  "regression_tests": [
+    "tests/ux/production-mcp-journey.e2e.mjs",
+    "scripts/check-walkthroughs.node-test.mjs"
+  ],
+  "residual_risks": [
+    "门岗判「库里不止一个项目」用的是「这份走查自己调了 nomi_project_create」这一个信号。若将来某条走查改从磁盘预置第二个项目、或经别的 IPC 建项目，同样的坏写法这条规则看不见——那时要把信号补上，而不是放宽规则。",
+    "本次只把项目卡这一族收干净。库里其它列表（素材、提示词、技能）同样按最近使用排序，它们的走查锚点没有逐个量过。"
+  ],
+  "internal_only_reason": "纯本仓走查锚点与库排序问题：排序规则、DOM 锚点、旅程脚本全在本仓，无第三方契约介入。",
+  "recurrence": {
+    "classification": "recurring",
+    "reason": "同一族在本仓已有两条教训：docs/lessons/dead-selector-lies-both-ways.md（失效锚点同时造假红与假绿）与 docs/lessons/assert-you-are-in-the-situation-you-claim.md（没证明自己在以为的现场）。本次是它的第三次变形——锚点本身没死，是「位置」这个坐标系被一个新兄弟改写了。只要走查还能按位置指认对象，任何一次新增兄弟都能再造一次。",
+    "same_class_scan": [
+      "实扫 tests/ evals/ scripts/ 下全部 `data-project-card` 用法（19 处）：7 处是单项目走查的正当 `.first()`；7 处已按 hasText/filter 选身份；1 处（production-mcp 旅程重启步）是「多项目 × 位置选择」的坏组合，即本次红。",
+      "阳性对照（本机 Electron 真跑）：不改任何等待时长，只在重启前对语义项目补一次 nomi_canvas_edit 让它成为最新 → 卡序翻转，`.first()` 点进 workspace-145046bd（语义项目），任务中心开出来是空的，`[data-production-task-card]` 10s 超时，报错与调用栈与 CI 逐字一致。",
+      "阴性对照：同一条旅程不加那次写入，本机跑 58/58 全绿，探针打出的卡序是「制作项目在前」且两张卡都显示「刚刚」——证实两者时间戳同秒、顺序本来就是掷硬币。",
+      "门岗反向验证：把旅程改回 `.first()` 那两行，check:walkthroughs 精确报出 tests/ux/production-mcp-journey.e2e.mjs:312 并以 exit 1 变红；改回修复版 exit 0。",
+      "规则单测阳性对照（scripts/check-walkthroughs.node-test.mjs）：建了第二个项目又 .first() → 命中并报出行号；单项目 .first()、data-project-id、hasText/filter 三种写法均不报，证明规则不误伤也不是恒绿。"
+    ]
+  },
+  "generality_proof": "防线落在两层，都在「写坏法的那一刻」而不是「CI 半年后掷到反面」：① 产品侧给项目卡加上 data-project-id，让身份选择在 DOM 上永远可用——没有这个锚点，走查只能退回按位置或按可变文案指认；② 门岗侧在既有 check:walkthroughs 棘轮里新增 positional-project-open 规则，专盯「这份走查自己建了第二个项目 × 却按位置点项目卡」这个组合，基线 0。c73db10ef 那天若有这条规则，加语义项目的那个 commit 当场就红，而不是两天后在别人的 PR 上以「制作卡超时」的名义炸两次。规则口径只覆盖坏组合，单项目走查的 `.first()` 不误伤，因此不会退化成噪音。",
+  "shared_boundaries": [
+    {
+      "path": "tests/ux/production-mcp-journey.e2e.mjs",
+      "symbol": "openProjectFromLibrary",
+      "responsibility": "本旅程唯一的「从项目库打开项目」边界：按 data-project-id 选身份，并用 hash 屏障证明真的进了那个项目。"
+    },
+    {
+      "path": "src/workbench/library/ProjectLibraryPage.tsx",
+      "symbol": "data-project-id",
+      "responsibility": "项目卡在 DOM 上的身份锚点，使「按身份选中」成为结构上可行的写法。"
+    },
+    {
+      "path": "scripts/lib/positionalProjectOpen.mjs",
+      "symbol": "findPositionalProjectOpens",
+      "responsibility": "「多项目 × 位置式项目卡选择」的唯一判定逻辑；check-walkthroughs 的 positional-project-open 规则与其阳性对照单测共用这一份。"
+    }
+  ],
+  "same_class_entry_points": [
+    {
+      "path": "tests/ux/production-mcp-journey.e2e.mjs",
+      "entry_point": "重启后打开项目（原 .first()）",
+      "disposition": "enforced",
+      "evidence": "改为 openProjectFromLibrary(gui.window, projectId)，按 data-project-id 选中并等 hash 含该 projectId；门岗对旧写法报红（exit 1）、对新写法放行（exit 0）。"
+    },
+    {
+      "path": "tests/ux/smoke.e2e.mjs",
+      "entry_point": "[data-project-card].first()",
+      "disposition": "not-affected",
+      "evidence": "该走查的隔离库里只有它自己建的那一个项目，位置即身份；无 nomi_project_create，门岗规则不覆盖它，也不会误伤。"
+    },
+    {
+      "path": "tests/ux/golden-path.e2e.mjs",
+      "entry_point": "[data-project-card].first()",
+      "disposition": "not-affected",
+      "evidence": "同上：单项目隔离库，位置即身份。"
+    },
+    {
+      "path": "tests/ux/agent-runtime-editing.walk.mjs",
+      "entry_point": "冷重启后打开同一项目",
+      "disposition": "not-affected",
+      "evidence": "已经写成 `.filter({ hasText: project.name })`，本来就是按身份选，不在本族。"
+    }
+  ],
+  "prevention": {
+    "kind": "static-gate",
+    "enforcement_path": "scripts/lib/positionalProjectOpen.mjs",
+    "invariant": "任何 tests/ux 走查，只要自己通过 nomi_project_create 建了第二个项目，就不得再用 .first()/.nth()/.last() 点 [data-project-card]；必须带 hasText / filter / data-project-id 的身份限定。",
+    "failure_mode": "违反时 check:walkthroughs 以 exit 1 报出文件与行号，并说明「排序是最近用过派生量，同秒建的两个项目就是掷硬币」——在写下那一行的 commit 上就红，而不是等 CI 掷到反面。",
+    "exception_policy": "none",
+    "strategy": "把「位置」这种派生坐标从走查里换成「身份」这种稳定坐标，并在产品 DOM 上补齐身份锚点让这条路走得通；再用既有的走查棘轮把坏组合钉死在 0。",
+    "artifacts": [
+      "scripts/lib/positionalProjectOpen.mjs",
+      "scripts/check-walkthroughs.mjs",
+      "scripts/check-walkthroughs.node-test.mjs",
+      "scripts/walkthrough-baseline.json",
+      "src/workbench/library/ProjectLibraryPage.tsx",
+      "tests/ux/production-mcp-journey.e2e.mjs"
+    ]
+  },
+  "class_regression_tests": [
+    "scripts/check-walkthroughs.node-test.mjs",
+    "tests/ux/production-mcp-journey.e2e.mjs"
+  ],
+  "legacy_paths": {
+    "status": "removed",
+    "removed_paths": [
+      "tests/ux/production-mcp-journey.e2e.mjs"
+    ],
+    "rationale": "位置式打开的那两行（`.first().click()` 与只等 `projectId=` 前缀的宽松 waitForFunction）在同 commit 删除，旅程里只剩 openProjectFromLibrary 一条路径，无并行版、无 fallback（P1）。"
+  },
+  "dependency_lifecycle": {
+    "decision": "not-applicable",
+    "rationale": "本次修复不引入也不升级任何依赖：只动了一个 data 属性、一段旅程脚本和一条既有门岗规则。",
+    "exit_criteria": []
+  }
+}

--- a/docs/lessons/INDEX.md
+++ b/docs/lessons/INDEX.md
@@ -45,6 +45,7 @@
 - [隔离实例的 key/设置组装三坑](iso-walkthrough-key-seeding-traps.md) — `hasApiKey=false` 不证解密失败；别手拷设置文件
 - [断言计算色：别比字面串、翻主题先等 transition](walkthrough-computed-color-asserts.md) — oklch 序列化 + 插值帧两坑
 - [一个死选择器同时造假红和假绿](dead-selector-lies-both-ways.md) — 找到一处失效锚点就 grep 它的全部用法
+- [按「位置」认对象的锚点，多一个兄弟就变成掷硬币](positional-anchor-breaks-when-a-sibling-appears.md) — `.first()` 不会报错，只会安静指错；失败顶着下游的名字出现，加超时永远修不好
 - [GitHub Windows runner 把窗口夹到下限](gh-windows-runner-clamps-window-to-minimum.md) — 「只有 Windows 红」的头号原因，先反推 stage 尺寸
 - [功能落地后要做体验测试并记情绪摩擦日志](experiential-qa-emotion-log.md) — 截图审查要问「舒服吗」，不只问「在不在」
 - [断言前先证明你在你以为的现场](assert-you-are-in-the-situation-you-claim.md) — 注入的 meta 会被归一，两种假绿看起来都和真绿一样

--- a/docs/lessons/positional-anchor-breaks-when-a-sibling-appears.md
+++ b/docs/lessons/positional-anchor-breaks-when-a-sibling-appears.md
@@ -1,0 +1,43 @@
+# 按「位置」认对象的锚点，多一个兄弟就变成掷硬币
+
+> 📎 教训 · 首次记录 2026-09-06 · 状态：现行
+> **触发场景**：某条走查/旅程间歇性红，报错落在一条「等某个元素出现」的超时上，而它前面的断言全过；或者你正准备给一份走查的隔离环境里再加一个同类对象（第二个项目、第二个节点、第二个素材）。
+
+**结论**：走查里凡是 `.first()` / `.nth()` / `.last()` 指认对象，用的都是**位置**这个派生坐标。只要哪天多出一个兄弟，它不报错、不变红，只是安静地指向另一个东西；失败随后出现在**下游**，顶着一个完全无关的名字。**加大超时永远修不好它。**
+
+## 实例（2026-09-05 CI 两次红）
+
+`production-mcp` 旅程重启后用 `locator('[data-project-card="true"]').first().click()` 打开项目。
+
+自 `c73db10ef`（2026-09-04）起，这条旅程在同一个隔离库里有**两个**项目：GUI 建的制作项目，和 MCP `nomi_project_create` 建的语义夹具。库卡顺序由 `sortByLibraryUsage` 按最近使用/`updatedAt` 倒序派生，两者时间戳落在**同一秒**内——`.first()` 于是在两者之间掷硬币。
+
+点错那次：任务中心正常打开，但里面是空的（「没有在跑的任务」），制作卡永不出现。报错却是
+
+```
+locator.waitFor: Timeout 10000ms exceeded.
+  waiting for locator('[data-production-task-card]') to be visible
+```
+
+——一条指向「等太短 / 卡不渲染 / 机器慢」的假线索。两个 PR 上各红一次，main 恒绿（同一枚硬币，正面多）。
+
+## 怎么定位（阳性对照 > 反复重跑）
+
+别等它再掷一次。**把硬币按到反面**：在重启前给另一个对象补一次写入，让它成为「最近」。
+
+- 强制翻转后：`.first()` 点进语义项目，10s 超时，报错与调用栈**与 CI 逐字一致** → 机制坐实。
+- 不翻转：58/58 全绿，探针打出的卡序两张都显示「刚刚」→ 证实同秒、顺序本就是掷硬币。
+- 修复后再翻转：58/58 全绿 → 证明修的是这个，不是碰巧。
+
+## 怎么修
+
+1. **按身份选**，不按位置：`[data-project-card="true"][data-project-id="${id}"]`。产品侧要给对象在 DOM 上留身份锚点（`data-*` id），否则走查只能退回位置或可变文案。
+2. **加一道现场屏障**：点完立刻证明进的就是那个对象（等 hash 里出现**那个具体的** id，而不是只等 `projectId=` 前缀）。这样「点错」当场按它真实的名字失败，不再伪装成下游超时。
+3. **别顺手收紧超时**：这次把 click 收成 10s 就撞上开屏动画（`SplashIntro` 5 段 × 2600ms ≈ 13.5s），换来另一种抖动。修身份问题不要连带改等待预算。
+
+## 门岗
+
+`scripts/check-walkthroughs.mjs` 的 `positional-project-open` 规则（判定逻辑在 `scripts/lib/positionalProjectOpen.mjs`，阳性对照单测在 `scripts/check-walkthroughs.node-test.mjs`）：一份走查只要自己调了 `nomi_project_create`（= 库里不止一个项目），就不许再按位置点 `[data-project-card]`。基线 0。单项目走查的 `.first()` 是正当写法，不误伤。
+
+**出处**：`tests/ux/production-mcp-journey.e2e.mjs`；CI run 33991470467 / 33993567585；根因合同 `docs/fixes/2026-09-06-production-mcp-taskcard-timeout.root-cause.json`。
+
+**相关**：[dead-selector-lies-both-ways](dead-selector-lies-both-ways.md)、[assert-you-are-in-the-situation-you-claim](assert-you-are-in-the-situation-you-claim.md)、[repeated-timeout-means-check-the-assertion](repeated-timeout-means-check-the-assertion.md)、[race-repro-needs-positive-control](race-repro-needs-positive-control.md)

--- a/scripts/check-walkthroughs.mjs
+++ b/scripts/check-walkthroughs.mjs
@@ -11,6 +11,7 @@ import fs from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { collectAriaLabelLiterals, extractInterpolatedValues, isAriaLabelAlive } from './lib/ariaLabelLiterals.mjs'
+import { findPositionalProjectOpens } from './lib/positionalProjectOpen.mjs'
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
 const BASELINE_FILE = path.join(repoRoot, 'scripts/walkthrough-baseline.json')
@@ -183,6 +184,20 @@ const RULES = [
         if (/readFileSync\(/.test(line)) hits.push({ line: i + 1, text: line.trim().slice(0, 120), file })
       })
       return hits
+    },
+  },
+  {
+    id: 'positional-project-open',
+    label: '库里不止一个项目，却按**位置**（.first()/nth）点项目卡——排序是「最近用过」派生量，同秒建的两个项目就是掷硬币',
+    appliesTo: (file) => file.includes(`${path.sep}tests${path.sep}ux${path.sep}`),
+    // 2026-09-06 实例：production-mcp 旅程自 c73db10ef 起在同一隔离库里有两个项目
+    // （GUI 建的制作项目 + MCP `nomi_project_create` 建的语义夹具），重启后仍 `.first()` 点卡。
+    // 两者 updatedAt 落在同一秒 → 一半概率点进语义项目 → 任务中心是空的，
+    // 报错却出现在下游「[data-production-task-card] 10s 超时」，把人一路引向「等太短/卡不渲染」。
+    // 门岗只盯**这个组合**（多项目 × 位置选择），单项目走查的 `.first()` 是正当的，不误伤。
+    // 判定逻辑住 scripts/lib/positionalProjectOpen.mjs（本文件一 import 就跑门岗，规则没法就地单测）。
+    scan(code, file) {
+      return findPositionalProjectOpens(code).map((hit) => ({ ...hit, file }))
     },
   },
 ]

--- a/scripts/check-walkthroughs.node-test.mjs
+++ b/scripts/check-walkthroughs.node-test.mjs
@@ -11,6 +11,7 @@ import {
   isAriaLabelAlive,
   templateCanProduce,
 } from './lib/ariaLabelLiterals.mjs'
+import { findPositionalProjectOpens } from './lib/positionalProjectOpen.mjs'
 
 const SRC = `
   const a = <button aria-label="打开设置" />
@@ -68,5 +69,46 @@ describe('dead-aria-label：字面量采集', () => {
       win.locator('[aria-label$="丙丙丙"]')
     `
     assert.deepEqual(deadIn(code).sort(), ['丙丙丙', '乙乙乙', '甲甲甲'])
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// positional-project-open：「多项目 × 位置式项目卡选择」（2026-09-06，R17 先验它会红）
+//
+// 起因：production-mcp 旅程重启后用 `.first()` 点项目卡。自 2026-09-04 起同一隔离库里有两个项目，
+// 排序按「最近用过」派生，两者 updatedAt 同秒 → `.first()` 掷硬币 → 一半概率进错项目，
+// 任务中心开出来是空的，而报错落在下游的「[data-production-task-card] 10s 超时」。
+// 这条规则要在**写下那一行的 commit** 上就红，而不是等 CI 掷到反面。
+// ─────────────────────────────────────────────────────────────────────────────
+describe('positional-project-open：多项目下的位置式选择', () => {
+  const MULTI = `await callTool('nomi_project_create', { name: 'fixture' })`
+
+  it('阳性对照：建了第二个项目又按位置点卡 → 报出来', () => {
+    const code = `${MULTI}\nawait win.locator('[data-project-card="true"]').first().click()`
+    const hits = findPositionalProjectOpens(code)
+    assert.equal(hits.length, 1)
+    assert.equal(hits[0].line, 2)
+  })
+
+  it('单项目走查的 .first() 不报（位置即身份，不误伤）', () => {
+    const code = `await win.locator('[data-project-card]').first().click()`
+    assert.deepEqual(findPositionalProjectOpens(code), [])
+  })
+
+  it('按身份选中的写法不报：data-project-id', () => {
+    const code = `${MULTI}\nawait win.locator('[data-project-card="true"][data-project-id="p1"]').click()`
+    assert.deepEqual(findPositionalProjectOpens(code), [])
+  })
+
+  it('按身份选中的写法不报：hasText / filter', () => {
+    const byText = `${MULTI}\nconst c = win.locator('[data-project-card]', { hasText: name }).first()`
+    const byFilter = `${MULTI}\nconst c = win.locator('[data-project-card="true"]').filter({ hasText: name }).first()`
+    assert.deepEqual(findPositionalProjectOpens(byText), [])
+    assert.deepEqual(findPositionalProjectOpens(byFilter), [])
+  })
+
+  it('.nth()/.last() 同属位置式，一并抓', () => {
+    const code = `${MULTI}\nwin.locator('[data-project-card]').nth(1)\nwin.locator('[data-project-card]').last()`
+    assert.equal(findPositionalProjectOpens(code).length, 2)
   })
 })

--- a/scripts/lib/positionalProjectOpen.mjs
+++ b/scripts/lib/positionalProjectOpen.mjs
@@ -1,0 +1,35 @@
+// 「多项目 × 位置式项目卡选择」的判定逻辑（check-walkthroughs.mjs 的 positional-project-open 规则）。
+//
+// 抽成独立模块只有一个理由：check-walkthroughs.mjs 一 import 就会跑整道门岗，规则本身没法单测。
+// 而 R17 要求「加规则先验它会红」——阳性对照住在 check-walkthroughs.node-test.mjs 里。
+//
+// 2026-09-06 实例：production-mcp 旅程自 c73db10ef 起在同一隔离库里有两个项目
+// （GUI 建的制作项目 + MCP nomi_project_create 建的语义夹具），重启后仍按 `.first()` 点项目卡。
+// 库卡顺序是「最近用过」派生量（src/workbench/library/libraryDiscovery.ts sortByLibraryUsage），
+// 两者 updatedAt 同秒 → `.first()` 掷硬币 → 一半概率进错项目，任务中心是空的，
+// 而报错出现在下游的「[data-production-task-card] 10s 超时」，把人引向「等太短」这个错方向。
+
+/** 「这份走查的库里不止一个项目」的信号：它自己又通过 MCP 建了一个。 */
+const MULTI_PROJECT_SIGNAL = /nomi_project_create/
+
+/** 位置式选择：位置是派生坐标，多一个兄弟就换了含义。 */
+const POSITIONAL = /\.first\(\)|\.nth\(|\.last\(\)/
+
+/** 身份限定：按名字或 id 选中才是稳定坐标。 */
+const IDENTITY_QUALIFIED = /hasText|\.filter\(|data-project-id/
+
+/**
+ * @param {string} code 走查源码（已剥注释）
+ * @returns {{ line: number, text: string }[]} 命中的行
+ */
+export function findPositionalProjectOpens(code) {
+  if (!MULTI_PROJECT_SIGNAL.test(code)) return []
+  const hits = []
+  code.split('\n').forEach((line, index) => {
+    if (!line.includes('[data-project-card')) return
+    if (IDENTITY_QUALIFIED.test(line)) return
+    if (!POSITIONAL.test(line)) return
+    hits.push({ line: index + 1, text: line.trim().slice(0, 120) })
+  })
+  return hits
+}

--- a/scripts/walkthrough-baseline.json
+++ b/scripts/walkthrough-baseline.json
@@ -5,6 +5,7 @@
   "dead-selector": 0,
   "dead-aria-label": 9,
   "source-scan-without-strip": 9,
+  "positional-project-open": 0,
   "assertion-density-thin": {
     "tests/ux/accent-soft-hue.walk.mjs": 0,
     "tests/ux/adapter-failed-unlock.walk.mjs": 0,

--- a/src/workbench/library/ProjectLibraryPage.tsx
+++ b/src/workbench/library/ProjectLibraryPage.tsx
@@ -430,6 +430,10 @@ export default function ProjectLibraryPage({
                 <div
                   key={project.id}
                   data-project-card="true"
+                  // 卡片顺序是「最近用过」派生量（libraryDiscovery.sortByLibraryUsage），同一秒内
+                  // 建的两个项目排序就是掷硬币。走查必须按**身份**点项目，不能按位置（`.first()`），
+                  // 所以身份要在 DOM 上拿得到——这条 data 属性就是那个锚点。
+                  data-project-id={project.id}
                   className={cn(
                     'group relative bg-nomi-paper border border-nomi-line rounded-nomi-lg overflow-visible text-left',
                     'transition-[box-shadow,transform,border-color] duration-150',

--- a/tests/ux/production-mcp-journey.e2e.mjs
+++ b/tests/ux/production-mcp-journey.e2e.mjs
@@ -115,6 +115,26 @@ async function openRunFromTaskCenter(window, shotName) {
   }
 }
 
+/**
+ * 按**身份**打开项目库里的某个项目，并证明真的进去了。
+ *
+ * 为什么不能 `.first()`：库卡的顺序是「最近用过」派生量（libraryDiscovery.sortByLibraryUsage），
+ * 本旅程自 2026-09-04 起在同一个隔离库里有**两个**项目（GUI 建的制作项目 + MCP 建的语义夹具），
+ * 两者 updatedAt 常落在同一秒里——`.first()` 于是变成掷硬币。点错那次，任务中心开出来是空的，
+ * 报错却是下游的「[data-production-task-card] 10s 超时」，一路指向假方向。
+ * 身份选择 + 这条 hash 屏障让「点错项目」当场按它真实的名字失败。
+ */
+async function openProjectFromLibrary(window, wantedProjectId) {
+  // 不给 click 加更紧的超时：开屏动画（SplashIntro，5 段 × 2600ms ≈ 13.5s）会挡住库页，
+  // 用 Playwright 默认超时才等得过它——收紧到 10s 会把这条重启步变成另一种抖动。
+  await window.locator(`[data-project-card="true"][data-project-id="${wantedProjectId}"]`).click()
+  await window.waitForFunction(
+    (id) => window.location.hash.includes(`projectId=${id}`),
+    wantedProjectId,
+    { timeout: 10_000 },
+  )
+}
+
 async function approveCurrentProductionGate(window) {
   await openRunFromTaskCenter(window)
   await window.locator('[data-production-primary-action]').first().click()
@@ -308,8 +328,7 @@ try {
   // 在逐镜头门等待时重启真实 Nomi；门与零提交状态必须从磁盘恢复。
   await gui.app.close()
   gui = await launchGui()
-  await gui.window.locator('[data-project-card="true"]').first().click()
-  await gui.window.waitForFunction(() => window.location.hash.includes('projectId='), undefined, { timeout: 10_000 })
+  await openProjectFromLibrary(gui.window, projectId)
   const afterRestartCanvas = await callTool('nomi_read', { target: 'canvas', leaseHandle, projectId: semanticProjectId })
   check(afterRestartCanvas.structuredContent?.nodes?.some((node) => node.id === nodeId), 'canvas semantic undo survives real Nomi restart')
   await openRunFromTaskCenter(gui.window)


### PR DESCRIPTION
## 根因（不是超时太短）
`production-mcp` 旅程重启后用 `[data-project-card].first().click()`。自 c73db10ef（09-04 加了 MCP `nomi_project_create` 语义夹具）起同一隔离库里有两个项目，库卡按「最近用过」排序、两者 `updatedAt` 落在同一秒，`.first()` 变成掷硬币；点中语义项目那次任务中心是空的，以下游 `[data-production-task-card]` 10s 超时的名义报出来。今晚 #521 / #524 各红一次、重跑绿，就是这个。

## 修法（R28 身份锚点建在最早那层）
- `ProjectLibraryPage.tsx` 项目卡补 `data-project-id`；
- 旅程改 `openProjectFromLibrary()`：按 id 选 + 等 hash 出现**那个** projectId，点错当场按真名失败；位置式两行同 commit 删（P1）；click 超时不收紧（开屏动画 ≈13.5s，收紧会换来另一种抖动，实测撞到）。
- 新门岗 `positional-project-open`（并入 `check:walkthroughs`，基线 0）：走查自己建了第二个项目就不许再按位置点项目卡。

## 证据
- 阳性对照：本机真 Electron，重启前给语义项目补一次写入让它成为最新 → 卡序翻转 → 报错与调用栈与 CI 逐字一致；阴性对照 58/58 绿；修复后再翻转 58/58 绿。
- R17：门岗改回 `.first()` → exit 1 精确报行号；改回修复版 → exit 0；单测钉死单项目 `.first()` 不误伤。
- R21 合同 `docs/fixes/2026-09-06-production-mcp-taskcard-timeout.root-cause.json`（recurring）；教训 `docs/lessons/positional-anchor-breaks-when-a-sibling-appears.md`。
- `pnpm run gates` 全绿。

顺带记录（未修，写进 residual_risks）：重启后 `SplashIntro` ≈13.5s 挡住库页，是这条旅程另一个独立抖动源。

🤖 Generated with [Claude Code](https://claude.com/claude-code)