### PR TITLE
fix(canvas): 框选后在选区罩子上右键不再被当成点空白

### DIFF
--- a/docs/fixes/2026-09-06-canvas-selection-overlay-context-menu.root-cause.json
+++ b/docs/fixes/2026-09-06-canvas-selection-overlay-context-menu.root-cause.json
@@ -1,0 +1,130 @@
+{
+  "schema_version": 3,
+  "id": "2026-09-06-canvas-selection-overlay-context-menu",
+  "problem_type": "画布右键落点用「不是节点 = 空白」的反向定义判断，覆盖在选中节点之上的图层被误判成空白并触发清选择",
+  "symptom": "shift 拖框选 ≥2 个生成节点后在选区上右键：选择被当场清空，弹出的是「添加节点」菜单而不是节点操作菜单，「建组」这条路凭空消失（真机实测 nodeMenu=0 / addMenu=1 / selectionToolbar=0，见 tests/ux/shots/group-frame-now/00b2、00b3 与 facts.json）",
+  "direct_cause": "useCanvasContextNodeMenu.prepareContextMenuPointerDown 只用 target.closest('.generation-canvas-v2-node') 取 nodeId。框选完成后 React Flow 在整片选中节点之上铺 .react-flow__nodesselection-rect，右键命中的是这层罩子，closest 取不到 data-node-id，nodeId 为 null，于是 finishContextMenuPointerUp 走 clearSelection() 并让 Overlays 渲染「添加节点」菜单",
+  "class_root": "「画布空白」是反向定义的：命中节点选择器才算节点，其余一律当空白。画布上还存在第三类落点——代表当前选中集的覆盖图层——反向定义把它整类吞进空白，于是任何盖在节点之上的选中集图层都会让右键清掉用户刚做出的选择",
+  "affected_population": [
+    "所有用 shift 框选（React Flow box-select）多选节点后想在选区上右键的用户",
+    "任意主题、任意窗口尺寸、任意节点种类：判定只看 DOM 命中，与数据无关",
+    "@xyflow/react 当前及后续版本中所有 nodesselection 图层实现"
+  ],
+  "scope_paths": [
+    "src/workbench/generationCanvas/components/canvasPointerGestureModel.ts",
+    "src/workbench/generationCanvas/components/useCanvasContextNodeMenu.ts",
+    "src/workbench/generationCanvas/reactFlow/GenerationCanvasReactFlowOverlays.tsx"
+  ],
+  "entry_points": [
+    "画布 stage 的 onPointerDownCapture → prepareContextMenuPointerDown（右键落点判定）",
+    "画布 stage 的 onPointerUp → finishContextMenuPointerUp（决定清不清选择、弹哪个菜单）",
+    "GenerationCanvasReactFlowOverlays 的菜单选型"
+  ],
+  "external_sources": [],
+  "internal_only_reason": "不变量是本仓自己的右键语义（哪种落点允许清选择），第三方文档不决定它；罩子的类名另有仓内真相源（generationCanvasReactFlow.css 给它上皮肤），已用交叉断言钉住",
+  "invariants": [
+    "只有『既不命中节点、也不命中当前选中集覆盖层』的右键才允许被当成空白，也只有这一支允许清选择",
+    "命中选中集覆盖层的右键 = 对当前选中集右键：弹节点操作菜单，选择原样不动",
+    "『这次右键点的是什么』只有一份判据，住在模型层，hook 与渲染层都从它读"
+  ],
+  "generality_proof": "落点判定从「反向排除」改成模型层一张正向三分表 resolveCanvasContextMenuTarget（node / selection / blank），hook 只负责把 DOM 命中结果喂给它、渲染层只根据 target 选菜单。任何新的『代表选中集的覆盖层』只需登记进 CANVAS_SELECTION_OVERLAY_SELECTOR 一处，不会再出现某个调用方忘记排除某图层而把用户选择清掉；clearSelection 现在被写死在 target === 'blank' 这一支，nodeId 是否存在不再充当菜单选型的替身判据",
+  "shared_boundaries": [
+    {
+      "path": "src/workbench/generationCanvas/components/canvasPointerGestureModel.ts",
+      "symbol": "resolveCanvasContextMenuTarget",
+      "responsibility": "画布右键落点三分的唯一真相表：命中节点 / 命中当前选中集覆盖层 / 真空白；只有真空白允许清选择"
+    },
+    {
+      "path": "src/workbench/generationCanvas/components/canvasPointerGestureModel.ts",
+      "symbol": "CANVAS_SELECTION_OVERLAY_SELECTOR",
+      "responsibility": "「哪些 DOM 图层代表当前选中集」的唯一登记处，供落点判定使用"
+    }
+  ],
+  "same_class_entry_points": [
+    {
+      "path": "src/workbench/generationCanvas/components/useCanvasContextNodeMenu.ts",
+      "entry_point": "prepareContextMenuPointerDown / finishContextMenuPointerUp",
+      "disposition": "enforced",
+      "evidence": "两处改为从 resolveCanvasContextMenuTarget 读 target；clearSelection 只在 target === 'blank' 时执行。canvasControlsStructure.test.ts 的 'routes the right-click landing through one three-way arbiter' 钉死这两条，并断言 hook 内不再出现第二份 nodesselection 清单"
+    },
+    {
+      "path": "src/workbench/generationCanvas/reactFlow/GenerationCanvasReactFlowOverlays.tsx",
+      "entry_point": "contextNodeMenu 菜单选型",
+      "disposition": "enforced",
+      "evidence": "由 contextNodeMenu?.nodeId 改为 contextNodeMenu.target !== 'blank'。nodeId 不再兼任『是不是节点菜单』的判据，同一结构测试断言旧写法不得复活"
+    },
+    {
+      "path": "src/workbench/generationCanvas/reactFlow/useGenerationCanvasReactFlowPointer.ts",
+      "entry_point": "handleCanvasPointerDownCapture / handleCanvasPointerDown",
+      "disposition": "not-affected",
+      "evidence": "平移与框选的空白判据是正向的 event.target.closest('.react-flow__pane')——罩子不是 pane，本来就不会被当成空白；左键落在罩子上由 React Flow 自己的 NodesSelection 拖拽接管（拖整批），语义正确"
+    },
+    {
+      "path": "src/workbench/generationCanvas/reactFlow/canvasConnectionDropTarget.ts",
+      "entry_point": "resolveCanvasDropTargetFromDom",
+      "disposition": "not-affected",
+      "evidence": "连线落点用 querySelectorAll + getBoundingClientRect 的几何包含判定，不做 elementFromPoint/closest 的顶层命中，罩子盖在上面不影响；连线起点只能从节点上的 handle 发起，罩子上没有 handle"
+    },
+    {
+      "path": "src/workbench/generationCanvas/reactFlow/GenerationCanvasReactFlow.tsx",
+      "entry_point": "onPaneClick={handlePaneClick}",
+      "disposition": "not-affected",
+      "evidence": "React Flow 只在 pane 本身被点时派发 onPaneClick，罩子上的点击不会触发它；画布上没有『双击空白建节点』这条路（generationCanvas 下无画布级 onDoubleClick），所以双击不在本类内"
+    }
+  ],
+  "recurrence": {
+    "classification": "recurring",
+    "reason": "同一机制不依赖这一个图层：只要画布上再出现一层盖在节点之上、且不带 data-node-id 的覆盖层（React Flow 升级换名、或本仓新增选中集装饰），反向定义就会再次把它吞成空白并清掉用户的选择。罩子类名还由第三方版本决定，本仓无法靠自觉记得排除",
+    "same_class_scan": [
+      "grep -rn \"nodesselection\" src/ tests/：修复前仅 generationCanvasReactFlow.css 与 canvasControlsStructure.test.ts 命中，落点判定层零命中——即『判定层根本不知道有这层东西』",
+      "grep -rn \"closest\\('\\.generation-canvas-v2-node'\\)|data-node-id\" src/workbench/generationCanvas/：逐一核对了 useCanvasContextNodeMenu、useGenerationCanvasReactFlowPointer、canvasConnectionDropTarget 三处 DOM 命中判定的口径",
+      "grep -rn \"onDoubleClick|onPaneClick|onSelectionEnd\" src/workbench/generationCanvas/：确认画布级双击没有『空白建节点』动作，onPaneClick 只由 pane 派发",
+      "真机取证：tests/ux/shots/group-frame-now/facts.json 的 marqueeAftermath 记录 topAtNodeCenter=react-flow__nodesselection-rect、右键后 nodeMenu 0 / addMenu 1 / selectionToolbar 0"
+    ]
+  },
+  "prevention": {
+    "kind": "centralized-boundary",
+    "enforcement_path": "src/workbench/generationCanvas/components/canvasPointerGestureModel.ts",
+    "invariant": "画布右键落点只能由 resolveCanvasContextMenuTarget 判成 node / selection / blank 三者之一；clearSelection 与「添加节点」菜单只允许出现在 blank 这一支",
+    "failure_mode": "命中选中集覆盖层时返回 'selection'，走节点菜单且不动选择；判据本身认不出的落点保持既有 blank 语义（右键仍有可见反馈，不会变成死右键）",
+    "exception_policy": "none",
+    "strategy": "把『这次右键点的是什么』从三个调用方各自的 closest 判断收进模型层一张正向表，覆盖层清单只登记一处；渲染层改看 target 而不是拿 nodeId 当替身，nodeId 退回纯数据",
+    "artifacts": [
+      "src/workbench/generationCanvas/components/canvasPointerGestureModel.ts",
+      "src/workbench/generationCanvas/components/useCanvasContextNodeMenu.ts",
+      "src/workbench/generationCanvas/reactFlow/GenerationCanvasReactFlowOverlays.tsx"
+    ]
+  },
+  "regression_tests": [
+    "src/workbench/generationCanvas/components/canvasPointerGestureModel.test.ts",
+    "src/workbench/generationCanvas/components/canvasControlsStructure.test.ts",
+    "tests/ux/canvas-marquee-group.walk.mjs"
+  ],
+  "class_regression_tests": [
+    "src/workbench/generationCanvas/components/canvasPointerGestureModel.test.ts",
+    "src/workbench/generationCanvas/components/canvasControlsStructure.test.ts"
+  ],
+  "legacy_paths": {
+    "status": "removed",
+    "removed_paths": [
+      "src/workbench/generationCanvas/components/useCanvasContextNodeMenu.ts",
+      "src/workbench/generationCanvas/reactFlow/GenerationCanvasReactFlowOverlays.tsx"
+    ],
+    "rationale": "同 commit 删掉旧判据：hook 里『nodeId 为空即清选择』的分支被 target === 'blank' 取代，Overlays 里 contextNodeMenu?.nodeId 作为菜单选型判据被 target !== 'blank' 取代。没有并行版、没有 fallback；结构测试断言旧写法不得复活"
+  },
+  "dependency_lifecycle": {
+    "decision": "retain-with-exit",
+    "rationale": "罩子由 @xyflow/react 渲染，类名 .react-flow__nodesselection-rect 是它的实现细节。当前版本行为已由真机走查证实，不需要升级；风险是未来升级换名后选择器悬空。退出判据是可机器验的：canvasPointerGestureModel.test.ts 拿画布 CSS 作为同一类名的第二真相源做交叉断言，走查另有『节点中心的最顶层元素必须是罩子』的现场断言，换名会让两者一起报红而不是静默失效",
+    "exit_criteria": [
+      "升级 @xyflow/react 时 canvasPointerGestureModel.test.ts 的 'points the selection-overlay selector at the class React Flow actually renders' 必须仍绿，否则同步更新 CANVAS_SELECTION_OVERLAY_SELECTOR 与画布 CSS",
+      "tests/ux/canvas-marquee-group.walk.mjs 的现场断言（节点中心最顶层元素是选中集罩子）必须仍绿"
+    ],
+    "current": "@xyflow/react 12.11.5",
+    "target": "保持当前版本（无需升级）；升级时按 exit_criteria 两条断言核验罩子类名"
+  },
+  "migration": "无数据或持久化涉及：改的只是一次指针事件的落点分类，不写 store、不改 schema、不影响任何已存工程",
+  "residual_risks": [
+    "组框（GroupFrame，[data-group-id]）上的右键仍然弹「添加节点」菜单：它同样是一层盖在节点之上的画布对象，但它不是『当前选中集的罩子』——右键它时组成员未必处于选中态（handleGroupFramePointerDown 只接 button===0），把它并入 'selection' 会让菜单作用在陈旧选择上。组的右键菜单本身是尚未设计的能力（画布上组没有右键菜单、没有改名、没有颜色，见 tests/ux/shots/group-frame-now/README.md §2），需要样张与用户拍板后单独交付，不在本次修复范围",
+    "Windows / Linux 上未真机复验：本次证据全部来自 macOS 真 Electron 构建。判定不含平台分支，风险低但未证"
+  ]
+}

--- a/src/workbench/generationCanvas/components/canvasControlsStructure.test.ts
+++ b/src/workbench/generationCanvas/components/canvasControlsStructure.test.ts
@@ -192,6 +192,26 @@ describe('generation canvas control structure', () => {
     expect(generationCanvas).toContain('onPaneContextMenu={handleFlowContextMenu}')
   })
 
+  it('routes the right-click landing through one three-way arbiter so a marquee selection survives it', () => {
+    // 2026-09-06 真机 bug：框选后 React Flow 铺的 nodesselection-rect 盖住节点，右键取不到
+    // data-node-id → 被「不是节点 = 空白」吞掉 → 清选择 + 弹添加菜单，「建组」当场不可达。
+    // 判据必须只有一份（模型层），且清选择只准发生在真空白这一支。
+    const contextMenu = source('./useCanvasContextNodeMenu.ts')
+    const overlays = source('../reactFlow/GenerationCanvasReactFlowOverlays.tsx')
+
+    expect(contextMenu).toContain('resolveCanvasContextMenuTarget({')
+    expect(contextMenu).toContain('selectionOverlay: isCanvasSelectionOverlayTarget(target)')
+    expect(contextMenu).toContain('target: menuTarget')
+    expect(contextMenu).toContain("else if (pending.menu.target === 'blank') clearSelection()")
+    // 落点判定不许在 hook 里再长第二份清单（模型层是唯一 owner）。
+    // 先剥注释再扫：不变量管的是代码行为，不该被记录这个 bug 的注释反噬。
+    const contextMenuCode = contextMenu.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '')
+    expect(contextMenuCode).not.toContain('nodesselection')
+    // 菜单选型跟着落点走，不再拿 nodeId 当「是不是节点菜单」的替身。
+    expect(overlays).toContain("contextNodeMenu && contextNodeMenu.target !== 'blank'")
+    expect(overlays).not.toContain('contextNodeMenu?.nodeId ?')
+  })
+
   it('cancels marquee when an explicit pan chord takes ownership after primary down', () => {
     const pointerInteractions = source('./useCanvasPointerInteractions.ts')
 

--- a/src/workbench/generationCanvas/components/canvasPointerGestureModel.test.ts
+++ b/src/workbench/generationCanvas/components/canvasPointerGestureModel.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
 import {
   CANVAS_MENU_TARGET_SELECTOR,
+  CANVAS_SELECTION_OVERLAY_SELECTOR,
+  resolveCanvasContextMenuTarget,
   canvasDragExceededThreshold,
   isCanvasCapturePanPointer,
   isCanvasPanButtonHeld,
@@ -160,5 +164,29 @@ describe('generation canvas pointer arbitration', () => {
     expect(isCanvasContextMenuPointer(0, true, 'iPad')).toBe(true)
     expect(isCanvasContextMenuPointer(0, true, 'Win32')).toBe(false)
     expect(isCanvasContextMenuPointer(0, false, 'MacIntel')).toBe(false)
+  })
+
+  // ── 右键落点三分（2026-09-06 真机取证的那个 bug 的类级不变量）──
+  it('never calls a hit on the selection overlay blank', () => {
+    // 报告的那一例：框选后罩子盖住节点，右键取不到 data-node-id。判成 'blank' 就会清掉刚框好的
+    // 一批 + 弹「添加节点」菜单，「建组」当场不可达。
+    expect(resolveCanvasContextMenuTarget({ nodeId: null, selectionOverlay: true })).toBe('selection')
+    // 类级：罩子的存在与否，永远不能把落点降级成空白——哪怕同时命中节点。
+    expect(resolveCanvasContextMenuTarget({ nodeId: 'gen-1', selectionOverlay: true })).toBe('node')
+    expect(resolveCanvasContextMenuTarget({ nodeId: 'gen-1', selectionOverlay: false })).toBe('node')
+    // 只有两者都不命中才是真空白——这是唯一允许清选择的分支。
+    expect(resolveCanvasContextMenuTarget({ nodeId: null, selectionOverlay: false })).toBe('blank')
+  })
+
+  it('points the selection-overlay selector at the class React Flow actually renders', () => {
+    // 本仓单测跑在 node 环境（无 DOM），选择器本身测不了「命中没命中」。但它指错类名的后果
+    // 和没修一样，所以拿**同一个类名的另一处真相**交叉验：画布 CSS 就是给这层罩子上皮肤的地方。
+    // 罩子换名（React Flow 升级）时这条会红，而不是等到用户又一次框选建不了组。
+    const flowStyles = readFileSync(
+      fileURLToPath(new URL('../reactFlow/generationCanvasReactFlow.css', import.meta.url)),
+      'utf8',
+    )
+    expect(CANVAS_SELECTION_OVERLAY_SELECTOR).toContain('.react-flow__nodesselection-rect')
+    expect(flowStyles).toContain('.react-flow__nodesselection-rect')
   })
 })

--- a/src/workbench/generationCanvas/components/canvasPointerGestureModel.ts
+++ b/src/workbench/generationCanvas/components/canvasPointerGestureModel.ts
@@ -94,3 +94,42 @@ export function isMacCanvasPlatform(platform: string): boolean {
 export function isCanvasContextMenuPointer(button: number, ctrlKey: boolean, platform: string): boolean {
   return button === 2 || (button === 0 && ctrlKey && isMacCanvasPlatform(platform))
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 右键落点判定（2026-09-06 真机取证：tests/ux/shots/group-frame-now/00b2、00b3）
+//
+// 「空白」原先是**反向定义**的：命中 `.generation-canvas-v2-node` 才算节点，其余一律当空白。
+// 可画布上还有第三种东西——**代表当前选中集的罩子**：shift 拖框选完成后，React Flow 会在整片
+// 选中节点之上铺一层 `nodesselection-rect`（本仓在 generationCanvasReactFlow.css 里给它上了中性皮肤，
+// 拖它 = 拖整批）。右键落在这层上取不到 data-node-id，于是被反向定义吞成「空白」→
+// 清掉刚框好的选择 + 弹「添加节点」菜单 →「建组」当场不可达（实测 nodeMenu 0 / addMenu 1）。
+//
+// 所以落点必须**正向**分三类，且这张表只此一份：谁想知道「这次右键点的是什么」都问它。
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** 框选完成后 React Flow 铺在选中节点之上的罩子。语义上它**就是当前选中集**，不是画布空白。 */
+export const CANVAS_SELECTION_OVERLAY_SELECTOR = '.react-flow__nodesselection, .react-flow__nodesselection-rect'
+
+export function isCanvasSelectionOverlayTarget(target: EventTarget | null): boolean {
+  return target instanceof Element ? Boolean(target.closest(CANVAS_SELECTION_OVERLAY_SELECTOR)) : false
+}
+
+/**
+ * 右键落在什么上：
+ *   · 'node'      某个节点 —— 先确保它在选中集里，再弹「节点操作」菜单
+ *   · 'selection' 当前选中集的罩子 —— 已经选好了，**原样保留**，同样弹「节点操作」菜单
+ *   · 'blank'     真空白 —— 清掉选择，弹「添加节点」菜单
+ */
+export type CanvasContextMenuTarget = 'node' | 'selection' | 'blank'
+
+/**
+ * 只有 'blank' 才允许清选择。命中罩子却判成 'blank' 就是本次修复的那个 bug，
+ * 真值表由 canvasPointerGestureModel.test.ts 钉死。
+ */
+export function resolveCanvasContextMenuTarget(input: {
+  nodeId: string | null
+  selectionOverlay: boolean
+}): CanvasContextMenuTarget {
+  if (input.nodeId) return 'node'
+  return input.selectionOverlay ? 'selection' : 'blank'
+}

--- a/src/workbench/generationCanvas/components/useCanvasContextNodeMenu.ts
+++ b/src/workbench/generationCanvas/components/useCanvasContextNodeMenu.ts
@@ -1,6 +1,12 @@
 import React from 'react'
 import { clampNumber } from './generationCanvasGeometry'
-import { canvasDragExceededThreshold, isCanvasContextMenuPointer } from './canvasPointerGestureModel'
+import {
+  canvasDragExceededThreshold,
+  isCanvasContextMenuPointer,
+  isCanvasSelectionOverlayTarget,
+  resolveCanvasContextMenuTarget,
+} from './canvasPointerGestureModel'
+import type { CanvasContextMenuTarget } from './canvasPointerGestureModel'
 
 type Offset = { x: number; y: number }
 
@@ -9,7 +15,12 @@ export type CanvasContextNodeMenu = {
   stageY: number
   canvasX: number
   canvasY: number
-  /** 右键落在某个节点上时带上它的 id → 弹「节点操作」菜单；空白处为 null → 弹「添加节点」菜单。 */
+  /**
+   * 右键落在什么上（唯一判据，见 canvasPointerGestureModel.resolveCanvasContextMenuTarget）：
+   * 'node' / 'selection' 都弹「节点操作」菜单，只有 'blank' 弹「添加节点」菜单并清选择。
+   */
+  target: CanvasContextMenuTarget
+  /** target === 'node' 时命中的节点 id；'selection' / 'blank' 为 null。 */
   nodeId: string | null
 }
 
@@ -98,8 +109,12 @@ export function useCanvasContextNodeMenu({
     const stageY = event.clientY - rect.top
     const zoom = zoomRef.current || 1
     const nodeId = target?.closest(NODE_SELECTOR)?.getAttribute('data-node-id') || null
+    const menuTarget = resolveCanvasContextMenuTarget({
+      nodeId,
+      selectionOverlay: isCanvasSelectionOverlayTarget(target),
+    })
     // 节点菜单比添加菜单矮：按各自高度夹边，免得贴着视口下缘弹出时被切掉。
-    const menuHeight = nodeId ? NODE_MENU_HEIGHT : MENU_HEIGHT
+    const menuHeight = menuTarget === 'blank' ? MENU_HEIGHT : NODE_MENU_HEIGHT
     pendingMenuRef.current = {
       pointerId: event.pointerId,
       button: event.button,
@@ -112,6 +127,7 @@ export function useCanvasContextNodeMenu({
         stageY: clampNumber(stageY, MENU_EDGE_GAP, Math.max(MENU_EDGE_GAP, rect.height - menuHeight - MENU_EDGE_GAP)),
         canvasX: Math.round((stageX - offsetRef.current.x) / zoom),
         canvasY: Math.round((stageY - offsetRef.current.y) / zoom),
+        target: menuTarget,
         nodeId,
       },
     }
@@ -156,9 +172,11 @@ export function useCanvasContextNodeMenu({
     )
     if (!suppressMenu && pendingMenuRef.current) {
       if (!pending.moved) {
-        // 节点上：先确保它选中（菜单动作都作用于选中项）；空白处：清掉选择再弹添加菜单。
-        if (pending.menu.nodeId) ensureNodeSelected(pending.menu.nodeId)
-        else clearSelection()
+        // 节点上：先确保它选中（菜单动作都作用于选中项）。
+        // 选中集罩子上：选择已经是对的，**碰都别碰**——清一下就等于把刚框好的一批扔掉。
+        // 只有真空白才清选择，再弹添加菜单。
+        if (pending.menu.target === 'node' && pending.menu.nodeId) ensureNodeSelected(pending.menu.nodeId)
+        else if (pending.menu.target === 'blank') clearSelection()
         setContextNodeMenu(pending.menu)
       }
     }

--- a/src/workbench/generationCanvas/reactFlow/GenerationCanvasReactFlowOverlays.tsx
+++ b/src/workbench/generationCanvas/reactFlow/GenerationCanvasReactFlowOverlays.tsx
@@ -85,7 +85,7 @@ export function GenerationCanvasReactFlowOverlays({
     <>
       {screenshotOverlay}
       {nodes.length === 0 ? <CanvasEmptyState activeCategoryId={activeCategoryId} onCreate={onCreateEmpty} /> : null}
-      {contextNodeMenu?.nodeId ? (
+      {contextNodeMenu && contextNodeMenu.target !== 'blank' ? (
         <NodeContextMenu
           className="generation-canvas-react-flow__node-context-menu generation-canvas-v2__node-context-menu z-[20]"
           style={{ left: contextNodeMenu.stageX, top: contextNodeMenu.stageY }}

--- a/tests/ux/canvas-marquee-group.walk.mjs
+++ b/tests/ux/canvas-marquee-group.walk.mjs
@@ -1,0 +1,273 @@
+// 框选 →（在框选罩子上）右键 → 建组：一条真实用户任务的端到端走查。
+//
+// 它证的是什么（2026-09-06 真机取证，取证截图见 tests/ux/shots/group-frame-now/00b2、00b3）：
+// shift 拖框选 ≥2 个节点后，React Flow 会在整片选中节点之上铺一层 `nodesselection-rect`。
+// 用户此刻要建组，最自然的动作就是在这片刚框好的东西上右键——而修复前那一下会落在罩子上，
+// 右键判定取不到 data-node-id，于是被「不是节点 = 空白」吞掉：**选择当场清空、弹出的是
+// 「添加节点」菜单**，「建组」这条路凭空消失（实测 nodeMenu 0 / addMenu 1 / selectionToolbar 0）。
+//
+// 断言的排法（阳性对照在前，避免空洞通过）：
+//   ① 真空白右键 → 证明「添加节点」菜单这个探针**确实抓得到东西**（proveProbe）；
+//   ② 框选后先证「罩子真的在、且真的盖在节点中心上」——不证这条，后面整段就不在它自称的现场；
+//   ③ 在罩子上右键 → 节点菜单出现、添加菜单 expectAbsent(provenBy ①)、选择条仍是「已选 3」、
+//      「建组」可点 → 点它 → 组框出现。
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { launchNomiApp } from './_launchApp.mjs'
+import {
+  clickOrFail,
+  expectAbsent,
+  expectCount,
+  expectVisible,
+  proveProbe,
+  screenshotSettled,
+  scopedText,
+  expect,
+} from './_assert.mjs'
+import { findCanvasBlankPoint, CANVAS_STAGE_SELECTOR } from './_canvasHit.mjs'
+import { addCanvasNodeFromRail } from './_canvasRail.mjs'
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
+const shotsDir = path.join(repoRoot, 'tests/ux/shots/canvas-marquee-group')
+fs.rmSync(shotsDir, { recursive: true, force: true })
+fs.mkdirSync(shotsDir, { recursive: true })
+const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'nomi-marquee-group-'))
+const userDataDir = path.join(tempRoot, 'user-data')
+const projectsDir = path.join(tempRoot, 'projects')
+fs.mkdirSync(userDataDir, { recursive: true })
+fs.mkdirSync(projectsDir, { recursive: true })
+
+const NODE_MENU = '.generation-canvas-v2__node-context-menu'
+const ADD_MENU = '.generation-canvas-v2__context-node-menu'
+const SELECTION_TOOLBAR = '.generation-canvas-v2__selection-toolbar'
+const SELECTION_OVERLAY = '.react-flow__nodesselection-rect'
+const GROUP_BOX = '.generation-canvas-v2__group-box'
+const NODE_COUNT = 3
+
+const log = (...args) => console.log('  ', ...args)
+
+const { app, win: initialWin } = await launchNomiApp({
+  name: 'canvas-marquee-group',
+  userDataDir,
+  settingsDir: userDataDir,
+  projectsDir,
+  args: ['--no-proxy-server'],
+  settleMs: 0,
+})
+let win = initialWin
+const getWin = () => {
+  const live = app.windows().filter((candidate) => !candidate.isClosed())
+  win = live.find((candidate) => /projectId=/.test(candidate.url())) || live[live.length - 1] || win
+  return win
+}
+
+async function snap(name) {
+  await screenshotSettled(getWin(), { path: path.join(shotsDir, `${name}.png`) })
+  log(`· 截图 ${name}.png`)
+}
+
+async function dismissFirstRun() {
+  for (let i = 0; i < 6; i += 1) {
+    const skip = getWin().locator('button, [role="button"], a', { hasText: /跳过|完成|知道了|开始创作|稍后/ }).first()
+    if (await skip.isVisible().catch(() => false)) await skip.click({ timeout: 900 }).catch(() => {})
+    await getWin().keyboard.press('Escape').catch(() => {})
+    await getWin().waitForTimeout(180)
+  }
+}
+
+/** 右键一下并等菜单安定。走查里所有右键都走它——手写三段 mouse 调用会各自漂。 */
+async function rightClickAt(point) {
+  await getWin().mouse.move(point.x, point.y)
+  await getWin().mouse.down({ button: 'right' })
+  await getWin().waitForTimeout(120)
+  await getWin().mouse.up({ button: 'right' })
+}
+
+async function closeMenus() {
+  await getWin().keyboard.press('Escape')
+  await expectCount(getWin().locator(`${NODE_MENU}, ${ADD_MENU}`), 0, 'Escape 之后菜单应当收起')
+}
+
+async function clearSelection() {
+  await closeMenus()
+  const blank = await findCanvasBlankPoint(getWin(), { preference: 'bottom' })
+  if (!blank) throw new Error('这一屏找不到画布空白点：后面「点空白清选择」这一步无从执行')
+  await getWin().mouse.click(blank.x, blank.y)
+  await expectCount(getWin().locator(SELECTION_TOOLBAR), 0, '点了空白，选择浮条应当消失')
+}
+
+/** stage 内边距：留出足够余量，让框选矩形的起点还能落在节点外的 pane 上。 */
+const FIT_MARGIN = 56
+
+async function readNodeFit() {
+  return getWin().evaluate(({ stageSelector, margin }) => {
+    const stage = document.querySelector(stageSelector)?.getBoundingClientRect()
+    const nodes = Array.from(document.querySelectorAll('.generation-canvas-v2-node')).map((el) => el.getBoundingClientRect())
+    if (!stage || nodes.length === 0) return null
+    const union = nodes.reduce((acc, r) => ({
+      x1: Math.min(acc.x1, r.x), y1: Math.min(acc.y1, r.y),
+      x2: Math.max(acc.x2, r.right), y2: Math.max(acc.y2, r.bottom),
+    }), { x1: Infinity, y1: Infinity, x2: -Infinity, y2: -Infinity })
+    return {
+      fits: union.x1 >= stage.left + margin && union.y1 >= stage.top + margin
+        && union.x2 <= stage.right - margin && union.y2 <= stage.bottom - margin,
+      union,
+      stage: { x: stage.x, y: stage.y, w: stage.width, h: stage.height },
+    }
+  }, { stageSelector: CANVAS_STAGE_SELECTOR, margin: FIT_MARGIN })
+}
+
+async function zoomOutUntilNodesFit() {
+  for (let step = 0; step < 10; step += 1) {
+    const fit = await readNodeFit()
+    if (fit?.fits) {
+      log(`· 节点已全部收进视口（第 ${step} 次缩放后）`)
+      return fit
+    }
+    const blank = await findCanvasBlankPoint(getWin(), { preference: 'default' })
+    const at = blank ?? { x: fit.stage.x + fit.stage.w / 2, y: fit.stage.y + fit.stage.h / 2 }
+    await getWin().mouse.move(at.x, at.y)
+    await getWin().mouse.wheel(0, 240)
+    await getWin().waitForTimeout(220)
+  }
+  const fit = await readNodeFit()
+  expect(
+    fit?.fits,
+    `缩了 10 次仍装不下全部节点（union=${JSON.stringify(fit?.union)} stage=${JSON.stringify(fit?.stage)}）：`
+      + '框选选不全，这趟走查证不了任何事，必须报红而不是继续。',
+  ).toBe(true)
+  return fit
+}
+
+try {
+  await getWin().waitForLoadState('domcontentloaded')
+  await dismissFirstRun()
+  await clickOrFail(getWin().locator('button, [role="button"]', { hasText: '新建空白项目' }), '新建空白项目')
+  await dismissFirstRun()
+  await clickOrFail(getWin().getByRole('button', { name: '生成', exact: true }), '生成（进画布）')
+  await expectVisible(getWin().locator('.generation-canvas-v2-toolbar').first(), '画布工具条应当出现')
+
+  // ── 布置现场：3 个节点，足够框选、也足够让「建组」可用（阈值是 ≥2）──
+  // 左缘工具条只走共享点法（_canvasRail.mjs）：常驻位与「更多」里的种类由它自己分辨，找不到就抛。
+  for (const kind of ['text', 'image', 'image']) {
+    await addCanvasNodeFromRail(getWin(), kind)
+  }
+  await expectCount(getWin().locator('.generation-canvas-v2-node'), NODE_COUNT, `画布上应当有 ${NODE_COUNT} 个节点`)
+  await clickOrFail(getWin().locator('[aria-label="适应视图"]'), '适应视图')
+  await clearSelection()
+  // 「适应视图」不放大到 1 以上，三张卡在默认缩放下装不进视口；装不下 = React Flow 的框选
+  // （SelectionMode.Full）永远选不全，那一步会以「框选没框住」的形式报红，把人引向错误的方向。
+  // 所以先用真实的滚轮缩放把它们收进来，收不进来就 fail-closed。
+  await zoomOutUntilNodesFit()
+  await snap('00-nodes-ready')
+
+  // ── ① 阳性对照：真空白右键**确实**会弹「添加节点」菜单 ──
+  // 没有这一步，后面「罩子上右键没弹添加菜单」就和「探针根本没生效」在观测上完全一样。
+  const blankPoint = await findCanvasBlankPoint(getWin(), { preference: 'bottom' })
+  if (!blankPoint) throw new Error('找不到画布空白点，阳性对照无从建立')
+  await rightClickAt(blankPoint)
+  const addMenuProof = await proveProbe(getWin().locator(ADD_MENU), '真空白右键会弹「添加节点」菜单')
+  await snap('01-blank-right-click-add-menu')
+  await closeMenus()
+
+  // ── ② 框选：shift + 在 pane 上拉一个罩住全部节点的矩形 ──
+  const stage = await getWin().evaluate((selector) => {
+    const rect = document.querySelector(selector).getBoundingClientRect()
+    return { x: rect.x, y: rect.y, w: rect.width, h: rect.height }
+  }, CANVAS_STAGE_SELECTOR)
+  const nodeBoxes = await getWin().evaluate(() => Array.from(document.querySelectorAll('.generation-canvas-v2-node')).map((el) => {
+    const rect = el.getBoundingClientRect()
+    return { id: el.getAttribute('data-node-id'), x: rect.x, y: rect.y, w: rect.width, h: rect.height }
+  }))
+  const union = nodeBoxes.reduce((acc, box) => ({
+    x1: Math.min(acc.x1, box.x), y1: Math.min(acc.y1, box.y),
+    x2: Math.max(acc.x2, box.x + box.w), y2: Math.max(acc.y2, box.y + box.h),
+  }), { x1: Infinity, y1: Infinity, x2: -Infinity, y2: -Infinity })
+  const start = { x: Math.max(stage.x + 6, union.x1 - 36), y: Math.max(stage.y + 6, union.y1 - 36) }
+  const end = { x: Math.min(stage.x + stage.w - 6, union.x2 + 36), y: Math.min(stage.y + stage.h - 6, union.y2 + 36) }
+  const startIsBlank = await getWin().evaluate(
+    ({ point, paneSelector }) => document.elementFromPoint(point.x, point.y)?.matches(paneSelector) ?? false,
+    { point: start, paneSelector: '.react-flow__pane' },
+  )
+  expect(startIsBlank, `框选起点 ${JSON.stringify(start)} 不在画布 pane 上：这一拖不会是框选，整趟走查失去意义`).toBe(true)
+  await getWin().keyboard.down('Shift')
+  await getWin().mouse.move(start.x, start.y)
+  await getWin().mouse.down()
+  await getWin().mouse.move((start.x + end.x) / 2, (start.y + end.y) / 2, { steps: 10 })
+  await getWin().mouse.move(end.x, end.y, { steps: 10 })
+  await getWin().mouse.up()
+  await getWin().keyboard.up('Shift')
+
+  const toolbar = getWin().locator(SELECTION_TOOLBAR).first()
+  await expectVisible(toolbar, '框选之后应当出现选择浮条')
+  const selectedText = await scopedText(toolbar)
+  expect(selectedText, `框选没把 ${NODE_COUNT} 个节点都框住（浮条：${selectedText}）`).toContain(`已选 ${NODE_COUNT} 个`)
+
+  // ── ③ 证明「我确实站在报告里那个现场」：罩子在，而且它就压在节点中心上 ──
+  // 这一条不成立的话，后面的右键根本没落在罩子上，绿灯只是绕过了被测物（而不是修好了它）。
+  await expectVisible(getWin().locator(SELECTION_OVERLAY).first(), '框选完成后 React Flow 应当铺出选中集罩子')
+  const overlayHit = await getWin().evaluate(() => {
+    const node = document.querySelector('.generation-canvas-v2-node')
+    if (!node) return null
+    const rect = node.getBoundingClientRect()
+    const point = { x: rect.x + rect.width / 2, y: rect.y + rect.height / 2 }
+    const top = document.elementFromPoint(point.x, point.y)
+    return {
+      point,
+      onOverlay: Boolean(top?.closest('.react-flow__nodesselection, .react-flow__nodesselection-rect')),
+      onNode: Boolean(top?.closest('.generation-canvas-v2-node')),
+    }
+  })
+  expect(overlayHit, '取不到节点中心点：现场不成立').not.toBe(null)
+  expect(
+    overlayHit.onOverlay && !overlayHit.onNode,
+    `节点中心的最顶层元素不是选中集罩子（onOverlay=${overlayHit?.onOverlay} onNode=${overlayHit?.onNode}）：`
+      + '这一版 React Flow 没铺罩子，或罩子换了类名——那么这趟走查证不了报告里的那个 bug，必须报红。',
+  ).toBe(true)
+  await snap('02-marquee-selection-overlay')
+
+  // ── ④ 在罩子上右键：这就是修复前断掉的那一下 ──
+  await rightClickAt(overlayHit.point)
+  await expectVisible(
+    getWin().locator(NODE_MENU).first(),
+    '在框选罩子上右键应当弹「节点操作」菜单——修复前这里弹的是「添加节点」菜单',
+  )
+  await expectAbsent(getWin().locator(ADD_MENU), {
+    provenBy: addMenuProof,
+    message: '在框选罩子上右键不该被当成「点空白」而弹出「添加节点」菜单',
+  })
+  await expectVisible(toolbar, '右键不该清掉刚框好的选择——浮条必须还在')
+  const toolbarAfterRightClick = await scopedText(toolbar)
+  expect(
+    toolbarAfterRightClick,
+    `右键之后选择被改动了（浮条：${toolbarAfterRightClick}）：修复前这里会被 clearSelection() 清空`,
+  ).toContain(`已选 ${NODE_COUNT} 个`)
+  const groupItem = getWin().locator(`${NODE_MENU} [role="menuitem"]`).filter({ hasText: '建组' }).first()
+  await expectVisible(groupItem, '菜单里应当有「建组」')
+  expect(
+    await groupItem.isDisabled(),
+    '「建组」被置灰：选中数应当还是 3（置灰意味着右键把多选打断成了单选或清空）',
+  ).toBe(false)
+  await snap('03-node-menu-on-selection-overlay')
+
+  // ── ⑤ 真的把组建出来：用户任务闭环 ──
+  await clickOrFail(groupItem, '建组')
+  await expectVisible(getWin().locator(GROUP_BOX).first(), '点了「建组」之后画布上应当出现组框')
+  const groupLabel = getWin().locator('.generation-canvas-v2__group-box-label').first()
+  await expectVisible(groupLabel, '组框应当带头部胶囊（组名 + 计数）')
+  const labelText = await scopedText(groupLabel)
+  expect(labelText, `组头计数不是 ${NODE_COUNT}（读到「${labelText}」）：建出来的组没把框选的三个都收进去`).toContain(String(NODE_COUNT))
+  await clearSelection()
+  await snap('04-grouped')
+
+  log('✅ 框选 → 罩子上右键 → 建组 全程通过')
+} catch (error) {
+  console.error('❌ 走查中断:', error?.message || error)
+  try { await snap('zz-error-state') } catch {}
+  await app.close()
+  process.exit(1)
+}
+await app.close()
+console.log('✅ canvas-marquee-group 走查完成 →', shotsDir)


### PR DESCRIPTION
## 现象（真机实测）

shift 拖框选 ≥2 个节点后，React Flow 会在整片选中节点之上铺一层 `react-flow__nodesselection-rect`。用户此刻要建组，最自然的动作就是**在这片刚框好的东西上右键**——而那一下会：

- 选择被当场清空
- 弹出的是「添加节点」菜单，不是节点操作菜单
- 「建组」这条路凭空消失

实测值：`selectionRects: 1`、右键后 `nodeMenu: 0 / addMenu: 1 / selectionToolbar: 0`（取证见 `tests/ux/shots/group-frame-now/00b2`、`00b3`、`facts.json`）。shift **逐个点选**没有这层罩子，右键正常——所以这个坑只在最常用的那条路上。

## 根因（不是少写一个选择器）

`useCanvasContextNodeMenu.prepareContextMenuPointerDown` 用 `target.closest('.generation-canvas-v2-node')` 取 nodeId，取不到就按空白处理（`clearSelection()` + 添加菜单）。

**类根因是「空白」被反向定义了**：命中节点才算节点，其余一律空白。可画布上还有第三类落点——**代表当前选中集的覆盖层**——反向定义把它整类吞进空白。这不是一次性失误：React Flow 升级换个类名、或本仓新增一层选中集装饰，同一族会原样复发，所以判为 `recurring` 并落了 schema-v3 合同。

## 改法

落点判定收进模型层一张**正向三分表**（`canvasPointerGestureModel.resolveCanvasContextMenuTarget`）：

| 落点 | 菜单 | 选择 |
|---|---|---|
| `node` | 节点操作菜单 | 确保该节点在选中集里（不打断已有多选） |
| `selection`（选中集罩子） | 节点操作菜单 | **原样不动** |
| `blank` | 添加节点菜单 | 清空 |

- 「哪些图层代表当前选中集」只登记一处（`CANVAS_SELECTION_OVERLAY_SELECTOR`）
- `clearSelection()` 写死在 `blank` 这一支
- 渲染层改看 `target`，`nodeId` 不再兼任「是不是节点菜单」的替身判据（旧写法同 commit 删除，无并行版）

画布主文件贴着 800 行上限，改动全落在对应 hook / 模型文件里，主文件未动。

## 同类入口实扫

| 入口 | 结论 |
|---|---|
| 平移 / 框选 `handleCanvasPointerDownCapture` | 不受影响：空白判据是正向的 `.react-flow__pane`，罩子本就不算 pane；左键落在罩子上由 React Flow 的 NodesSelection 接管（拖整批），语义正确 |
| 连线 `resolveCanvasDropTargetFromDom` | 不受影响：按几何包含解析落点，不做顶层命中；连线**起点**只能从节点 handle 发起，罩子上没有 handle |
| 双击 | 不受影响：画布上不存在「双击空白建节点」这条路 |
| `onPaneClick` | 不受影响：React Flow 只在 pane 本身被点时派发 |
| 组框（`[data-group-id]`）右键 | **仍弹添加菜单，本次不改**。它不是「当前选中集的罩子」——右键它时组成员未必处于选中态，并进来会让菜单作用在陈旧选择上。组的右键菜单本身是尚未设计的能力（画布上组没有右键菜单、没有改名、没有颜色），需样张 + 拍板后单独交付。已写进合同 `residual_risks` |

## 验证

- **单测**：真值表（罩子永远不能被判成 blank）+ 选择器交叉断言（画布 CSS 是同一类名的第二真相源，React Flow 换名会一起报红）
- **结构测试**：钉住三分表路由、`clearSelection` 只在 blank 支、旧写法不复活
- **新走查** `tests/ux/canvas-marquee-group.walk.mjs`：框选 → 罩子上右键 → 建组，含
  - 阳性对照：先在真空白右键证明「添加节点」菜单探针是活的（`proveProbe` → `expectAbsent`）
  - 现场证明：节点中心的最顶层元素必须是罩子，否则报红（不证这条，整段就不在它自称的现场）
  - 断言选择没被动过（浮条仍是「已选 3 个」）、「建组」未置灰、点完真的出组框且计数 = 3
  - **改前跑红**（节点菜单不出现）、**改后跑绿**，真机截图已人眼过
- `pnpm run gates` 全绿；`check:root-cause-contracts` 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)