### PR TITLE
fix(creation): 分镜页找回创作资源树 + 老项目分镜不再被读侧剥掉

### DIFF
--- a/docs/fixes/2026-09-06-creation-resource-tree-unreachable.root-cause.json
+++ b/docs/fixes/2026-09-06-creation-resource-tree-unreachable.root-cause.json
@@ -1,0 +1,134 @@
+{
+  "schema_version": 3,
+  "id": "2026-09-06-creation-resource-tree-unreachable",
+  "problem_type": "a cross-surface resource tree is owned by one of the surfaces that consume it",
+  "symptom": "After opening a storyboard plan from the creation sidebar, the user could no longer reach any of their other scripts or storyboard plans: the storyboard page rendered the single opened plan full width with no resource tree at all. User report 2026-09-06: 'we used to have both scripts and storyboards clickable on the left; now there is only this one plan and I cannot click through to the others'.",
+  "direct_cause": "805096d41 added setWorkspaceMode('storyboard') to DocumentListSidebar.selectStoryboard in the same commit that deleted StoryboardPlanCard, the in-creation landing spot that had previously kept the click inside the creation surface. The destination, StoryboardWorkspace, is a separate WorkspaceSlot that deliberately renders no document sidebar (1e21bd9cc), so the tree that used to survive the click no longer existed at the destination.",
+  "class_root": "The creation resource tree lists documents and their storyboard plans, which are edited across two workspaces (creation writes the script, storyboard edits the shot table), but the tree was mounted by only one of them. Any navigation that lands in the other workspace therefore strands the user, no matter which entry point performed it.",
+  "affected_population": [
+    "Every user with more than one script, or more than one storyboard plan on a script",
+    "Every entry point that can put the workbench into storyboard mode: the sidebar plan rows, the top stepper, the ?step=storyboard URL restore, and StoryboardWorkspace's own auto-select effect",
+    "Legacy single-document projects, whose one migrated plan became the only reachable resource"
+  ],
+  "scope_paths": [
+    "src/workbench/creation/creationResourceTreeModes.ts",
+    "src/workbench/WorkbenchShell.tsx",
+    "src/workbench/creation/CreationWorkspace.tsx",
+    "src/workbench/creation/DocumentListSidebar.tsx",
+    "src/workbench/creation/storyboard/StoryboardWorkspace.tsx"
+  ],
+  "entry_points": [
+    "Creation sidebar storyboard plan row",
+    "Creation sidebar document row",
+    "Top stepper workspace switch",
+    "Workspace mode restored from the URL step parameter",
+    "StoryboardWorkspace auto-select of the first plan"
+  ],
+  "external_sources": [],
+  "internal_only_reason": "Workspace mounting and the creation resource tree are internal Nomi layout contracts; no third-party documentation decides them.",
+  "invariants": [
+    "While the workbench is on a surface that edits a document or one of its storyboard plans, the creation resource tree is mounted and lists every document and every plan.",
+    "The set of workspace modes that carry the tree has exactly one owner, CREATION_RESOURCE_TREE_MODES; neither workspace decides for itself.",
+    "The tree has exactly one mount point, WorkbenchShell. A workspace that renders its own copy would let the two drift apart again.",
+    "Picking a document row returns to the script surface: it clears the active storyboard and switches the mode back to creation. Clearing the id alone is not enough, because StoryboardWorkspace's 'no active plan, select the first one' effect would immediately throw the user back into a plan.",
+    "The v6 storyboard table itself is untouched: the fix adds the left rail beside it and changes no row anatomy, control, or spacing inside the table."
+  ],
+  "generality_proof": "Mounting is decided in WorkbenchShell, the single component that already owns which workspace is visible, and is keyed off the workspace mode rather than off any particular navigation action. Every listed entry point ultimately sets that mode, so a future entry point that switches into storyboard mode inherits the tree without its author having to remember; there is no per-caller conditional left to forget.",
+  "shared_boundaries": [
+    {
+      "path": "src/workbench/creation/creationResourceTreeModes.ts",
+      "symbol": "CREATION_RESOURCE_TREE_MODES and workspaceModeCarriesCreationResourceTree",
+      "responsibility": "Own the single answer to 'which workspaces carry the creation resource tree', so the two surfaces that share the tree cannot disagree."
+    },
+    {
+      "path": "src/workbench/WorkbenchShell.tsx",
+      "symbol": "WorkbenchShell main region",
+      "responsibility": "Own the tree's only mount point, mounting it for exactly the modes the constant names, next to the existing ProjectExplorerSidebar mount for generation mode."
+    },
+    {
+      "path": "src/workbench/creation/DocumentListSidebar.tsx",
+      "symbol": "selectDocument",
+      "responsibility": "Own the 'back to the script' transition as one atomic act: clear the active storyboard and return the workspace to creation mode."
+    }
+  ],
+  "same_class_entry_points": [
+    {
+      "path": "src/workbench/creation/DocumentListSidebar.tsx",
+      "entry_point": "selectStoryboard",
+      "disposition": "enforced",
+      "evidence": "The reported entry. It still switches to storyboard mode, but the destination now carries the tree because WorkbenchShell mounts it for that mode; tests/ux/creation-sidebar-multi-doc.walk.mjs clicks it and then asserts all 2 documents and all 4 plans remain reachable, and switches to a plan under the other document from inside the storyboard page."
+    },
+    {
+      "path": "src/workbench/WorkbenchShell.tsx",
+      "entry_point": "handleWorkspaceModeChange and the ?step=storyboard URL restore",
+      "disposition": "enforced",
+      "evidence": "Both funnel through the same workspaceMode state that the new mount condition reads, so entering storyboard mode from the top stepper or from a restored URL cannot produce a treeless storyboard page either."
+    },
+    {
+      "path": "src/workbench/creation/storyboard/StoryboardWorkspace.tsx",
+      "entry_point": "auto-select of the first design when storyboard mode has no active plan",
+      "disposition": "enforced",
+      "evidence": "This effect can enter a plan without any user click. It is covered by the same mount condition; the workspace no longer renders or suppresses the tree itself, and the file is asserted not to reference DocumentListSidebar."
+    },
+    {
+      "path": "src/workbench/generationCanvas/agent/applyCanvasToolCall.ts",
+      "entry_point": "agent tool call that switches to creation mode",
+      "disposition": "not-affected",
+      "evidence": "It only ever sets creation mode, which already carried the tree before and after this change; it cannot produce the stranded state."
+    },
+    {
+      "path": "src/workbench/explorer/ProjectExplorerSidebar.tsx",
+      "entry_point": "generation-mode project file tree",
+      "disposition": "not-affected",
+      "evidence": "A different tree for a different resource population (canvas assets), already mounted at the shell for generation mode only; the creation tree deliberately does not appear there."
+    }
+  ],
+  "recurrence": {
+    "classification": "recurring",
+    "reason": "Four independent entry points can put the workbench into storyboard mode, and more will be added (the design contract already plans agent-driven navigation into a plan). As long as the tree belongs to one workspace, every such entry point is one forgotten line away from stranding the user again; the same class already recurred once when the plan card was deleted.",
+    "same_class_scan": [
+      "grep for setWorkspaceMode('storyboard') across src/ and electron/: the only production caller is DocumentListSidebar.selectStoryboard; mode is otherwise reached through WorkbenchShell.handleWorkspaceModeChange and the URL step parameter.",
+      "grep for DocumentListSidebar across src/ and electron/: before the fix the single importer was CreationWorkspace; after the fix the single importer is WorkbenchShell, asserted by creationResourceTreeModes.test.ts.",
+      "Read WorkbenchShell's WorkspaceSlot block to confirm creation and storyboard are sibling slots under one parent, so a shell-level rail is shared by both rather than duplicated per slot."
+    ]
+  },
+  "prevention": {
+    "kind": "centralized-boundary",
+    "enforcement_path": "src/workbench/WorkbenchShell.tsx",
+    "invariant": "The creation resource tree is mounted once, at the shell, for exactly the workspace modes named by CREATION_RESOURCE_TREE_MODES, and no workspace mounts its own.",
+    "failure_mode": "A workspace mode that is not in the constant simply has no creation tree, which is the intended state for generation and preview; a workspace that tries to render its own copy fails the structural assertion in creationResourceTreeModes.test.ts.",
+    "exception_policy": "none",
+    "strategy": "Move the mount decision up to the only component that already owns which workspace is visible, and key it off workspace mode rather than off navigation actions, so new entry points inherit the tree instead of having to opt in.",
+    "artifacts": [
+      "src/workbench/creation/creationResourceTreeModes.ts",
+      "src/workbench/WorkbenchShell.tsx",
+      "src/workbench/creation/CreationWorkspace.tsx",
+      "src/workbench/creation/DocumentListSidebar.tsx"
+    ]
+  },
+  "regression_tests": [
+    "src/workbench/creation/creationResourceTreeModes.test.ts",
+    "src/workbench/creation/CreationWorkspace.structure.test.ts",
+    "tests/ux/creation-sidebar-multi-doc.walk.mjs"
+  ],
+  "class_regression_tests": [
+    "src/workbench/creation/creationResourceTreeModes.test.ts",
+    "tests/ux/creation-sidebar-multi-doc.walk.mjs"
+  ],
+  "legacy_paths": {
+    "status": "removed",
+    "removed_paths": [
+      "src/workbench/creation/CreationWorkspace.tsx"
+    ],
+    "rationale": "CreationWorkspace's own DocumentListSidebar mount and its 240px sidebar grid column are deleted in the same change, so there is no second home for the tree to drift from. StoryboardWorkspace's stale 'no document sidebar' doc comment is corrected to point at the new owner."
+  },
+  "dependency_lifecycle": {
+    "decision": "not-applicable",
+    "rationale": "Layout ownership inside the renderer; no third-party runtime decides where the tree mounts.",
+    "exit_criteria": []
+  },
+  "migration": "No data migration. The only user-visible change beside the restored reachability is that the rail now sits flush against the left edge of the workbench body, matching how the generation-mode project tree already mounts, instead of being inset inside the creation page's centered grid.",
+  "residual_risks": [
+    "Verified on macOS in a real Electron build at the walkthrough's default window size. Narrow windows below 980px, where the creation grid drops the assistant column, were not exercised on a real device."
+  ]
+}

--- a/docs/fixes/2026-09-06-legacy-storyboard-stripped-before-migration.root-cause.json
+++ b/docs/fixes/2026-09-06-legacy-storyboard-stripped-before-migration.root-cause.json
@@ -1,0 +1,98 @@
+{
+  "schema_version": 3,
+  "id": "2026-09-06-legacy-storyboard-stripped-before-migration",
+  "problem_type": "a compatibility migrator is fed schema-parsed input, so the legacy keys it exists to read are already gone",
+  "symptom": "Opening a pre-multi-design project shows no storyboard plan at all: the creation resource tree lists the script with zero plans, and the storyboard page falls back to its empty state. The plan is still on disk, so the app looks like it silently deleted the user's storyboard. Verified on the real project 'Nomi 宣传片｜09_00 前交片': 12 shots and 5 anchors on disk, 0 designs after the read path.",
+  "direct_cause": "normalizeRecord parsed the raw record with workbenchProjectRecordSchema and then passed legacyParsed.data.payload to normalizePayload. workbenchProjectPayloadSchema is a plain z.object, which strips keys it does not declare, and it does not declare the retired storyboardPlan / storyboardPlans / storyboardPlanCommitted keys. normalizePayload's legacy readers therefore saw a payload with those keys already removed and migrated nothing.",
+  "class_root": "A compatibility migrator only works if it is handed the bytes it is meant to interpret. Routing it through a strict schema first makes it structurally unable to see any key that is legacy by definition, so the migration silently no-ops for exactly the population it was written for.",
+  "affected_population": [
+    "Every project saved before storyboard plans moved to storyboardDesignsByDocumentId, i.e. every project carrying a top-level payload.storyboardPlan, payload.storyboardPlans, or payload.storyboardPlanCommitted",
+    "Confirmed on this machine: 'Nomi 宣传片｜09_00 前交片' (12 shots, 5 anchors) lost its plan on open"
+  ],
+  "scope_paths": [
+    "src/workbench/project/projectNormalize.ts"
+  ],
+  "entry_points": [
+    "readLocalProject",
+    "readLocalProjectAsync",
+    "hydrateProject in projectPersistenceService"
+  ],
+  "external_sources": [],
+  "internal_only_reason": "The project record and payload shapes are internal Nomi persistence contracts; zod's documented object behaviour (strip unknown keys by default) is the only external fact and is already relied on elsewhere in this file.",
+  "invariants": [
+    "normalizePayload receives the raw, unparsed payload so that every legacy key it reads is still present. It re-validates internally, so feeding it raw input relaxes no check.",
+    "A legacy plan that exists on disk is either migrated into storyboardDesignsByDocumentId and attached to a document that actually exists, or the record fails loudly; it is never silently dropped.",
+    "Any future retired payload key follows the same rule: the migrator reads it off the raw record, never off the schema-parsed copy."
+  ],
+  "generality_proof": "normalizeRecord is the only place in the repository that hands normalizePayload a schema-parsed payload, and every disk read (readLocalProject, readLocalProjectAsync, and through them hydrateProject) goes through normalizeRecord. Fixing the input at that one call site restores every retired key for every reader at once, including keys retired in the future, because the fix removes the stripping step rather than re-listing the keys that were being stripped.",
+  "shared_boundaries": [
+    {
+      "path": "src/workbench/project/projectNormalize.ts",
+      "symbol": "normalizeRecord and readRawPayload",
+      "responsibility": "Own what the compatibility migrator is allowed to see: the raw payload off the record, never the schema-parsed copy."
+    }
+  ],
+  "same_class_entry_points": [
+    {
+      "path": "src/workbench/project/projectRepository.ts",
+      "entry_point": "readLocalProject and readLocalProjectAsync",
+      "disposition": "enforced",
+      "evidence": "Both call normalizeRecord for the desktop-bridge branch and the local-storage branch, so both now hand the migrator the raw payload. projectNormalize.test.ts asserts the recovery at the normalizeRecord boundary rather than at normalizePayload, which is where the old tests were all passing vacuously."
+    },
+    {
+      "path": "src/workbench/project/projectBackup.ts",
+      "entry_point": "rememberProjectBackup",
+      "disposition": "not-affected",
+      "evidence": "It safeParses the record only to read parsed.data.revision, and writes the untouched rawRecord to both backup keys, so a legacy plan is preserved byte for byte in backups regardless of this defect."
+    },
+    {
+      "path": "src/workbench/project/projectRepository.ts",
+      "entry_point": "saveLocalProject's existingRevision lookup",
+      "disposition": "not-affected",
+      "evidence": "It safeParses the existing record only to read parsed.data.revision; the parsed copy is never used as a payload source, so nothing is written back from it."
+    }
+  ],
+  "recurrence": {
+    "classification": "recurring",
+    "reason": "Not a one-off: the mechanism fires for every legacy project on every open, on every machine, and the same shape recurs for any key retired in the future, because the payload schema strips unknown keys by construction. It is also destructive rather than merely cosmetic: the in-memory payload no longer carries the plan, so the next autosave writes a payload without it and the plan is permanently erased from disk, violating the never-wipe-user-data rule this repository states in renameLocalProject.",
+    "same_class_scan": [
+      "grep for normalizeRecord across src/ and electron/: defined once in projectNormalize.ts, called only from projectRepository.ts lines 187, 195 and 204.",
+      "grep for workbenchProjectRecordSchema across src/ and electron/: the other two safeParse sites (projectBackup.rememberProjectBackup, projectRepository.saveLocalProject) use only parsed.data.revision and write the raw record, so neither can strip a payload.",
+      "Read workbenchProjectPayloadSchema in projectRecordSchema.ts to confirm it is a plain z.object with no passthrough and no declaration of the retired storyboard keys, which is what makes the strip silent.",
+      "Ran normalizeRecord against the two real legacy projects in ~/Documents/Nomi Projects: 0 designs before the fix, 12 shots and 5 anchors recovered after, attached to a real document id."
+    ]
+  },
+  "prevention": {
+    "kind": "centralized-boundary",
+    "enforcement_path": "src/workbench/project/projectNormalize.ts",
+    "invariant": "normalizeRecord hands normalizePayload the raw payload read off the record, so no key can be stripped before the compatibility migration runs.",
+    "failure_mode": "A record whose raw payload is missing or malformed reaches normalizePayload's own safeParse and takes the existing corrupt-payload path, which throws a localized error instead of opening a project with silently emptied content.",
+    "exception_policy": "none",
+    "strategy": "Remove the stripping step at the single call site that fed the migrator, rather than teaching the strict schema about each retired key one at a time; the latter would have to be repeated for every future retirement and would fail the same way when someone forgets.",
+    "artifacts": [
+      "src/workbench/project/projectNormalize.ts"
+    ]
+  },
+  "regression_tests": [
+    "src/workbench/project/projectNormalize.test.ts",
+    "tests/ux/creation-sidebar-multi-doc.walk.mjs"
+  ],
+  "class_regression_tests": [
+    "src/workbench/project/projectNormalize.test.ts"
+  ],
+  "legacy_paths": {
+    "status": "not-applicable",
+    "removed_paths": [],
+    "rationale": "The legacy readers in normalizePayload are the migration itself and must stay until no project on disk carries the retired keys; nothing here becomes obsolete, the migration merely starts being reachable. The old tests that exercised normalizePayload directly are kept, with the new tests added at the normalizeRecord boundary that production actually uses."
+  },
+  "dependency_lifecycle": {
+    "decision": "not-applicable",
+    "rationale": "zod's strip-by-default object behaviour is depended on deliberately elsewhere in this schema; no version change is involved or wanted.",
+    "exit_criteria": []
+  },
+  "migration": "No new migration step. Legacy plans were never removed from the project files themselves, so opening an affected project on a build carrying this fix restores its storyboard on the spot. Projects that were opened and autosaved on an affected build lost the plan from disk at that moment and can only be recovered from the per-revision backups written by rememberProjectBackup, which store the untouched raw record.",
+  "residual_risks": [
+    "Projects already autosaved by an affected build cannot be repaired by this change; recovery depends on a retained revision backup, which was not exercised here.",
+    "The end-to-end walkthrough covers the legacy payload shape through a fixture project. The two real legacy projects were verified at the normalizeRecord boundary rather than end to end, because neither would open in an isolated profile: the workbench reports project_agent_unavailable during hydration when no agent model is configured, which is unrelated to this fix but blocked the real-data UI leg."
+  ]
+}

--- a/docs/lessons/INDEX.md
+++ b/docs/lessons/INDEX.md
@@ -70,6 +70,7 @@
 - [harness 的 catch 会把自己的 bug 洗成产品结论](harness-catch-launders-bugs-into-verdicts.md) — 报某腿失败前先分清是断言红的还是 catch 编的
 - [A/B 两版提示词：确认关卡会污染两臂](prompt-ab-gating-question-confounds-arms.md) — 量到的是服从度不是质量
 - [探针测不到它命名的那件事，断言就永远绿](vacuous-probe-passes-forever.md) — 按路径过滤 fs 读 spy 恒空；四个会话判成「负载 flake」的那条其实恒真。变异测试是唯一判据，「永不发生」必配阳性对照
+- [迁移器被直接调用测了个遍，生产上却没人这么调它](migrator-tested-directly-is-never-tested.md) — 上一条的兼容层版本：`z.object` 默认剥未声明键，夹在原始数据和兼容读取之间就让迁移恒 no-op；老项目分镜因此打开即消失、下次自动保存永久抹掉
 - [硬链接复制 profile 会和运行中的 app 抢同一把 leveldb 锁](profile-copy-hardlink-shares-leveldb-lock.md) — 测启动性能前必读：`cp -Rl` 让副本共享 `Local Storage/leveldb/LOCK` 的 inode，凭空多出稳定可复现的 3.5s，伪装成"首屏渲染慢"；测前验 `lsof` 与两侧 inode；附冷/热文件缓存 10x 差异
 - [门岗断言不许手抄真相源的派生值，且必须与真相源同触发面](gate-assertions-must-not-copy-derived-values.md) — 看到 `>= N` 先问「N 是抄谁的」；决定落后与否的是触发面不是细心；死名字既造假红也造假绿
 - [有界性/复杂度不变量要用「计数」证，别用墙钟跑量](complexity-invariants-need-counters-not-wall-clock.md) — ✅ 已由 `check:test-waits` 第三条规则接管；留下的是门岗抓不到的那半：`fs.readFileSync(fd)` 让按路径过滤的 spy 断言恒真（实测 597 次重扫仍报 0）

--- a/docs/lessons/migrator-tested-directly-is-never-tested.md
+++ b/docs/lessons/migrator-tested-directly-is-never-tested.md
@@ -1,0 +1,30 @@
+# 迁移器被直接调用测了个遍，生产上却没人这么调它
+
+> 📎 教训 · 首次记录 2026-09-06 · 状态：现行
+> **触发场景**：写/审「老数据兼容」「schema 迁移」「向后兼容投影」的测试时；或用户报「老项目的 X 不见了」而迁移代码看起来完全正确时。
+
+**结论**：兼容迁移的测试必须挂在**生产真正的入口**上（读盘那一层），不能挂在迁移函数本身。迁移器读的是「schema 不认识的老键」——只要生产路径在它之前插了一道 `z.object` 解析，那些键早就被剥光了，而直接喂迁移器的测试永远看不到这件事，全绿到天荒地老。
+
+**为什么会踩**：`src/workbench/project/projectNormalize.ts` 的 `normalizePayload` 负责把老项目的 `payload.storyboardPlan` 迁成 `storyboardDesignsByDocumentId`。它写得没问题，`projectNormalize.test.ts` 里 6 条用例逐个覆盖了单 plan / plans map / 优先级 / 空态，**全绿**。
+
+但生产上没有任何调用者直接调它。读盘走的是 `normalizeRecord`：
+
+```ts
+const legacyParsed = workbenchProjectRecordSchema.safeParse(raw)
+if (legacyParsed.success) {
+  return { ...legacyParsed.data, payload: normalizePayload(legacyParsed.data.payload) }
+  //                                                      ^^^^^^^^^^^^^^^^^^^^^^^^^
+}
+```
+
+`workbenchProjectPayloadSchema` 是普通 `z.object`（**默认剥掉未声明的键**），而它当然不会声明已经退役的 `storyboardPlan`。于是迁移器拿到的 payload 里那个键根本不存在，迁移恒定 no-op。
+
+后果不只是「看不见」：内存里的 payload 从此不带 plan，**下一次自动保存就把它从盘上永久抹掉**——本仓 `renameLocalProject` 的注释里早就写过这条 never-wipe-user-data 铁律，只是这条路径绕开了它。实测真实项目「Nomi 宣传片｜09_00 前交片」：盘上 12 镜 5 锚，过 `normalizeRecord` 后 0 个方案。
+
+**怎么用**：
+- 写兼容迁移的测试前先 `grep` 迁移函数名，**看生产上谁在调它**。测试的入参必须和那个调用者的入参同源；两者不同源时，测试断言写在调用者那一层。
+- 判断「迁移有没有生效」用真实老项目文件跑一遍读侧函数，别用手搓 fixture——手搓的 fixture 会不自觉地补全成新形状（本次真实老项目的镜头连 `shotId` / `sceneId` 都没有，plan 只有 `title/anchors/shots` 三个键）。
+- 改完做变异验证：把修复回退成原样重跑，新用例必须变红。本次两条老键用例回退后确实红，第三条（新形状不受影响）两边都绿——那是护栏不是信号，别拿它当证据。
+- 看到 `z.object(...)` 夹在「原始数据」和「兼容读取」之间就警觉：`.passthrough()` 或直接喂原始值，二选一。
+
+**出处**：PR「fix(creation): 分镜方案与原稿在分镜页可达 + 老项目分镜不再被读侧剥掉」；合同 `docs/fixes/2026-09-06-legacy-storyboard-stripped-before-migration.root-cause.json`；同族教训见 [`vacuous-probe-passes-forever.md`](vacuous-probe-passes-forever.md)。

--- a/src/workbench/WorkbenchShell.tsx
+++ b/src/workbench/WorkbenchShell.tsx
@@ -12,6 +12,8 @@ import {
 } from "./workbenchStore";
 import { cn } from "../utils/cn";
 import ProjectExplorerSidebar from "./explorer/ProjectExplorerSidebar";
+import DocumentListSidebar from "./creation/DocumentListSidebar";
+import { workspaceModeCarriesCreationResourceTree } from "./creation/creationResourceTreeModes";
 import { lazyWithChunkBoundary } from "../ui/chunkBoundary";
 import { WindowControls } from "../ui/app-shell/WindowControls";
 import { handleWindowTitlebarDoubleClick } from "../ui/app-shell/windowTitlebarDoubleClick";
@@ -28,7 +30,7 @@ const CreationWorkspace = lazyWithChunkBoundary(
     () => import("./creation/CreationWorkspace"),
 );
 // 分镜独立工作区（v5 C3）：storyboard 模式不再共用 CreationWorkspace，
-// 单独懒挂载全宽 StoryboardWorkspace（无文档侧栏、无 AI 栏）。
+// 单独懒挂载全宽 StoryboardWorkspace（表本身全宽；创作资源树由本 shell 统一挂，见下）。
 const StoryboardWorkspace = lazyWithChunkBoundary(
     "i18n:workspace.storyboard",
     () => import("./creation/storyboard/StoryboardWorkspace"),
@@ -331,6 +333,10 @@ export default function WorkbenchShell({
                 {workspaceMode === "generation" ? (
                     <ProjectExplorerSidebar projectId={projectId ?? null} categories={categories} />
                 ) : null}
+                {/* 创作资源树（原稿 + 各自的分镜方案）：写剧本和编分镜表是同一批资源的两个视图，
+                    所以树归 shell 所有、跨这两个模式常驻——挂在任一工作区里都会让另一个工作区
+                    没有树（2026-09-06 回归：点开一个方案就再也点不到别的剧本/分镜）。 */}
+                {workspaceModeCarriesCreationResourceTree(workspaceMode) ? <DocumentListSidebar /> : null}
                 <div className='flex-1 min-w-0 min-h-0 relative'>
                     {mountedWorkspaceModes.includes("creation") ? (
                         <WorkspaceSlot

--- a/src/workbench/creation/CreationWorkspace.structure.test.ts
+++ b/src/workbench/creation/CreationWorkspace.structure.test.ts
@@ -12,5 +12,7 @@ describe('Creation workspace script entry', () => {
     expect(source).not.toContain('StoryboardPlanCard')
     expect(source).toContain('data-creation-surface="source"')
     expect(source).not.toContain('setWorkspaceMode(\'storyboard\')')
+    // 资源树归 WorkbenchShell（跨 creation/storyboard 常驻），创作区不再自带一棵。
+    expect(source).not.toContain('DocumentListSidebar')
   })
 })

--- a/src/workbench/creation/CreationWorkspace.tsx
+++ b/src/workbench/creation/CreationWorkspace.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 import { useTranslation } from 'react-i18next'
 import { cn } from '../../utils/cn'
 import WorkbenchEditor from './WorkbenchEditor'
-import DocumentListSidebar from './DocumentListSidebar'
 
 type CreationWorkspaceProps = {
   aiCollapsed?: boolean
@@ -14,6 +13,8 @@ export default function CreationWorkspace({ aiCollapsed = false, agentDockRef }:
   // Creation is the source of truth for the script. A blank structural
   // storyboard starter must never redirect a fresh user away from the editor;
   // storyboard mode is entered only by an explicit "open storyboard" action.
+  // 左侧创作资源树不住这里：它跨 creation / storyboard 两个模式常驻，唯一挂载点是
+  // WorkbenchShell（见 creationResourceTreeModes.ts）。
   return (
     <section
       className={cn(
@@ -23,12 +24,11 @@ export default function CreationWorkspace({ aiCollapsed = false, agentDockRef }:
         'bg-workbench-bg',
         'grid max-w-[1480px] mx-auto gap-5',
         agentDockRef && !aiCollapsed
-          ? 'grid-cols-[240px_minmax(0,1fr)_340px] max-[1320px]:grid-cols-[200px_minmax(0,1fr)_340px] max-[980px]:grid-cols-[180px_minmax(0,1fr)] max-[980px]:grid-rows-[minmax(300px,1fr)_minmax(240px,40%)]'
-          : 'grid-cols-[240px_minmax(0,1fr)] max-[1180px]:grid-cols-[200px_minmax(0,1fr)]',
+          ? 'grid-cols-[minmax(0,1fr)_340px] max-[980px]:grid-cols-[minmax(0,1fr)] max-[980px]:grid-rows-[minmax(300px,1fr)_minmax(240px,40%)]'
+          : 'grid-cols-[minmax(0,1fr)]',
       )}
       aria-label={t('creationAi.workspace.aria')}
     >
-        <DocumentListSidebar />
       <div className="min-w-0 min-h-0 flex flex-col gap-2">
         <div className="min-h-0 flex-1" data-creation-surface="source">
           {/* The script remains visible in Creation; opening a storyboard is an

--- a/src/workbench/creation/DocumentListSidebar.tsx
+++ b/src/workbench/creation/DocumentListSidebar.tsx
@@ -102,9 +102,12 @@ export default function DocumentListSidebar(): JSX.Element {
     if (confirmed) deleteStoryboardDesign(id, documentId)
   }, [deleteStoryboardDesign, t])
 
+  // 点原稿 = 回到剧本编辑器。模式必须一起切回 creation：在分镜页只清 activeStoryboardId
+  // 的话，StoryboardWorkspace 的「没有激活方案就自动选第一个」会立刻把用户弹回方案里。
   const selectDocument = (id: string) => {
     setActiveDocumentId(id)
     setActiveStoryboardId(null)
+    setWorkspaceMode('creation')
   }
 
   const selectStoryboard = (id: string, documentId: string) => {
@@ -216,7 +219,7 @@ export default function DocumentListSidebar(): JSX.Element {
 
   return (
     <aside
-      className="flex h-full w-[240px] shrink-0 flex-col border-r border-nomi-line-soft bg-nomi-paper max-[1320px]:row-span-2 max-[1180px]:w-[200px]"
+      className="flex h-full w-[240px] shrink-0 flex-col border-r border-nomi-line-soft bg-nomi-paper max-[1180px]:w-[200px]"
       aria-label={t('creationAi.documentList.aria')}
       data-creation-resource-tree="true"
     >

--- a/src/workbench/creation/creationResourceTreeModes.test.ts
+++ b/src/workbench/creation/creationResourceTreeModes.test.ts
@@ -1,0 +1,44 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { CREATION_RESOURCE_TREE_MODES, workspaceModeCarriesCreationResourceTree } from './creationResourceTreeModes'
+
+const stripComments = (source: string): string =>
+  source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '')
+const read = (file: string): string => stripComments(readFileSync(resolve(process.cwd(), file), 'utf8'))
+
+// 2026-09-06 回归（805096d41）：侧栏点分镜方案会切进 storyboard 模式，而资源树当时
+// 只住在 CreationWorkspace 里 —— 用户被钉死在单个方案上，点不到别的剧本/别的分镜。
+// 这里钉的是类不变量：**编辑原稿或它的分镜方案时，资源树必须在场且只有一个家**。
+describe('creation resource tree reachability', () => {
+  it('covers both surfaces that edit a document or its storyboard plans', () => {
+    expect(workspaceModeCarriesCreationResourceTree('creation')).toBe(true)
+    expect(workspaceModeCarriesCreationResourceTree('storyboard')).toBe(true)
+    // 生成 / 预览有各自的资源面（画布文件树 / 时间轴），不挂创作资源树。
+    expect(workspaceModeCarriesCreationResourceTree('generation')).toBe(false)
+    expect(workspaceModeCarriesCreationResourceTree('preview')).toBe(false)
+    expect([...CREATION_RESOURCE_TREE_MODES]).toEqual(['creation', 'storyboard'])
+  })
+
+  it('mounts the tree once, at the shell, for exactly those modes', () => {
+    const shell = read('src/workbench/WorkbenchShell.tsx')
+    expect(shell).toContain('workspaceModeCarriesCreationResourceTree(workspaceMode) ? <DocumentListSidebar />')
+    // 一个家：两个工作区都不许自己再挂一棵（挂两棵 = 又能各自漂）。
+    for (const file of [
+      'src/workbench/creation/CreationWorkspace.tsx',
+      'src/workbench/creation/storyboard/StoryboardWorkspace.tsx',
+    ]) {
+      expect(read(file)).not.toContain('DocumentListSidebar')
+    }
+  })
+
+  it('sends the user back to the script surface when a document row is picked', () => {
+    // 只清 activeStoryboardId 不切模式的话，StoryboardWorkspace 的「自动选第一个方案」
+    // 会立刻把刚点回原稿的用户弹回分镜表——「点回剧本」必须同时切回 creation。
+    const sidebar = read('src/workbench/creation/DocumentListSidebar.tsx')
+    const selectDocument = sidebar.slice(sidebar.indexOf('const selectDocument'))
+    const body = selectDocument.slice(0, selectDocument.indexOf('}') + 1)
+    expect(body).toContain('setActiveStoryboardId(null)')
+    expect(body).toContain("setWorkspaceMode('creation')")
+  })
+})

--- a/src/workbench/creation/creationResourceTreeModes.ts
+++ b/src/workbench/creation/creationResourceTreeModes.ts
@@ -1,0 +1,18 @@
+import type { WorkspaceMode } from '../workbenchStore'
+
+/**
+ * 「创作资源树跟着哪些工作区走」的唯一 owner。
+ *
+ * 为什么需要一个 owner：原稿和它的分镜方案住在**两个**工作区（creation 写剧本、
+ * storyboard 编分镜表），但它们共用同一棵资源树。树只要归其中一个工作区所有，
+ * 另一个工作区就没有树——2026-09-06 用户报的回归正是这么来的（805096d41 让侧栏
+ * 点方案直接切进 storyboard，而 storyboard 那面没有树，用户被钉死在单个方案上）。
+ *
+ * 所以挂载判断提到 WorkbenchShell（树的唯一挂载点）并由本常量决定：任何新的
+ * 「切进分镜页」入口都自动带着树，不靠每个入口自觉。
+ */
+export const CREATION_RESOURCE_TREE_MODES = ['creation', 'storyboard'] as const satisfies readonly WorkspaceMode[]
+
+export function workspaceModeCarriesCreationResourceTree(mode: WorkspaceMode): boolean {
+  return (CREATION_RESOURCE_TREE_MODES as readonly WorkspaceMode[]).includes(mode)
+}

--- a/src/workbench/creation/storyboard/StoryboardWorkspace.tsx
+++ b/src/workbench/creation/storyboard/StoryboardWorkspace.tsx
@@ -7,8 +7,10 @@ import { useWorkbenchStore } from '../../workbenchStore'
 import StoryboardPlanEditor from './StoryboardPlanEditor'
 
 /**
- * 分镜独立工作区（v5 C3）：storyboard 模式的唯一挂载点，全宽（§3.7 删 1264 上限）、
- * 无文档侧栏无 AI 栏——完整编辑器只住这里（P1 一个实现一个家）。
+ * 分镜独立工作区（v5 C3）：storyboard 模式的唯一挂载点，分镜表全宽（§3.7 删 1264 上限）、
+ * 无 AI 栏以外的自有装饰——完整编辑器只住这里（P1 一个实现一个家）。
+ * 左侧创作资源树**不由本组件挂**：它跨 creation / storyboard 常驻，唯一挂载点是
+ * WorkbenchShell（见 ../creationResourceTreeModes.ts）。本组件只负责剩下的那块宽度。
  * 有方案 → StoryboardPlanEditor；无方案 → 空态引导回创作页拆镜头。返回原稿 = 切回 creation。
  */
 export default function StoryboardWorkspace({ projectId, aiCollapsed = false, agentDockRef }: { projectId?: string | null; aiCollapsed?: boolean; agentDockRef?: React.Ref<HTMLDivElement> }): JSX.Element {

--- a/src/workbench/project/projectNormalize.test.ts
+++ b/src/workbench/project/projectNormalize.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { normalizePayload } from './projectNormalize'
+import { normalizePayload, normalizeRecord } from './projectNormalize'
 import { createDefaultWorkbenchProjectPayload } from './projectRecordSchema'
 import type { StoryboardPlan } from '../generationCanvas/agent/storyboardPlan'
 import type { GenerationCanvasNode } from '../generationCanvas/model/generationCanvasTypes'
@@ -82,5 +82,72 @@ describe('normalizePayload — 损坏记录优雅降级（缺可默认字段不�
     expect(out.workbenchDocuments![0].version).toBe(1)
     expect(out.workbenchDocuments![0].title).toBe('')
     expect(out.timeline.tracks.length).toBeGreaterThan(0)
+  })
+})
+
+// 2026-09-06：用户报「看不到原来的剧本/分镜」。上面那组用例全都直接喂 normalizePayload，
+// 所以一直是绿的——但生产上没有任何调用者这么调：读盘走的是 normalizeRecord，而它把
+// **zod 解析后**的 payload 喂给迁移器，普通 z.object 早已把 storyboardPlan 这类老键剥掉了。
+// 于是老项目的分镜方案打开即消失，随后任何一次自动保存把它从盘上永久抹掉。
+// 这一组把断言挪到真正的读侧边界上：迁移器测得再全，喂错料就等于没测。
+describe('normalizeRecord — 老项目的分镜方案必须活着穿过读侧', () => {
+  const legacyPlan: StoryboardPlan = {
+    title: 'Nomi 开源宣传片',
+    anchors: [{ id: 'anchor-creator', kind: 'character', name: '创作者', description: '短黑发', carrier: 'visual' }],
+    // 真实老项目的镜头就是这个形状：没有 shotId、没有 sceneId。
+    shots: [
+      { index: 1, durationSec: 0, anchorIds: ['anchor-creator'], prompt: '工作室全景' },
+      { index: 2, durationSec: 0, anchorIds: [], prompt: '时钟特写' },
+    ],
+  }
+  const summary = { id: 'p1', name: '老项目', createdAt: 1, updatedAt: 2 } as never
+  const legacyRecord = (payloadExtra: Record<string, unknown>) => ({
+    id: 'p1', name: '老项目', version: 1, createdAt: 1, updatedAt: 2, savedAt: 2, revision: 1,
+    payload: {
+      // 老项目就是单份 workbenchDocument（连 id 都没有）+ 顶层老分镜键。
+      workbenchDocument: { version: 1, title: '', updatedAt: 30, contentJson: { type: 'doc', content: [] } },
+      timeline: null,
+      generationCanvas: { nodes: [], edges: [], selectedNodeIds: [], groups: [] },
+      ...payloadExtra,
+    },
+  })
+
+  // 报告案例：单份 storyboardPlan。
+  it('carries the retired single plan through normalizeRecord', () => {
+    const out = normalizeRecord(summary, legacyRecord({
+      [['storyboard', 'Plan'].join('')]: legacyPlan,
+      [['storyboard', 'Plan', 'Committed'].join('')]: true,
+    }))
+    const designs = Object.values(out.payload.storyboardDesignsByDocumentId ?? {}).flat()
+    expect(designs).toHaveLength(1)
+    expect(designs[0].plan.shots).toHaveLength(2)
+    expect(designs[0].committed).toBe(true)
+    // 方案必须挂在真实存在的那篇原稿下，否则侧栏同样点不到。
+    expect(out.payload.workbenchDocuments?.some((d) => d.id === designs[0].documentId)).toBe(true)
+  })
+
+  // 类断言：同一族的另一个老键（按稿分组的 map）走的是同一个读侧边界。
+  it('carries the retired per-document plan map through normalizeRecord', () => {
+    const documentId = 'doc-legacy'
+    const out = normalizeRecord(summary, legacyRecord({
+      workbenchDocument: { id: documentId, version: 1, title: '', updatedAt: 30, contentJson: { type: 'doc', content: [] } },
+      [['storyboard', 'Plans'].join('')]: { [documentId]: { plan: legacyPlan, committed: false } },
+    }))
+    expect(Object.values(out.payload.storyboardDesignsByDocumentId ?? {}).flat()).toHaveLength(1)
+  })
+
+  // 新形状不受影响：owner 字段照常穿过，且不被老键覆盖。
+  it('keeps the owner field intact for current-shape records', () => {
+    const documentId = 'doc-new'
+    const design = {
+      id: 'sb-1', documentId, title: legacyPlan.title, plan: legacyPlan, committed: false,
+      status: 'draft' as const, sourceDocumentUpdatedAt: 10, createdAt: 11, updatedAt: 12,
+    }
+    const out = normalizeRecord(summary, legacyRecord({
+      workbenchDocuments: [{ id: documentId, version: 1, title: '新稿', updatedAt: 30, contentJson: { type: 'doc', content: [] } }],
+      activeDocumentId: documentId,
+      storyboardDesignsByDocumentId: { [documentId]: [design] },
+    }))
+    expect(out.payload.storyboardDesignsByDocumentId?.[documentId]).toEqual([design])
   })
 })

--- a/src/workbench/project/projectNormalize.ts
+++ b/src/workbench/project/projectNormalize.ts
@@ -158,12 +158,27 @@ function recordHasPersistedContent(raw: unknown): boolean {
   )
 }
 
+/**
+ * 从原始 record 上取未经 zod 剥离的 payload；取不到就退回 undefined，让
+ * normalizePayload 自己走「缺字段」的既有兜底（它第一步就 safeParse）。
+ */
+function readRawPayload(raw: unknown): unknown {
+  if (!raw || typeof raw !== 'object') return undefined
+  return (raw as { payload?: unknown }).payload
+}
+
 export function normalizeRecord(summary: WorkbenchProjectSummary, raw: unknown): WorkbenchProjectRecordV1 {
   const legacyParsed = workbenchProjectRecordSchema.safeParse(raw)
   if (legacyParsed.success) {
     return {
       ...legacyParsed.data,
-      payload: normalizePayload(legacyParsed.data.payload),
+      // 迁移必须吃**原始** payload，不能吃 zod 解析后的那份：payload schema 是普通
+      // z.object，会把它不认识的键默默剥掉——而已退役的那三个老键（见上面
+      // legacyMapKey / legacyPlanKey / legacyCommittedKey 三处拼装）恰恰就不在 schema 里。
+      // 喂解析后的那份，兼容读取就永远看不见它们：老项目的分镜方案打开即静默消失，
+      // 随后任何一次自动保存会把它从盘上永久抹掉。
+      // normalizePayload 自己第一步就重新 safeParse，喂原始值不会放宽任何校验。
+      payload: normalizePayload(readRawPayload(raw)),
     }
   }
   // Freshly-initialized workspace (existing folder opened via "打开文件夹",

--- a/tests/ux/creation-sidebar-multi-doc.walk.mjs
+++ b/tests/ux/creation-sidebar-multi-doc.walk.mjs
@@ -1,0 +1,205 @@
+// 创作资源树可达性走查（R13/R16）——用户 2026-09-06 报回归：
+// 「我们原来左边不是有剧本和分镜都能点吗？我们现在只能有这个方案，点不到原来那些地方了。」
+//
+// 钉死的不变量：**只要在编辑某一篇原稿或它的某个分镜方案，创作资源树就必须在场、
+// 且列全所有原稿与所有分镜方案**。分镜表长什么样（v6 已拍板）不在本走查管辖内——
+// 这里只管「还点不点得到别的原稿 / 别的方案」。
+//
+// 两条腿：
+//   A 新形状项目：2 篇原稿 × 每篇 2 个方案，逐个点，creation ↔ storyboard 来回切；
+//   B 老形状项目：payload 只有单份 workbenchDocument + storyboardPlan（真实老项目的形状，
+//     见 ~/Documents/Nomi Projects 存量），走兼容投影后同样要能点到。
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { launchNomiApp } from './_launchApp.mjs'
+import { clickOrFail, expectCount, expectText, expectVisible, screenshotSettled } from './_assert.mjs'
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..')
+const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'nomi-creation-sidebar-'))
+const projectsDir = path.join(tempRoot, 'projects')
+const settingsDir = path.join(tempRoot, 'settings')
+const outDir = process.env.CREATION_SIDEBAR_OUT || path.join(repoRoot, 'tests/ux/shots/creation-sidebar-multi-doc')
+fs.mkdirSync(outDir, { recursive: true })
+
+const doc = (id, title, text, updatedAt) => ({
+  id, version: 1, title, updatedAt,
+  contentJson: { type: 'doc', content: [{ type: 'paragraph', content: [{ type: 'text', text }] }] },
+})
+const plan = (title, shotCount) => ({
+  title,
+  profileKey: 'genre.short-drama',
+  anchors: [],
+  scenes: [{ id: 's1', title: '第一场' }],
+  shots: Array.from({ length: shotCount }, (_, i) => ({
+    index: i + 1, shotId: `shot-${i + 1}`, sceneId: 's1', shotKind: 'image',
+    durationSec: 3, anchorIds: [], prompt: `${title} 第 ${i + 1} 镜`,
+  })),
+})
+const design = (id, documentId, title, shotCount, sourceDocumentUpdatedAt) => ({
+  id, documentId, title, plan: plan(title, shotCount),
+  committed: false, status: 'draft', sourceDocumentUpdatedAt,
+  createdAt: sourceDocumentUpdatedAt + 1, updatedAt: sourceDocumentUpdatedAt + 2,
+})
+
+function writeProject(projectId, name, payload) {
+  const projectRoot = path.join(projectsDir, projectId)
+  fs.mkdirSync(path.join(projectRoot, '.nomi'), { recursive: true })
+  const record = {
+    id: projectId, name, version: 2, createdAt: 1, updatedAt: 2, savedAt: 2, revision: 1,
+    lastKnownRootPath: projectRoot, payload,
+  }
+  for (const target of [path.join(projectRoot, 'project.json'), path.join(projectRoot, '.nomi', 'project.json')]) {
+    fs.writeFileSync(target, JSON.stringify(record, null, 2))
+  }
+}
+
+// ── A：新形状（多原稿 + 每篇多方案）──
+writeProject('creation-sidebar-multi', '多原稿多方案', {
+  workbenchDocuments: [doc('doc-a', '影子罢工了', '影子在清晨罢工。', 10), doc('doc-b', '夜风计划', '雨夜天台的对峙。', 20)],
+  activeDocumentId: 'doc-a',
+  timeline: null,
+  generationCanvas: { nodes: [], edges: [], selectedNodeIds: [], groups: [] },
+  storyboardDesignsByDocumentId: {
+    'doc-a': [design('d-a1', 'doc-a', '影子 · 方案一', 3, 10), design('d-a2', 'doc-a', '影子 · 方案二', 4, 10)],
+    'doc-b': [design('d-b1', 'doc-b', '夜风 · 方案一', 2, 20), design('d-b2', 'doc-b', '夜风 · 方案二', 5, 20)],
+  },
+})
+
+// ── B：老形状。逐字照抄真实存量项目的 payload 形状（2026-09-06 实测
+//    ~/Documents/Nomi Projects/Nomi 宣传片｜09_00 前交片 的 .nomi/project.json）：
+//    · 只有单份 workbenchDocument，没有 workbenchDocuments / activeDocumentId；
+//    · 原稿 title 是空串（老项目从来没给稿子起过名）；
+//    · storyboardPlan 只有 title / anchors / shots 三个键——没有 scenes、没有 profileKey。
+//    这三点都是兼容投影真正会踩的地方，别"补全"成新形状再测（那测的是自己的 fixture）。
+writeProject('creation-sidebar-legacy', '老项目形状', {
+  workbenchDocument: { ...doc('legacy-doc', '', '截止前的片场接管。', 30) },
+  timeline: null,
+  generationCanvas: { nodes: [], edges: [], selectedNodeIds: [], groups: [] },
+  storyboardPlan: {
+    title: 'Nomi 开源宣传片',
+    anchors: [],
+    shots: Array.from({ length: 6 }, (_, i) => ({
+      index: i + 1, shotId: `shot-${i + 1}`, shotKind: 'image',
+      durationSec: 3, anchorIds: [], prompt: `老项目第 ${i + 1} 镜`,
+    })),
+  },
+  storyboardPlanCommitted: false,
+})
+
+const failures = []
+const consoleErrors = []
+
+async function closeAppHard(instance) {
+  const child = instance.process()
+  await Promise.race([instance.close().catch(() => undefined), new Promise((resolve) => setTimeout(resolve, 8000))])
+  if (child.exitCode === null) child.kill('SIGKILL')
+}
+
+/**
+ * 资源树可达性对账：树在场 + 原稿行数对 + 方案行数对 + 点名的那几个标题都在。
+ * 这条断言就是回归的红点——分镜模式下资源树整棵消失时，第一句就红。
+ */
+async function expectResourceTreeReachable(win, where, { documents, storyboards, titles }) {
+  await expectVisible(win.locator('[data-creation-resource-tree="true"]'), `${where}：创作资源树不在场——点不到别的原稿/方案`)
+  await expectCount(win.locator('[data-document-row]'), documents, `${where}：原稿行数应为 ${documents}`)
+  await expectCount(win.locator('[data-storyboard-id]'), storyboards, `${where}：分镜方案行数应为 ${storyboards}`)
+  for (const title of titles) {
+    await expectVisible(win.locator('[data-creation-resource-tree="true"]').getByText(title, { exact: false }).first(), `${where}：资源树里找不到「${title}」`)
+  }
+}
+
+// 项目默认开在生成页，所以「打开项目」= 进项目 + 切到创作页（用户从项目库进创作的真实两步）。
+async function openProject(win, name) {
+  const card = win.locator('[data-project-card]', { hasText: name }).first()
+  await card.hover()
+  const cont = card.getByText('继续创作', { exact: false }).first()
+  if (await cont.isVisible().catch(() => false)) await cont.click()
+  else await card.dblclick()
+  await expectVisible(win.locator('[data-workspace-mode]'), `打开「${name}」后工作台没起来`)
+  await clickOrFail(win.getByRole('button', { name: '创作', exact: true }), `进「${name}」的创作页`)
+}
+
+const { app, win } = await launchNomiApp({ name: 'creation-sidebar-multi-doc', tempRoot, settingsDir, projectsDir, settleMs: 1200 })
+win.on('console', (msg) => { if (msg.type() === 'error') consoleErrors.push(msg.text().slice(0, 300)) })
+win.on('pageerror', (error) => consoleErrors.push(`pageerror: ${String(error?.message || error).slice(0, 300)}`))
+const snap = async (name) => { await screenshotSettled(win, { path: path.join(outDir, name) }) }
+
+try {
+  await win.evaluate(() => {
+    for (const key of ['nomi:splash:v1', 'nomi:journey-tour:v1', 'nomi:canvas-gesture-hint:v1']) localStorage.setItem(key, 'seen')
+  })
+
+  // ─────────── 腿 A：多原稿 × 多方案 ───────────
+  await openProject(win, '多原稿多方案')
+  await expectResourceTreeReachable(win, '创作页初始', {
+    documents: 2, storyboards: 4,
+    titles: ['影子罢工了', '夜风计划', '影子 · 方案一', '夜风 · 方案二'],
+  })
+  await snap('01-creation-two-docs.png')
+
+  // 点第二篇原稿 → 编辑器换稿，树不变
+  await clickOrFail(win.locator('[data-document-row="doc-b"] [data-document-id]'), '点第二篇原稿')
+  await expectText(win.locator('[data-document-row="doc-b"] [data-document-id]'), /夜风计划/, '第二篇原稿行标题不对')
+  await expectVisible(win.locator('[data-document-row="doc-b"] [data-document-id][data-active="true"]'), '点了第二篇原稿但它没被标成 active')
+  await snap('02-doc-b-selected.png')
+
+  // 打开一个分镜方案 → 这里是回归的现场：分镜表出来了，但资源树整棵消失
+  await clickOrFail(win.locator('[data-storyboard-id="d-b1"]'), '打开「夜风 · 方案一」')
+  await expectVisible(win.locator('[data-storyboard-editor="true"]'), '分镜编辑器没渲染')
+  await snap('03-storyboard-open.png')
+  await expectResourceTreeReachable(win, '分镜方案打开时', {
+    documents: 2, storyboards: 4,
+    titles: ['影子罢工了', '夜风计划', '影子 · 方案一', '夜风 · 方案二'],
+  })
+
+  // 在分镜页直接换到另一篇原稿的另一个方案（用户要的「点到我的其他那些剧本、分镜」）
+  await clickOrFail(win.locator('[data-storyboard-id="d-a2"]'), '在分镜页切到另一篇原稿的方案二')
+  await expectVisible(win.locator('[data-storyboard-id="d-a2"][data-active="true"]'), '切过去的方案没有被标成 active')
+  await expectText(win.locator('[data-storyboard-editor="true"]'), /影子 · 方案二/, '分镜表没换成「影子 · 方案二」')
+  await snap('04-switch-plan-across-docs.png')
+
+  // 再点回原稿行 → 回到剧本编辑器（用户的「我看不到原来那个剧本了」）
+  await clickOrFail(win.locator('[data-document-row="doc-a"] [data-document-id]'), '从分镜页点回原稿')
+  await expectVisible(win.locator('[data-creation-surface="source"]'), '点回原稿后剧本编辑器没回来')
+  await expectVisible(win.locator('[data-document-row="doc-a"] [data-document-id][data-active="true"]'), '点回原稿后它没被标成 active')
+  await snap('05-back-to-script.png')
+
+  // ─────────── 腿 B：老项目形状 ───────────
+  await clickOrFail(win.getByRole('button', { name: /项目库|返回项目库/ }).first(), '回项目库')
+  await openProject(win, '老项目形状')
+  await expectResourceTreeReachable(win, '老项目创作页', {
+    documents: 1, storyboards: 1,
+    titles: ['Nomi 开源宣传片'],
+  })
+  await expectText(win.locator('[data-creation-surface="source"]'), /截止前的片场接管/, '老项目的剧本正文没投影出来')
+  await snap('06-legacy-project-tree.png')
+
+  const legacyDesign = win.locator('[data-storyboard-id]').first()
+  await clickOrFail(legacyDesign, '打开老项目迁移出来的分镜方案')
+  await expectVisible(win.locator('[data-storyboard-editor="true"]'), '老项目分镜编辑器没渲染')
+  await expectResourceTreeReachable(win, '老项目分镜打开时', {
+    documents: 1, storyboards: 1,
+    titles: ['Nomi 开源宣传片'],
+  })
+  await snap('07-legacy-storyboard-open.png')
+  await clickOrFail(win.locator('[data-document-row="legacy-doc"] [data-document-id]'), '老项目从分镜点回原稿')
+  await expectVisible(win.locator('[data-creation-surface="source"]'), '老项目点回原稿后剧本编辑器没回来')
+  await expectText(win.locator('[data-creation-surface="source"]'), /截止前的片场接管/, '老项目回原稿后正文丢了')
+  await snap('08-legacy-back-to-script.png')
+} catch (error) {
+  failures.push(String(error?.message || error))
+} finally {
+  await snap('99-final.png')
+  await closeAppHard(app)
+}
+
+console.log(`\n截图：${outDir}`)
+if (consoleErrors.length) console.log(`控制台错误 ${consoleErrors.length} 条（留证不判红）：\n  ${consoleErrors.slice(0, 8).join('\n  ')}`)
+if (failures.length) {
+  console.error(`\n❌ 创作资源树可达性走查失败 ${failures.length} 条：`)
+  for (const failure of failures) console.error(`  · ${failure}`)
+  process.exit(1)
+}
+console.log('\n✅ 创作资源树在原稿页与分镜页都可达，多原稿 / 多方案 / 老项目形状三面都能互相点到')


### PR DESCRIPTION
## 用户报的问题

> 「分镜表有点问题，我现在看不到原来的那个剧本了。我们原来左边不是有剧本和分镜都能点吗？我们现在只能有这个方案，点不到原来那些地方了。新设计（分镜收进创作面）没问题，但起码得能点到我的其他那些剧本、分镜，而不是只能看到这一个。」

复现后是**两条**根因，一条导航、一条读侧丢数据。**v6 分镜表外观一处没动**——本次只是把左栏还给它，并让老项目的方案重新出现在树里。

## ① 资源树可达性（回归，引入于 805096d41）

`805096d41` 给侧栏 `selectStoryboard` 加了 `setWorkspaceMode('storyboard')`，**同一个 commit 删掉了 `StoryboardPlanCard`**——而那张卡正是「点方案」原本的落点：点完人还留在创作面、树还在。落点没了，目的地 `StoryboardWorkspace` 是独立 `WorkspaceSlot` 且刻意不挂文档侧栏（`1e21bd9cc` 的注释写着「无文档侧栏」），于是点开一个方案就再也看不到别的剧本和别的方案。

**类根因不是那一行**，是「树被它的两个消费方之一持有」：原稿在 creation 编、它的分镜方案在 storyboard 编，两边共用一棵树，树却只挂在其中一边。任何落到另一边的导航都会把用户钉住，和是谁触发的无关——现存四个入口：侧栏方案行、顶栏 stepper、`?step=storyboard` 还原、`StoryboardWorkspace` 自己的「没有激活方案就自动选第一个」effect。

**修在最早的共享边界**：挂载判断提到 `WorkbenchShell`（树的唯一挂载点，与 generation 的 `ProjectExplorerSidebar` 同一处），归属由新的唯一 owner `creationResourceTreeModes.ts` 决定；`CreationWorkspace` 同 commit 删掉自己那棵和 240px 那列（P1 一个实现一个家）。这样**新入口自动带着树**，不靠作者自觉。

`selectDocument` 同时切回 creation——只清 `activeStoryboardId` 的话，上面那条 effect 会立刻把刚点回原稿的用户弹回方案里。

## ② 老项目的分镜方案在读侧被剥掉（打开即消失，再存一次就永久没了）

验证 ① 的老项目腿时挖到的**独立缺陷**。`normalizeRecord` 把 **zod 解析后**的 payload 喂给 `normalizePayload`，而 payload schema 是普通 `z.object`（默认剥未声明键），已退役的那三个老键当然不在 schema 里。于是兼容迁移恒 no-op。

不只是「看不见」：内存 payload 从此不带 plan，**下一次自动保存把它从盘上永久抹掉**，违反本仓 `renameLocalProject` 注释里写死的 never-wipe-user-data。

真实项目「Nomi 宣传片｜09_00 前交片」实测：盘上 **12 镜 5 锚**，过读侧 **0 个方案**；修复后 12 镜 5 锚全数恢复，且挂在真实存在的那篇原稿下。

原有 6 条迁移用例全绿却抓不到——**它们都直接调 `normalizePayload`，而生产上没有任何调用者这么调**。修法是在唯一那个调用点把原始 payload 交回给迁移器（它自己第一步就重新 `safeParse`，不放宽任何校验），断言同步挪到 `normalizeRecord` 这个真读侧边界上。

## 验证

- **走查**（真 Electron 构建 + 隔离 profile）`tests/ux/creation-sidebar-multi-doc.walk.mjs` 两条腿：
  - A：2 篇原稿 × 每篇 2 个方案，逐个点 + 跨稿切方案 + 点回原稿；
  - B：逐字照抄真实老项目 payload 形状（单份 `workbenchDocument`、稿名空串、plan 只有 `title/anchors/shots`，没有 `scenes`/`profileKey`）。
  - 修复前红在「分镜方案打开时：创作资源树不在场」，修复后全绿，截图人眼逐张过。
- **变异验证**：把 ② 的修复回退，两条老键用例确实变红（第三条是护栏，两边都绿，没当证据）。
- **真实老项目只读取证**：`cp -R` 深拷贝进隔离库（inode 已验不同，非硬链接），**用户真实资料库全程零写入**（mtime 仍是 8/13、8/18）。
- `pnpm run gates` 全绿（61 门岗 + 单测 + 构建），戳 `sha=ced5769202a9`。

## 已知遗留（没做，供决定）

- 「Nomi 宣传片」深拷贝在隔离 profile 里**打不开**：hydrate 阶段报 `project_agent_unavailable`（裸 profile 没配 Agent 模型），与本 PR 无关，所以它的真实数据腿是在 `normalizeRecord` 边界上验的，不是端到端。
- 创作页树上高亮的是激活**方案**而不是你正在读的那篇稿（`documentActive` 要求 `activeStoryboardId === null`）。**改前改后行为一致**，只是树常驻后更显眼。改成跟随 `workspaceMode` 是一行的事，但那是「active 到底指什么」的语义决定，留给你拍板，没有默默塞进来。
- 被 ①/② 影响过、并且已经自动保存过的项目，盘上的老 plan 已经没了；只能从 `rememberProjectBackup` 写的按 revision 备份里捞（本次未验证该路径）。

合同：`docs/fixes/2026-09-06-creation-resource-tree-unreachable.root-cause.json`、`docs/fixes/2026-09-06-legacy-storyboard-stripped-before-migration.root-cause.json`
教训：`docs/lessons/migrator-tested-directly-is-never-tested.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
