### PR TITLE
fix(design-lab): 走查入口的死参数当场抛，报错里的端口不再是 undefined

### DIFF
--- a/tests/ux/design-lab/labFailureTriage.test.mjs
+++ b/tests/ux/design-lab/labFailureTriage.test.mjs
@@ -16,6 +16,7 @@ import {
   triageLabRun,
 } from './failureTriage.mjs'
 import { LAB_ROLES, classifyPortHolder, labPortFor, portHolder } from './labServer.mjs'
+import { REPO_ROOT } from './labStates.mjs'
 import { FAILURE_TAIL_LINES } from '../../../scripts/run-gates-contracts.mjs'
 
 const CONNECTION_REFUSED_RUN = `
@@ -227,5 +228,28 @@ describe('实验室端口的 worktree 归属', () => {
     } finally {
       await new Promise((resolve) => server.close(resolve))
     }
+  })
+
+  // 立项根因（2026-09-06）：端口从写死改成 labPortFor(role) 派生后，两份走查入口
+  // （host-config、agent-panel-v4）还留着 `port: 5202` / `port: 5241`、都没传 `role`。
+  // 运行时 labPortFor(undefined) 会当场抛，但**走查本身不在 gates 里**——于是「这两条 npm
+  // script 一次都跑不起来」只能等有人手动跑才暴露，中间隔了好几个 PR。
+  // 这条测试是那道跑在 CI 里的防线：入口的声明对不对，静态读文本就能判，不用把浏览器拉起来。
+  it('每份走查入口都认领了一个登记过的角色，且不再写死端口', () => {
+    const uxDir = path.join(REPO_ROOT, 'tests/ux')
+    const entries = fs.readdirSync(uxDir).filter((name) => /^design-lab-.*\.walk\.mjs$/.test(name))
+    expect(entries.length).toBeGreaterThan(0)
+    const claimed = []
+    for (const entry of entries) {
+      const source = fs.readFileSync(path.join(uxDir, entry), 'utf8')
+      const body = source.replace(/^\s*\/\/.*$/gm, '')
+      const role = body.match(/\brole:\s*'([^']+)'/)?.[1]
+      expect(role, `${entry} 没有认领角色`).toBeTruthy()
+      expect(LAB_ROLES, `${entry} 的角色 ${role} 没登记进 LAB_ROLES`).toContain(role)
+      expect(body, `${entry} 还在写死端口，端口该由 labPortFor(role) 派生`).not.toMatch(/\bport:\s*\d/)
+      claimed[claimed.length] = role
+    }
+    // 每个角色只能被一份入口认领：两份共用一个角色 = 并行跑时又撞回同一口。
+    expect(new Set(claimed).size).toBe(claimed.length)
   })
 })

--- a/tests/ux/design-lab/walkScreen.mjs
+++ b/tests/ux/design-lab/walkScreen.mjs
@@ -41,6 +41,17 @@ function waitForServer(url, timeoutMs = 60000) {
 }
 
 /**
+ * 入口文件传进来的取景参数，**只认这几个键**。
+ *
+ * 立项根因（2026-09-06）：端口写死那一版留下的 `port` 键，在改成 `labPortFor(role)` 派生之后
+ * 变成了没人读的死参数，而当时两份入口（host-config、agent-panel-v4）都还传着它、都没传 `role`。
+ * 少一个键有 labPortFor 兜底（当场抛「未知的实验室角色：undefined」），**多一个键以前没人管**——
+ * 于是「这两条 npm script 从来没跑起来过」只能等有人手动跑那条 script 才会暴露。
+ * 这里把多出来的键也变成当场抛：死参数不许安静地躺着（R28 防线建在最早能拦住的那层）。
+ */
+const CONFIG_KEYS = new Set(['screen', 'title', 'role', 'cellWidth', 'columns', 'viewport', 'assertState'])
+
+/**
  * @param {{
  *   screen: string,
  *   title: string,
@@ -52,6 +63,10 @@ function waitForServer(url, timeoutMs = 60000) {
  * }} config
  */
 export async function walkDesignLabScreen(config) {
+  const strayKeys = Object.keys(config).filter((key) => !CONFIG_KEYS.has(key))
+  if (strayKeys.length) {
+    throw new Error(`走查入口传了没人读的参数：${strayKeys.join(', ')}（已登记：${[...CONFIG_KEYS].join(', ')}）`)
+  }
   const OUT_DIR = path.join(REPO_ROOT, `tests/ux/shots/design-lab-${config.screen}`)
   const HOST = '127.0.0.1'
   // 端口按 worktree 派生，不再写死（labServer.mjs）：写死的端口是整台机器的全局单例，
@@ -117,9 +132,10 @@ export async function walkDesignLabScreen(config) {
       const overlap = parsed.filter((id) => (live || []).includes(id)).length
       if (overlap === 0) {
         throw new Error(
-          `端口 ${config.port} 上应答的不是本 worktree 的实验室（活页面的状态和本仓一个都对不上）。`
-          + `\n先查是谁占着：lsof -nP -iTCP:${config.port} -sTCP:LISTEN`
-          + `\n别去 kill 别人的 dev server——给本屏换一个没人用的端口。`,
+          `端口 ${PORT} 上应答的不是本 worktree 的实验室（活页面的状态和本仓一个都对不上）。`
+          + `\n先查是谁占着：lsof -nP -iTCP:${PORT} -sTCP:LISTEN`
+          + `\n别去 kill 别人的 dev server，也别在入口里写死另一个端口`
+          + `——端口按 worktree + 角色派生（labServer.mjs），撞上就是那台机器问不出 cwd，等对方跑完。`,
         )
       }
     }


### PR DESCRIPTION
接替 #540（分支 `claude/funny-shannon-30d51d` 与 main 冲突严重，`gh pr update-branch` 失败）。逐 hunk 对照今天的 `origin/main`（8a0471b6c）后，#540 六处改动的判定：

**已被 main 等价覆盖（不搬）**
1. `LAB_ROLES` 补登记 `walk-host-config` / `walk-agent-panel-v4` — main 已登记 8 个角色（`tests/ux/design-lab/labServer.mjs:30`），比 #540 那版还多 4 个。
2. 四份入口改成认领 `role`、删掉写死端口 — main 的 7 份入口全部只传 `role`，一份都没有 `port:`（`tests/ux/design-lab-host-config.walk.mjs:14`、`design-lab-agent-panel-v4.walk.mjs:16`）。
3. `labServer` 的「段宽随角色数走、别在注释里数」注释 — main 已有等价表述（`labServer.mjs:33-36`）。#540 的「四屏」字样反而已经过期（现在是 7 屏），main 的「各屏」写法更好。

**main 至今仍缺（本 PR 只搬这三处）**
4. `walkScreen` 只认登记过的配置键。少一个键有 `labPortFor` 兜底当场抛，**多一个键以前没人管**——`port: 5202` 那类死参数可以安静躺着，直到有人手动跑那条 script 才发现它从来没跑起来过。这里把 main 新增的 `assertState` 也纳入了登记。
5. `walkScreen.mjs:120-122` 的 `config.port` 是**死引用**（端口早已改由 `labPortFor(role)` 派生），overlap===0 时恒打印「端口 undefined 上应答的不是本 worktree 的实验室」，还叫人「换一个端口」——而端口不再是入口能换的东西。改用真正派生出来的 `PORT`，口径改成归属断言的口径。
6. `labFailureTriage` 的静态断言：每份 walk 入口都认领了登记过、互不重复的角色，且不再写死端口。走查本身不在 gates 里，这条跑在 `pnpm run test` 里才拦得住下一次（R28 防线建在最早能拦住的那层）。

**两道防线都验过会红**
- 静态断言：给 host-config 入口塞回 `port: 5202` → `1 failed | 17 passed`，报「还在写死端口」。
- 运行时守卫：`walkDesignLabScreen({..., port: 5202})` → 抛「走查入口传了没人读的参数：port（已登记：screen, title, role, cellWidth, columns, viewport, assertState）」。

**门岗**
- `pnpm run gates:contracts`：67/67 通过（含 `check:design-lab`、`check:walkthroughs`），0 阻断失败。
- `pnpm run gates` 五门全过：`Test Files 1228 passed | 1 skipped`、`Tests 11364 passed | 2 skipped`，build 通过，已盖戳。

不含产品代码改动，只动 `tests/ux/`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)