### PR TITLE
fix(research): 小红书搜索取空的根因是条目层级，四家字段翻成实抓核对

### DIFF
--- a/docs/research/tikhub-api-notes.md
+++ b/docs/research/tikhub-api-notes.md
@@ -71,7 +71,26 @@ TikHub 是一个多平台自媒体数据聚合 API：一个 key、一套鉴权�
 
 query 参数：`keyword`（必填）、`page`（从 1 开始）、`sort_type`（默认 `general`）、`note_type`（`不限`/`视频笔记`/`普通笔记`/`直播笔记`）、`time_filter`（`不限`/`一天内`/`一周内`/`半年内`）、`search_id`、`search_session_id`（后两个翻页时回传首次搜索的返回值）、`source`、`ai_mode`。
 
-注意：时间筛选是**中文枚举**，不是时间戳。
+注意：时间筛选是**中文枚举**，不是时间戳。⚠️ **填错不会报错**——2026-09-06 实测 `time_filter=one_week` 与 `time_filter=<10 位时间戳>` 都照样返回 HTTP 200，只是筛选静默失效。所以枚举值只能靠测试钉住（`XHS_TIME_FILTERS` + `xhsTimeFilter()` 的四档映射有夹具逐档断言）。
+
+**响应形状（2026-09-06 用真实 key 实抓核对）**——比其它三家**多包一层**信封：
+
+```
+{ code, request_id, …, data: {                      ← TikHub 信封
+    code, success, msg, page, next_page,
+    search_id, search_session_id,
+    data: {                                          ← 小红书自己的信封
+      items: [ { mix_track_id, model_type: 'note',
+                 note: { id, title, desc, timestamp,   ← 秒级
+                         type, xsec_token,
+                         user: { nickname, userid, red_id } } }, … ] } } }
+```
+
+三条要点：
+1. 条目在 **`data.data.items[]`**，不是 `data.items`。写成后者时 `pickFirst` 会退到 `data.data` 拿回一个**对象**，`Array.isArray` 判否 → **HTTP 200、退出码 0、0 条记录**，在报告里和「今天没人聊」一模一样。
+2. `items[]` 里混着 `model_type` 非 `note` 的卡片（广告/用户），归一前要剔掉。
+3. 笔记链接必须带 **`xsec_token`**：裸 `/explore/<id>` 对未登录访客打不开。正确形状是 `https://www.xiaohongshu.com/explore/<id>?xsec_token=<token>&xsec_source=pc_search`。
+4. 翻页看服务端给的 **`next_page`**（没有 `has_more`）；给不出就是到底了，不许自己 `page + 1` 硬翻。
 
 ### 2.3 B站 · `GET /api/v1/bilibili/web/fetch_general_search`
 
@@ -82,6 +101,19 @@ query 参数：`keyword`、`order`、`page`、`page_size` **四个都是必填**
 ### 2.4 X（Twitter）· `GET /api/v1/twitter/web/fetch_search_timeline`
 
 query 参数：`keyword`（必填）、`search_type`（默认 `Top`）、`cursor`（游标翻页）。
+
+### 2.5 各平台结果流里都混着非内容卡片
+
+四家都会在搜索结果里塞非创作者内容的卡片，归一前必须剔掉，否则它们会在报告里堆成一排**假的**「未解析出字段」：
+
+| 平台 | 混入的东西 | 判据 |
+|---|---|---|
+| 抖音 | `type: 6` 相关搜索词卡片（只有 `related_word_list`） | 有没有 `aweme_info` |
+| 小红书 | 广告 / 用户卡片 | `model_type === 'note'` |
+| B站 | `type: 'ketang'` 付费课程投放（`pubdate` 恒 0） | `type === 'video'` |
+| X | 非推文模块卡片 | `type === 'tweet'` |
+
+另：抖音的 `share_url` 带着 TikHub 抓取账号的 `did` / `iid` 等追踪参数，不该进调研产物——脚本改用规范短链 `https://www.douyin.com/video/<aweme_id>`。
 
 ## 3. 统一响应信封（`ResponseModel`）
 
@@ -94,6 +126,8 @@ query 参数：`keyword`（必填）、`search_type`（默认 `Top`）、`cursor
 
 `422` 返回 FastAPI 的 `HTTPValidationError`（`{ detail: [ValidationError, …] }`）。
 
+**400 的含义（2026-09-06 定性，重要）**：spec 里每个端点都只声明 `200` 和 `422`；参数类型不合走 FastAPI 的 **422**，而枚举值填错**照样 200**（见 §2.2）。也就是说 **400 在这套 API 上不可能是「参数不对」**，只能是上游平台抓取层当时没抓到——那是重试能救的一类抖动。脚本因此把 400 归进 `isRetriableStatus`；2026-09-06 的验收跑里小红书正好吃到一次 400，重试后拿回 3 条，实地印证了这条判断。把 400 当致命错的代价是**一次抖动抹掉整个平台**。
+
 **401 的真实形状**（2026-09-06 用假 token 实测，见 §5）：
 
 ```
@@ -102,15 +136,22 @@ query 参数：`keyword`（必填）、`search_type`（默认 `Top`）、`cursor
 
 ⚠️ **这条很重要**：TikHub 会把你提交的 token **原样回显在错误信息里**。所以任何把响应体写进日志/报告/截图的代码，都必须先脱敏——`tikhub-search-lib.mjs` 的 `redact()` 就是为这条存在的，并且有测试盯着（`401：不重试，且响应里回显的 token 被抹成 ***`）。
 
-## 4. 字段归一的诚实边界
+## 4. 字段归一：四家均已实抓核对（2026-09-06）
 
-spec 把每个端点的 `data` 都声明为**无类型**（`ResponseModel.data` 没有 schema）。这意味着：
+spec 把每个端点的 `data` 都声明为**无类型**（`ResponseModel.data` 没有 schema），所以字段路径只能靠真实响应核对。**四家已各用真实 key 实抓一次并逐字段对账**，全部记为 `fieldConfidence: verified-against-live-response` + `fieldsVerifiedOn: 2026-09-06`：
 
-- **抖音**的字段路径 = 已用真实响应核对（记为 `fieldConfidence: verified-against-live-response`）。
-- **小红书 / B站 / X** 的字段路径 = 按各平台通用字段名写成**多路候选**，**未经真实响应核对**（本机无 key），记为 `best-effort-unverified`，并在生成的 Markdown 抬头明写。
-- 归一层因此必须容错：少字段留空 + 记进 `missingFields`，**不许静默丢条目**——「这个平台今天没人聊」和「我们没解析出字段」在报告里长得一模一样，那是最贵的一种假绿。
+| 平台 | 条目路径 | id | 时间 | 作者 | 正文 | 本轮 `missingFields` |
+|---|---|---|---|---|---|---|
+| 抖音 | `data.data[]` → `aweme_info` | `aweme_id` | `create_time`（秒） | `author.nickname` / `author.uid` | `desc` | 空 |
+| 小红书 | `data.data.items[]` → `note` | `id` | `timestamp`（秒） | `user.nickname` / `user.userid` | `desc` | 空 |
+| B站 | `data.data.result[]` | `bvid` | `pubdate`（秒） | `author` / `mid` | `title` + `description` | 空 |
+| X | `data.timeline[]`（**扁平**） | `tweet_id` | `created_at`（字符串） | `user_info.name` / `screen_name` | `text` | 空 |
 
-拿到 key 后的第一件事：对三家各跑一次 `--limit 3`，看 `missingFields` 是不是空，不空就回来修路径并把 `verified` 翻真。
+两处原先写错、已修：
+- **小红书**条目层级少数一层（详见 §2.2），结果是静默 0 条。
+- **X** 的条目是**扁平**的，原先按 `rest_id` / `user.screen_name` 取，两个都恒空 → 每条都缺 `id` 和 `url`。真实字段是顶层的 `tweet_id` / `screen_name`，作者名在 `user_info.name`。
+
+归一层仍然保持容错：上游随时会改形状，少字段要留空 + 记进 `missingFields`，**不许静默丢条目**——「这个平台今天没人聊」和「我们没解析出字段」在报告里长得一模一样，那是最贵的一种假绿。产物 JSON 的 `summary` 段就是为了让这三种状态（`ok` / `empty` / `failed`）一眼分得开。
 
 ## 5. 本机验证记录（2026-09-06，无 key 环境）
 
@@ -121,7 +162,16 @@ spec 把每个端点的 `data` 都声明为**无类型**（`ResponseModel.data` 
 | **缺 key** | `env -u TIKHUB_API_KEY node scripts/research/tikhub-search.mjs --q … --out …` | `✖ TikHub 未配置：TIKHUB_API_KEY 为空，今天没查成`，**exit 2** |
 | **坏 key** | `TIKHUB_API_KEY=<假值> node scripts/research/tikhub-search.mjs --q … --platform douyin,bilibili` | 两个平台各 HTTP 401、**不重试**、回显 token 被抹成 `***`；全平台失败时 **exit 3** |
 
-真实 key 从未在本机存在过，也没有出现在仓库、文档、测试、日志或截图的任何位置。
+## 5b. 真实 key 验收记录（2026-09-06）
+
+| 项 | 结果 |
+|---|---|
+| 四平台各 `--limit 3` | 抖音 3 / 小红书 3 / B站 3 / X 3，**四家 `missingFields` 全空** |
+| 小红书 400 复现 | 验收跑里实地吃到一次 HTTP 400，重试后成功拿回 3 条 → 印证 §3「400 = 上游抖动」 |
+| 枚举容错实测 | `time_filter=one_week` / `=<时间戳>` 均返回 200（**填错不报错**，只有测试拦得住） |
+| 脱敏 | 跑完 `grep` 产物与全仓，key 前 12 位命中 **0 个文件** |
+
+真实 key 只存在于用户 `~/.zshenv`，没有出现在仓库、文档、测试、日志或截图的任何位置。
 
 ## 6. 怎么设 key
 

--- a/scripts/research/tikhub-search-lib.mjs
+++ b/scripts/research/tikhub-search-lib.mjs
@@ -161,6 +161,26 @@ export function extractToolMentions(text) {
 
 // ───────────────────────── 平台适配 ─────────────────────────
 
+/**
+ * 小红书的筛选值是**中文枚举**，不是时间戳、也不是英文（spec 的 `time_filter` 描述逐字如此）。
+ *
+ * 这里必须是常量而不是散落的字面量，因为填错**不会报错**：2026-09-06 实测
+ * `time_filter=one_week` 和 `time_filter=<10 位时间戳>` 都照样返回 HTTP 200，只是筛选静默失效。
+ * 唯一能拦住打错的只有测试，所以映射表被夹具逐档钉死。
+ */
+export const XHS_NOTE_TYPE_ALL = '不限'
+export const XHS_TIME_FILTERS = { all: '不限', day: '一天内', week: '一周内', halfYear: '半年内' }
+
+/** `--since` → 小红书四档中文枚举（服务端只是省流量的近似，客户端仍按 `publishedAt` 精筛）。 */
+export function xhsTimeFilter(sinceMs, nowMs) {
+  if (!sinceMs) return XHS_TIME_FILTERS.all
+  const days = Math.ceil((nowMs - sinceMs) / 86_400_000)
+  if (days <= 1) return XHS_TIME_FILTERS.day
+  if (days <= 7) return XHS_TIME_FILTERS.week
+  if (days <= 180) return XHS_TIME_FILTERS.halfYear
+  return XHS_TIME_FILTERS.all
+}
+
 /** 抖音只认 0/1/7/180 四档发布时间；把 `--since` 折成最贴近的那一档（客户端仍会精筛）。 */
 function douyinPublishBucket(sinceMs, nowMs) {
   if (!sinceMs) return '0'
@@ -174,10 +194,10 @@ function douyinPublishBucket(sinceMs, nowMs) {
 /**
  * 每个平台一条适配：端点、翻页游标怎么传、条目从哪层取、字段怎么归一。
  *
- * 诚实标注：`douyin` 的 `items`/字段路径是拿免费 demo 端点
- * （`/api/v1/demo/douyin_search/app/general_search`）的**真实响应**核对过的；
- * 其余三家 spec 把 `data` 声明为无类型，路径按平台通用字段名写成多路候选，
- * 未经真实响应核对——所以归一必须容错，并把没取到的字段记进 `missingFields`。
+ * 诚实标注：spec 把每个端点的 `data` 都声明为无类型，所以字段路径只能靠真实响应核对。
+ * **四家已于 2026-09-06 各用真实 key 实抓一次并逐字段对账**（`verifiedOn`），
+ * 记录里因此标 `verified-against-live-response`。归一仍然保持容错：上游随时会改形状，
+ * 少字段要留空并记进 `missingFields`，**不许静默丢条目**。
  */
 export const PLATFORMS = {
   douyin: {
@@ -186,6 +206,7 @@ export const PLATFORMS = {
     method: 'POST',
     path: '/api/v1/douyin/search/fetch_video_search_v1',
     verified: true,
+    verifiedOn: '2026-09-06',
     buildRequest({ keyword, cursor, sinceMs, nowMs }) {
       return {
         body: {
@@ -200,7 +221,13 @@ export const PLATFORMS = {
         },
       }
     },
-    itemsOf: (payload) => pickFirst(payload, ['data.data', 'data.aweme_list', 'data']) ?? [],
+    itemsOf(payload) {
+      const items = pickFirst(payload, ['data.data', 'data.aweme_list']) ?? []
+      if (!Array.isArray(items)) return []
+      // 搜索流里混着非作品卡片（`type: 6` 是「相关搜索词」，只有 related_word_list）。
+      // 按「有没有 aweme_info」筛而不是按 type 码，上游加新卡片类型时不用回来改。
+      return items.filter((item) => item?.aweme_info ?? item?.aweme_list?.[0])
+    },
     nextCursorOf(payload) {
       const inner = payload?.data ?? {}
       if (!inner.has_more) return null
@@ -215,8 +242,11 @@ export const PLATFORMS = {
       const id = pickFirst(post, ['aweme_id', 'statistics.aweme_id'])
       return {
         id: id ? String(id) : null,
-        url: pickFirst(post, ['share_url', 'share_info.share_url'])
-          ?? (id ? `https://www.douyin.com/video/${id}` : null),
+        // 规范短链优先：`share_url` 里带着 TikHub 抓取账号的 did/iid 等追踪参数，
+        // 那些既没用又不该进调研产物；拿不到 id 时才退回原始 share_url。
+        url: id
+          ? `https://www.douyin.com/video/${id}`
+          : (pickFirst(post, ['share_url', 'share_info.share_url']) ?? null),
         author: pickFirst(post, ['author.nickname', 'author.unique_id']) ?? null,
         authorId: pickFirst(post, ['author.uid', 'author.sec_uid']) ?? null,
         publishedAt: toIsoTimestamp(pickFirst(post, ['create_time', 'createTime'])),
@@ -231,44 +261,61 @@ export const PLATFORMS = {
     label: '小红书',
     method: 'GET',
     path: '/api/v1/xiaohongshu/app_v2/search_notes',
-    verified: false,
+    verified: true,
+    verifiedOn: '2026-09-06',
     buildRequest({ keyword, cursor, sinceMs, nowMs }) {
-      const days = sinceMs ? Math.ceil((nowMs - sinceMs) / 86_400_000) : 0
-      const timeFilter = !sinceMs ? '不限' : days <= 1 ? '一天内' : days <= 7 ? '一周内' : days <= 180 ? '半年内' : '不限'
       return {
         query: {
           keyword,
           page: Number(cursor?.page ?? 1),
           sort_type: 'general',
-          note_type: '不限',
-          time_filter: timeFilter,
+          note_type: XHS_NOTE_TYPE_ALL,
+          time_filter: xhsTimeFilter(sinceMs, nowMs),
           search_id: String(cursor?.searchId ?? ''),
           search_session_id: String(cursor?.sessionId ?? ''),
         },
       }
     },
-    itemsOf: (payload) => pickFirst(payload, ['data.items', 'data.notes', 'data.data', 'data']) ?? [],
+    /**
+     * 条目在 `data.data.items[]`——**比其它三家多包一层**（外层 `data` 是小红书自己的
+     * 信封：`{ code, data, success, msg, search_id, search_session_id, page, next_page }`）。
+     * 原先写成 `data.items` 时 `pickFirst` 会退到 `data.data` 拿到一个**对象**，
+     * `Array.isArray` 判否 → 静默 0 条：HTTP 200、退出码 0、报告里和「今天没人聊」一模一样。
+     * 那是这份文件开头就点名要防的那种假绿，所以路径写死，不留会退化成静默的候选。
+     */
+    itemsOf(payload) {
+      const items = pickFirst(payload, ['data.data.items', 'data.items']) ?? []
+      if (!Array.isArray(items)) return []
+      // 结果流里除 note 外还会混入 `model_type` 为广告/用户卡片的条目，归一前先剔掉。
+      return items.filter((item) => (item?.model_type ?? 'note') === 'note')
+    },
     nextCursorOf(payload, { page }) {
       const inner = payload?.data ?? {}
-      if (inner.has_more === false) return null
+      // 服务端直接给 `next_page`（没有 `has_more`）；给不出就当到底了，别自己 +1 硬翻。
+      const nextPage = Number(inner.next_page ?? 0)
+      if (!Number.isFinite(nextPage) || nextPage <= page) return null
       return {
-        page: page + 1,
+        page: nextPage,
         searchId: String(pickFirst(inner, ['search_id', 'searchId']) ?? ''),
         sessionId: String(pickFirst(inner, ['search_session_id', 'sessionId']) ?? ''),
       }
     },
     normalize(item) {
-      const note = item?.note_card ?? item?.note ?? item ?? {}
-      const id = pickFirst(item ?? {}, ['id', 'note_id']) ?? pickFirst(note, ['note_id', 'id'])
+      const note = item?.note ?? item?.note_card ?? item ?? {}
+      const id = pickFirst(note, ['id', 'note_id']) ?? pickFirst(item ?? {}, ['id', 'note_id'])
+      // 小红书笔记链接现在要带 `xsec_token` 才打得开（不带的 /explore/<id> 对未登录访客 404）。
+      const xsecToken = pickFirst(note, ['xsec_token'])
+      const url = id
+        ? `https://www.xiaohongshu.com/explore/${id}${xsecToken ? `?xsec_token=${encodeURIComponent(String(xsecToken))}&xsec_source=pc_search` : ''}`
+        : null
       return {
         id: id ? String(id) : null,
-        url: pickFirst(note, ['share_info.link', 'url'])
-          ?? (id ? `https://www.xiaohongshu.com/explore/${id}` : null),
+        url,
         author: pickFirst(note, ['user.nickname', 'user.nick_name', 'user.name']) ?? null,
-        authorId: pickFirst(note, ['user.user_id', 'user.userid', 'user.id']) ?? null,
-        publishedAt: toIsoTimestamp(pickFirst(note, ['time', 'create_time', 'timestamp'])),
-        title: pickFirst(note, ['display_title', 'title']) ?? null,
-        body: pickFirst(note, ['desc', 'display_title', 'title']) ?? '',
+        authorId: pickFirst(note, ['user.userid', 'user.user_id', 'user.red_id']) ?? null,
+        publishedAt: toIsoTimestamp(pickFirst(note, ['timestamp', 'time', 'create_time'])),
+        title: pickFirst(note, ['title', 'display_title']) ?? null,
+        body: pickFirst(note, ['desc', 'title', 'display_title']) ?? '',
       }
     },
   },
@@ -278,7 +325,8 @@ export const PLATFORMS = {
     label: 'B站',
     method: 'GET',
     path: '/api/v1/bilibili/web/fetch_general_search',
-    verified: false,
+    verified: true,
+    verifiedOn: '2026-09-06',
     buildRequest({ keyword, cursor, sinceMs, nowMs }) {
       return {
         query: {
@@ -300,7 +348,9 @@ export const PLATFORMS = {
         const videos = result.find((group) => group?.result_type === 'video') ?? result[0]
         return Array.isArray(videos?.data) ? videos.data : []
       }
-      return result
+      // 扁平数组里混着 `type: 'ketang'`（付费课程投放）：那是商品不是创作者内容，
+      // 而且 `pubdate` 恒 0——留着只会在报告里堆一排「未解析出时间」的假缺字段。
+      return result.filter((item) => (item?.type ?? 'video') === 'video')
     },
     nextCursorOf(payload, { page, collected }) {
       const numPages = Number(pickFirst(payload, ['data.data.numPages', 'data.numPages']) ?? 0)
@@ -328,30 +378,37 @@ export const PLATFORMS = {
     label: 'X（Twitter）',
     method: 'GET',
     path: '/api/v1/twitter/web/fetch_search_timeline',
-    verified: false,
+    verified: true,
+    verifiedOn: '2026-09-06',
     buildRequest({ keyword, cursor }) {
       const query = { keyword, search_type: 'Top' }
       if (cursor?.cursor) query.cursor = String(cursor.cursor)
       return { query }
     },
-    itemsOf: (payload) => pickFirst(payload, ['data.timeline', 'data.tweets', 'data.data', 'data']) ?? [],
+    itemsOf(payload) {
+      const items = pickFirst(payload, ['data.timeline', 'data.tweets']) ?? []
+      if (!Array.isArray(items)) return []
+      // timeline 里除 tweet 外还会混 `type` 为提示/模块的条目，归一前先剔掉。
+      return items.filter((item) => (item?.type ?? 'tweet') === 'tweet')
+    },
     nextCursorOf(payload) {
-      const next = pickFirst(payload?.data ?? {}, ['cursor.bottom', 'next_cursor', 'cursor'])
+      const next = pickFirst(payload?.data ?? {}, ['next_cursor', 'cursor.bottom'])
       return next ? { cursor: String(next) } : null
     },
     normalize(item) {
       const tweet = item?.tweet ?? item ?? {}
-      const id = pickFirst(tweet, ['rest_id', 'id_str', 'id'])
-      const handle = pickFirst(tweet, ['user.screen_name', 'author.screen_name', 'screen_name'])
+      // 条目是**扁平**的：`tweet_id` / `screen_name` / `text` 都在顶层，作者名在 `user_info.name`。
+      // 之前按 `rest_id` / `user.screen_name` 取，两个都恒空 → 每条都缺 id 和 url。
+      const id = pickFirst(tweet, ['tweet_id', 'rest_id', 'id_str', 'id'])
+      const handle = pickFirst(tweet, ['screen_name', 'user_info.screen_name', 'user.screen_name'])
       return {
         id: id ? String(id) : null,
-        url: pickFirst(tweet, ['url'])
-          ?? (handle && id ? `https://x.com/${handle}/status/${id}` : null),
-        author: pickFirst(tweet, ['user.name', 'author.name']) ?? (handle ? String(handle) : null),
+        url: handle && id ? `https://x.com/${handle}/status/${id}` : (pickFirst(tweet, ['url']) ?? null),
+        author: pickFirst(tweet, ['user_info.name', 'user.name']) ?? (handle ? String(handle) : null),
         authorId: handle ? String(handle) : null,
         publishedAt: toIsoTimestamp(pickFirst(tweet, ['created_at', 'legacy.created_at', 'timestamp'])),
         title: null,
-        body: pickFirst(tweet, ['full_text', 'text', 'legacy.full_text']) ?? '',
+        body: pickFirst(tweet, ['text', 'full_text', 'legacy.full_text']) ?? '',
       }
     },
   },
@@ -374,9 +431,17 @@ export function resolvePlatforms(name) {
 
 // ───────────────────────── 传输：超时 + 有上限的重试退避 ─────────────────────────
 
-/** 哪些失败值得再试一次。401/403/404/422 是「你问错了」，重试只会白烧配额。 */
+/**
+ * 哪些失败值得再试一次。401/403/404/422 是「你问错了」，重试只会白烧配额。
+ *
+ * **400 属于可重试**——这条反直觉，所以写清依据（2026-09-06 实测，见 notes §5）：
+ * TikHub 是 FastAPI，参数校验失败返回的是 **422**（spec 里每个端点都只声明 200/422）；
+ * 而枚举值填错（`time_filter=one_week` / 传时间戳）**照样返回 200**，只是结果为空。
+ * 也就是说 400 在这套 API 上**不可能**是「参数不对」，只能是上游平台抓取层当时没抓到——
+ * 那正是重试能救的一类。把它当致命错会让一次抖动直接抹掉整个平台。
+ */
 export function isRetriableStatus(status) {
-  return status === 408 || status === 425 || status === 429 || status >= 500
+  return status === 400 || status === 408 || status === 425 || status === 429 || status >= 500
 }
 
 /** 第 attempt 次失败后等多久。服务端给了 Retry-After 就听它的，否则指数退避，无抖动。 */
@@ -498,6 +563,8 @@ export function toRecord(platform, rawItem) {
     excerpt: excerptOf(body),
     mentions: extractToolMentions(`${title ?? ''} ${body}`),
     fieldConfidence: platform.verified ? 'verified-against-live-response' : 'best-effort-unverified',
+    // 核对日期跟着记录走：上游改形状时，「这条证据是哪天对的账」比一个 boolean 有用得多。
+    fieldsVerifiedOn: platform.verifiedOn ?? null,
   }
   record.missingFields = REQUIRED_FIELDS.filter((field) => !record[field])
   return record
@@ -553,6 +620,49 @@ export async function searchPlatform({
   return { platform: platform.id, platformLabel: platform.label, records, pages }
 }
 
+// ───────────────────────── 汇总 ─────────────────────────
+
+/**
+ * 每平台一行的对账摘要。
+ *
+ * 为什么要单独一段：`results[].records` 是给下游消费的，但「这轮到底靠不靠谱」
+ * 得把整个数组读完才看得出来。三种状态在原始数组里长得太像——
+ * `failed`（打不通）、`empty`（打通了但没命中）、`ok` 且带一堆 `missingFields`
+ * （打通了、有条目、但我们没解析出字段）——最后一种最危险，因为它在报告里最像正常。
+ * 摘要把三者摊平，调用方一眼就能判断该不该信这轮数据。
+ */
+export function summarizeResults(results = []) {
+  const platforms = results.map((group) => {
+    const records = Array.isArray(group.records) ? group.records : []
+    const missingFields = {}
+    for (const record of records) {
+      for (const field of record.missingFields ?? []) {
+        missingFields[field] = (missingFields[field] ?? 0) + 1
+      }
+    }
+    return {
+      platform: group.platform,
+      platformLabel: group.platformLabel,
+      status: group.error ? 'failed' : records.length === 0 ? 'empty' : 'ok',
+      items: records.length,
+      pagesFetched: Array.isArray(group.pages) ? group.pages.length : 0,
+      missingFields,
+      fieldConfidence: records[0]?.fieldConfidence ?? (PLATFORMS[group.platform]?.verified
+        ? 'verified-against-live-response'
+        : 'best-effort-unverified'),
+      fieldsVerifiedOn: records[0]?.fieldsVerifiedOn ?? PLATFORMS[group.platform]?.verifiedOn ?? null,
+      error: group.error ?? null,
+    }
+  })
+  return {
+    totalRecords: platforms.reduce((sum, row) => sum + row.items, 0),
+    platformsOk: platforms.filter((row) => row.status === 'ok').length,
+    platformsEmpty: platforms.filter((row) => row.status === 'empty').length,
+    platformsFailed: platforms.filter((row) => row.status === 'failed').length,
+    platforms,
+  }
+}
+
 // ───────────────────────── 渲染 ─────────────────────────
 
 function mdEscape(text) {
@@ -573,7 +683,30 @@ export function renderMarkdown({ keyword, since, generatedAt, results }) {
     '> 摘要是**原文前 300 字**，没有任何 AI 改写；`framework/tool` 是正则抽取的提及，不是判断。',
     '> 标 `best-effort-unverified` 的平台字段路径未经真实响应核对，读结论时以 URL 原文为准。',
     '',
+    '## 本轮对账',
+    '',
+    '| 平台 | 状态 | 条数 | 页数 | 缺字段 | 字段路径 |',
+    '|---|---|---|---|---|---|',
   ]
+
+  const summary = summarizeResults(results)
+  for (const row of summary.platforms) {
+    const missing = Object.entries(row.missingFields)
+    lines.push([
+      '',
+      row.platformLabel,
+      // 三种状态必须在同一列里区分得开，否则「打不通」会被读成「没人聊」。
+      row.status === 'failed' ? `✗ 失败：${mdEscape(row.error ?? '')}` : row.status === 'empty' ? '⚠️ 没命中' : '✓',
+      String(row.items),
+      String(row.pagesFetched),
+      missing.length === 0 ? '（无）' : missing.map(([field, count]) => `${field}×${count}`).join('、'),
+      row.fieldConfidence === 'verified-against-live-response'
+        ? `已核对 ${row.fieldsVerifiedOn ?? ''}`.trim()
+        : '未核对',
+      '',
+    ].join(' | '))
+  }
+  lines.push('')
 
   for (const group of results) {
     lines.push(`## ${group.platformLabel}（${group.records.length} 条）`, '')

--- a/scripts/research/tikhub-search.mjs
+++ b/scripts/research/tikhub-search.mjs
@@ -28,6 +28,7 @@ import {
   renderMarkdown,
   resolvePlatforms,
   searchPlatform,
+  summarizeResults,
 } from './tikhub-search-lib.mjs'
 
 const USAGE = `用法：node scripts/research/tikhub-search.mjs --q "<关键词>" [--platform douyin|xhs|bilibili|x|all] [--limit 20] [--since 2026-01-01] --out <dir>
@@ -126,6 +127,9 @@ async function main() {
     limitPerPlatform: options.limit,
     generatedAt,
     failures,
+    // 摘要放在 results 之前：调用方（含 agent）第一眼就该看到「这轮靠不靠谱」，
+    // 而不是先读完几百条 records 才发现某个平台其实是空的。
+    summary: summarizeResults(results),
     results,
   }
   const jsonPath = path.join(outDir, 'tikhub-search.json')
@@ -133,8 +137,15 @@ async function main() {
   fs.writeFileSync(jsonPath, `${JSON.stringify(bundle, null, 2)}\n`)
   fs.writeFileSync(mdPath, renderMarkdown({ keyword: options.query, since: options.since, generatedAt, results }))
 
-  const total = results.reduce((sum, group) => sum + group.records.length, 0)
-  process.stdout.write(`${jsonPath}\n${mdPath}\n共 ${total} 条${failures.length > 0 ? `（${failures.length} 个平台失败）` : ''}\n`)
+  const { totalRecords, platforms: summaryRows } = bundle.summary
+  process.stdout.write(`${jsonPath}\n${mdPath}\n`)
+  for (const row of summaryRows) {
+    const missing = Object.entries(row.missingFields)
+      .map(([field, count]) => `${field}×${count}`)
+      .join('、')
+    process.stdout.write(`  ${row.status === 'ok' ? '✓' : row.status === 'empty' ? '⚠️' : '✗'} ${row.platformLabel}：${row.items} 条${missing ? ` · 缺字段 ${missing}` : ''}${row.error ? ` · ${row.error}` : ''}\n`)
+  }
+  process.stdout.write(`共 ${totalRecords} 条${failures.length > 0 ? `（${failures.length} 个平台失败）` : ''}\n`)
   return failures.length === platforms.length && platforms.length > 0 ? 3 : 0
 }
 

--- a/scripts/research/tikhub-search.node-test.mjs
+++ b/scripts/research/tikhub-search.node-test.mjs
@@ -20,6 +20,9 @@ import {
   isRetriableStatus,
   PLATFORMS,
   readApiKey,
+  summarizeResults,
+  XHS_TIME_FILTERS,
+  xhsTimeFilter,
   renderMarkdown,
   requestJson,
   resolvePlatforms,
@@ -101,6 +104,12 @@ test('422 参数错同样不重试', () => {
   assert.equal(isRetriableStatus(401), false)
   assert.equal(isRetriableStatus(429), true)
   assert.equal(isRetriableStatus(503), true)
+})
+
+test('400 可重试：这套 API 的参数错是 422，400 只可能是上游抓取抖动', () => {
+  // 依据实测（notes §5）：枚举填错返回 200、schema 不合返回 422，
+  // 所以 400 不可能是「我们问错了」。把它当致命错，一次抖动就抹掉整个平台。
+  assert.equal(isRetriableStatus(400), true)
 })
 
 // ── 3. 限流退避 ────────────────────────────────────────────
@@ -303,8 +312,232 @@ test('Markdown 渲染：出处/平台/作者/时间/摘要/提及六件都在', 
     },
   })] }
   const md = renderMarkdown({ keyword: 'ComfyUI', since: null, generatedAt: '2026-09-06T00:00:00.000Z', results: [group] })
-  for (const needle of ['https://example.invalid/7', '抖音', '张三', 'ComfyUI 真香', '提到的框架/工具']) {
+  for (const needle of ['https://www.douyin.com/video/7', '抖音', '张三', 'ComfyUI 真香', '提到的框架/工具']) {
     assert.ok(md.includes(needle), `渲染结果里少了 ${needle}`)
   }
   assert.ok(md.includes('原文前 300 字'))
+})
+
+// ── 6. 真实响应形状回归 ────────────────────────────────────
+/**
+ * 下面四段夹具是 **2026-09-06 用真实 key 各抓一次**、逐字段对完账后按原样**结构**
+ * 缩写而成（值已脱敏：token/链接换成 fixture 值，嵌套层级一层不改）。
+ *
+ * 为什么必须钉结构而不是钉字段名：这四家翻车过的地方全在**外层包了几层**，
+ * 而包错的代价是 HTTP 200 + 退出码 0 + 0 条记录——报告里和「今天没人聊」一模一样。
+ * 所以每条都断言「条数」而不只是「不抛」。
+ */
+
+/** 小红书：条目在 `data.data.items[]`，比其它三家多包一层信封。 */
+function xhsPage({ items, page = 1, nextPage = 2 }) {
+  return {
+    code: 200,
+    data: {
+      code: 0,
+      success: true,
+      page,
+      next_page: nextPage,
+      search_id: `sid-${page}`,
+      search_session_id: `ssid-${page}`,
+      data: {
+        items: items.map((n) => ({
+          mix_track_id: `NOTE__${n}`,
+          model_type: 'note',
+          note: {
+            id: `note${n}`,
+            title: `第 ${n} 条：我用 ComfyUI 出片`,
+            desc: `正文 ${n}`,
+            timestamp: 1_788_000_000 + n,
+            type: 'normal',
+            xsec_token: `tok${n}`,
+            user: { nickname: `小红薯${n}`, userid: `uid${n}`, red_id: `red${n}` },
+          },
+        })),
+      },
+    },
+  }
+}
+
+test('小红书：条目在 data.data.items，不是 data.items（曾静默返回 0 条）', () => {
+  const items = PLATFORMS.xhs.itemsOf(xhsPage({ items: [1, 2, 3] }))
+  assert.equal(items.length, 3, 'itemsOf 没扒到 data.data.items —— 这正是那次「200 但 0 条」的形状')
+  const record = toRecord(PLATFORMS.xhs, items[0])
+  assert.deepEqual(record.missingFields, [])
+  assert.equal(record.id, 'note1')
+  assert.equal(record.author, '小红薯1')
+  assert.equal(record.authorId, 'uid1')
+  assert.equal(record.title, '第 1 条：我用 ComfyUI 出片')
+  assert.equal(record.publishedAt, new Date(1_788_000_001 * 1000).toISOString())
+  // 不带 xsec_token 的 /explore/<id> 对未登录访客打不开，链接必须带上。
+  assert.equal(record.url, 'https://www.xiaohongshu.com/explore/note1?xsec_token=tok1&xsec_source=pc_search')
+  assert.equal(record.fieldConfidence, 'verified-against-live-response')
+  assert.equal(record.fieldsVerifiedOn, '2026-09-06')
+})
+
+test('小红书：非 note 卡片（广告/用户）在归一前剔掉', () => {
+  const payload = xhsPage({ items: [1] })
+  payload.data.data.items.push({ model_type: 'user', user: { nickname: '某账号' } })
+  assert.equal(PLATFORMS.xhs.itemsOf(payload).length, 1)
+})
+
+test('小红书翻页：认服务端的 next_page，给不出就停（不自己 +1 硬翻）', async () => {
+  const { impl, calls } = stubFetch([
+    { json: xhsPage({ items: [1, 2], page: 1, nextPage: 2 }) },
+    { json: xhsPage({ items: [3], page: 2, nextPage: 0 }) },
+  ])
+  const { sleep } = recordingSleep()
+  const group = await searchPlatform({
+    platform: PLATFORMS.xhs, keyword: 'ComfyUI', limit: 10, apiKey: FAKE_KEY, fetchImpl: impl, sleep,
+  })
+  assert.equal(group.records.length, 3)
+  const secondUrl = new URL(calls[1].url)
+  assert.equal(secondUrl.searchParams.get('page'), '2')
+  assert.equal(secondUrl.searchParams.get('search_id'), 'sid-1', '翻页没回传首次搜索的 search_id')
+  assert.equal(secondUrl.searchParams.get('search_session_id'), 'ssid-1')
+  assert.equal(calls.length, 2, 'next_page 为 0 之后还在继续翻')
+})
+
+test('小红书筛选值是中文枚举，且 --since 按四档映射（填错不会报错，只有测试拦得住）', async () => {
+  const nowMs = Date.parse('2026-09-06T00:00:00.000Z')
+  const day = 86_400_000
+  assert.equal(xhsTimeFilter(null, nowMs), '不限')
+  assert.equal(xhsTimeFilter(nowMs - day, nowMs), '一天内')
+  assert.equal(xhsTimeFilter(nowMs - 5 * day, nowMs), '一周内')
+  assert.equal(xhsTimeFilter(nowMs - 30 * day, nowMs), '半年内')
+  assert.equal(xhsTimeFilter(nowMs - 400 * day, nowMs), '不限', '超出半年该回落到不限，不是继续传半年内')
+  // 边界：正好 1 天 / 7 天 / 180 天都落在本档内。
+  assert.equal(xhsTimeFilter(nowMs - 7 * day, nowMs), '一周内')
+  assert.equal(xhsTimeFilter(nowMs - 180 * day, nowMs), '半年内')
+  assert.deepEqual(Object.values(XHS_TIME_FILTERS), ['不限', '一天内', '一周内', '半年内'])
+
+  // 真发出去的那一条也得是中文，不能是时间戳/英文。
+  const { impl, calls } = stubFetch([{ json: xhsPage({ items: [1], nextPage: 0 }) }])
+  const { sleep } = recordingSleep()
+  await searchPlatform({
+    platform: PLATFORMS.xhs, keyword: 'x', limit: 1, sinceMs: nowMs - 5 * day, nowMs,
+    apiKey: FAKE_KEY, fetchImpl: impl, sleep,
+  })
+  const sent = new URL(calls[0].url)
+  assert.equal(sent.searchParams.get('time_filter'), '一周内')
+  assert.equal(sent.searchParams.get('note_type'), '不限')
+  assert.equal(sent.searchParams.get('sort_type'), 'general')
+})
+
+test('X：条目是扁平的 tweet_id/screen_name/user_info.name（曾整列缺 id 和 url）', () => {
+  const payload = {
+    code: 200,
+    data: {
+      status: 'ok',
+      next_cursor: 'CUR-2',
+      timeline: [
+        {
+          type: 'tweet',
+          tweet_id: '2089959315843039598',
+          screen_name: 'fixture_handle',
+          created_at: 'Wed Aug 19 06:15:05 +0000 2026',
+          text: 'This open-source AI video tool runs locally.',
+          user_info: { screen_name: 'fixture_handle', name: '夹具作者', rest_id: '1818918150504603648' },
+        },
+        { type: 'module', text: '这是非推文卡片' },
+      ],
+    },
+  }
+  const items = PLATFORMS.x.itemsOf(payload)
+  assert.equal(items.length, 1, '非 tweet 卡片没被剔掉')
+  const record = toRecord(PLATFORMS.x, items[0])
+  assert.deepEqual(record.missingFields, [])
+  assert.equal(record.id, '2089959315843039598')
+  assert.equal(record.url, 'https://x.com/fixture_handle/status/2089959315843039598')
+  assert.equal(record.author, '夹具作者')
+  assert.equal(record.authorId, 'fixture_handle')
+  assert.equal(record.publishedAt, '2026-08-19T06:15:05.000Z')
+  assert.deepEqual(PLATFORMS.x.nextCursorOf(payload, { page: 1, collected: 1 }), { cursor: 'CUR-2' })
+})
+
+test('抖音：搜索流里的非作品卡片（相关搜索词）剔掉，链接用规范短链', () => {
+  const payload = {
+    code: 200,
+    data: {
+      has_more: 1,
+      cursor: 8,
+      data: [
+        {
+          type: 1,
+          aweme_info: {
+            aweme_id: '7626746141451048299',
+            desc: '一分钟教你用 ComfyUI 生成视频',
+            create_time: 1_788_000_000,
+            // 真实响应的 share_url 带着抓取账号的 did/iid 追踪参数，不该进调研产物。
+            share_url: 'https://www.iesdouyin.com/share/video/7626746141451048299/?did=REDACTED&iid=REDACTED',
+            author: { uid: '913067793217818', nickname: '夹具作者' },
+          },
+        },
+        { type: 6, related_word_list: [{ word: '相关搜索' }] },
+      ],
+    },
+  }
+  const items = PLATFORMS.douyin.itemsOf(payload)
+  assert.equal(items.length, 1, 'type 6「相关搜索词」卡片没被剔掉')
+  const record = toRecord(PLATFORMS.douyin, items[0])
+  assert.deepEqual(record.missingFields, [])
+  assert.equal(record.url, 'https://www.douyin.com/video/7626746141451048299')
+  assert.ok(!record.url.includes('did='), 'URL 里不该带抓取账号的追踪参数')
+})
+
+test('B站：付费课程投放（type ketang，pubdate 恒 0）剔掉，只留创作者视频', () => {
+  const payload = {
+    code: 200,
+    data: {
+      data: {
+        numPages: 50,
+        result: [
+          { type: 'video', bvid: 'BV1yPtn6MExc', title: 'AI 接吻', author: 'UP主', mid: 37, pubdate: 1_788_000_000 },
+          { type: 'ketang', bvid: 'BV1course', title: '【限时优惠】玩转 AI 视频', author: '课堂', mid: 9, pubdate: 0 },
+        ],
+      },
+    },
+  }
+  const items = PLATFORMS.bilibili.itemsOf(payload)
+  assert.equal(items.length, 1, 'ketang 付费课程没被剔掉——它会在报告里堆一排假的「未解析出时间」')
+  assert.deepEqual(toRecord(PLATFORMS.bilibili, items[0]).missingFields, [])
+})
+
+// ── 7. 汇总段 ──────────────────────────────────────────────
+test('summary：打不通 / 没命中 / 有条目但缺字段，三种状态分得开', () => {
+  const ok = toRecord(PLATFORMS.douyin, {
+    aweme_info: { aweme_id: '1', desc: '正文', create_time: 1_788_000_000, author: { uid: 'u', nickname: '作者' } },
+  })
+  const lossy = toRecord(PLATFORMS.douyin, { aweme_info: { desc: '只有正文' } })
+  const summary = summarizeResults([
+    { platform: 'douyin', platformLabel: '抖音', records: [ok, lossy], pages: [{ page: 1, received: 2 }] },
+    { platform: 'xhs', platformLabel: '小红书', records: [], pages: [{ page: 1, received: 0 }] },
+    { platform: 'x', platformLabel: 'X（Twitter）', records: [], pages: [], error: 'HTTP 400: upstream' },
+  ])
+  assert.equal(summary.totalRecords, 2)
+  assert.deepEqual(
+    summary.platforms.map((row) => row.status),
+    ['ok', 'empty', 'failed'],
+    '「打不通」和「没命中」必须分得开，否则报告里长得一样',
+  )
+  assert.equal(summary.platformsOk, 1)
+  assert.equal(summary.platformsEmpty, 1)
+  assert.equal(summary.platformsFailed, 1)
+  assert.deepEqual(summary.platforms[0].missingFields, { url: 1, author: 1, publishedAt: 1 })
+  assert.equal(summary.platforms[0].fieldsVerifiedOn, '2026-09-06')
+  assert.equal(summary.platforms[2].error, 'HTTP 400: upstream')
+})
+
+test('Markdown 抬头带对账表：三种状态各自看得出来', () => {
+  const md = renderMarkdown({
+    keyword: 'ComfyUI',
+    since: null,
+    generatedAt: '2026-09-06T00:00:00.000Z',
+    results: [
+      { platform: 'xhs', platformLabel: '小红书', records: [], pages: [{ page: 1, received: 0 }] },
+      { platform: 'x', platformLabel: 'X（Twitter）', records: [], pages: [], error: 'HTTP 400: upstream' },
+    ],
+  })
+  assert.ok(md.includes('## 本轮对账'))
+  assert.ok(md.includes('⚠️ 没命中'))
+  assert.ok(md.includes('✗ 失败：HTTP 400: upstream'))
 })


### PR DESCRIPTION
## 根因

TikHub 小红书 `search_notes` 反复取回 0 条，在报告里和「今天没人聊」一模一样。实抓核对后是两件事叠在一起：

1. **条目层级少数一层**。真实响应是 `data.data.items[]`——外层 `data` 是 TikHub 信封，里面还有小红书自己的一层信封。我们按 `data.items` 取，`pickFirst` 退到 `data.data` 拿回一个**对象**，`Array.isArray` 判否 → **HTTP 200、退出码 0、0 条记录**。
2. **400 被当成致命错**。spec 里每个端点只声明 `200`/`422`：参数类型不合走 FastAPI 的 422，枚举值填错**照样 200**。所以 400 在这套 API 上不可能是「参数不对」，只能是上游抓取层的抖动——归进 `isRetriableStatus`。验收跑里小红书正好吃到一次 400，重试后拿回 3 条，实地印证。

顺手把另外三家也用真实 key 实抓了一遍，**X 也是错的**：条目是**扁平**的，原先按 `rest_id` / `user.screen_name` 取，两个都恒空 → 每条都缺 `id` 和 `url`。

## 改了什么

- 中文枚举提成常量 `XHS_TIME_FILTERS` + `xhsTimeFilter()`，`--since` 按四档映射，夹具逐档钉死——**填错不报错**（实测 `time_filter=one_week` / 传时间戳都返回 200 只是筛选静默失效），只有测试拦得住。
- 翻页认服务端给的 `next_page`，不再自己 `page + 1` 硬翻。
- 笔记链接补 `xsec_token`（裸 `/explore/<id>` 对未登录访客打不开）。
- 四家结果流里混着的非内容卡片（抖音相关搜索词 / 小红书广告卡 / B站付费课程 / X 提示模块）在归一前剔掉，否则会在报告里堆成一排**假的**「未解析出字段」。
- 抖音改用规范短链，不再把抓取账号的 `did`/`iid` 追踪参数写进产物。
- 新增 `summarizeResults()` + 产物 `summary` 段 + Markdown 对账表：`failed`（打不通）/ `empty`（没命中）/ `ok` 但缺字段——三种状态在原始 records 数组里长得太像，摘要把它们摊平，调用方一眼能判断该不该信这轮数据。
- 四家 `verified` 翻真 + `fieldsVerifiedOn: 2026-09-06` 跟着每条记录走（上游改形状时，「这条证据是哪天对的账」比一个 boolean 有用）。
- `docs/research/tikhub-api-notes.md` 补上响应形状、400 的定性、四家字段对账表、真实 key 验收记录。

## 验证

- 真实 key 四平台各 `--limit 3`：抖音 3 / 小红书 3 / B站 3 / X 3，**四家 `missingFields` 全空**。
- 产物与全仓 `grep` key 前 12 位 → 命中 **0 个文件**。
- `node --test scripts/research/tikhub-search.node-test.mjs` → **29 项全绿**。
- `pnpm run gates` 全绿（戳 `ccb4598c712e`）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)