### PR TITLE
docs(research): pi 包生态调研 —— 借什么 / 发什么 / 学什么

### DIFF
--- a/docs/research/2026-09-07-pi-package-ecosystem.md
+++ b/docs/research/2026-09-07-pi-package-ecosystem.md
@@ -1,0 +1,267 @@
+# pi 包生态调研（2026-09-07）
+
+> 状态：📎 交接/日志 —— **只调研不改码，一行产品代码未动。**
+> 日期：2026-09-07 · 基线：`origin/main@620b658cb` · 依赖：`@earendil-works/pi-{coding-agent,agent-core,ai}@0.85.1`（`package.json:202-204` 已锁精确版本）
+> 服务对象：[`docs/plan/2026-09-07-agent-runtime-rebuild.md`](../plan/2026-09-07-agent-runtime-rebuild.md)（Agent 运行时重做）的阶段 3 / 阶段 5，以及 [`docs/research/2026-09-07-pi-reference-implementation-conformance.md`](2026-09-07-pi-reference-implementation-conformance.md)（参考实现逐层对照）留下的层 7「扩展 API」缺口
+> 起因：2026-09-07 用户原话 —— **「有调查 pi agent package 吗，类似他们的生态，可能对我们有帮助」**
+
+---
+
+## 0. 一句话先答
+
+pi 的「包」= **一个 npm/git 包，用 `package.json` 里的 `pi` 键声明四类资源（extensions / skills / prompts / themes），`pi install` 装进 `~/.pi/agent/` 或 `.pi/`，装完那段代码就以你的完整系统权限跑**。生态是真的：npm 上带 `pi-package` 关键字的包**实测 5 250 个**，其中 **2 791 个是 2026-08 一个月里冒出来的**，官方目录分页到第 106 页。
+
+对 Nomi 的三句判断（详见 §5–§6）：**扩展一个都不装**（它把「任意代码 + 完整系统权限」引进一个握着用户密钥和钱包的桌面应用）；**技能格式该换 owner**（pi / Claude Code / Codex 三家已经收敛到 Agent Skills 标准的单文件 frontmatter，我们还在维护第二份 `skill.json`）；**「发」的最短路不是发包，是给 MCP 补一个 pi 客户端档**——半天的事，而且和现有 MCP 完全同源。
+
+---
+
+## 1. 方法与证据边界
+
+**读的是什么**：① `node_modules/@earendil-works/pi-coding-agent@0.85.1` 的编译产物 `.js`/`.d.ts` + 随包 `docs/`（33 篇）+ `examples/`（79 个示例扩展、13 个 SDK 示例、1 个 plugin 示例）；② npm registry 与 downloads API 实测；③ `https://pi.dev/packages` 官方目录页实抓 HTML；④ TikHub 三组关键词（见 §7）。
+
+**引用格式**：`node_modules/@earendil-works/` 下的一律相对该目录（例：`pi-coding-agent/docs/packages.md:63`）；仓库侧一律相对仓库根；外部给完整 URL。
+
+**数字怎么来的（可复核）**：`https://registry.npmjs.org/-/v1/search?text=keywords:pi-package&size=250&from=0…5000` 共 20 次请求、按包名去重得 **5 250**。npm search 自报的 `total: 9267` 是相关度分页的模糊值，**不作数**——但抽查 `from=0/200/1000/4000` 四页，返回的 20/100 条 **100% 真的带 `pi-package` 关键字**，所以「几千个」这个量级是硬的，只有精确到个位数的那个 9267 不可信。
+
+**没查成的，明着标**：
+
+| 没查成的 | 为什么 |
+|---|---|
+| `pi.dev/packages` 的**逐条**清单与 5 250 的差集 | 只抓了第 1 页与第 106 页确认分页边界（`?page=106` 是最后一页），没有逐页抓 106 页 |
+| GitHub topic 计数 | `api.github.com/search/repositories?q=topic:pi-package` 自报 `total_count: 1002`，但 search API 本身只允许翻前 1000 条，无法自证；**且 star 数在这个生态里不可信**——`mksglu/context-mode` 直连仓库 API 是 20 492 star 而周下载只有 17 960，另有若干两三个月新仓带着 1 900–4 500 的整数 star。**本文一律用 npm 下载量，不用 star** |
+| 「Oh My Pi」发行版（`@oh-my-pi/*`，核心分发 113 949/wk）的源仓库 | 猜 `github.com/oh-my-pi/pi` 是 404，没找到真实 org |
+| Discord（`https://discord.com/invite/3cU7Bz4UPx`，从主仓 README 链出）里的讨论 | 没加入，未取样 |
+| 下载量的时间窗 | `api.npmjs.org/downloads/point/last-week/*` 当天返回的是 **2026-08-23 → 08-29** 那一周，不是最近 7 天。所有下载数字都指这一周 |
+
+---
+
+## 2. 包系统本身
+
+### 2.1 清单格式与「一个包能装什么」
+
+| 问 | 答 | 出处 |
+|---|---|---|
+| 清单在哪 | `package.json` 的 **`pi` 键**，四个可选字符串数组：`extensions` / `skills` / `prompts` / `themes` | `pi-coding-agent/dist/core/pi-manifest.d.ts:1-7`（`PiManifest` 接口 + `readPiManifest`）；文档 `pi-coding-agent/docs/packages.md:118-131` |
+| 没有清单呢 | 按约定目录自动发现：`extensions/`（`.ts`/`.js`）、`skills/`（递归找 `SKILL.md` 目录 + 顶层 `.md`）、`prompts/`（`.md`）、`themes/`（`.json`） | `pi-coding-agent/docs/packages.md:158-166` |
+| 路径写法 | 相对包根；支持 glob 与 `!排除`；正向 glob 只发现可见路径、点开头的要显式列；glob 不穿符号链接 | `pi-coding-agent/docs/packages.md:133` |
+| 怎么被发现 | `keywords` 里加 `pi-package` 才进[官方目录](https://pi.dev/packages)；可另加 `video`（仅 MP4，hover 自动播）/ `image` 做预览图 | `pi-coding-agent/docs/packages.md:118`、`:135-154` |
+| **包里没有的东西** | **工具**。四类资源里没有「tool」——工具是 extension 在运行时用 `pi.registerTool({name,label,description,promptSnippet,promptGuidelines,parameters,execute})` 注册出来的 | 示例 `pi-coding-agent/examples/extensions/dynamic-tools.ts:32-40`；API 文档 `pi-coding-agent/docs/extensions.md:1365`（`pi.registerTool`） |
+
+**这一格的含义**：`pi install` 装的不是数据，**是一段会在你机器上执行的 Node 代码**。文档在三个地方用红字说同一句话：包以完整系统权限运行、扩展执行任意代码、技能可以指使模型运行任何东西（`pi-coding-agent/docs/packages.md:20`、`docs/extensions.md:111`、`docs/skills.md:22`）。这是后面所有判断的地基。
+
+### 2.2 源、作用域、版本锁
+
+| 维度 | pi 怎么做 | 出处 |
+|---|---|---|
+| 三种源 | `npm:@scope/pkg@1.2.3` / `git:github.com/user/repo@v1`（含 `ssh://`、`git@host:path`、裸 `https://`）/ 本地绝对或相对路径（**不复制，直接登记**） | `pi-coding-agent/docs/packages.md:52-114` |
+| 全局 vs 项目 | 默认写用户设置 `~/.pi/agent/settings.json`，装到 `~/.pi/agent/{npm,git}/`；`-l` 写项目 `.pi/settings.json`，装到 `.pi/{npm,git}/` | `pi-coding-agent/docs/packages.md:43`、`:64-65`、`:92` |
+| 团队分发 | 项目 settings 可以随仓库提交；**项目被信任之后 pi 启动时自动补装缺的包** | `pi-coding-agent/docs/packages.md:43` |
+| 试用不安装 | `pi -e npm:@foo/bar` 装进临时目录，只对本次运行有效（scope 标 `temporary`） | `pi-coding-agent/docs/packages.md:45-50`；`dist/core/package-manager.d.ts:73` |
+| **版本锁在哪** | **锁在 source 字符串本身**：带版本的 npm spec 与带 `@ref` 的 git 源都算 pinned，`pi update --extensions` / `--all` **跳过它们**；换版本要重新 `pi install …@新版` | `pi-coding-agent/docs/packages.md:63`、`:90-91` |
+| 更新判据 | 读装好的 `package.json` 版本，与 registry 最新比 `gt(target, installed)`；查不到版本就**默认更新** | `pi-coding-agent/dist/core/package-manager.js:894-907` |
+| **完整性 / 签名** | **没有。** `dist/core/package-manager.js` 全文 `integrity\|checksum\|signature\|verify` 零命中；唯一的 `createHash("sha256")` 用于给临时目录取名 | `pi-coding-agent/dist/core/package-manager.js:1771-1775` |
+| 依赖纪律 | 运行时依赖进 `dependencies`（git 包按 `npm install --omit=dev` 装）；引用 pi 自家包（`pi-ai`/`pi-agent-core`/`pi-coding-agent`/`pi-tui`/`typebox`）必须写 `peerDependencies: "*"` 且不许打包；引用**别的 pi 包**必须 `bundledDependencies` 打进 tarball 并走 `node_modules/` 路径——**pi 用独立 module root 加载每个包，所以两个包各自装的同名依赖不会串** | `pi-coding-agent/docs/packages.md:167-188` |
+
+### 2.3 加载顺序、过滤、去重
+
+- **顺序即优先级**：扩展按解析出的路径顺序装载（`dist/core/resource-loader.js:447-452`），名字冲突（同名工具/命令/flag）**不报错、只记一条诊断**，"precedence is handled by load order"（`:461` 注释原文）。
+- **CLI 临时包排在 settings 包之前**：`mergePaths(cliEnabled, settingsEnabled)`（`dist/core/resource-loader.js:317-319`）。
+- **过滤器只收不放**：settings 里的对象形式支持 `["extensions/*.ts", "!extensions/legacy.ts"]`、`+精确路径`（强收）、`-精确路径`（强排）、`[]`（一个都不要）；文档明写 "Filters layer on top of the manifest. They narrow down what is already allowed."（`pi-coding-agent/docs/packages.md:190-216`）——**过滤器永远不能扩大包自己声明的面**。
+- **去重与身份**：同一个包在全局与项目都出现时，**项目条目胜出**；若项目条目写了 `autoload:false`，它就当成叠在全局条目上的 delta。身份判据：npm 看包名、git 看去掉 ref 的仓库 URL、本地看解析后的绝对路径（`pi-coding-agent/docs/packages.md:222-227`）。
+- **开关**：`pi config` 逐条启用/停用扩展、技能、提示模板、主题；Tab 在全局与项目之间切；`pi config -l` 从项目覆盖开始、继承的全局项灰显（`pi-coding-agent/docs/packages.md:218-220`）。停用的条目在 `ResolvedResource.enabled=false`，加载时被过滤掉（`dist/core/resource-loader.js:287-295`）。
+
+### 2.4 `DefaultResourceLoader` 怎么发现它们
+
+`DefaultResourceLoader` 内部持有一个 `packageManager`（`pi-coding-agent/dist/core/resource-loader.d.ts:120-125`）。链路是：
+
+1. `PackageManager.resolve()` → `ResolvedPaths { extensions, skills, prompts, themes }`，**每条路径都带 `PathMetadata { source, scope: "user"|"project"|"temporary", origin: "package"|"top-level", baseDir }`**（`dist/core/package-manager.d.ts:2-18`、`:39-40`）。元数据是后面一切（诊断、去重、显示来源）的依据。
+2. loader 把 `enabled` 的挑出来、记住每条的 metadata（`dist/core/resource-loader.js:287-296`），再合并 CLI 临时路径。
+3. **启动之后还能再加**：`resources_discover` 事件（`dist/core/extensions/types.d.ts:403-411`，`reason: "startup"|"reload"`）允许任一扩展返回 `{ skillPaths, promptPaths, themePaths }` 动态补路径；`extendResources()` 把它们并进来（`dist/core/resource-loader.d.ts:57`）。官方示例只有 8 行：`pi-coding-agent/examples/extensions/dynamic-resources/index.ts:7-14`。
+   > **这一条对 Nomi 直接有用**：技能不必躺在磁盘固定位置也能被发现——正是「skill hub / 运行时决定给哪些技能」需要的孔。
+
+### 2.5 信任与安全模型
+
+| 问 | 答 | 出处 |
+|---|---|---|
+| 什么时候问 | 只有当 cwd 下**确实存在需要信任的项目资源**时才问（`.pi/` 里的受信项 或 cwd/祖先目录的 `.agents/skills`）；没有就直接 `true` | `pi-coding-agent/dist/core/trust-manager.d.ts:20-27`、`dist/core/project-trust.js:21-23` |
+| 谁能抢答 | 扩展的 `project_trust` 事件**先于**存储与 UI，返回 `{trusted, remember}` 即定夺 | `pi-coding-agent/dist/core/project-trust.js:24-36` |
+| 存哪、继承吗 | `~/.pi/agent/trust.json`；**向上继承**（选项里可以「信任父目录」，`getProjectTrustParentPath`） | `dist/core/trust-manager.d.ts:16-19`、`:28-35` |
+| 默认档 | `defaultProjectTrust: "always" \| "never" \| "ask"`（默认 ask） | `dist/core/project-trust.js:41-48` |
+| **无 UI 怎么办** | **fail-closed 到 `false`** | `dist/core/project-trust.js:49-51` |
+| 装包也归它管 | `install` / `remove` 在动项目作用域之前先 `assertProjectTrustedForScope(scope)` | `dist/core/package-manager.js:767`、`:794` |
+| 路径包容 | 安装根做**前缀断言**：解析后不在根下就 `Refusing to use path outside package install root` 抛错 | `dist/core/package-manager.js:1778-1784` |
+| **trust 不管什么** | 不管加载之后能干什么。信任只决定「加不加载项目本地配置与包」，**不是沙箱**；`AGENTS.md`/`CLAUDE.md` 无论信不信任都加载 | `pi.dev/docs/latest/security`（随包同文 `pi-coding-agent/docs/security.md`），本仓已在 [conformance §9.1](2026-09-07-pi-reference-implementation-conformance.md) 记过 |
+
+### 2.6 技能格式：pi 采用的是行业标准，不是自家格式
+
+- pi 明写实现 **[Agent Skills 标准](https://agentskills.io/specification)**，"warning about most violations but remaining lenient"，唯一有意偏离是**不要求 `name` 与父目录同名**（理由：多 harness 共享技能目录时那条规则不合适）——`pi-coding-agent/docs/skills.md:7`、`:141`。
+- frontmatter 七个字段：`name`(必) `description`(必) `license` `compatibility` `metadata`（**任意键值**）`allowed-tools` `disable-model-invocation` —— `pi-coding-agent/docs/skills.md:135-146`。
+- **它直接吃别家的技能目录**：文档给的例子就是把 `~/.claude/skills` 和 `~/.codex/skills` 写进 settings —— `pi-coding-agent/docs/skills.md:47-58`。
+- 技能怎么到模型：启动时只扫 name+description 进系统提示词（XML 格式，按标准），正文靠模型自己用 `read` 加载；文档自陈 **"models don't always do this"** —— `pi-coding-agent/docs/skills.md:66-72`。
+
+---
+
+## 3. 社区生态实况
+
+### 3.1 规模（2026-09-07 实测）
+
+| 指标 | 数字 | 怎么量的 |
+|---|---|---|
+| npm 带 `pi-package` 关键字的包 | **5 250**（去重后实数） | registry search 分页 `from=0…5000, size=250`，20 次请求按包名去重 |
+| npm search 自报 total | 9 267（**模糊值，不作数**） | 同上；抽查四页命中率 100%，但无法分页自证到 9 267 |
+| 官方目录 `pi.dev/packages` | 分页到**第 106 页**（末页 21 条），量级与 5 250 一致 | 实抓 HTML，`?page=106` 是最后一个分页链接 |
+| **月度新增/更新分布** | 2026-03: 63 · 04: 104 · 05: 258 · 06: 234 · **07: 712 · 08: 2 791 · 09（前 7 天）: 1 062** | 上述语料的 `date` 字段直方图 |
+| 主仓 `earendil-works/pi` | 102 408 star，最后 push 2026-09-06 | `api.github.com/repos/earendil-works/pi` 直读 |
+| 社区入口 | Discord `https://discord.com/invite/3cU7Bz4UPx`（主仓 README 链出）；官方目录页 `https://pi.dev/packages` | 见 §1「没查成」 |
+
+**读法**：这不是一个成熟生态，是一个**两个月内炸开的生态**——8 月一个月的量是 3–6 月总和的 4 倍。对我们的意思有两面：一面是「这里有真实的人在解决和我们一样的问题」，另一面是「这批包的中位质量与存活期都未经时间检验」，**不能因为下载量高就当依赖**。
+
+### 3.2 下载量前 15（窗口 2026-08-23 → 08-29）
+
+> 只列能在 npm downloads API 上直接核到数字的。**不用 star**（§1 已说明理由）。
+
+| # | 包 | 做什么 | 周下载 | 与 Nomi 的关系 |
+|---|---|---|---|---|
+| 1 | [`pi-mcp-adapter`](https://www.npmjs.com/package/pi-mcp-adapter) | 给 pi 接 MCP 服务器；读标准 `.mcp.json` / `~/.config/mcp/mcp.json`；**一个代理工具（~200 token）代替上百个工具定义**，服务器按需冷启 | **252 501** | ⭐ 直接相关：pi 用户接 Nomi 的现成通道；`pi` 清单见 registry：`{extensions:['./index.ts'], skills:['./skills'], video:…}` |
+| 2 | [`pi-web-access`](https://www.npmjs.com/package/pi-web-access) | 网页搜索 / 抓取 / 克隆仓库 / PDF 抽取 / **YouTube 视频理解** | 132 228 | 视频**理解**不是生成 |
+| 3 | [`@companion-ai/feynman`](https://www.npmjs.com/package/@companion-ai/feynman) | 基于 pi 的 research-first CLI | 125 554 | 无 |
+| 4 | [`pi-subagents`](https://www.npmjs.com/package/pi-subagents) | 子 agent 派工 / 可脚本化多 agent 工作流 | 122 432 | 与 R27 编排手册同题，可读设计 |
+| 5 | [`@oh-my-pi/pi-coding-agent`](https://www.npmjs.com/package/@oh-my-pi/pi-coding-agent) | 社区发行版对核心 CLI 的再分发 | 113 949 | 无（源仓未找到，见 §1） |
+| 6 | [`@oh-my-pi/pi-natives`](https://www.npmjs.com/package/@oh-my-pi/pi-natives) | Rust 原生绑定（PDF/音频/图像处理、PTY、剪贴板） | 95 757 | 媒体处理放原生层，思路可参考 |
+| 7 | [`billion-context`](https://www.npmjs.com/package/billion-context) | 上下文压缩代理 | 32 514 | 与压缩层同题 |
+| 8 | [`pi-background-tasks`](https://www.npmjs.com/package/pi-background-tasks) | 持久后台任务 / 只读委派 agent | 26 575 | 与「生成跑几十分钟」同题 |
+| 9 | [`pi-goal-x`](https://www.npmjs.com/package/pi-goal-x) | 长目标持续推进 | 20 787 | 无 |
+| 10 | [`pi-lens`](https://www.npmjs.com/package/pi-lens) | 实时代码反馈 | 19 100 | 无 |
+| 11 | [`context-mode`](https://www.npmjs.com/package/context-mode) | 上下文压缩 MCP 插件 | 17 960 | star 数异常，见 §1 |
+| 12 | [`bigpowers`](https://www.npmjs.com/package/bigpowers) | **73 个 agent skills 的技能包** | 17 545 | ⭐ 技能包这条分发路子的样板 |
+| 13 | [`pi-memory`](https://www.npmjs.com/package/pi-memory) | 语义检索记忆扩展 | 11 145 | 无 |
+| 14 | [`@gotgenes/pi-permission-system`](https://www.npmjs.com/package/@gotgenes/pi-permission-system) | 权限执行扩展 | 8 568 | ⭐ 与 K2 审批同题 |
+| 15 | [`pi-web-ui`](https://www.npmjs.com/package/pi-web-ui) | 给 pi 套 Web 聊天界面 | ~6 241 | 「外部宿主给 pi 换壳」的对照 |
+
+### 3.3 按 Nomi 关心的六类分桶（对 5 250 条语料做名称+描述正则分类）
+
+| 类 | 命中数 | 头部与最相关的 |
+|---|---|---|
+| **MCP 桥** | 172 | `pi-mcp-adapter` 252 501/wk（全生态第一）；`@nklisch/pi-mcp-adapter` 879/wk（"independently maintained MCP client with a programmatic source lifecycle"）；`@agimon-ai/doompi-mcp`（按域收窄 MCP 服务器可见面） |
+| **技能包** | 458 | `bigpowers` 17 545/wk（73 skills）；`@getpipher/keystone`（"anti-AI-slop design skill with an executable gate engine"）；`@agimon-ai/doompi-skill`（技能目录 + 延迟发现 + 技能浏览器） |
+| **审批 / 权限 / 沙箱** | 170 | `@zhushanwen/pi-permission` 269/wk（yolo/auto/approve/strict 四档 + 三层）；`@georgedong32/permission-modes` 80/wk（Claude Code 风格 ask/plan/auto）；`@agimon-ai/doompi-sandbox`（Docker 里跑 agent+扩展+工具）；`@amaster.ai/pi-security`（资源感知的工具授权策略引擎）；`@agentapprove/pi`（**在 iPhone / Apple Watch 上批准或拒绝工具调用**，91/wk） |
+| **UI / TUI / 面板** | 312 | `@zhuxixi/pi-agent-board`（派工/监控/peek-reply/attach 的 agent 看板）；`@tt-a1i/openpi`（多 agent 工作台）；`pi-cockpit`、`pi-sidebar-tui` |
+| **花费 / 用量** | 245 | `@robhowley/pi-openrouter`（实时 spend 覆盖层）；`@sreetej510/pi-usage`、`@alexanderfortin/pi-usage-lib`（**共享用量库**——生态自己长出了「用量」这层的公共抽象） |
+| **图像 / 视频** | 125（其中真做视频生成的 ≤6） | `@amaster.ai/pi-image-gen` **2 830/wk**（gpt-image / Nano Banana / Qwen-Image）；`@amaster.ai/pi-video-gen` **1 225/wk**（AI 视频生成 + 本地合成：无损拼接、图视混排）；`@speclip/pi-media` **894/wk**（workspace-safe 媒体分析/编辑/渲染/审阅/素材库）；`@speclip/pi-talking-head` **962/wk**（口播剪辑 + B-roll 规划，**导出通用 `pi-media` EDL**）；`pi-comfyui-paint` 38/wk；`kling-ai-pi` 39/wk（可灵，带 OAuth 与中国/全球区） |
+
+**这张表里最该被注意到的一行不是最大的那行，是 `@speclip/*`**：有人已经在 pi 上做「口播剪辑 + B-roll」，而且**在定义一个跨包的 EDL 交换格式**。它周下载不到一千，但它说明 pi 生态里正在自发长出**视频创作的中间层契约**。Nomi 在这条线上是有护城河的（画布/分镜/参考槽/时间轴是我们的领域资产），但**格式话语权是先到先得的**——这一条应该进模型雷达同款的定期观察，不是一次性结论。
+
+---
+
+## 4. 「借」：哪些可以拿进来，格式的唯一 owner 该是谁
+
+### 4.1 判断：**代码一行不借；格式借，而且要借成唯一 owner**
+
+**为什么代码不借（R20 + R28）**：pi 包 = 任意代码 + 完整系统权限（`pi-coding-agent/docs/packages.md:20`）。pi 是一个**信任本机用户的本地 CLI**；Nomi 是**打包桌面应用 + MCP 宿主 + 握着用户加密密钥存储 + 会花用户真钱**。把一个 5 250 包、中位年龄两个月、无签名无完整性校验（§2.2）的生态接进这样的进程，是把别人的威胁模型搬进我们家。
+
+而且我们**已经**在这条线上做对了，不能为了「借」拆掉它：Nomi 的技能包导入器只收 `md|markdown|json|txt|ya?ml|csv`，`scripts/` `bin/` `hooks/` 显式识别为「可执行区」并跳过，还留了人话理由让 UI 诚实告诉用户跳过了什么（`electron/skills/skillPackage.ts:27-35`、`:43-47`）。这比 pi 严，是对的，保持。
+
+### 4.2 格式：Nomi 现在有两份，pi/Claude Code/Codex 已经收敛成一份
+
+| | Nomi | pi（= Agent Skills 标准） |
+|---|---|---|
+| 必需面 | 目录 + `SKILL.md`；**另有可选 `skill.json` 清单**（33 个内置技能里 9 个带） | 目录 + `SKILL.md`，**只有 frontmatter**，无第二份文件 |
+| 权威 schema | `electron/skills/skillManifestSchema.ts:91-128`（`name/version/description/audience?/selectableInWorkbench?/requestedCapabilities?/tools/requiredProviders/permissions/inputs?/examples?/stages?`） | `pi-coding-agent/docs/skills.md:135-146`（`name/description/license?/compatibility?/metadata?/allowed-tools?/disable-model-invocation?`） |
+| 没有 `skill.json` 时 | 退回正则读 frontmatter，只认 `name` / `description` / `disable-model-invocation` / `audience`（`electron/skills/skillStore.ts:89-111`）；清单存在时清单胜出（`:203-213`） | 只有这一条路 |
+| 发现规则 | 只认 `<root>/<dir>/SKILL.md`，不递归、不收散落 `.md`（`electron/skills/skillStore.ts:136-220`） | 递归找 `SKILL.md`，另按位置决定收不收顶层 `.md`（`pi-coding-agent/docs/skills.md:36-41`） |
+| 完整性 | 顺序无关的 SHA-256 覆盖整个文件映射，读取时比对不上就返回 null（`electron/skills/skillPackage.ts:82-91`、`skillStore.ts:336-338`） | 无 |
+| 跨 harness | 无 | **文档直接教你把 `~/.claude/skills` / `~/.codex/skills` 挂进来**（`pi-coding-agent/docs/skills.md:47-58`） |
+
+**结论（P1「一份格式」+ P4「通用第一」）：让 frontmatter 成为唯一必需面，`skill.json` 降级成可选扩展块。** 落地形状是现成的——标准的 `metadata` 就是**任意键值**（`pi-coding-agent/docs/skills.md:141`），Nomi 独有的 `requestedCapabilities` / `stages` / `audience` 全部塞进 `metadata.nomi.*` 即可，schema 与授权语义一个字不用改（`requestedCapabilities` 只能收窄能力天花板这条铁律在 `electron/harness/agentChatPolicy.ts:101-103`、`:206-208`，与格式无关）。
+
+**为什么值得做，用大白话（D6）**：今天用户在 Claude Code 里攒了一堆技能目录，想在 Nomi 里用，得**重打一个包**；换过来也一样。改完之后是「把目录拖进来就能用」。这不是为了兼容 pi——是因为 pi、Claude Code、Codex **已经是同一个格式**，我们是唯一那个多一份文件的人。**真实摩擦在这里，不在 pi。**
+
+### 4.3 可以借的三样设计（只读，不装）
+
+| 借什么 | 出处 | 对 Nomi 的用法 |
+|---|---|---|
+| **「一个代理工具代替上百个工具定义」** | `pi-mcp-adapter` README（registry 上 2.32.1，2026-09-01）：一个 proxy 工具约 200 token，模型按需发现，服务器用到才起 | 直接打在重做方案 **S7（任一 profile ≤12 工具、schema ≤4 000 token）** 上：production profile 今天 30 个工具 / 12 641 token（方案 §3.2）。静态合并很可能压不到 12——这是 conformance **G-09**（`addedToolNames` 动态装载）之外的第二条现成解法 |
+| **`tool_call → {block, reason}` 的最小形状** | `pi-coding-agent/examples/extensions/permission-gate.ts:13-33`：命中危险模式 → 有 UI 就问、**无 UI 直接 block**，`reason` 成为模型看到的正文 | 正是 K2 审批要挂的孔（方案已选对 `before_tool`）。这 34 行是官方给的最短参考实现，值得在阶段 3 开工前逐行对一遍 |
+| **通用媒体 EDL 交换格式** | `@speclip/pi-talking-head`（962/wk）自陈"exported as generic `pi-media` EDLs" | 不是抄它的格式，是**知道有人在抢这个位置**。Nomi 的时间轴/分镜是领域资产，导出面该按「别人能读」设计（对照 K5 时间轴的 16 内部工具 vs MCP 1 个） |
+
+---
+
+## 5. 「发」：Nomi 能不能作为 pi 包发布
+
+### 5.1 先把事实摆清楚
+
+1. **pi 没有内置 MCP。** 文档原话：*"It intentionally does not include built-in MCP, sub-agents, permission popups, plan mode, to-dos, or background bash. You can build or install those workflows as extensions or packages"*（`pi-coding-agent/docs/usage.md:309`）。
+2. **但生态补上了，而且是全生态第一。** `pi-mcp-adapter` 252 501/wk，**自动读标准 `.mcp.json` 与 `~/.config/mcp/mcp.json`**，无需额外配置。
+3. **Nomi 的一键接入今天不覆盖 pi。** 固定客户端档只有三个：`~/.claude.json`、`~/.cursor/mcp.json`、`~/.codex/config.toml`（`electron/capabilityCore/mcpConfig.ts:56-60`）。**但客户端身份早已从三值泛化成可注册的 profile**（名字 + 配置路径 + 格式，`mcpConfig.ts:104-126` 的 `listCustomMcpProfiles` / `registerCustomMcpProfile`），另有「复制配置」兜底（`mcpConfig.ts:277-279`，UI 在 `src/ui/onboarding/ConnectAssistantCard.tsx:174`）。
+4. **Nomi 仓库现在 `private: true`**（`package.json`），要发 npm 包必须单开一个可发布的产物，不是给主包加个字段。
+
+### 5.2 四条路的结构对比
+
+| 路子 | 用户看到什么 | 代价 | 和 MCP 的关系 | 判断 |
+|---|---|---|---|---|
+| **① 什么都不做（今天）** | pi 用户先 `pi install npm:pi-mcp-adapter`，再**手抄**一段 JSON 进 `.mcp.json`。Nomi 的一键写入帮不上他 | 0 | 同源，但缺门牌 | 摩擦在「手抄」这一步，可以消掉 |
+| **② 给 MCP 一键接入加一个 pi 客户端档** | 「接入 AI 编程助手」卡片里多一个 pi；点一下，Nomi 写 `.mcp.json`（项目级）或 `~/.config/mcp/mcp.json`（全局），pi 侧只需装那个 252k/wk 的 adapter | **≈ 半天**：内置客户端档表在 `mcpConfig.ts:56-60`（今天三个），加第四条即可；写入侧 `:246-258` 的 merge / `.nomi-backup` / 原子改名一行不用改；另有已就绪的自定义档注册机制 `:104-126` 可先用它验一遍。剩下是 i18n 文案与一次走查 | **完全同源**。不新增任何契约、不新增任何可执行面 | ✅ **做。这就是「比 MCP 更短的路」的正确读法——不是绕开 MCP，是给它补一个门牌** |
+| **③ 发 skills-only 的 pi 包（`pi install npm:@nomi/pi-skills`）** | 一行命令，pi 的模型立刻知道「分镜怎么拆、镜头提示词怎么写、什么时候该调哪个 `nomi_*` 工具」 | 一个可发布子包 + 发布流程 + 双语技能正文；**零可执行代码**（`pi.skills` 只指向 `.md`），零新增攻击面 | 它**教模型怎么用 ② 装好的工具**，是说明书不是第二条通路 | 🟡 **值得做，但要用户拍板**（见 §7） |
+| **④ 发 extension 包，自己注册 `nomi_*` 工具绕过 MCP** | 表面上少装一个 adapter | 工具契约立刻有**两个 owner**（`mcpCapabilityProjection.ts` 的投影 + pi extension 里手写的一份）；并把 Nomi 的发布节奏耦合进 pi 的版本节奏 | **和 MCP 重复** | ❌ **不做。** 这是 P1 的并行版，也正是 #546「同一语义两份定义」的复发形状；上游 0.85.0 误发布内部实验代码直接搞坏 SDK 导入（conformance §3 坑 3）已经证明这条耦合的成本 |
+
+### 5.3 为什么 ③ 是「技能包」而不是「扩展包」
+
+pi 包的四类资源里，**只有 skills 是纯数据**（`.md`），其余三类都要么是代码（extensions）要么要进 pi 的渲染层（themes/prompts）。发 skills 意味着：我们发出去的东西**在别人机器上不执行**，出了问题最坏是模型被误导，不是任意代码执行。这和我们自己对导入技能的要求（`electron/skills/skillPackage.ts:27-35` 拒可执行）是**同一条纪律的两个方向**——对内不收可执行，对外不发可执行。
+
+对照生态样板：`bigpowers`（73 skills，17 545/wk）证明纯技能包这条分发路子在 pi 生态里跑得通。
+
+---
+
+## 6. 「学」：R29 三档判定
+
+> 三档：`一致` / `有意不同(理由必须是领域约束)` / `没想到`（`没想到` 必须标「补在哪个阶段前」）。对照对象是**重做方案的阶段 3（工具契约与扩展 API）与阶段 5（内外同源）**。
+
+| # | 机制 | pi 怎么做 | 我们怎么做 | 判定 | 补在哪个阶段前 |
+|---|---|---|---|---|---|
+| **P-1** | **资源发现是事件驱动的，不是路径写死的** | `resources_discover`（`dist/core/extensions/types.d.ts:403-411`）在 session_start 之后触发，任一扩展可返回 `{skillPaths,promptPaths,themePaths}`；`extendResources()` 并入（`dist/core/resource-loader.d.ts:57`） | 技能根路径写死在 `electron/runtimePaths.ts:57-67`（六个固定根，用户根排最后防遮蔽）；`electron/harness/runtime/pi/resources.mts:13-27` 是**全空 loader** | **没想到** | **阶段 5 之前。** 不是要改成 pi 的实现（空 loader 是有意的，见 P-2），而是**我们自己那一层缺同款接缝**：技能一旦不都在磁盘上（skill hub 是已定方向），「哪些技能可见」就是运行时判断，而今天它是六个常量。补法：让 `formatNomiSkillIndex`（`electron/harness/skillIndex.ts:22-53`）的输入来自一个可注入的 provider，而不是直接读 `skillStore` |
+| **P-2** | **空 ResourceLoader** | pi 默认加载项目本地 `.pi/*` 与 `AGENTS.md` | 全空（`electron/harness/runtime/pi/resources.mts:13-27`），理由写在 `:3-12` | **有意不同（领域约束）** | — 已在 `docs/engineering/framework-boundaries.json:158-165` 登记成有意隔离决定 + 债；conformance D-05 亦记 |
+| **P-3** | **信任决策向上继承，且无 UI 时 fail-closed** | `getProjectTrustParentPath`（`dist/core/trust-manager.d.ts:16`）；`hasUI === false → return false`（`dist/core/project-trust.js:49-51`） | Nomi 无「项目信任」概念（我们的项目是自己创建的创作项目）；但**导入的技能一律强制 `audience:"internal"`，不管清单声称什么**（`electron/skills/skillStore.ts:212-213`） | **一致（同一条 fail-closed 纪律，落在不同对象上）** | — |
+| **P-4** | **版本锁锁在 source 字符串里，pinned 的更新时跳过** | `npm:@foo/bar@1.2.3` 与 `git:…@ref` 都算 pinned（`docs/packages.md:63`、`:90`）；换版本要显式重装 | Nomi 技能包的 `version` 是自由字符串、无 semver 校验（`electron/skills/skillManifestSchema.ts:94-95`）；包封套版本是单一常量、不匹配硬拒（`skillPackage.ts:13`、`:122-124`） | **有意不同（领域约束：我们的技能不从网上更新，只有本地导入）** | — 但见 P-5 |
+| **P-5** | **完整性校验** | **pi 没有**（`package-manager.js` 零命中；唯一 sha256 用于临时目录命名 `:1771-1775`） | **我们有**：顺序无关 SHA-256 覆盖整个文件映射，读取时 `packageVersion + contentHash` 对不上直接返回 null（`electron/skills/skillPackage.ts:82-91`、`skillStore.ts:336-338`），`load_skill` 映射成 `skill_changed_before_load`（`electron/capabilityCore/skillReadTransportAdapters.ts:76-80`） | **有意不同（我们更严）** | — **这一处别向 pi 看齐**。如果将来走 §5.3 的发布路，反过来**我们应该把 contentHash 一起发出去** |
+| **P-6** | **加载顺序即优先级，冲突只记诊断不报错** | `orderedExtensions` 按路径顺序（`dist/core/resource-loader.js:447-452`）；同名冲突"Keep all extensions loaded… precedence is handled by load order"（`:461`） | 技能发现第一根胜出（`electron/skills/skillStore.ts:170-171`、`:200`），导入永不覆盖内置（改名加后缀，`skillPackage.ts:160-173`） | **一致** | — |
+| **P-7** | **过滤器只能收窄，不能放宽** | `+path`/`-path`/`!glob` 层叠在 manifest 之上，文档明写"They narrow down what is already allowed"（`docs/packages.md:216`） | 同构：技能清单的 `requestedCapabilities` **只能收窄**宿主能力天花板（`electron/harness/agentChatPolicy.ts:101-103`、`:206-208`；`electron/skills/skillCapability.ts:26-42`） | **一致（而且是独立想到的同一条不变量——值得写进 ARCHITECTURE-NOW 当通用原则）** | — |
+| **P-8** | **依赖纪律：核心包必须 peerDeps，别的包必须 bundled；每个包独立 module root** | `docs/packages.md:171-173` | 不适用（我们不装第三方包） | **有意不同（领域约束：不装外部代码）** | — |
+| **P-9** | **安装根做路径前缀断言** | `resolveManagedPath` 解析后不在根下就抛（`package-manager.js:1778-1784`）——注意 pi 在**包路径**上做了这件事，却在**模型可达的工具路径**上一点都不做（conformance 9.3 / G-07） | 我们两边都还没有统一的 `containPath()`（conformance 已开 **S11**） | **没想到（已登记）** | **阶段 2 之前**（沿用 conformance G-07 的排期）。本次新增的只是一条证据：**pi 自己在包管理这一侧是做了包容的**，所以「上游不做」不能当作我们不做的理由 |
+| **P-10** | **`pi config` 让用户逐条开关已装资源，全局/项目双层** | `docs/packages.md:218-220`；停用项在 `ResolvedResource.enabled=false` 被过滤（`resource-loader.js:287-295`） | Nomi 有 `selectableInWorkbench`（`skillManifestSchema.ts:101`）与两层 MCP 可见性（`skillStore.ts:246-263`），但**没有「用户逐条停用某个内置技能」的面** | **没想到（低优先）** | 可延后。真实摩擦要等技能数量上去才出现；今天 33 个内置技能里公开层（`audience:"mcp"`）**一个都没有**，先解决那个 |
+
+---
+
+## 7. 自媒体来源（TikHub）
+
+附件：[`docs/research/2026-09-07-pi-package-ecosystem/tikhub/`](2026-09-07-pi-package-ecosystem/tikhub/) —— 三组关键词、四平台，共 80 条：
+
+| 关键词 | 平台 | 条数 | 附件 |
+|---|---|---|---|
+| `pi coding agent` | 抖音 / 小红书 / B站 / X | 40 | [`tikhub/pi-coding-agent/`](2026-09-07-pi-package-ecosystem/tikhub/pi-coding-agent/tikhub-search.md) |
+| `pi agent 扩展` | 抖音 / 小红书 / B站 | 24 | [`tikhub/pi-agent-extensions/`](2026-09-07-pi-package-ecosystem/tikhub/pi-agent-extensions/tikhub-search.md) |
+| `pi install` | X / B站 | 16 | [`tikhub/pi-install/`](2026-09-07-pi-package-ecosystem/tikhub/pi-install/tikhub-search.md) |
+
+**这一层给了什么别处没有的**：
+
+1. **「装扩展」已经是中文用户的默认动作，不是极客行为。** 抖音/小红书上出现大量「给 Pi 装上这 10 个扩展能力翻倍」「9 个 Pi 扩展包｜让你的 Pi 更好用」「我的 Pi Agent 配置清单：6 个插件，够用」这类**清单式内容**（`tikhub/pi-agent-extensions/tikhub-search.md:21`、`:124`、`:151`、`:115`）。一个生态到了「有人靠推荐清单涨粉」的阶段，说明装包已经过了门槛期。
+2. **自媒体里点名的包，registry 关键字搜索**未必**排在前面**——这一层补出了以下具体名字：`@tintinweb/pi-subagents`（X，作者自陈 "Dynamic Workflows … Claude Code-compatible"）、`pi-antigravity`（用 Antigravity 订阅在 pi 里跑 Gemini）、`@ff-labs/pi-fff`（FFF 模糊搜索）、mem0 的 pi 插件（跨会话语义记忆）、Neon 数据库官方发的 pi 技能包（作者原话 "It's now live in the Pi package catalog"）、`nicobailon/pi-web-access` + `pi-mcp-adapter` + `pi-powerline-footer` 三件套（B站 `tikhub/pi-install/tikhub-search.md:36`、`:54`、`:63`、`:74`、`:103`；`tikhub/pi-agent-extensions/tikhub-search.md:196`）。
+3. **对「为什么是 pi」的解释在中文侧收敛得很干净**：「Pi 只有四个默认工具（读文件、写文件、改文件、运行命令），系统提示词仅一千 Token…还有极其开放的插件生态」（`tikhub/pi-agent-extensions/tikhub-search.md:214`）。另有一条把 pi 与 DeepSeek Harness 逐层对比的（`:198`、`:48`：「Pi 把扩展放在工作流附近，DeepSeek Harness 把扩展深入运行时」）——这条对我们判断「扩展 API 该开在哪一层」有参考价值。
+4. **也有反面声音**：「Pi Agent，有点劝退」（`tikhub/pi-coding-agent/tikhub-search.md`，抖音 2026-09-01）；以及一条很实在的：「Pi Agent 的设计美学除了 minimal 之外，就是自己有什么需求就自己 DIY，所以我的插件不一定能适配你的需求」（`tikhub/pi-agent-extensions/tikhub-search.md:232`）。**这句话是这次调研最该记住的一句**——一个 5 250 包的生态，中位包是「作者为自己写的」，不是可依赖的组件。
+
+**噪音说明**：`pi install` 这组混进了 Pi Network（加密货币）与 `pip install` 的无关内容，已人工剔除，未计入上面的结论。
+
+---
+
+## 8. 一个顺带的发现：我们已经在用一个 pi 包了，只是没走 `pi install`
+
+`@dietrichgebert/ponytail`（npm registry 实读，latest 4.9.0）的 `keywords` 是 `["opencode-plugin","opencode","ponytail","pi-package","pi","skills","qoder"]`，`pi` 清单是 `{"extensions":["./pi-extension/index.js"],"skills":["./skills"]}` —— **它就是官方目录里的一个 pi 包**（gallery 第一页可见）。而 Nomi 的 R25 提交/推送闸调的正是它的技能面（`scripts/ponytail-review-hook.mjs:36-45`，通过宿主 skill `/ponytail-review` / `@ponytail-review` 触发，门岗 `check:ponytail-review`）。
+
+**这条说明一件事**：同一份技能资产今天已经在**四个宿主**（pi / opencode / Claude Code / Codex）上分发，靠的就是 Agent Skills 标准那一份 frontmatter。§4.2 那个「格式换 owner」的建议不是理论——**我们自己每次 commit 都在受益于它**。
+
+---
+
+## 9. 我的判断（三句）
+
+1. **现在该做**：把 **pi 加进 MCP 一键接入的客户端档**（§5.2 路子 ②，≈ 半天，`electron/capabilityCore/mcpConfig.ts:104-126` 的自定义档机制已经在，写 `.mcp.json` 即可被 252k/wk 的 `pi-mcp-adapter` 自动读到）；同时把 **技能格式的唯一 owner 定成 Agent Skills frontmatter**，`skill.json` 的 Nomi 专有字段收进标准的 `metadata`（§4.2）——这条要在重做方案**阶段 3 开工前**定下来，否则新工具契约会再绕着旧格式长一圈。
+2. **不该做**：**不装任何第三方 pi extension 进 Nomi**（R20：不在护城河上；R28：把「任意代码 + 完整系统权限 + 无签名无完整性校验」引进一个握着用户密钥与钱包的桌面应用，是把防线建在最晚那层）；**不发 extension 版的 `nomi_*` 工具包**（P1 并行版，工具契约会有两个 owner，正是 #546 的复发形状）。
+3. **要用户拍板的一个点**：**要不要以 `@nomi/pi-skills` 的形式，把 Nomi 的创作方法论（分镜怎么拆、镜头提示词怎么写、参考槽怎么填）做成 skills-only 的公开 npm 包发出去。** 取舍点一句话说清：**这是把我们最容易被抄的东西（方法论）免费送进一个 5 250 包的生态，换一个 `pi install` 一行的入口**——护城河在产物与工具（画布/分镜/时间轴/生成编排），不在方法论；但公开发布是不可逆的，且一旦发了就要跟着 pi 的节奏维护。**我倾向发**（成本低、零可执行面、`bigpowers` 已证明这条路走得通），但这属于「产品方向 + 不可逆」，按决策自治该停下来问。

--- a/docs/research/2026-09-07-pi-package-ecosystem/tikhub/pi-agent-extensions/tikhub-search.json
+++ b/docs/research/2026-09-07-pi-package-ecosystem/tikhub/pi-agent-extensions/tikhub-search.json
@@ -1,0 +1,479 @@
+{
+  "source": "tikhub",
+  "baseUrl": "https://api.tikhub.io",
+  "keyword": "pi agent 扩展",
+  "since": null,
+  "limitPerPlatform": 8,
+  "generatedAt": "2026-09-07T01:17:44.535Z",
+  "failures": [],
+  "summary": {
+    "totalRecords": 24,
+    "platformsOk": 3,
+    "platformsEmpty": 0,
+    "platformsFailed": 0,
+    "platforms": [
+      {
+        "platform": "douyin",
+        "platformLabel": "抖音",
+        "status": "ok",
+        "items": 8,
+        "pagesFetched": 2,
+        "missingFields": {},
+        "fieldConfidence": "verified-against-live-response",
+        "fieldsVerifiedOn": "2026-09-06",
+        "error": null
+      },
+      {
+        "platform": "xhs",
+        "platformLabel": "小红书",
+        "status": "ok",
+        "items": 8,
+        "pagesFetched": 1,
+        "missingFields": {},
+        "fieldConfidence": "verified-against-live-response",
+        "fieldsVerifiedOn": "2026-09-06",
+        "error": null
+      },
+      {
+        "platform": "bilibili",
+        "platformLabel": "B站",
+        "status": "ok",
+        "items": 8,
+        "pagesFetched": 1,
+        "missingFields": {},
+        "fieldConfidence": "verified-against-live-response",
+        "fieldsVerifiedOn": "2026-09-06",
+        "error": null
+      }
+    ]
+  },
+  "results": [
+    {
+      "platform": "douyin",
+      "platformLabel": "抖音",
+      "records": [
+        {
+          "platform": "douyin",
+          "platformLabel": "抖音",
+          "id": "7681283787493330186",
+          "url": "https://www.douyin.com/video/7681283787493330186",
+          "author": "AI樟榆树",
+          "authorId": "136815609655199",
+          "publishedAt": "2026-09-03T12:24:16.000Z",
+          "title": "给Pi装上这10个扩展能力翻倍 Pi Agent最近越来越多的人用了，给Pi装上这10个扩展，能力至少翻一番#Agent  #ai工具  #ai编程  #Vibecoding  #Pi",
+          "excerpt": "给Pi装上这10个扩展能力翻倍 Pi Agent最近越来越多的人用了，给Pi装上这10个扩展，能力至少翻一番#Agent #ai工具 #ai编程 #Vibecoding #Pi",
+          "mentions": [
+            "Agent",
+            "Vibecoding"
+          ],
+          "fieldConfidence": "verified-against-live-response",
+          "fieldsVerifiedOn": "2026-09-06",
+          "missingFields": []
+        },
+        {
+          "platform": "douyin",
+          "platformLabel": "抖音",
+          "id": "7674590359871065370",
+          "url": "https://www.douyin.com/video/7674590359871065370",
+          "author": "技术爬爬虾",
+          "authorId": "99840012512",
+          "publishedAt": "2026-08-16T12:22:17.000Z",
+          "title": "Pi:超越Codex跟Claude Code的极简Agent 保姆级攻略，一期精通#AI新星计划   #Agent #智能体 #科技 #教程",
+          "excerpt": "Pi:超越Codex跟Claude Code的极简Agent 保姆级攻略，一期精通#AI新星计划 #Agent #智能体 #科技 #教程",
+          "mentions": [
+            "Agent",
+            "Claude"
+          ],
+          "fieldConfidence": "verified-against-live-response",
+          "fieldsVerifiedOn": "2026-09-06",
+          "missingFields": []
+        },
+        {
+          "platform": "douyin",
+          "platformLabel": "抖音",
+          "id": "7675193290211249408",
+          "url": "https://www.douyin.com/video/7675193290211249408",
+          "author": "算力炼丹炉",
+          "authorId": "2526033811356787",
+          "publishedAt": "2026-08-18T02:29:57.000Z",
+          "title": "PI agent 五大插件！ #科技 #deepseek #程序员",
+          "excerpt": "PI agent 五大插件！ #科技 #deepseek #程序员",
+          "mentions": [
+            "deepseek"
+          ],
+          "fieldConfidence": "verified-against-live-response",
+          "fieldsVerifiedOn": "2026-09-06",
+          "missingFields": []
+        },
+        {
+          "platform": "douyin",
+          "platformLabel": "抖音",
+          "id": "7674597597608201535",
+          "url": "https://www.douyin.com/video/7674597597608201535",
+          "author": "产品总监看AI",
+          "authorId": "3086458865",
+          "publishedAt": "2026-08-16T11:58:26.000Z",
+          "title": "Pi vs Harness：Agent 扩展放哪层？ Pi 把扩展放在工作流附近，DeepSeek Harness 把扩展深入运行时。想让 Agent 独立运行，先分清任务单元、运行层和组织治理层。 #AI智能体  #Agent  #DeepSeek  #Pi  #企业AI",
+          "excerpt": "Pi vs Harness：Agent 扩展放哪层？ Pi 把扩展放在工作流附近，DeepSeek Harness 把扩展深入运行时。想让 Agent 独立运行，先分清任务单元、运行层和组织治理层。 #AI智能体 #Agent #DeepSeek #Pi #企业AI",
+          "mentions": [
+            "Agent",
+            "DeepSeek"
+          ],
+          "fieldConfidence": "verified-against-live-response",
+          "fieldsVerifiedOn": "2026-09-06",
+          "missingFields": []
+        },
+        {
+          "platform": "douyin",
+          "platformLabel": "抖音",
+          "id": "7680204069788486950",
+          "url": "https://www.douyin.com/video/7680204069788486950",
+          "author": "费曼学徒冬瓜",
+          "authorId": "92481351764",
+          "publishedAt": "2026-08-31T14:34:23.000Z",
+          "title": "【完整版】一口气说完pi-agent的原理和二开实践 从学习Agent的角度看，piagent是最好的学习对象。\n从开发Agent的角度看，piagent是最好的底层框架（没错，我认为比DSH好）",
+          "excerpt": "【完整版】一口气说完pi-agent的原理和二开实践 从学习Agent的角度看，piagent是最好的学习对象。 从开发Agent的角度看，piagent是最好的底层框架（没错，我认为比DSH好）",
+          "mentions": [],
+          "fieldConfidence": "verified-against-live-response",
+          "fieldsVerifiedOn": "2026-09-06",
+          "missingFields": []
+        },
+        {
+          "platform": "douyin",
+          "platformLabel": "抖音",
+          "id": "7681718046213435619",
+          "url": "https://www.douyin.com/video/7681718046213435619",
+          "author": "弗洛已得",
+          "authorId": "969137867729932",
+          "publishedAt": "2026-09-04T16:29:18.000Z",
+          "title": "pi-agent桌面版介绍 #pi-agent  #Agent  #环步",
+          "excerpt": "pi-agent桌面版介绍 #pi-agent #Agent #环步",
+          "mentions": [
+            "Agent",
+            "pi-agent"
+          ],
+          "fieldConfidence": "verified-against-live-response",
+          "fieldsVerifiedOn": "2026-09-06",
+          "missingFields": []
+        },
+        {
+          "platform": "douyin",
+          "platformLabel": "抖音",
+          "id": "7668226078036666354",
+          "url": "https://www.douyin.com/video/7668226078036666354",
+          "author": "EasyShip.AI",
+          "authorId": "2799787099033759",
+          "publishedAt": "2026-07-30T07:53:35.000Z",
+          "title": "Pi- Agent！一个远远被低估的 Agent Harness 框架！#chatgpt应用领域 #Ai人工智能 #ai #大模型应用 #人工智能发展",
+          "excerpt": "Pi- Agent！一个远远被低估的 Agent Harness 框架！#chatgpt应用领域 #Ai人工智能 #ai #大模型应用 #人工智能发展",
+          "mentions": [
+            "chatgpt"
+          ],
+          "fieldConfidence": "verified-against-live-response",
+          "fieldsVerifiedOn": "2026-09-06",
+          "missingFields": []
+        },
+        {
+          "platform": "douyin",
+          "platformLabel": "抖音",
+          "id": "7679446879129570560",
+          "url": "https://www.douyin.com/video/7679446879129570560",
+          "author": "筱筱AI学习放映室",
+          "authorId": "4323729048877720",
+          "publishedAt": "2026-08-29T13:36:08.000Z",
+          "title": "删掉大部分功能，Pi Agent 反而更强？ 没有 MCP，没有子 Agent，没有计划模式，甚至没有权限弹窗。\nPi Agent 默认只保留了 read、write、edit、bash 四个核心工具。\n但这不是一个没做完的半成品，而是一次主动的“做减法”。\n第一期，我们先把 Pi Agent 的整体框架讲清楚：\nPi 到底是工具、教材，还是 SDK？\n四个核心包分别负责什么？\n为什么它的系统提示词可以这么短？\n缺失的功能，如何通过 Extensions、Skills、Prompt Templates、Themes 和 Pi Packages 补回来？\n如果你也想从“会使用 AI”走向“读懂 Agent、自己构建 Agent”，可以和我一起把这套源码学完。\n你更喜欢功能齐全的 Cursor、Claude Code，还是可以自由拆装的 Pi？\n#抖音创作者大会 #我将认真品鉴AIGC界的权威 #PiAgent   #AI编程  #Agent开发",
+          "excerpt": "删掉大部分功能，Pi Agent 反而更强？ 没有 MCP，没有子 Agent，没有计划模式，甚至没有权限弹窗。 Pi Agent 默认只保留了 read、write、edit、bash 四个核心工具。 但这不是一个没做完的半成品，而是一次主动的“做减法”。 第一期，我们先把 Pi Agent 的整体框架讲清楚： Pi 到底是工具、教材，还是 SDK？ 四个核心包分别负责什么？ 为什么它的系统提示词可以这么短？ 缺失的功能，如何通过 Extensions、Skills、Prompt Templates、Themes 和 Pi Packages 补回来？ 如果你也想从“会使用 AI”走向“读懂 …",
+          "mentions": [
+            "Agent",
+            "Claude",
+            "MCP",
+            "PiAgent"
+          ],
+          "fieldConfidence": "verified-against-live-response",
+          "fieldsVerifiedOn": "2026-09-06",
+          "missingFields": []
+        }
+      ],
+      "pages": [
+        {
+          "page": 1,
+          "received": 7
+        },
+        {
+          "page": 2,
+          "received": 7
+        }
+      ]
+    },
+    {
+      "platform": "xhs",
+      "platformLabel": "小红书",
+      "records": [
+        {
+          "platform": "xhs",
+          "platformLabel": "小红书",
+          "id": "6a6e0f470000000008011847",
+          "url": "https://www.xiaohongshu.com/explore/6a6e0f470000000008011847?xsec_token=YBHMiOg8ZX_jsz_541ZbiskGu-h2Te_EuJoOHsdyGF9t4%3D&xsec_source=pc_search",
+          "author": "AI",
+          "authorId": "61ff8abf0000000021028433",
+          "publishedAt": "2026-08-01T15:22:47.000Z",
+          "title": "把 Pi Agent 装进你的桌面，也太爽了吧！",
+          "excerpt": "✨ 先说说为什么爽 最近看 DeepSeek V4 Flash 在 Pi 里工作，有种莫名的爽感： ✅ 模型能力强",
+          "mentions": [],
+          "fieldConfidence": "verified-against-live-response",
+          "fieldsVerifiedOn": "2026-09-06",
+          "missingFields": []
+        },
+        {
+          "platform": "xhs",
+          "platformLabel": "小红书",
+          "id": "6a808415000000002500446e",
+          "url": "https://www.xiaohongshu.com/explore/6a808415000000002500446e?xsec_token=YBTzk7G3t15qXhrtMvfphB1lROZq1leGp5IsiO_d5Qk1Q%3D&xsec_source=pc_search",
+          "author": "咕叽",
+          "authorId": "630aad5e0000000012002939",
+          "publishedAt": "2026-08-15T15:21:57.000Z",
+          "title": "我的 Pi Agent配置清单：6 个插件，够用",
+          "excerpt": "我的 Pi Agent配置清单：6 个插件，够用",
+          "mentions": [],
+          "fieldConfidence": "verified-against-live-response",
+          "fieldsVerifiedOn": "2026-09-06",
+          "missingFields": []
+        },
+        {
+          "platform": "xhs",
+          "platformLabel": "小红书",
+          "id": "6a996793000000002601505d",
+          "url": "https://www.xiaohongshu.com/explore/6a996793000000002601505d?xsec_token=YBspiEnypqM9g0GZw-VktGIlzVDNYKh5cGrzzqgTf6EYg%3D&xsec_source=pc_search",
+          "author": "AI樟榆树",
+          "authorId": "61b22b830000000021021fd0",
+          "publishedAt": "2026-09-03T12:26:59.000Z",
+          "title": "给Pi装上这10个扩展能力至少翻一翻",
+          "excerpt": "Pi Agent最近越来越多的人用了，给Pi装上这10个扩展，能力至少翻一番#Agent #ai工具 #ai编程",
+          "mentions": [
+            "Agent"
+          ],
+          "fieldConfidence": "verified-against-live-response",
+          "fieldsVerifiedOn": "2026-09-06",
+          "missingFields": []
+        },
+        {
+          "platform": "xhs",
+          "platformLabel": "小红书",
+          "id": "6a4f0d4c000000000702d134",
+          "url": "https://www.xiaohongshu.com/explore/6a4f0d4c000000000702d134?xsec_token=YBSMmZYA4j1qbJlTEaWmQU4PTcoGjz8--b6CZ9LPDH8gs%3D&xsec_source=pc_search",
+          "author": "帕格尼尼的左手",
+          "authorId": "659b644c00000000220067a7",
+          "publishedAt": "2026-07-09T02:54:04.000Z",
+          "title": "Pi agent-如何扩展和构建你自己的 harness",
+          "excerpt": "Pi Agent 架构设计：构建以用户为中心的自进化与高扩展 Harness 体系 1.极简底座与三大扩展入口 Pi 仅",
+          "mentions": [],
+          "fieldConfidence": "verified-against-live-response",
+          "fieldsVerifiedOn": "2026-09-06",
+          "missingFields": []
+        },
+        {
+          "platform": "xhs",
+          "platformLabel": "小红书",
+          "id": "6a46559800000000080324cd",
+          "url": "https://www.xiaohongshu.com/explore/6a46559800000000080324cd?xsec_token=YBfpTAt5Q1QjFM1UjbvBX4LCzxPKw4MKUXSF3Vd0job08%3D&xsec_source=pc_search",
+          "author": "无糖AI",
+          "authorId": "5c2824d3000000000600753e",
+          "publishedAt": "2026-07-02T12:12:08.000Z",
+          "title": "【开源】pi-workflow 是Pi Agent专用子任务编排扩展，基于pi-subagent实现多子Agent协同流",
+          "excerpt": "【开源】pi-workflow 是Pi Agent专用子任务编排扩展，基于pi-subagent实现多子Agent协同流",
+          "mentions": [],
+          "fieldConfidence": "verified-against-live-response",
+          "fieldsVerifiedOn": "2026-09-06",
+          "missingFields": []
+        },
+        {
+          "platform": "xhs",
+          "platformLabel": "小红书",
+          "id": "6a914a7f000000000303d5d1",
+          "url": "https://www.xiaohongshu.com/explore/6a914a7f000000000303d5d1?xsec_token=YBAH6CEnL01-85GyBb6qwhtkfJHJEVLJunXG9aJ2r_JMM%3D&xsec_source=pc_search",
+          "author": "右转",
+          "authorId": "6683ee1c000000000f0377fc",
+          "publishedAt": "2026-08-28T08:44:47.000Z",
+          "title": "9 个 Pi 扩展包｜让你的 Pi 更好用",
+          "excerpt": "你是不是也遇到过这种情况—— 用 Pi 写代码时，需要联网查询发现Pi调用了一堆curl命令，Token消耗还很快？ 改",
+          "mentions": [],
+          "fieldConfidence": "verified-against-live-response",
+          "fieldsVerifiedOn": "2026-09-06",
+          "missingFields": []
+        },
+        {
+          "platform": "xhs",
+          "platformLabel": "小红书",
+          "id": "6a998206000000002a02c2dd",
+          "url": "https://www.xiaohongshu.com/explore/6a998206000000002a02c2dd?xsec_token=YBspiEnypqM9g0GZw-VktGItWQH60WOFElGNm-FwjnsO8%3D&xsec_source=pc_search",
+          "author": "消失在天际",
+          "authorId": "649020a5000000001f004155",
+          "publishedAt": "2026-09-03T14:19:50.000Z",
+          "title": "Pi Agent 使用指南｜终端AI速查手册",
+          "excerpt": "刚入坑 Pi Agent？这份中英对照速查手册帮你快速上手",
+          "mentions": [],
+          "fieldConfidence": "verified-against-live-response",
+          "fieldsVerifiedOn": "2026-09-06",
+          "missingFields": []
+        },
+        {
+          "platform": "xhs",
+          "platformLabel": "小红书",
+          "id": "6a941dd6000000002003bc5f",
+          "url": "https://www.xiaohongshu.com/explore/6a941dd6000000002003bc5f?xsec_token=YBz24r1I7rCK9JHmQvpVGUv0RgmRSmYEUpuYUpUdDcOZg%3D&xsec_source=pc_search",
+          "author": "AI圈的那些事",
+          "authorId": "59400c6edb2e6049d5b07b49",
+          "publishedAt": "2026-08-30T12:11:02.000Z",
+          "title": "Pi Agent 真的有点上头了",
+          "excerpt": "速度快、占用轻，而且特别省 Token。 Pi 是一个开源的 AI Agent 框架/CLI，可以让模型直接调用工具、读",
+          "mentions": [],
+          "fieldConfidence": "verified-against-live-response",
+          "fieldsVerifiedOn": "2026-09-06",
+          "missingFields": []
+        }
+      ],
+      "pages": [
+        {
+          "page": 1,
+          "received": 20
+        }
+      ]
+    },
+    {
+      "platform": "bilibili",
+      "platformLabel": "B站",
+      "records": [
+        {
+          "platform": "bilibili",
+          "platformLabel": "B站",
+          "id": "BV1MSti6XEui",
+          "url": "https://www.bilibili.com/video/BV1MSti6XEui",
+          "author": "Hucci写代码",
+          "authorId": "1318868",
+          "publishedAt": "2026-09-04T06:23:14.000Z",
+          "title": "7 分钟学会使用 Pi，现在最好的 agent（之一）",
+          "excerpt": "7 分钟学会使用 Pi，现在最好的 agent（之一） 这个视频介绍了 pi coding agent 的使用方法。",
+          "mentions": [],
+          "fieldConfidence": "verified-against-live-response",
+          "fieldsVerifiedOn": "2026-09-06",
+          "missingFields": []
+        },
+        {
+          "platform": "bilibili",
+          "platformLabel": "B站",
+          "id": "BV1k6E167Ext",
+          "url": "https://www.bilibili.com/video/BV1k6E167Ext",
+          "author": "夜未央-天将亮",
+          "authorId": "517516711",
+          "publishedAt": "2026-06-12T10:32:22.000Z",
+          "title": "推荐一些Pi Agent插件",
+          "excerpt": "推荐一些Pi Agent插件 我的 pi 配置： https://github.com/cap153/config/tree/main/pi/.pi 视频中提到的插件或项目： https://github.com/nicobailon/pi-web-access https://github.com/nicobailon/pi-mcp-adapter https://github.com/mrexodia/ida-pro-mcp https://github.com/nicobailon/pi-powerline-footer htt",
+          "mentions": [
+            "MCP"
+          ],
+          "fieldConfidence": "verified-against-live-response",
+          "fieldsVerifiedOn": "2026-09-06",
+          "missingFields": []
+        },
+        {
+          "platform": "bilibili",
+          "platformLabel": "B站",
+          "id": "BV1CTbf6CEGu",
+          "url": "https://www.bilibili.com/video/BV1CTbf6CEGu",
+          "author": "YangAgent",
+          "authorId": "24110153",
+          "publishedAt": "2026-08-20T13:35:00.000Z",
+          "title": "同样灵活、可扩展，Pi和DeepSeek Harness的核心设计有什么不同？",
+          "excerpt": "同样灵活、可扩展，Pi和DeepSeek Harness的核心设计有什么不同？ 欢迎关注我的知识星球：https://t.zsxq.com/1TNtY 我会分享最新的AI教程、使用技巧和资讯、回答你的问题、分享工作流等。 本期视频内容： 同样灵活、可扩展，Pi和DeepSeek Harness的核心设计有什么不同？ Pi通过一套稳定的Agent骨架和大量扩展事件，让用户深入改变输入、上下文、工具与运行行为；DeepSeek Harness则进一步把模型、工具、会话，甚至默认的Agent Loop都做成可以重新组合的插件。 本期视频从架构设计出发，带你看懂两种扩展思路、Cordis",
+          "mentions": [],
+          "fieldConfidence": "verified-against-live-response",
+          "fieldsVerifiedOn": "2026-09-06",
+          "missingFields": []
+        },
+        {
+          "platform": "bilibili",
+          "platformLabel": "B站",
+          "id": "BV139bD6gEa8",
+          "url": "https://www.bilibili.com/video/BV139bD6gEa8",
+          "author": "技术爬爬虾",
+          "authorId": "316183842",
+          "publishedAt": "2026-08-16T07:53:45.000Z",
+          "title": "Pi 大道至简，超越Codex和Claude Code的极简Agent，保姆级全攻略， 一期视频精通",
+          "excerpt": "Pi 大道至简，超越Codex和Claude Code的极简Agent，保姆级全攻略， 一期视频精通 Pi是近期热度超高的AI Agent。用四个字形容那就是大道至简。 Pi只有四个默认工具，（读文件，写文件，改文件，运行命令），系统提示词也仅仅只有一千Token。极致的精简带来了极致效率提升，在多项权威基准测试里，Pi 的代码质量，工作速度，成本等方面多方面超过主流Agent Codex和Claude Code。 Pi还有极其开放的插件生态，可以自己编写插件扩展Pi的能力。",
+          "mentions": [
+            "Claude"
+          ],
+          "fieldConfidence": "verified-against-live-response",
+          "fieldsVerifiedOn": "2026-09-06",
+          "missingFields": []
+        },
+        {
+          "platform": "bilibili",
+          "platformLabel": "B站",
+          "id": "BV1tAto61EcM",
+          "url": "https://www.bilibili.com/video/BV1tAto61EcM",
+          "author": "闭关修炼啊哈",
+          "authorId": "386045526",
+          "publishedAt": "2026-09-03T13:17:39.000Z",
+          "title": "PI进阶：打造更丝滑的π，增强Agent",
+          "excerpt": "PI进阶：打造更丝滑的π，增强Agent 仓库地址：https://github.com/yangfeng20/pi-ultimate",
+          "mentions": [],
+          "fieldConfidence": "verified-against-live-response",
+          "fieldsVerifiedOn": "2026-09-06",
+          "missingFields": []
+        },
+        {
+          "platform": "bilibili",
+          "platformLabel": "B站",
+          "id": "BV1kRg36hE4W",
+          "url": "https://www.bilibili.com/video/BV1kRg36hE4W",
+          "author": "咲凌_Arisa",
+          "authorId": "85829166",
+          "publishedAt": "2026-08-12T09:08:02.000Z",
+          "title": "不太负责任的Pi插件推荐 | 果穗也能看懂的名片网页制作教程【EP12.个人自用Pi扩展推荐】",
+          "excerpt": "不太负责任的Pi插件推荐 | 果穗也能看懂的名片网页制作教程【EP12.个人自用Pi扩展推荐】 其实我一直在想要不要录这期视频的，因为Pi Agent的设计美学除了minimal之外，就是自己有什么需求就自己DIY，所以我的插件不一定能够适配你的需求。就像我完全不使用goal和btw两个功能，所以在我这里我是没有安装对应的插件的。 另外Pi Agent本身设计的时候没有带的一些功能，是作者自己的取舍，也提供了一些alternative的方案，推荐阅读：https://mariozechner.at/posts/2025-11-30-pi-coding-agent/ 有一些不内置的功能作者有自己…",
+          "mentions": [],
+          "fieldConfidence": "verified-against-live-response",
+          "fieldsVerifiedOn": "2026-09-06",
+          "missingFields": []
+        },
+        {
+          "platform": "bilibili",
+          "platformLabel": "B站",
+          "id": "BV18Bto6DERk",
+          "url": "https://www.bilibili.com/video/BV18Bto6DERk",
+          "author": "AI樟榆树",
+          "authorId": "1463655031",
+          "publishedAt": "2026-09-03T12:29:30.000Z",
+          "title": "给Pi装上这10个扩展能力至少翻一翻",
+          "excerpt": "给Pi装上这10个扩展能力至少翻一翻 Pi Agent最近越来越多的人用了，给Pi装上这10个扩展，能力至少翻一番",
+          "mentions": [],
+          "fieldConfidence": "verified-against-live-response",
+          "fieldsVerifiedOn": "2026-09-06",
+          "missingFields": []
+        },
+        {
+          "platform": "bilibili",
+          "platformLabel": "B站",
+          "id": "BV1ETug6DExy",
+          "url": "https://www.bilibili.com/video/BV1ETug6DExy",
+          "author": "deepwrite开发者",
+          "authorId": "3707049464563718",
+          "publishedAt": "2026-08-08T08:35:28.000Z",
+          "title": "开源写作harness agent发布！短篇，剧本，长篇！",
+          "excerpt": "开源写作harness agent发布！短篇，剧本，长篇！ -",
+          "mentions": [],
+          "fieldConfidence": "verified-against-live-response",
+          "fieldsVerifiedOn": "2026-09-06",
+          "missingFields": []
+        }
+      ],
+      "pages": [
+        {
+          "page": 1,
+          "received": 19
+        }
+      ]
+    }
+  ]
+}

--- a/docs/research/2026-09-07-pi-package-ecosystem/tikhub/pi-agent-extensions/tikhub-search.md
+++ b/docs/research/2026-09-07-pi-package-ecosystem/tikhub/pi-agent-extensions/tikhub-search.md
@@ -1,0 +1,251 @@
+# TikHub 自媒体检索：「pi agent 扩展」
+
+- 抓取时间：2026-09-07T01:17:44.535Z
+- 关键词：`pi agent 扩展`
+- 平台：抖音(8) · 小红书(8) · B站(8)
+- 合计 24 条
+
+> 摘要是**原文前 300 字**，没有任何 AI 改写；`framework/tool` 是正则抽取的提及，不是判断。
+> 标 `best-effort-unverified` 的平台字段路径未经真实响应核对，读结论时以 URL 原文为准。
+
+## 本轮对账
+
+| 平台 | 状态 | 条数 | 页数 | 缺字段 | 字段路径 |
+|---|---|---|---|---|---|
+ | 抖音 | ✓ | 8 | 2 | （无） | 已核对 2026-09-06 | 
+ | 小红书 | ✓ | 8 | 1 | （无） | 已核对 2026-09-06 | 
+ | B站 | ✓ | 8 | 1 | （无） | 已核对 2026-09-06 | 
+
+## 抖音（8 条）
+
+### 给Pi装上这10个扩展能力翻倍 Pi Agent最近越来越多的人用了，给Pi装上这10个扩展，能力至少翻一番#Agent  #ai工具  #ai编程  #Vibecoding  #Pi
+
+- 出处：https://www.douyin.com/video/7681283787493330186
+- 平台 / 作者：抖音 · AI樟榆树
+- 发布时间：2026-09-03T12:24:16.000Z
+- 提到的框架/工具：Agent、Vibecoding
+
+> 给Pi装上这10个扩展能力翻倍 Pi Agent最近越来越多的人用了，给Pi装上这10个扩展，能力至少翻一番#Agent #ai工具 #ai编程 #Vibecoding #Pi
+
+### Pi:超越Codex跟Claude Code的极简Agent 保姆级攻略，一期精通#AI新星计划   #Agent #智能体 #科技 #教程
+
+- 出处：https://www.douyin.com/video/7674590359871065370
+- 平台 / 作者：抖音 · 技术爬爬虾
+- 发布时间：2026-08-16T12:22:17.000Z
+- 提到的框架/工具：Agent、Claude
+
+> Pi:超越Codex跟Claude Code的极简Agent 保姆级攻略，一期精通#AI新星计划 #Agent #智能体 #科技 #教程
+
+### PI agent 五大插件！ #科技 #deepseek #程序员
+
+- 出处：https://www.douyin.com/video/7675193290211249408
+- 平台 / 作者：抖音 · 算力炼丹炉
+- 发布时间：2026-08-18T02:29:57.000Z
+- 提到的框架/工具：deepseek
+
+> PI agent 五大插件！ #科技 #deepseek #程序员
+
+### Pi vs Harness：Agent 扩展放哪层？ Pi 把扩展放在工作流附近，DeepSeek Harness 把扩展深入运行时。想让 Agent 独立运行，先分清任务单元、运行层和组织治理层。 #AI智能体  #Agent  #DeepSeek  #Pi  #企业AI
+
+- 出处：https://www.douyin.com/video/7674597597608201535
+- 平台 / 作者：抖音 · 产品总监看AI
+- 发布时间：2026-08-16T11:58:26.000Z
+- 提到的框架/工具：Agent、DeepSeek
+
+> Pi vs Harness：Agent 扩展放哪层？ Pi 把扩展放在工作流附近，DeepSeek Harness 把扩展深入运行时。想让 Agent 独立运行，先分清任务单元、运行层和组织治理层。 #AI智能体 #Agent #DeepSeek #Pi #企业AI
+
+### 【完整版】一口气说完pi-agent的原理和二开实践 从学习Agent的角度看，piagent是最好的学习对象。
+从开发Agent的角度看，piagent是最好的底层框架（没错，我认为比DSH好）
+
+- 出处：https://www.douyin.com/video/7680204069788486950
+- 平台 / 作者：抖音 · 费曼学徒冬瓜
+- 发布时间：2026-08-31T14:34:23.000Z
+- 提到的框架/工具：（无）
+
+> 【完整版】一口气说完pi-agent的原理和二开实践 从学习Agent的角度看，piagent是最好的学习对象。 从开发Agent的角度看，piagent是最好的底层框架（没错，我认为比DSH好）
+
+### pi-agent桌面版介绍 #pi-agent  #Agent  #环步
+
+- 出处：https://www.douyin.com/video/7681718046213435619
+- 平台 / 作者：抖音 · 弗洛已得
+- 发布时间：2026-09-04T16:29:18.000Z
+- 提到的框架/工具：Agent、pi-agent
+
+> pi-agent桌面版介绍 #pi-agent #Agent #环步
+
+### Pi- Agent！一个远远被低估的 Agent Harness 框架！#chatgpt应用领域 #Ai人工智能 #ai #大模型应用 #人工智能发展
+
+- 出处：https://www.douyin.com/video/7668226078036666354
+- 平台 / 作者：抖音 · EasyShip.AI
+- 发布时间：2026-07-30T07:53:35.000Z
+- 提到的框架/工具：chatgpt
+
+> Pi- Agent！一个远远被低估的 Agent Harness 框架！#chatgpt应用领域 #Ai人工智能 #ai #大模型应用 #人工智能发展
+
+### 删掉大部分功能，Pi Agent 反而更强？ 没有 MCP，没有子 Agent，没有计划模式，甚至没有权限弹窗。
+Pi Agent 默认只保留了 read、write、edit、bash 四个核心工具。
+但这不是一个没做完的半成品，而是一次主动的“做减法”。
+第一期，我们先把 Pi Agent 的整体框架讲清楚：
+Pi 到底是工具、教材，还是 SDK？
+四个核心包分别负责什么？
+为什么它的系统提示词可以这么短？
+缺失的功能，如何通过 Extensions、Skills、Prompt Templates、Themes 和 Pi Packages 补回来？
+如果你也想从“会使用 AI”走向“读懂 Agent、自己构建 Agent”，可以和我一起把这套源码学完。
+你更喜欢功能齐全的 Cursor、Claude Code，还是可以自由拆装的 Pi？
+#抖音创作者大会 #我将认真品鉴AIGC界的权威 #PiAgent   #AI编程  #Agent开发
+
+- 出处：https://www.douyin.com/video/7679446879129570560
+- 平台 / 作者：抖音 · 筱筱AI学习放映室
+- 发布时间：2026-08-29T13:36:08.000Z
+- 提到的框架/工具：Agent、Claude、MCP、PiAgent
+
+> 删掉大部分功能，Pi Agent 反而更强？ 没有 MCP，没有子 Agent，没有计划模式，甚至没有权限弹窗。 Pi Agent 默认只保留了 read、write、edit、bash 四个核心工具。 但这不是一个没做完的半成品，而是一次主动的“做减法”。 第一期，我们先把 Pi Agent 的整体框架讲清楚： Pi 到底是工具、教材，还是 SDK？ 四个核心包分别负责什么？ 为什么它的系统提示词可以这么短？ 缺失的功能，如何通过 Extensions、Skills、Prompt Templates、Themes 和 Pi Packages 补回来？ 如果你也想从“会使用 AI”走向“读懂 …
+
+## 小红书（8 条）
+
+### 把 Pi Agent 装进你的桌面，也太爽了吧！
+
+- 出处：https://www.xiaohongshu.com/explore/6a6e0f470000000008011847?xsec_token=YBHMiOg8ZX_jsz_541ZbiskGu-h2Te_EuJoOHsdyGF9t4%3D&xsec_source=pc_search
+- 平台 / 作者：小红书 · AI
+- 发布时间：2026-08-01T15:22:47.000Z
+- 提到的框架/工具：（无）
+
+> ✨ 先说说为什么爽 最近看 DeepSeek V4 Flash 在 Pi 里工作，有种莫名的爽感： ✅ 模型能力强
+
+### 我的 Pi Agent配置清单：6 个插件，够用
+
+- 出处：https://www.xiaohongshu.com/explore/6a808415000000002500446e?xsec_token=YBTzk7G3t15qXhrtMvfphB1lROZq1leGp5IsiO_d5Qk1Q%3D&xsec_source=pc_search
+- 平台 / 作者：小红书 · 咕叽
+- 发布时间：2026-08-15T15:21:57.000Z
+- 提到的框架/工具：（无）
+
+> 我的 Pi Agent配置清单：6 个插件，够用
+
+### 给Pi装上这10个扩展能力至少翻一翻
+
+- 出处：https://www.xiaohongshu.com/explore/6a996793000000002601505d?xsec_token=YBspiEnypqM9g0GZw-VktGIlzVDNYKh5cGrzzqgTf6EYg%3D&xsec_source=pc_search
+- 平台 / 作者：小红书 · AI樟榆树
+- 发布时间：2026-09-03T12:26:59.000Z
+- 提到的框架/工具：Agent
+
+> Pi Agent最近越来越多的人用了，给Pi装上这10个扩展，能力至少翻一番#Agent #ai工具 #ai编程
+
+### Pi agent-如何扩展和构建你自己的 harness
+
+- 出处：https://www.xiaohongshu.com/explore/6a4f0d4c000000000702d134?xsec_token=YBSMmZYA4j1qbJlTEaWmQU4PTcoGjz8--b6CZ9LPDH8gs%3D&xsec_source=pc_search
+- 平台 / 作者：小红书 · 帕格尼尼的左手
+- 发布时间：2026-07-09T02:54:04.000Z
+- 提到的框架/工具：（无）
+
+> Pi Agent 架构设计：构建以用户为中心的自进化与高扩展 Harness 体系 1.极简底座与三大扩展入口 Pi 仅
+
+### 【开源】pi-workflow 是Pi Agent专用子任务编排扩展，基于pi-subagent实现多子Agent协同流
+
+- 出处：https://www.xiaohongshu.com/explore/6a46559800000000080324cd?xsec_token=YBfpTAt5Q1QjFM1UjbvBX4LCzxPKw4MKUXSF3Vd0job08%3D&xsec_source=pc_search
+- 平台 / 作者：小红书 · 无糖AI
+- 发布时间：2026-07-02T12:12:08.000Z
+- 提到的框架/工具：（无）
+
+> 【开源】pi-workflow 是Pi Agent专用子任务编排扩展，基于pi-subagent实现多子Agent协同流
+
+### 9 个 Pi 扩展包｜让你的 Pi 更好用
+
+- 出处：https://www.xiaohongshu.com/explore/6a914a7f000000000303d5d1?xsec_token=YBAH6CEnL01-85GyBb6qwhtkfJHJEVLJunXG9aJ2r_JMM%3D&xsec_source=pc_search
+- 平台 / 作者：小红书 · 右转
+- 发布时间：2026-08-28T08:44:47.000Z
+- 提到的框架/工具：（无）
+
+> 你是不是也遇到过这种情况—— 用 Pi 写代码时，需要联网查询发现Pi调用了一堆curl命令，Token消耗还很快？ 改
+
+### Pi Agent 使用指南｜终端AI速查手册
+
+- 出处：https://www.xiaohongshu.com/explore/6a998206000000002a02c2dd?xsec_token=YBspiEnypqM9g0GZw-VktGItWQH60WOFElGNm-FwjnsO8%3D&xsec_source=pc_search
+- 平台 / 作者：小红书 · 消失在天际
+- 发布时间：2026-09-03T14:19:50.000Z
+- 提到的框架/工具：（无）
+
+> 刚入坑 Pi Agent？这份中英对照速查手册帮你快速上手
+
+### Pi Agent 真的有点上头了
+
+- 出处：https://www.xiaohongshu.com/explore/6a941dd6000000002003bc5f?xsec_token=YBz24r1I7rCK9JHmQvpVGUv0RgmRSmYEUpuYUpUdDcOZg%3D&xsec_source=pc_search
+- 平台 / 作者：小红书 · AI圈的那些事
+- 发布时间：2026-08-30T12:11:02.000Z
+- 提到的框架/工具：（无）
+
+> 速度快、占用轻，而且特别省 Token。 Pi 是一个开源的 AI Agent 框架/CLI，可以让模型直接调用工具、读
+
+## B站（8 条）
+
+### 7 分钟学会使用 Pi，现在最好的 agent（之一）
+
+- 出处：https://www.bilibili.com/video/BV1MSti6XEui
+- 平台 / 作者：B站 · Hucci写代码
+- 发布时间：2026-09-04T06:23:14.000Z
+- 提到的框架/工具：（无）
+
+> 7 分钟学会使用 Pi，现在最好的 agent（之一） 这个视频介绍了 pi coding agent 的使用方法。
+
+### 推荐一些Pi Agent插件
+
+- 出处：https://www.bilibili.com/video/BV1k6E167Ext
+- 平台 / 作者：B站 · 夜未央-天将亮
+- 发布时间：2026-06-12T10:32:22.000Z
+- 提到的框架/工具：MCP
+
+> 推荐一些Pi Agent插件 我的 pi 配置： https://github.com/cap153/config/tree/main/pi/.pi 视频中提到的插件或项目： https://github.com/nicobailon/pi-web-access https://github.com/nicobailon/pi-mcp-adapter https://github.com/mrexodia/ida-pro-mcp https://github.com/nicobailon/pi-powerline-footer htt
+
+### 同样灵活、可扩展，Pi和DeepSeek Harness的核心设计有什么不同？
+
+- 出处：https://www.bilibili.com/video/BV1CTbf6CEGu
+- 平台 / 作者：B站 · YangAgent
+- 发布时间：2026-08-20T13:35:00.000Z
+- 提到的框架/工具：（无）
+
+> 同样灵活、可扩展，Pi和DeepSeek Harness的核心设计有什么不同？ 欢迎关注我的知识星球：https://t.zsxq.com/1TNtY 我会分享最新的AI教程、使用技巧和资讯、回答你的问题、分享工作流等。 本期视频内容： 同样灵活、可扩展，Pi和DeepSeek Harness的核心设计有什么不同？ Pi通过一套稳定的Agent骨架和大量扩展事件，让用户深入改变输入、上下文、工具与运行行为；DeepSeek Harness则进一步把模型、工具、会话，甚至默认的Agent Loop都做成可以重新组合的插件。 本期视频从架构设计出发，带你看懂两种扩展思路、Cordis
+
+### Pi 大道至简，超越Codex和Claude Code的极简Agent，保姆级全攻略， 一期视频精通
+
+- 出处：https://www.bilibili.com/video/BV139bD6gEa8
+- 平台 / 作者：B站 · 技术爬爬虾
+- 发布时间：2026-08-16T07:53:45.000Z
+- 提到的框架/工具：Claude
+
+> Pi 大道至简，超越Codex和Claude Code的极简Agent，保姆级全攻略， 一期视频精通 Pi是近期热度超高的AI Agent。用四个字形容那就是大道至简。 Pi只有四个默认工具，（读文件，写文件，改文件，运行命令），系统提示词也仅仅只有一千Token。极致的精简带来了极致效率提升，在多项权威基准测试里，Pi 的代码质量，工作速度，成本等方面多方面超过主流Agent Codex和Claude Code。 Pi还有极其开放的插件生态，可以自己编写插件扩展Pi的能力。
+
+### PI进阶：打造更丝滑的π，增强Agent
+
+- 出处：https://www.bilibili.com/video/BV1tAto61EcM
+- 平台 / 作者：B站 · 闭关修炼啊哈
+- 发布时间：2026-09-03T13:17:39.000Z
+- 提到的框架/工具：（无）
+
+> PI进阶：打造更丝滑的π，增强Agent 仓库地址：https://github.com/yangfeng20/pi-ultimate
+
+### 不太负责任的Pi插件推荐 \| 果穗也能看懂的名片网页制作教程【EP12.个人自用Pi扩展推荐】
+
+- 出处：https://www.bilibili.com/video/BV1kRg36hE4W
+- 平台 / 作者：B站 · 咲凌_Arisa
+- 发布时间：2026-08-12T09:08:02.000Z
+- 提到的框架/工具：（无）
+
+> 不太负责任的Pi插件推荐 | 果穗也能看懂的名片网页制作教程【EP12.个人自用Pi扩展推荐】 其实我一直在想要不要录这期视频的，因为Pi Agent的设计美学除了minimal之外，就是自己有什么需求就自己DIY，所以我的插件不一定能够适配你的需求。就像我完全不使用goal和btw两个功能，所以在我这里我是没有安装对应的插件的。 另外Pi Agent本身设计的时候没有带的一些功能，是作者自己的取舍，也提供了一些alternative的方案，推荐阅读：https://mariozechner.at/posts/2025-11-30-pi-coding-agent/ 有一些不内置的功能作者有自己…
+
+### 给Pi装上这10个扩展能力至少翻一翻
+
+- 出处：https://www.bilibili.com/video/BV18Bto6DERk
+- 平台 / 作者：B站 · AI樟榆树
+- 发布时间：2026-09-03T12:29:30.000Z
+- 提到的框架/工具：（无）
+
+> 给Pi装上这10个扩展能力至少翻一翻 Pi Agent最近越来越多的人用了，给Pi装上这10个扩展，能力至少翻一番
+
+### 开源写作harness agent发布！短篇，剧本，长篇！
+
+- 出处：https://www.bilibili.com/video/BV1ETug6DExy
+- 平台 / 作者：B站 · deepwrite开发者
+- 发布时间：2026-08-08T08:35:28.000Z
+- 提到的框架/工具：（无）
+
+> 开源写作harness agent发布！短篇，剧本，长篇！ -
+

--- a/docs/research/2026-09-07-pi-package-ecosystem/tikhub/pi-coding-agent/tikhub-search.json
+++ b/docs/research/2026-09-07-pi-package-ecosystem/tikhub/pi-coding-agent/tikhub-search.json
@@ -1,0 +1,762 @@
+{
+  "source": "tikhub",
+  "baseUrl": "https://api.tikhub.io",
+  "keyword": "pi coding agent",
+  "since": null,
+  "limitPerPlatform": 10,
+  "generatedAt": "2026-09-07T01:17:26.824Z",
+  "failures": [],
+  "summary": {
+    "totalRecords": 40,
+    "platformsOk": 4,
+    "platformsEmpty": 0,
+    "platformsFailed": 0,
+    "platforms": [
+      {
+        "platform": "douyin",
+        "platformLabel": "抖音",
+        "status": "ok",
+        "items": 10,
+        "pagesFetched": 2,
+        "missingFields": {},
+        "fieldConfidence": "verified-against-live-response",
+        "fieldsVerifiedOn": "2026-09-06",
+        "error": null
+      },
+      {
+        "platform": "xhs",
+        "platformLabel": "小红书",
+        "status": "ok",
+        "items": 10,
+        "pagesFetched": 1,
+        "missingFields": {},
+        "fieldConfidence": "verified-against-live-response",
+        "fieldsVerifiedOn": "2026-09-06",
+        "error": null
+      },
+      {
+        "platform": "bilibili",
+        "platformLabel": "B站",
+        "status": "ok",
+        "items": 10,
+        "pagesFetched": 1,
+        "missingFields": {},
+        "fieldConfidence": "verified-against-live-response",
+        "fieldsVerifiedOn": "2026-09-06",
+        "error": null
+      },
+      {
+        "platform": "x",
+        "platformLabel": "X（Twitter）",
+        "status": "ok",
+        "items": 10,
+        "pagesFetched": 1,
+        "missingFields": {},
+        "fieldConfidence": "verified-against-live-response",
+        "fieldsVerifiedOn": "2026-09-06",
+        "error": null
+      }
+    ]
+  },
+  "results": [
+    {
+      "platform": "douyin",
+      "platformLabel": "抖音",
+      "records": [
+        {
+          "platform": "douyin",
+          "platformLabel": "抖音",
+          "id": "7674590359871065370",
+          "url": "https://www.douyin.com/video/7674590359871065370",
+          "author": "技术爬爬虾",
+          "authorId": "99840012512",
+          "publishedAt": "2026-08-16T12:22:17.000Z",
+          "title": "Pi:超越Codex跟Claude Code的极简Agent 保姆级攻略，一期精通#AI新星计划   #Agent #智能体 #科技 #教程",
+          "excerpt": "Pi:超越Codex跟Claude Code的极简Agent 保姆级攻略，一期精通#AI新星计划 #Agent #智能体 #科技 #教程",
+          "mentions": [
+            "Agent",
+            "Claude"
+          ],
+          "fieldConfidence": "verified-against-live-response",
+          "fieldsVerifiedOn": "2026-09-06",
+          "missingFields": []
+        },
+        {
+          "platform": "douyin",
+          "platformLabel": "抖音",
+          "id": "7680381933458084195",
+          "url": "https://www.douyin.com/video/7680381933458084195",
+          "author": "阿图AI",
+          "authorId": "2615107546782560",
+          "publishedAt": "2026-09-01T02:04:31.000Z",
+          "title": "Pi Agent，有点劝退 #pi #piagent #codex #AI新手村 #普通人在AI时代",
+          "excerpt": "Pi Agent，有点劝退 #pi #piagent #codex #AI新手村 #普通人在AI时代",
+          "mentions": [
+            "codex",
+            "piagent"
+          ],
+          "fieldConfidence": "verified-against-live-response",
+          "fieldsVerifiedOn": "2026-09-06",
+          "missingFields": []
+        },
+        {
+          "platform": "douyin",
+          "platformLabel": "抖音",
+          "id": "7681561699970747699",
+          "url": "https://www.douyin.com/video/7681561699970747699",
+          "author": "Hucci写代码",
+          "authorId": "185196708902535",
+          "publishedAt": "2026-09-04T06:22:39.000Z",
+          "title": "7 分钟学会使用 Pi，现在最好的 agent（之一） 这个视频介绍了 pi coding agent 的使用方法\n\n#AI新星计划",
+          "excerpt": "7 分钟学会使用 Pi，现在最好的 agent（之一） 这个视频介绍了 pi coding agent 的使用方法 #AI新星计划",
+          "mentions": [],
+          "fieldConfidence": "verified-against-live-response",
+          "fieldsVerifiedOn": "2026-09-06",
+          "missingFields": []
+        },
+        {
+          "platform": "douyin",
+          "platformLabel": "抖音",
+          "id": "7675555534191285146",
+          "url": "https://www.douyin.com/video/7675555534191285146",
+          "author": "庖丁智能",
+          "authorId": "907532884255515",
+          "publishedAt": "2026-08-19T01:55:36.000Z",
+          "title": "pi coding agent 用pi可以直接在服务器上写代码，太爽了😂",
+          "excerpt": "pi coding agent 用pi可以直接在服务器上写代码，太爽了😂",
+          "mentions": [],
+          "fieldConfidence": "verified-against-live-response",
+          "fieldsVerifiedOn": "2026-09-06",
+          "missingFields": []
+        },
+        {
+          "platform": "douyin",
+          "platformLabel": "抖音",
+          "id": "7677827421571124345",
+          "url": "https://www.douyin.com/video/7677827421571124345",
+          "author": "椰叶",
+          "authorId": "2033451977943147",
+          "publishedAt": "2026-08-25T04:51:40.000Z",
+          "title": "#pi #ai #ai时代 #ai学习 #分享 \n一分钟带你盘明白！！",
+          "excerpt": "#pi #ai #ai时代 #ai学习 #分享 一分钟带你盘明白！！",
+          "mentions": [],
+          "fieldConfidence": "verified-against-live-response",
+          "fieldsVerifiedOn": "2026-09-06",
+          "missingFields": []
+        },
+        {
+          "platform": "douyin",
+          "platformLabel": "抖音",
+          "id": "7677909429782029672",
+          "url": "https://www.douyin.com/video/7677909429782029672",
+          "author": "迈AI克的杰克逊",
+          "authorId": "2380881668619385",
+          "publishedAt": "2026-08-25T10:09:55.000Z",
+          "title": "Pi是什么？ 很多人把 Pi 和 Pi coding agent 傻傻分不清，今天用一分钟给你讲透！\n先说结论：Pi 是一整套底层框架，你可以把它理解为发动机、轮子、车架这些配件；而 Pi coding agent，就是基于这套配件组装好的整车，是专门给你写代码的成品。\n两者到底有啥不一样？\n第一，层级不同。Pi 包含对接模型接口、核心循环等底层东西，你平时敲的 pi 命令，其实只是最上层的 coding 版本。\n第二，默认配置不同。纯 Pi 很干净，几乎啥也不预装；但 Pi coding agent 已经给你配好了读、写、改文件和执行命令的“基础四件套”，所以很多人一安装就能直接干活。\n第三，使用场景不同。底层扩展机制是一样的，但 Pi 适合从零搭建自己的 Agent，而 coding agent 就是拿来即用。\n那实际怎么选？只想快速用 AI 写代码、改项目，直接装 Pi coding agent 就够了！想自己定义 Agent 行为、改工作流，甚至做成别的形态，那你才需要去玩 Pi 这套底层框架。\n一句话总结：Pi 是个壳子，包含作者的 Agent 哲学；Pi coding agent 是配好的写代码版本。大部分人用的都是后者，却以为自己在玩整个 Pi。\n#ai #人工智能 #AI新星计划 #vibecoding #AI工具",
+          "excerpt": "Pi是什么？ 很多人把 Pi 和 Pi coding agent 傻傻分不清，今天用一分钟给你讲透！ 先说结论：Pi 是一整套底层框架，你可以把它理解为发动机、轮子、车架这些配件；而 Pi coding agent，就是基于这套配件组装好的整车，是专门给你写代码的成品。 两者到底有啥不一样？ 第一，层级不同。Pi 包含对接模型接口、核心循环等底层东西，你平时敲的 pi 命令，其实只是最上层的 coding 版本。 第二，默认配置不同。纯 Pi 很干净，几乎啥也不预装；但 Pi coding agent 已经给你配好了读、写、改文件和执行命令的“基础四件套”，所以很多人一安装就能直接干活。 第三…",
+          "mentions": [
+            "vibecoding"
+          ],
+          "fieldConfidence": "verified-against-live-response",
+          "fieldsVerifiedOn": "2026-09-06",
+          "missingFields": []
+        },
+        {
+          "platform": "douyin",
+          "platformLabel": "抖音",
+          "id": "7680204069788486950",
+          "url": "https://www.douyin.com/video/7680204069788486950",
+          "author": "费曼学徒冬瓜",
+          "authorId": "92481351764",
+          "publishedAt": "2026-08-31T14:34:23.000Z",
+          "title": "【完整版】一口气说完pi-agent的原理和二开实践 从学习Agent的角度看，piagent是最好的学习对象。\n从开发Agent的角度看，piagent是最好的底层框架（没错，我认为比DSH好）",
+          "excerpt": "【完整版】一口气说完pi-agent的原理和二开实践 从学习Agent的角度看，piagent是最好的学习对象。 从开发Agent的角度看，piagent是最好的底层框架（没错，我认为比DSH好）",
+          "mentions": [],
+          "fieldConfidence": "verified-against-live-response",
+          "fieldsVerifiedOn": "2026-09-06",
+          "missingFields": []
+        },
+        {
+          "platform": "douyin",
+          "platformLabel": "抖音",
+          "id": "7666572664886070568",
+          "url": "https://www.douyin.com/video/7666572664886070568",
+          "author": "肖恩君Sean",
+          "authorId": "9988918976",
+          "publishedAt": "2026-07-25T20:57:52.000Z",
+          "title": "一口气学会Pi Agent极简Harness系统设计 Pi 是一个刻意做减法的 coding agent harness, GitHub 77000+ star, 但它官网上有一整段叫\"我们没有做什么\": 不做 MCP, 不做子智能体, 不做 plan mode, 不做 to-do, 不弹权限窗口。这期我把它的系统设计从白板画到终端, 顺便用我自己的 Waku Agent 把 Pi 当成 coding 子智能体调了一次。零基础也能看懂。 \n章节:\n0:00 Pi 刻意没做的那些功能\n0:50 Waku Agent: 我们用来测试的 harness\n1:36 实测: Waku 把写代码任务交给 Pi\n2:58 Pi 的四种形态: TUI / CLI / JSON / RPC\n3:22 安装, 登录, 切换模型\n4:43 实测: --mode json 事件流\n6:03 上下文准备: agents.md\n7:20 系统提示词, 简单到不敢相信\n8:00 循环内部: 工具, 权限, 执行\n9:04 只有四个工具: read write edit bash\n9:49 会话是一棵树: /fork 和 ~/.pi/agent/sessions\n12:42 agent-loop.ts, 792 行\n13:32 这不是很笨吗? 聊聊 MCP 的上下文税\n14:53 变强一: skills 就是程序性记忆\n17:14 变强二: extensions 才能加真工具\n19:05 变强三: packages 和社区生态\n21:27 总结: 它的强大来自它没做的东西 \nYou Can Build Anything. You Can Learn Anything. 💪",
+          "excerpt": "一口气学会Pi Agent极简Harness系统设计 Pi 是一个刻意做减法的 coding agent harness, GitHub 77000+ star, 但它官网上有一整段叫\"我们没有做什么\": 不做 MCP, 不做子智能体, 不做 plan mode, 不做 to-do, 不弹权限窗口。这期我把它的系统设计从白板画到终端, 顺便用我自己的 Waku Agent 把 Pi 当成 coding 子智能体调了一次。零基础也能看懂。 章节: 0:00 Pi 刻意没做的那些功能 0:50 Waku Agent: 我们用来测试的 harness 1:36 实测: Waku 把写代码任务交给 P…",
+          "mentions": [
+            "GitHub 77000",
+            "MCP",
+            "RPC\n3"
+          ],
+          "fieldConfidence": "verified-against-live-response",
+          "fieldsVerifiedOn": "2026-09-06",
+          "missingFields": []
+        },
+        {
+          "platform": "douyin",
+          "platformLabel": "抖音",
+          "id": "7666019378948853030",
+          "url": "https://www.douyin.com/video/7666019378948853030",
+          "author": "Saywer Tech",
+          "authorId": "193156063432871",
+          "publishedAt": "2026-07-24T09:10:32.000Z",
+          "title": "Pi：凭什么拿到 7.6 万 Star？ 它和 Claude Code、Codex 一样，都是 coding agent。但 Pi 没有追求把所有功能都预装进去，而是选择开源、极简和可塑：把 agent harness 的控制权交给开发者。\n【它为什么好用】\n• 默认核心只有 Read、Write、Edit、Bash，机制简单，容易理解和改造\n• 缺工作流或界面时，可以让 Pi 写 extension，再用 `/reload` 直接加载\n• 会话支持分叉、回退和模型切换，开发者可以主动管理上下文\n【为什么突然大火】\n•Pi 在 OpenClaw 爆红阶段作为早期底层 harness 获得了大量曝光，随后又得到 Armin Ronacher 等开发者公开讨论和背书。\n•再加上 MIT 协议、可自定义扩展和多模型支持，它很符合现在开发者对“透明、可控 coding agent”的需求。\n截至 2026 年 7 月 24 日，项目有 76,604 Stars、9,427 Forks。这个数字是制作视频时的 GitHub 快照，之后还会继续变化。\n【需要注意】\nPi 默认没有内建权限沙箱，会继承当前用户权限。处理不可信仓库时，官方建议放进容器或其他隔离环境。 \n如果你喜欢自己定义工作流、模型和上下文，Pi 很值得试；如果你更想要开箱即用、权限边界明确的成品体验，就要先评估它的取舍。\n#Pi #claude #AI #知识分享",
+          "excerpt": "Pi：凭什么拿到 7.6 万 Star？ 它和 Claude Code、Codex 一样，都是 coding agent。但 Pi 没有追求把所有功能都预装进去，而是选择开源、极简和可塑：把 agent harness 的控制权交给开发者。 【它为什么好用】 • 默认核心只有 Read、Write、Edit、Bash，机制简单，容易理解和改造 • 缺工作流或界面时，可以让 Pi 写 extension，再用 `/reload` 直接加载 • 会话支持分叉、回退和模型切换，开发者可以主动管理上下文 【为什么突然大火】 •Pi 在 OpenClaw 爆红阶段作为早期底层 harness 获得了大量…",
+          "mentions": [
+            "claude",
+            "Claude"
+          ],
+          "fieldConfidence": "verified-against-live-response",
+          "fieldsVerifiedOn": "2026-09-06",
+          "missingFields": []
+        },
+        {
+          "platform": "douyin",
+          "platformLabel": "抖音",
+          "id": "7643805974544780580",
+          "url": "https://www.douyin.com/video/7643805974544780580",
+          "author": "第四种黑猩猩",
+          "authorId": "2955957561736269",
+          "publishedAt": "2026-05-25T12:31:13.000Z",
+          "title": "Pi Agent：比 Codex 更适合普通人的AI工具 #PiAgent#AI新星计划#抖音前沿科技首发计划#vibecoding大赏 #ClaudeCode",
+          "excerpt": "Pi Agent：比 Codex 更适合普通人的AI工具 #PiAgent#AI新星计划#抖音前沿科技首发计划#vibecoding大赏 #ClaudeCode",
+          "mentions": [
+            "ClaudeCode",
+            "PiAgent",
+            "vibecoding"
+          ],
+          "fieldConfidence": "verified-against-live-response",
+          "fieldsVerifiedOn": "2026-09-06",
+          "missingFields": []
+        }
+      ],
+      "pages": [
+        {
+          "page": 1,
+          "received": 7
+        },
+        {
+          "page": 2,
+          "received": 7
+        }
+      ]
+    },
+    {
+      "platform": "xhs",
+      "platformLabel": "小红书",
+      "records": [
+        {
+          "platform": "xhs",
+          "platformLabel": "小红书",
+          "id": "6a8172030000000008013d7b",
+          "url": "https://www.xiaohongshu.com/explore/6a8172030000000008013d7b?xsec_token=YBqYdoa0K0mlFs0kjOhqtjlpcYCC5FalmMr68KXgIl6J4%3D&xsec_source=pc_search",
+          "author": "技术爬爬虾",
+          "authorId": "5d4e1f9b0000000012026818",
+          "publishedAt": "2026-08-16T08:17:07.000Z",
+          "title": "Pi大道至简: 超越Claude跟Codex的极简Agent",
+          "excerpt": "#AI #AI实用技巧howto #科技 #计算机 #编程 #AI人工智能 #智能体 #教程",
+          "mentions": [
+            "Claude"
+          ],
+          "fieldConfidence": "verified-against-live-response",
+          "fieldsVerifiedOn": "2026-09-06",
+          "missingFields": []
+        },
+        {
+          "platform": "xhs",
+          "platformLabel": "小红书",
+          "id": "6a60950d0000000004028859",
+          "url": "https://www.xiaohongshu.com/explore/6a60950d0000000004028859?xsec_token=YBbkTMYSpYDCvrWZJ0a_ProZ8kRxaPZ1h9roLHaEoKTFw%3D&xsec_source=pc_search",
+          "author": "AI产品赵哥",
+          "authorId": "5571335f3fef922bf3f96339",
+          "publishedAt": "2026-07-22T10:01:49.000Z",
+          "title": "Pi Agent实战指南：从安全配置到技能开发！",
+          "excerpt": "#WAIC2026 在昨天的笔记里，我们一起深入探索了 Pi Agent 的设计逻辑，了解了它的极简主义设计哲学。我们",
+          "mentions": [
+            "WAIC2026"
+          ],
+          "fieldConfidence": "verified-against-live-response",
+          "fieldsVerifiedOn": "2026-09-06",
+          "missingFields": []
+        },
+        {
+          "platform": "xhs",
+          "platformLabel": "小红书",
+          "id": "6a8ad80d0000000017002f27",
+          "url": "https://www.xiaohongshu.com/explore/6a8ad80d0000000017002f27?xsec_token=YBl2bn5aNiXoXNvDPkT6rfV-wMRYy61_02CuOztw7anKM%3D&xsec_source=pc_search",
+          "author": "费曼学徒冬瓜",
+          "authorId": "602f316b000000000100af74",
+          "publishedAt": "2026-08-23T13:00:30.000Z",
+          "title": "如何使用pi-agent开发自己的智能体",
+          "excerpt": "Agent 框架那么多，为什么选 pi-agent？ 因为它先是顶尖 coding-agent，才是开发框架——二开等于",
+          "mentions": [],
+          "fieldConfidence": "verified-against-live-response",
+          "fieldsVerifiedOn": "2026-09-06",
+          "missingFields": []
+        },
+        {
+          "platform": "xhs",
+          "platformLabel": "小红书",
+          "id": "69e06ed60000000023012b6e",
+          "url": "https://www.xiaohongshu.com/explore/69e06ed60000000023012b6e?xsec_token=YBIsChBdCAJRz0oiETc_Mq9ft9voQa16rizIqfmmM_F0Y%3D&xsec_source=pc_search",
+          "author": "雷哥AI",
+          "authorId": "5b9e4b2f4a74c100013c5cc5",
+          "publishedAt": "2026-04-16T09:00:48.000Z",
+          "title": "认真做Agent 一定要看 PI",
+          "excerpt": "pi Coding Agent：一种“少即是多”的AI智能体哲学。极简的核心，换来无限的扩展可能，这才是企业级AI落地该",
+          "mentions": [],
+          "fieldConfidence": "verified-against-live-response",
+          "fieldsVerifiedOn": "2026-09-06",
+          "missingFields": []
+        },
+        {
+          "platform": "xhs",
+          "platformLabel": "小红书",
+          "id": "6a324972000000000f02a4a4",
+          "url": "https://www.xiaohongshu.com/explore/6a324972000000000f02a4a4?xsec_token=YBx86Q2qTy-r_2VmOd1VLH9vzF_KkAdADIbj5kNjC9tVc%3D&xsec_source=pc_search",
+          "author": "Kieran的AI笔记",
+          "authorId": "648f21b4000000001c02a873",
+          "publishedAt": "2026-06-17T07:14:59.000Z",
+          "title": "Pi Agent 配置指南：打造你的专属 AI Agent",
+          "excerpt": "非常值得自己从零到一配置的专属 Agent，开箱最小可用的 coding agent，比较适合喜欢自己折腾的极客们",
+          "mentions": [],
+          "fieldConfidence": "verified-against-live-response",
+          "fieldsVerifiedOn": "2026-09-06",
+          "missingFields": []
+        },
+        {
+          "platform": "xhs",
+          "platformLabel": "小红书",
+          "id": "6a808415000000002500446e",
+          "url": "https://www.xiaohongshu.com/explore/6a808415000000002500446e?xsec_token=YBicJVKqpNmNQdP54Ufb0RshyB6iIuxMvoTV-hrUvCni0%3D&xsec_source=pc_search",
+          "author": "咕叽",
+          "authorId": "630aad5e0000000012002939",
+          "publishedAt": "2026-08-15T15:21:57.000Z",
+          "title": "我的 Pi Agent配置清单：6 个插件，够用",
+          "excerpt": "我的 Pi Agent配置清单：6 个插件，够用",
+          "mentions": [],
+          "fieldConfidence": "verified-against-live-response",
+          "fieldsVerifiedOn": "2026-09-06",
+          "missingFields": []
+        },
+        {
+          "platform": "xhs",
+          "platformLabel": "小红书",
+          "id": "6a143ad500000000070118a8",
+          "url": "https://www.xiaohongshu.com/explore/6a143ad500000000070118a8?xsec_token=YBepoCgQai8-0cpqFkxImrAQJeIc_IUKcE0egHoX9AXrk%3D&xsec_source=pc_search",
+          "author": "第四种黑猩猩",
+          "authorId": "62fb991800000000120027ee",
+          "publishedAt": "2026-05-25T12:04:37.000Z",
+          "title": "Pi Agent：比 Codex 更适合普通人的AI工具",
+          "excerpt": "#教程 #人工智能 #vibecoding #AIAgent #ClaudeCode #Codex #Pi",
+          "mentions": [
+            "AIAgent",
+            "ClaudeCode",
+            "Codex",
+            "vibecoding"
+          ],
+          "fieldConfidence": "verified-against-live-response",
+          "fieldsVerifiedOn": "2026-09-06",
+          "missingFields": []
+        },
+        {
+          "platform": "xhs",
+          "platformLabel": "小红书",
+          "id": "6a85c2d100000000210212fe",
+          "url": "https://www.xiaohongshu.com/explore/6a85c2d100000000210212fe?xsec_token=YBeW9FQ68vnrly8uOJmFrcL3YomSNx5ih9tCjDSllc3yo%3D&xsec_source=pc_search",
+          "author": "李惠子Huizi Li",
+          "authorId": "5482e718d6e4a96b15132aec",
+          "publishedAt": "2026-08-19T14:50:57.000Z",
+          "title": "Pi: 构建一个极简且高度主观的coding Agent",
+          "excerpt": "Pi: 构建一个极简且高度主观的coding Agent",
+          "mentions": [],
+          "fieldConfidence": "verified-against-live-response",
+          "fieldsVerifiedOn": "2026-09-06",
+          "missingFields": []
+        },
+        {
+          "platform": "xhs",
+          "platformLabel": "小红书",
+          "id": "6a7c366d000000002500367d",
+          "url": "https://www.xiaohongshu.com/explore/6a7c366d000000002500367d?xsec_token=YBznPdecopfZ2e4SvkvRCcA8f6SPLBsCiJWVnOoHyesB4%3D&xsec_source=pc_search",
+          "author": "小方薯",
+          "authorId": "647d97c5000000002a037b7b",
+          "publishedAt": "2026-08-12T09:01:34.000Z",
+          "title": "在服务器上使用 pi-coding-agent",
+          "excerpt": "pi非常轻量，相比opencode，内存占用量很少。 在.bashrc里面添加下面内容： ```bash # vim",
+          "mentions": [],
+          "fieldConfidence": "verified-against-live-response",
+          "fieldsVerifiedOn": "2026-09-06",
+          "missingFields": []
+        },
+        {
+          "platform": "xhs",
+          "platformLabel": "小红书",
+          "id": "6a8bab67000000002b0032a0",
+          "url": "https://www.xiaohongshu.com/explore/6a8bab67000000002b0032a0?xsec_token=YBZu-jl2bwOpPrwn5_Wu3Pw82xOR9pWg9FvXcqSAYQsNs%3D&xsec_source=pc_search",
+          "author": "残荷听雨",
+          "authorId": "6a898d02000000001400c803",
+          "publishedAt": "2026-08-24T02:24:39.000Z",
+          "title": "Pi Agent 为什么只给模型 4 个工具？",
+          "excerpt": "第一次看 Pi，我最意外的不是它功能多，而是它默认只给模型 4 个工具：read / write / edit / ba",
+          "mentions": [],
+          "fieldConfidence": "verified-against-live-response",
+          "fieldsVerifiedOn": "2026-09-06",
+          "missingFields": []
+        }
+      ],
+      "pages": [
+        {
+          "page": 1,
+          "received": 20
+        }
+      ]
+    },
+    {
+      "platform": "bilibili",
+      "platformLabel": "B站",
+      "records": [
+        {
+          "platform": "bilibili",
+          "platformLabel": "B站",
+          "id": "BV139bD6gEa8",
+          "url": "https://www.bilibili.com/video/BV139bD6gEa8",
+          "author": "技术爬爬虾",
+          "authorId": "316183842",
+          "publishedAt": "2026-08-16T07:53:45.000Z",
+          "title": "Pi 大道至简，超越Codex和Claude Code的极简Agent，保姆级全攻略， 一期视频精通",
+          "excerpt": "Pi 大道至简，超越Codex和Claude Code的极简Agent，保姆级全攻略， 一期视频精通 Pi是近期热度超高的AI Agent。用四个字形容那就是大道至简。 Pi只有四个默认工具，（读文件，写文件，改文件，运行命令），系统提示词也仅仅只有一千Token。极致的精简带来了极致效率提升，在多项权威基准测试里，Pi 的代码质量，工作速度，成本等方面多方面超过主流Agent Codex和Claude Code。 Pi还有极其开放的插件生态，可以自己编写插件扩展Pi的能力。",
+          "mentions": [
+            "Claude"
+          ],
+          "fieldConfidence": "verified-against-live-response",
+          "fieldsVerifiedOn": "2026-09-06",
+          "missingFields": []
+        },
+        {
+          "platform": "bilibili",
+          "platformLabel": "B站",
+          "id": "BV1MSti6XEui",
+          "url": "https://www.bilibili.com/video/BV1MSti6XEui",
+          "author": "Hucci写代码",
+          "authorId": "1318868",
+          "publishedAt": "2026-09-04T06:23:14.000Z",
+          "title": "7 分钟学会使用 Pi，现在最好的 agent（之一）",
+          "excerpt": "7 分钟学会使用 Pi，现在最好的 agent（之一） 这个视频介绍了 pi coding agent 的使用方法。",
+          "mentions": [],
+          "fieldConfidence": "verified-against-live-response",
+          "fieldsVerifiedOn": "2026-09-06",
+          "missingFields": []
+        },
+        {
+          "platform": "bilibili",
+          "platformLabel": "B站",
+          "id": "BV1JB8o6BEit",
+          "url": "https://www.bilibili.com/video/BV1JB8o6BEit",
+          "author": "费曼学徒冬瓜",
+          "authorId": "367678065",
+          "publishedAt": "2026-08-30T13:00:00.000Z",
+          "title": "【完整版】一口气学会pi-agent的底层原理和二开实践",
+          "excerpt": "【完整版】一口气学会pi-agent的底层原理和二开实践 一口气学会pi-agent的底层原理和二开实践",
+          "mentions": [],
+          "fieldConfidence": "verified-against-live-response",
+          "fieldsVerifiedOn": "2026-09-06",
+          "missingFields": []
+        },
+        {
+          "platform": "bilibili",
+          "platformLabel": "B站",
+          "id": "BV1CTbf6CEGu",
+          "url": "https://www.bilibili.com/video/BV1CTbf6CEGu",
+          "author": "YangAgent",
+          "authorId": "24110153",
+          "publishedAt": "2026-08-20T13:35:00.000Z",
+          "title": "同样灵活、可扩展，Pi和DeepSeek Harness的核心设计有什么不同？",
+          "excerpt": "同样灵活、可扩展，Pi和DeepSeek Harness的核心设计有什么不同？ 欢迎关注我的知识星球：https://t.zsxq.com/1TNtY 我会分享最新的AI教程、使用技巧和资讯、回答你的问题、分享工作流等。 本期视频内容： 同样灵活、可扩展，Pi和DeepSeek Harness的核心设计有什么不同？ Pi通过一套稳定的Agent骨架和大量扩展事件，让用户深入改变输入、上下文、工具与运行行为；DeepSeek Harness则进一步把模型、工具、会话，甚至默认的Agent Loop都做成可以重新组合的插件。 本期视频从架构设计出发，带你看懂两种扩展思路、Cordis",
+          "mentions": [],
+          "fieldConfidence": "verified-against-live-response",
+          "fieldsVerifiedOn": "2026-09-06",
+          "missingFields": []
+        },
+        {
+          "platform": "bilibili",
+          "platformLabel": "B站",
+          "id": "BV1jrbx6GEEg",
+          "url": "https://www.bilibili.com/video/BV1jrbx6GEEg",
+          "author": "Titor12138",
+          "authorId": "477166874",
+          "publishedAt": "2026-09-06T16:21:41.000Z",
+          "title": "你的Pi我的Pi，好像不一样~~~",
+          "excerpt": "你的Pi我的Pi，好像不一样~~~ 自我实现的pi插件，极简Pi的极客使用。不久后上线详细介绍哦~~~",
+          "mentions": [],
+          "fieldConfidence": "verified-against-live-response",
+          "fieldsVerifiedOn": "2026-09-06",
+          "missingFields": []
+        },
+        {
+          "platform": "bilibili",
+          "platformLabel": "B站",
+          "id": "BV1tAto61EcM",
+          "url": "https://www.bilibili.com/video/BV1tAto61EcM",
+          "author": "闭关修炼啊哈",
+          "authorId": "386045526",
+          "publishedAt": "2026-09-03T13:17:39.000Z",
+          "title": "PI进阶：打造更丝滑的π，增强Agent",
+          "excerpt": "PI进阶：打造更丝滑的π，增强Agent 仓库地址：https://github.com/yangfeng20/pi-ultimate",
+          "mentions": [],
+          "fieldConfidence": "verified-against-live-response",
+          "fieldsVerifiedOn": "2026-09-06",
+          "missingFields": []
+        },
+        {
+          "platform": "bilibili",
+          "platformLabel": "B站",
+          "id": "BV1nWtB6EEoX",
+          "url": "https://www.bilibili.com/video/BV1nWtB6EEoX",
+          "author": "妙码学院",
+          "authorId": "3546571232774842",
+          "publishedAt": "2026-09-05T02:21:00.000Z",
+          "title": "基于 PI Agent 深入 Loop、Graph Engineering 详解，架构师带你拆解全球顶级 TS Agent 架构精要",
+          "excerpt": "基于 PI Agent 深入 Loop、Graph Engineering 详解，架构师带你拆解全球顶级 TS Agent 架构精要",
+          "mentions": [],
+          "fieldConfidence": "verified-against-live-response",
+          "fieldsVerifiedOn": "2026-09-06",
+          "missingFields": []
+        },
+        {
+          "platform": "bilibili",
+          "platformLabel": "B站",
+          "id": "BV1akKp6eEVf",
+          "url": "https://www.bilibili.com/video/BV1akKp6eEVf",
+          "author": "第四种黑猩猩CHIMP",
+          "authorId": "3546830396721763",
+          "publishedAt": "2026-07-20T11:34:40.000Z",
+          "title": "Pi 为什么能打赢 Claude Code 和 Codex",
+          "excerpt": "Pi 为什么能打赢 Claude Code 和 Codex",
+          "mentions": [
+            "Claude"
+          ],
+          "fieldConfidence": "verified-against-live-response",
+          "fieldsVerifiedOn": "2026-09-06",
+          "missingFields": []
+        },
+        {
+          "platform": "bilibili",
+          "platformLabel": "B站",
+          "id": "BV1CDtC6NERX",
+          "url": "https://www.bilibili.com/video/BV1CDtC6NERX",
+          "author": "五里墩茶社",
+          "authorId": "615957867",
+          "publishedAt": "2026-09-05T00:09:31.000Z",
+          "title": "Matt Pocock 都称好的Agent Skill show-me：让 Coding Agent 把代码讲清楚",
+          "excerpt": "Matt Pocock 都称好的Agent Skill show-me：让 Coding Agent 把代码讲清楚 一个 key 用全球大模型🔴 https://DMXAPI.cn 🚀 国内直连 OpenAI、Claude、Gemini，💰￥1 元起充！ - 加入我的知识星球：https://t.zsxq.com/W5Oj7 `show-me` 为 Coding Agent 增加了一套轻量的视觉表达方法。Agent 会先理解问题，再选择能把关键点讲清楚的最小视图。 这期视频通过七段真实操作，展示它如何用伪代码、调用树、组件树、文件树、Mermaid 和 HTML 图解解释缓存逻辑、Rea…",
+          "mentions": [
+            "Claude",
+            "Gemini"
+          ],
+          "fieldConfidence": "verified-against-live-response",
+          "fieldsVerifiedOn": "2026-09-06",
+          "missingFields": []
+        },
+        {
+          "platform": "bilibili",
+          "platformLabel": "B站",
+          "id": "BV1ZnEJ6NEJ6",
+          "url": "https://www.bilibili.com/video/BV1ZnEJ6NEJ6",
+          "author": "程序员暮闲",
+          "authorId": "640287748",
+          "publishedAt": "2026-06-06T15:45:29.000Z",
+          "title": "pi agent 最佳实践 | Harness Agent 定制全流程实战",
+          "excerpt": "pi agent 最佳实践 | Harness Agent 定制全流程实战 本期视频系统演示 pi agent 的安装、模型配置与扩展开发流程，重点讲解如何通过 TypeScript extensions、skills、themes、prompt template和 pi package完成拓展，把 pi agent 打造成适合自己工作流的高度定制化 AI Agent。",
+          "mentions": [],
+          "fieldConfidence": "verified-against-live-response",
+          "fieldsVerifiedOn": "2026-09-06",
+          "missingFields": []
+        }
+      ],
+      "pages": [
+        {
+          "page": 1,
+          "received": 19
+        }
+      ]
+    },
+    {
+      "platform": "x",
+      "platformLabel": "X（Twitter）",
+      "records": [
+        {
+          "platform": "x",
+          "platformLabel": "X（Twitter）",
+          "id": "2032163088045142243",
+          "url": "https://x.com/nicht_tintin/status/2032163088045142243",
+          "author": "tintinweb",
+          "authorId": "nicht_tintin",
+          "publishedAt": "2026-03-12T18:33:30.000Z",
+          "title": "Let's give pi-coding-agent a heartbeat 🤖♥️ Add Memory + Mes",
+          "excerpt": "Let's give pi-coding-agent a heartbeat 🤖♥️ Add Memory + Messenger + Skill Discovery 🦞. Make it autonomous. #OpenClaw-level chaos included 🙂🔥 https://t.co/7AnkOUql87 #AI #DevTools #pi https://t.co/Poohk1hUfO",
+          "mentions": [
+            "DevTools",
+            "OpenClaw-level"
+          ],
+          "fieldConfidence": "verified-against-live-response",
+          "fieldsVerifiedOn": "2026-09-06",
+          "missingFields": []
+        },
+        {
+          "platform": "x",
+          "platformLabel": "X（Twitter）",
+          "id": "2052770995333747117",
+          "url": "https://x.com/nikiforovall/status/2052770995333747117",
+          "author": "Oleksii Nikiforov 🇺🇦",
+          "authorId": "nikiforovall",
+          "publishedAt": "2026-05-08T15:21:58.000Z",
+          "title": "Just shipped pi-kanban — a web workspace for the pi coding a",
+          "excerpt": "Just shipped pi-kanban — a web workspace for the pi coding agent. Sessions, todos, subagents, all in one kanban view. Read-only, zero config, watches your ~/.pi sessions live. Try the demo: https://t.co/RBQ4baZzPZ cc: @mitsuhiko https://t.co/bEZ41dcvWF",
+          "mentions": [],
+          "fieldConfidence": "verified-against-live-response",
+          "fieldsVerifiedOn": "2026-09-06",
+          "missingFields": []
+        },
+        {
+          "platform": "x",
+          "platformLabel": "X（Twitter）",
+          "id": "2095892849678229790",
+          "url": "https://x.com/thisistonydang/status/2095892849678229790",
+          "author": "Tony Dang",
+          "authorId": "thisistonydang",
+          "publishedAt": "2026-09-04T15:12:49.000Z",
+          "title": "Been loving @pidotdev as my main terminal coding agent, so I",
+          "excerpt": "Been loving @pidotdev as my main terminal coding agent, so I made a Pi package for @neondatabase skills. It’s now live in the Pi package catalog. 😎 Neon + Pi 🤝 https://t.co/F6XPVJ16zq https://t.co/DJH3V90FeP",
+          "mentions": [],
+          "fieldConfidence": "verified-against-live-response",
+          "fieldsVerifiedOn": "2026-09-06",
+          "missingFields": []
+        },
+        {
+          "platform": "x",
+          "platformLabel": "X（Twitter）",
+          "id": "2087304957011911157",
+          "url": "https://x.com/DODOREACH/status/2087304957011911157",
+          "author": "dodo-reach 🦤",
+          "authorId": "DODOREACH",
+          "publishedAt": "2026-08-11T22:27:36.000Z",
+          "title": "stop sending bad prompts to your Pi coding agent. you liked ",
+          "excerpt": "stop sending bad prompts to your Pi coding agent. you liked pi-clarify, so i published it on npm too: pi install npm:pi-clarify it rewrites your prompt before sending, so you spend fewer turns explaining what you meant here's how it works",
+          "mentions": [],
+          "fieldConfidence": "verified-against-live-response",
+          "fieldsVerifiedOn": "2026-09-06",
+          "missingFields": []
+        },
+        {
+          "platform": "x",
+          "platformLabel": "X（Twitter）",
+          "id": "2064933797846798508",
+          "url": "https://x.com/nidhisinghattri/status/2064933797846798508",
+          "author": "Nidhi Singh",
+          "authorId": "nidhisinghattri",
+          "publishedAt": "2026-06-11T04:52:36.000Z",
+          "title": "i tested a fully local ai coding setup: gemma4 from @GoogleD",
+          "excerpt": "i tested a fully local ai coding setup: gemma4 from @GoogleDeepMind running through @lmstudio, paired with pi which is a minimal open source coding harness this is part 1 of a two part series. here we cover the why and the complete hands-on setup 0:00 - Running a coding agent fully local 0:47 - Why …",
+          "mentions": [
+            "Gemma 4",
+            "Part 2"
+          ],
+          "fieldConfidence": "verified-against-live-response",
+          "fieldsVerifiedOn": "2026-09-06",
+          "missingFields": []
+        },
+        {
+          "platform": "x",
+          "platformLabel": "X（Twitter）",
+          "id": "2007013292498464954",
+          "url": "https://x.com/nicopreme/status/2007013292498464954",
+          "author": "Nico Bailon",
+          "authorId": "nicopreme",
+          "publishedAt": "2026-01-02T08:57:12.000Z",
+          "title": "The \"interview\" workflow for agentic coding is a must, but a",
+          "excerpt": "The \"interview\" workflow for agentic coding is a must, but answering 40+ questions in a terminal gets exhausting fast. So I built a custom tool for Pi coding agent that spins up a rich web UI for the interview. https://t.co/pv5ttDwhSS https://t.co/gGCFtfZUI5 https://t.co/IHxIP4AkqJ",
+          "mentions": [],
+          "fieldConfidence": "verified-against-live-response",
+          "fieldsVerifiedOn": "2026-09-06",
+          "missingFields": []
+        },
+        {
+          "platform": "x",
+          "platformLabel": "X（Twitter）",
+          "id": "2048383338935939284",
+          "url": "https://x.com/paraschopra/status/2048383338935939284",
+          "author": "Paras Chopra",
+          "authorId": "paraschopra",
+          "publishedAt": "2026-04-26T12:46:59.000Z",
+          "title": "I tried replicating fully agentic coding on my laptop and I'",
+          "excerpt": "I tried replicating fully agentic coding on my laptop and I'm impressed! My setup - Qwen 27bn (4bit quant) https://t.co/GKN1BKYcAV - Pi coding agent https://t.co/Sv0oeo7asH - CCO sandboxing for yolo mode https://t.co/rRgfTsHOI3 My Mac M3 has 36GB ram. It's surreal to see a local model read prompt, f…",
+          "mentions": [
+            "Qwen"
+          ],
+          "fieldConfidence": "verified-against-live-response",
+          "fieldsVerifiedOn": "2026-09-06",
+          "missingFields": []
+        },
+        {
+          "platform": "x",
+          "platformLabel": "X（Twitter）",
+          "id": "2096660279216034079",
+          "url": "https://x.com/0xZenad/status/2096660279216034079",
+          "author": "Zenad",
+          "authorId": "0xZenad",
+          "publishedAt": "2026-09-06T18:02:19.000Z",
+          "title": "KEEP THESE 5 REPOS OPEN coding agents are moving past the \"o",
+          "excerpt": "KEEP THESE 5 REPOS OPEN coding agents are moving past the \"one terminal, one agent\" phase these are building what comes next 1) stablyai/orca Run Claude Code, Codex, Pi and other agents side by side One prompt can fan out across isolated git worktrees - compare the results and merge the winner https…",
+          "mentions": [
+            "Claude",
+            "THESE 5",
+            "TnGyHmsSK8"
+          ],
+          "fieldConfidence": "verified-against-live-response",
+          "fieldsVerifiedOn": "2026-09-06",
+          "missingFields": []
+        },
+        {
+          "platform": "x",
+          "platformLabel": "X（Twitter）",
+          "id": "2027128222442532961",
+          "url": "https://x.com/ollama/status/2027128222442532961",
+          "author": "ollama",
+          "authorId": "ollama",
+          "publishedAt": "2026-02-26T21:06:45.000Z",
+          "title": "Ollama can now launch Pi, a minimal coding agent which you c",
+          "excerpt": "Ollama can now launch Pi, a minimal coding agent which you can customize for your workflow ollama launch pi You can even ask pi to write extensions for itself https://t.co/hlUYnA3vl4",
+          "mentions": [],
+          "fieldConfidence": "verified-against-live-response",
+          "fieldsVerifiedOn": "2026-09-06",
+          "missingFields": []
+        },
+        {
+          "platform": "x",
+          "platformLabel": "X（Twitter）",
+          "id": "2085166100787134600",
+          "url": "https://x.com/shawmakesmagic/status/2085166100787134600",
+          "author": "Shaw (spirit/acc)",
+          "authorId": "shawmakesmagic",
+          "publishedAt": "2026-08-06T00:48:33.000Z",
+          "title": "It’s a good agent harness Coding harnesses are solved basica",
+          "excerpt": "It’s a good agent harness Coding harnesses are solved basically pi back on top after months of Hermes dominance",
+          "mentions": [],
+          "fieldConfidence": "verified-against-live-response",
+          "fieldsVerifiedOn": "2026-09-06",
+          "missingFields": []
+        }
+      ],
+      "pages": [
+        {
+          "page": 1,
+          "received": 19
+        }
+      ]
+    }
+  ]
+}

--- a/docs/research/2026-09-07-pi-package-ecosystem/tikhub/pi-coding-agent/tikhub-search.md
+++ b/docs/research/2026-09-07-pi-package-ecosystem/tikhub/pi-coding-agent/tikhub-search.md
@@ -1,0 +1,431 @@
+# TikHub 自媒体检索：「pi coding agent」
+
+- 抓取时间：2026-09-07T01:17:26.824Z
+- 关键词：`pi coding agent`
+- 平台：抖音(10) · 小红书(10) · B站(10) · X（Twitter）(10)
+- 合计 40 条
+
+> 摘要是**原文前 300 字**，没有任何 AI 改写；`framework/tool` 是正则抽取的提及，不是判断。
+> 标 `best-effort-unverified` 的平台字段路径未经真实响应核对，读结论时以 URL 原文为准。
+
+## 本轮对账
+
+| 平台 | 状态 | 条数 | 页数 | 缺字段 | 字段路径 |
+|---|---|---|---|---|---|
+ | 抖音 | ✓ | 10 | 2 | （无） | 已核对 2026-09-06 | 
+ | 小红书 | ✓ | 10 | 1 | （无） | 已核对 2026-09-06 | 
+ | B站 | ✓ | 10 | 1 | （无） | 已核对 2026-09-06 | 
+ | X（Twitter） | ✓ | 10 | 1 | （无） | 已核对 2026-09-06 | 
+
+## 抖音（10 条）
+
+### Pi:超越Codex跟Claude Code的极简Agent 保姆级攻略，一期精通#AI新星计划   #Agent #智能体 #科技 #教程
+
+- 出处：https://www.douyin.com/video/7674590359871065370
+- 平台 / 作者：抖音 · 技术爬爬虾
+- 发布时间：2026-08-16T12:22:17.000Z
+- 提到的框架/工具：Agent、Claude
+
+> Pi:超越Codex跟Claude Code的极简Agent 保姆级攻略，一期精通#AI新星计划 #Agent #智能体 #科技 #教程
+
+### Pi Agent，有点劝退 #pi #piagent #codex #AI新手村 #普通人在AI时代
+
+- 出处：https://www.douyin.com/video/7680381933458084195
+- 平台 / 作者：抖音 · 阿图AI
+- 发布时间：2026-09-01T02:04:31.000Z
+- 提到的框架/工具：codex、piagent
+
+> Pi Agent，有点劝退 #pi #piagent #codex #AI新手村 #普通人在AI时代
+
+### 7 分钟学会使用 Pi，现在最好的 agent（之一） 这个视频介绍了 pi coding agent 的使用方法
+
+#AI新星计划
+
+- 出处：https://www.douyin.com/video/7681561699970747699
+- 平台 / 作者：抖音 · Hucci写代码
+- 发布时间：2026-09-04T06:22:39.000Z
+- 提到的框架/工具：（无）
+
+> 7 分钟学会使用 Pi，现在最好的 agent（之一） 这个视频介绍了 pi coding agent 的使用方法 #AI新星计划
+
+### pi coding agent 用pi可以直接在服务器上写代码，太爽了😂
+
+- 出处：https://www.douyin.com/video/7675555534191285146
+- 平台 / 作者：抖音 · 庖丁智能
+- 发布时间：2026-08-19T01:55:36.000Z
+- 提到的框架/工具：（无）
+
+> pi coding agent 用pi可以直接在服务器上写代码，太爽了😂
+
+### #pi #ai #ai时代 #ai学习 #分享 
+一分钟带你盘明白！！
+
+- 出处：https://www.douyin.com/video/7677827421571124345
+- 平台 / 作者：抖音 · 椰叶
+- 发布时间：2026-08-25T04:51:40.000Z
+- 提到的框架/工具：（无）
+
+> #pi #ai #ai时代 #ai学习 #分享 一分钟带你盘明白！！
+
+### Pi是什么？ 很多人把 Pi 和 Pi coding agent 傻傻分不清，今天用一分钟给你讲透！
+先说结论：Pi 是一整套底层框架，你可以把它理解为发动机、轮子、车架这些配件；而 Pi coding agent，就是基于这套配件组装好的整车，是专门给你写代码的成品。
+两者到底有啥不一样？
+第一，层级不同。Pi 包含对接模型接口、核心循环等底层东西，你平时敲的 pi 命令，其实只是最上层的 coding 版本。
+第二，默认配置不同。纯 Pi 很干净，几乎啥也不预装；但 Pi coding agent 已经给你配好了读、写、改文件和执行命令的“基础四件套”，所以很多人一安装就能直接干活。
+第三，使用场景不同。底层扩展机制是一样的，但 Pi 适合从零搭建自己的 Agent，而 coding agent 就是拿来即用。
+那实际怎么选？只想快速用 AI 写代码、改项目，直接装 Pi coding agent 就够了！想自己定义 Agent 行为、改工作流，甚至做成别的形态，那你才需要去玩 Pi 这套底层框架。
+一句话总结：Pi 是个壳子，包含作者的 Agent 哲学；Pi coding agent 是配好的写代码版本。大部分人用的都是后者，却以为自己在玩整个 Pi。
+#ai #人工智能 #AI新星计划 #vibecoding #AI工具
+
+- 出处：https://www.douyin.com/video/7677909429782029672
+- 平台 / 作者：抖音 · 迈AI克的杰克逊
+- 发布时间：2026-08-25T10:09:55.000Z
+- 提到的框架/工具：vibecoding
+
+> Pi是什么？ 很多人把 Pi 和 Pi coding agent 傻傻分不清，今天用一分钟给你讲透！ 先说结论：Pi 是一整套底层框架，你可以把它理解为发动机、轮子、车架这些配件；而 Pi coding agent，就是基于这套配件组装好的整车，是专门给你写代码的成品。 两者到底有啥不一样？ 第一，层级不同。Pi 包含对接模型接口、核心循环等底层东西，你平时敲的 pi 命令，其实只是最上层的 coding 版本。 第二，默认配置不同。纯 Pi 很干净，几乎啥也不预装；但 Pi coding agent 已经给你配好了读、写、改文件和执行命令的“基础四件套”，所以很多人一安装就能直接干活。 第三…
+
+### 【完整版】一口气说完pi-agent的原理和二开实践 从学习Agent的角度看，piagent是最好的学习对象。
+从开发Agent的角度看，piagent是最好的底层框架（没错，我认为比DSH好）
+
+- 出处：https://www.douyin.com/video/7680204069788486950
+- 平台 / 作者：抖音 · 费曼学徒冬瓜
+- 发布时间：2026-08-31T14:34:23.000Z
+- 提到的框架/工具：（无）
+
+> 【完整版】一口气说完pi-agent的原理和二开实践 从学习Agent的角度看，piagent是最好的学习对象。 从开发Agent的角度看，piagent是最好的底层框架（没错，我认为比DSH好）
+
+### 一口气学会Pi Agent极简Harness系统设计 Pi 是一个刻意做减法的 coding agent harness, GitHub 77000+ star, 但它官网上有一整段叫"我们没有做什么": 不做 MCP, 不做子智能体, 不做 plan mode, 不做 to-do, 不弹权限窗口。这期我把它的系统设计从白板画到终端, 顺便用我自己的 Waku Agent 把 Pi 当成 coding 子智能体调了一次。零基础也能看懂。 
+章节:
+0:00 Pi 刻意没做的那些功能
+0:50 Waku Agent: 我们用来测试的 harness
+1:36 实测: Waku 把写代码任务交给 Pi
+2:58 Pi 的四种形态: TUI / CLI / JSON / RPC
+3:22 安装, 登录, 切换模型
+4:43 实测: --mode json 事件流
+6:03 上下文准备: agents.md
+7:20 系统提示词, 简单到不敢相信
+8:00 循环内部: 工具, 权限, 执行
+9:04 只有四个工具: read write edit bash
+9:49 会话是一棵树: /fork 和 ~/.pi/agent/sessions
+12:42 agent-loop.ts, 792 行
+13:32 这不是很笨吗? 聊聊 MCP 的上下文税
+14:53 变强一: skills 就是程序性记忆
+17:14 变强二: extensions 才能加真工具
+19:05 变强三: packages 和社区生态
+21:27 总结: 它的强大来自它没做的东西 
+You Can Build Anything. You Can Learn Anything. 💪
+
+- 出处：https://www.douyin.com/video/7666572664886070568
+- 平台 / 作者：抖音 · 肖恩君Sean
+- 发布时间：2026-07-25T20:57:52.000Z
+- 提到的框架/工具：GitHub 77000、MCP、RPC
+3
+
+> 一口气学会Pi Agent极简Harness系统设计 Pi 是一个刻意做减法的 coding agent harness, GitHub 77000+ star, 但它官网上有一整段叫"我们没有做什么": 不做 MCP, 不做子智能体, 不做 plan mode, 不做 to-do, 不弹权限窗口。这期我把它的系统设计从白板画到终端, 顺便用我自己的 Waku Agent 把 Pi 当成 coding 子智能体调了一次。零基础也能看懂。 章节: 0:00 Pi 刻意没做的那些功能 0:50 Waku Agent: 我们用来测试的 harness 1:36 实测: Waku 把写代码任务交给 P…
+
+### Pi：凭什么拿到 7.6 万 Star？ 它和 Claude Code、Codex 一样，都是 coding agent。但 Pi 没有追求把所有功能都预装进去，而是选择开源、极简和可塑：把 agent harness 的控制权交给开发者。
+【它为什么好用】
+• 默认核心只有 Read、Write、Edit、Bash，机制简单，容易理解和改造
+• 缺工作流或界面时，可以让 Pi 写 extension，再用 `/reload` 直接加载
+• 会话支持分叉、回退和模型切换，开发者可以主动管理上下文
+【为什么突然大火】
+•Pi 在 OpenClaw 爆红阶段作为早期底层 harness 获得了大量曝光，随后又得到 Armin Ronacher 等开发者公开讨论和背书。
+•再加上 MIT 协议、可自定义扩展和多模型支持，它很符合现在开发者对“透明、可控 coding agent”的需求。
+截至 2026 年 7 月 24 日，项目有 76,604 Stars、9,427 Forks。这个数字是制作视频时的 GitHub 快照，之后还会继续变化。
+【需要注意】
+Pi 默认没有内建权限沙箱，会继承当前用户权限。处理不可信仓库时，官方建议放进容器或其他隔离环境。 
+如果你喜欢自己定义工作流、模型和上下文，Pi 很值得试；如果你更想要开箱即用、权限边界明确的成品体验，就要先评估它的取舍。
+#Pi #claude #AI #知识分享
+
+- 出处：https://www.douyin.com/video/7666019378948853030
+- 平台 / 作者：抖音 · Saywer Tech
+- 发布时间：2026-07-24T09:10:32.000Z
+- 提到的框架/工具：claude、Claude
+
+> Pi：凭什么拿到 7.6 万 Star？ 它和 Claude Code、Codex 一样，都是 coding agent。但 Pi 没有追求把所有功能都预装进去，而是选择开源、极简和可塑：把 agent harness 的控制权交给开发者。 【它为什么好用】 • 默认核心只有 Read、Write、Edit、Bash，机制简单，容易理解和改造 • 缺工作流或界面时，可以让 Pi 写 extension，再用 `/reload` 直接加载 • 会话支持分叉、回退和模型切换，开发者可以主动管理上下文 【为什么突然大火】 •Pi 在 OpenClaw 爆红阶段作为早期底层 harness 获得了大量…
+
+### Pi Agent：比 Codex 更适合普通人的AI工具 #PiAgent#AI新星计划#抖音前沿科技首发计划#vibecoding大赏 #ClaudeCode
+
+- 出处：https://www.douyin.com/video/7643805974544780580
+- 平台 / 作者：抖音 · 第四种黑猩猩
+- 发布时间：2026-05-25T12:31:13.000Z
+- 提到的框架/工具：ClaudeCode、PiAgent、vibecoding
+
+> Pi Agent：比 Codex 更适合普通人的AI工具 #PiAgent#AI新星计划#抖音前沿科技首发计划#vibecoding大赏 #ClaudeCode
+
+## 小红书（10 条）
+
+### Pi大道至简: 超越Claude跟Codex的极简Agent
+
+- 出处：https://www.xiaohongshu.com/explore/6a8172030000000008013d7b?xsec_token=YBqYdoa0K0mlFs0kjOhqtjlpcYCC5FalmMr68KXgIl6J4%3D&xsec_source=pc_search
+- 平台 / 作者：小红书 · 技术爬爬虾
+- 发布时间：2026-08-16T08:17:07.000Z
+- 提到的框架/工具：Claude
+
+> #AI #AI实用技巧howto #科技 #计算机 #编程 #AI人工智能 #智能体 #教程
+
+### Pi Agent实战指南：从安全配置到技能开发！
+
+- 出处：https://www.xiaohongshu.com/explore/6a60950d0000000004028859?xsec_token=YBbkTMYSpYDCvrWZJ0a_ProZ8kRxaPZ1h9roLHaEoKTFw%3D&xsec_source=pc_search
+- 平台 / 作者：小红书 · AI产品赵哥
+- 发布时间：2026-07-22T10:01:49.000Z
+- 提到的框架/工具：WAIC2026
+
+> #WAIC2026 在昨天的笔记里，我们一起深入探索了 Pi Agent 的设计逻辑，了解了它的极简主义设计哲学。我们
+
+### 如何使用pi-agent开发自己的智能体
+
+- 出处：https://www.xiaohongshu.com/explore/6a8ad80d0000000017002f27?xsec_token=YBl2bn5aNiXoXNvDPkT6rfV-wMRYy61_02CuOztw7anKM%3D&xsec_source=pc_search
+- 平台 / 作者：小红书 · 费曼学徒冬瓜
+- 发布时间：2026-08-23T13:00:30.000Z
+- 提到的框架/工具：（无）
+
+> Agent 框架那么多，为什么选 pi-agent？ 因为它先是顶尖 coding-agent，才是开发框架——二开等于
+
+### 认真做Agent 一定要看 PI
+
+- 出处：https://www.xiaohongshu.com/explore/69e06ed60000000023012b6e?xsec_token=YBIsChBdCAJRz0oiETc_Mq9ft9voQa16rizIqfmmM_F0Y%3D&xsec_source=pc_search
+- 平台 / 作者：小红书 · 雷哥AI
+- 发布时间：2026-04-16T09:00:48.000Z
+- 提到的框架/工具：（无）
+
+> pi Coding Agent：一种“少即是多”的AI智能体哲学。极简的核心，换来无限的扩展可能，这才是企业级AI落地该
+
+### Pi Agent 配置指南：打造你的专属 AI Agent
+
+- 出处：https://www.xiaohongshu.com/explore/6a324972000000000f02a4a4?xsec_token=YBx86Q2qTy-r_2VmOd1VLH9vzF_KkAdADIbj5kNjC9tVc%3D&xsec_source=pc_search
+- 平台 / 作者：小红书 · Kieran的AI笔记
+- 发布时间：2026-06-17T07:14:59.000Z
+- 提到的框架/工具：（无）
+
+> 非常值得自己从零到一配置的专属 Agent，开箱最小可用的 coding agent，比较适合喜欢自己折腾的极客们
+
+### 我的 Pi Agent配置清单：6 个插件，够用
+
+- 出处：https://www.xiaohongshu.com/explore/6a808415000000002500446e?xsec_token=YBicJVKqpNmNQdP54Ufb0RshyB6iIuxMvoTV-hrUvCni0%3D&xsec_source=pc_search
+- 平台 / 作者：小红书 · 咕叽
+- 发布时间：2026-08-15T15:21:57.000Z
+- 提到的框架/工具：（无）
+
+> 我的 Pi Agent配置清单：6 个插件，够用
+
+### Pi Agent：比 Codex 更适合普通人的AI工具
+
+- 出处：https://www.xiaohongshu.com/explore/6a143ad500000000070118a8?xsec_token=YBepoCgQai8-0cpqFkxImrAQJeIc_IUKcE0egHoX9AXrk%3D&xsec_source=pc_search
+- 平台 / 作者：小红书 · 第四种黑猩猩
+- 发布时间：2026-05-25T12:04:37.000Z
+- 提到的框架/工具：AIAgent、ClaudeCode、Codex、vibecoding
+
+> #教程 #人工智能 #vibecoding #AIAgent #ClaudeCode #Codex #Pi
+
+### Pi: 构建一个极简且高度主观的coding Agent
+
+- 出处：https://www.xiaohongshu.com/explore/6a85c2d100000000210212fe?xsec_token=YBeW9FQ68vnrly8uOJmFrcL3YomSNx5ih9tCjDSllc3yo%3D&xsec_source=pc_search
+- 平台 / 作者：小红书 · 李惠子Huizi Li
+- 发布时间：2026-08-19T14:50:57.000Z
+- 提到的框架/工具：（无）
+
+> Pi: 构建一个极简且高度主观的coding Agent
+
+### 在服务器上使用 pi-coding-agent
+
+- 出处：https://www.xiaohongshu.com/explore/6a7c366d000000002500367d?xsec_token=YBznPdecopfZ2e4SvkvRCcA8f6SPLBsCiJWVnOoHyesB4%3D&xsec_source=pc_search
+- 平台 / 作者：小红书 · 小方薯
+- 发布时间：2026-08-12T09:01:34.000Z
+- 提到的框架/工具：（无）
+
+> pi非常轻量，相比opencode，内存占用量很少。 在.bashrc里面添加下面内容： ```bash # vim
+
+### Pi Agent 为什么只给模型 4 个工具？
+
+- 出处：https://www.xiaohongshu.com/explore/6a8bab67000000002b0032a0?xsec_token=YBZu-jl2bwOpPrwn5_Wu3Pw82xOR9pWg9FvXcqSAYQsNs%3D&xsec_source=pc_search
+- 平台 / 作者：小红书 · 残荷听雨
+- 发布时间：2026-08-24T02:24:39.000Z
+- 提到的框架/工具：（无）
+
+> 第一次看 Pi，我最意外的不是它功能多，而是它默认只给模型 4 个工具：read / write / edit / ba
+
+## B站（10 条）
+
+### Pi 大道至简，超越Codex和Claude Code的极简Agent，保姆级全攻略， 一期视频精通
+
+- 出处：https://www.bilibili.com/video/BV139bD6gEa8
+- 平台 / 作者：B站 · 技术爬爬虾
+- 发布时间：2026-08-16T07:53:45.000Z
+- 提到的框架/工具：Claude
+
+> Pi 大道至简，超越Codex和Claude Code的极简Agent，保姆级全攻略， 一期视频精通 Pi是近期热度超高的AI Agent。用四个字形容那就是大道至简。 Pi只有四个默认工具，（读文件，写文件，改文件，运行命令），系统提示词也仅仅只有一千Token。极致的精简带来了极致效率提升，在多项权威基准测试里，Pi 的代码质量，工作速度，成本等方面多方面超过主流Agent Codex和Claude Code。 Pi还有极其开放的插件生态，可以自己编写插件扩展Pi的能力。
+
+### 7 分钟学会使用 Pi，现在最好的 agent（之一）
+
+- 出处：https://www.bilibili.com/video/BV1MSti6XEui
+- 平台 / 作者：B站 · Hucci写代码
+- 发布时间：2026-09-04T06:23:14.000Z
+- 提到的框架/工具：（无）
+
+> 7 分钟学会使用 Pi，现在最好的 agent（之一） 这个视频介绍了 pi coding agent 的使用方法。
+
+### 【完整版】一口气学会pi-agent的底层原理和二开实践
+
+- 出处：https://www.bilibili.com/video/BV1JB8o6BEit
+- 平台 / 作者：B站 · 费曼学徒冬瓜
+- 发布时间：2026-08-30T13:00:00.000Z
+- 提到的框架/工具：（无）
+
+> 【完整版】一口气学会pi-agent的底层原理和二开实践 一口气学会pi-agent的底层原理和二开实践
+
+### 同样灵活、可扩展，Pi和DeepSeek Harness的核心设计有什么不同？
+
+- 出处：https://www.bilibili.com/video/BV1CTbf6CEGu
+- 平台 / 作者：B站 · YangAgent
+- 发布时间：2026-08-20T13:35:00.000Z
+- 提到的框架/工具：（无）
+
+> 同样灵活、可扩展，Pi和DeepSeek Harness的核心设计有什么不同？ 欢迎关注我的知识星球：https://t.zsxq.com/1TNtY 我会分享最新的AI教程、使用技巧和资讯、回答你的问题、分享工作流等。 本期视频内容： 同样灵活、可扩展，Pi和DeepSeek Harness的核心设计有什么不同？ Pi通过一套稳定的Agent骨架和大量扩展事件，让用户深入改变输入、上下文、工具与运行行为；DeepSeek Harness则进一步把模型、工具、会话，甚至默认的Agent Loop都做成可以重新组合的插件。 本期视频从架构设计出发，带你看懂两种扩展思路、Cordis
+
+### 你的Pi我的Pi，好像不一样~~~
+
+- 出处：https://www.bilibili.com/video/BV1jrbx6GEEg
+- 平台 / 作者：B站 · Titor12138
+- 发布时间：2026-09-06T16:21:41.000Z
+- 提到的框架/工具：（无）
+
+> 你的Pi我的Pi，好像不一样~~~ 自我实现的pi插件，极简Pi的极客使用。不久后上线详细介绍哦~~~
+
+### PI进阶：打造更丝滑的π，增强Agent
+
+- 出处：https://www.bilibili.com/video/BV1tAto61EcM
+- 平台 / 作者：B站 · 闭关修炼啊哈
+- 发布时间：2026-09-03T13:17:39.000Z
+- 提到的框架/工具：（无）
+
+> PI进阶：打造更丝滑的π，增强Agent 仓库地址：https://github.com/yangfeng20/pi-ultimate
+
+### 基于 PI Agent 深入 Loop、Graph Engineering 详解，架构师带你拆解全球顶级 TS Agent 架构精要
+
+- 出处：https://www.bilibili.com/video/BV1nWtB6EEoX
+- 平台 / 作者：B站 · 妙码学院
+- 发布时间：2026-09-05T02:21:00.000Z
+- 提到的框架/工具：（无）
+
+> 基于 PI Agent 深入 Loop、Graph Engineering 详解，架构师带你拆解全球顶级 TS Agent 架构精要
+
+### Pi 为什么能打赢 Claude Code 和 Codex
+
+- 出处：https://www.bilibili.com/video/BV1akKp6eEVf
+- 平台 / 作者：B站 · 第四种黑猩猩CHIMP
+- 发布时间：2026-07-20T11:34:40.000Z
+- 提到的框架/工具：Claude
+
+> Pi 为什么能打赢 Claude Code 和 Codex
+
+### Matt Pocock 都称好的Agent Skill show-me：让 Coding Agent 把代码讲清楚
+
+- 出处：https://www.bilibili.com/video/BV1CDtC6NERX
+- 平台 / 作者：B站 · 五里墩茶社
+- 发布时间：2026-09-05T00:09:31.000Z
+- 提到的框架/工具：Claude、Gemini
+
+> Matt Pocock 都称好的Agent Skill show-me：让 Coding Agent 把代码讲清楚 一个 key 用全球大模型🔴 https://DMXAPI.cn 🚀 国内直连 OpenAI、Claude、Gemini，💰￥1 元起充！ - 加入我的知识星球：https://t.zsxq.com/W5Oj7 `show-me` 为 Coding Agent 增加了一套轻量的视觉表达方法。Agent 会先理解问题，再选择能把关键点讲清楚的最小视图。 这期视频通过七段真实操作，展示它如何用伪代码、调用树、组件树、文件树、Mermaid 和 HTML 图解解释缓存逻辑、Rea…
+
+### pi agent 最佳实践 \| Harness Agent 定制全流程实战
+
+- 出处：https://www.bilibili.com/video/BV1ZnEJ6NEJ6
+- 平台 / 作者：B站 · 程序员暮闲
+- 发布时间：2026-06-06T15:45:29.000Z
+- 提到的框架/工具：（无）
+
+> pi agent 最佳实践 | Harness Agent 定制全流程实战 本期视频系统演示 pi agent 的安装、模型配置与扩展开发流程，重点讲解如何通过 TypeScript extensions、skills、themes、prompt template和 pi package完成拓展，把 pi agent 打造成适合自己工作流的高度定制化 AI Agent。
+
+## X（Twitter）（10 条）
+
+### Let's give pi-coding-agent a heartbeat 🤖♥️ Add Memory + Mes
+
+- 出处：https://x.com/nicht_tintin/status/2032163088045142243
+- 平台 / 作者：X（Twitter） · tintinweb
+- 发布时间：2026-03-12T18:33:30.000Z
+- 提到的框架/工具：DevTools、OpenClaw-level
+
+> Let's give pi-coding-agent a heartbeat 🤖♥️ Add Memory + Messenger + Skill Discovery 🦞. Make it autonomous. #OpenClaw-level chaos included 🙂🔥 https://t.co/7AnkOUql87 #AI #DevTools #pi https://t.co/Poohk1hUfO
+
+### Just shipped pi-kanban — a web workspace for the pi coding a
+
+- 出处：https://x.com/nikiforovall/status/2052770995333747117
+- 平台 / 作者：X（Twitter） · Oleksii Nikiforov 🇺🇦
+- 发布时间：2026-05-08T15:21:58.000Z
+- 提到的框架/工具：（无）
+
+> Just shipped pi-kanban — a web workspace for the pi coding agent. Sessions, todos, subagents, all in one kanban view. Read-only, zero config, watches your ~/.pi sessions live. Try the demo: https://t.co/RBQ4baZzPZ cc: @mitsuhiko https://t.co/bEZ41dcvWF
+
+### Been loving @pidotdev as my main terminal coding agent, so I
+
+- 出处：https://x.com/thisistonydang/status/2095892849678229790
+- 平台 / 作者：X（Twitter） · Tony Dang
+- 发布时间：2026-09-04T15:12:49.000Z
+- 提到的框架/工具：（无）
+
+> Been loving @pidotdev as my main terminal coding agent, so I made a Pi package for @neondatabase skills. It’s now live in the Pi package catalog. 😎 Neon + Pi 🤝 https://t.co/F6XPVJ16zq https://t.co/DJH3V90FeP
+
+### stop sending bad prompts to your Pi coding agent. you liked 
+
+- 出处：https://x.com/DODOREACH/status/2087304957011911157
+- 平台 / 作者：X（Twitter） · dodo-reach 🦤
+- 发布时间：2026-08-11T22:27:36.000Z
+- 提到的框架/工具：（无）
+
+> stop sending bad prompts to your Pi coding agent. you liked pi-clarify, so i published it on npm too: pi install npm:pi-clarify it rewrites your prompt before sending, so you spend fewer turns explaining what you meant here's how it works
+
+### i tested a fully local ai coding setup: gemma4 from @GoogleD
+
+- 出处：https://x.com/nidhisinghattri/status/2064933797846798508
+- 平台 / 作者：X（Twitter） · Nidhi Singh
+- 发布时间：2026-06-11T04:52:36.000Z
+- 提到的框架/工具：Gemma 4、Part 2
+
+> i tested a fully local ai coding setup: gemma4 from @GoogleDeepMind running through @lmstudio, paired with pi which is a minimal open source coding harness this is part 1 of a two part series. here we cover the why and the complete hands-on setup 0:00 - Running a coding agent fully local 0:47 - Why …
+
+### The "interview" workflow for agentic coding is a must, but a
+
+- 出处：https://x.com/nicopreme/status/2007013292498464954
+- 平台 / 作者：X（Twitter） · Nico Bailon
+- 发布时间：2026-01-02T08:57:12.000Z
+- 提到的框架/工具：（无）
+
+> The "interview" workflow for agentic coding is a must, but answering 40+ questions in a terminal gets exhausting fast. So I built a custom tool for Pi coding agent that spins up a rich web UI for the interview. https://t.co/pv5ttDwhSS https://t.co/gGCFtfZUI5 https://t.co/IHxIP4AkqJ
+
+### I tried replicating fully agentic coding on my laptop and I'
+
+- 出处：https://x.com/paraschopra/status/2048383338935939284
+- 平台 / 作者：X（Twitter） · Paras Chopra
+- 发布时间：2026-04-26T12:46:59.000Z
+- 提到的框架/工具：Qwen
+
+> I tried replicating fully agentic coding on my laptop and I'm impressed! My setup - Qwen 27bn (4bit quant) https://t.co/GKN1BKYcAV - Pi coding agent https://t.co/Sv0oeo7asH - CCO sandboxing for yolo mode https://t.co/rRgfTsHOI3 My Mac M3 has 36GB ram. It's surreal to see a local model read prompt, f…
+
+### KEEP THESE 5 REPOS OPEN coding agents are moving past the "o
+
+- 出处：https://x.com/0xZenad/status/2096660279216034079
+- 平台 / 作者：X（Twitter） · Zenad
+- 发布时间：2026-09-06T18:02:19.000Z
+- 提到的框架/工具：Claude、THESE 5、TnGyHmsSK8
+
+> KEEP THESE 5 REPOS OPEN coding agents are moving past the "one terminal, one agent" phase these are building what comes next 1) stablyai/orca Run Claude Code, Codex, Pi and other agents side by side One prompt can fan out across isolated git worktrees - compare the results and merge the winner https…
+
+### Ollama can now launch Pi, a minimal coding agent which you c
+
+- 出处：https://x.com/ollama/status/2027128222442532961
+- 平台 / 作者：X（Twitter） · ollama
+- 发布时间：2026-02-26T21:06:45.000Z
+- 提到的框架/工具：（无）
+
+> Ollama can now launch Pi, a minimal coding agent which you can customize for your workflow ollama launch pi You can even ask pi to write extensions for itself https://t.co/hlUYnA3vl4
+
+### It’s a good agent harness Coding harnesses are solved basica
+
+- 出处：https://x.com/shawmakesmagic/status/2085166100787134600
+- 平台 / 作者：X（Twitter） · Shaw (spirit/acc)
+- 发布时间：2026-08-06T00:48:33.000Z
+- 提到的框架/工具：（无）
+
+> It’s a good agent harness Coding harnesses are solved basically pi back on top after months of Hermes dominance
+

--- a/docs/research/2026-09-07-pi-package-ecosystem/tikhub/pi-install/tikhub-search.json
+++ b/docs/research/2026-09-07-pi-package-ecosystem/tikhub/pi-install/tikhub-search.json
@@ -1,0 +1,311 @@
+{
+  "source": "tikhub",
+  "baseUrl": "https://api.tikhub.io",
+  "keyword": "pi install",
+  "since": null,
+  "limitPerPlatform": 8,
+  "generatedAt": "2026-09-07T01:17:54.175Z",
+  "failures": [],
+  "summary": {
+    "totalRecords": 16,
+    "platformsOk": 2,
+    "platformsEmpty": 0,
+    "platformsFailed": 0,
+    "platforms": [
+      {
+        "platform": "x",
+        "platformLabel": "X（Twitter）",
+        "status": "ok",
+        "items": 8,
+        "pagesFetched": 1,
+        "missingFields": {},
+        "fieldConfidence": "verified-against-live-response",
+        "fieldsVerifiedOn": "2026-09-06",
+        "error": null
+      },
+      {
+        "platform": "bilibili",
+        "platformLabel": "B站",
+        "status": "ok",
+        "items": 8,
+        "pagesFetched": 1,
+        "missingFields": {},
+        "fieldConfidence": "verified-against-live-response",
+        "fieldsVerifiedOn": "2026-09-06",
+        "error": null
+      }
+    ]
+  },
+  "results": [
+    {
+      "platform": "x",
+      "platformLabel": "X（Twitter）",
+      "records": [
+        {
+          "platform": "x",
+          "platformLabel": "X（Twitter）",
+          "id": "2042357503854592103",
+          "url": "https://x.com/micLivs/status/2042357503854592103",
+          "author": "Michael Livs",
+          "authorId": "micLivs",
+          "publishedAt": "2026-04-09T21:42:28.000Z",
+          "title": "you know what time it is... introducing pi-monitor pi-monito",
+          "excerpt": "you know what time it is... introducing pi-monitor pi-monitor give @badlogicgames's pi a tool for running background bash commands and notify pi when its done. it writes outputs to @DanielGri's glimpse and also to disk in case the agent needs to investigate further. obviously awesome idea @noahzwebe…",
+          "mentions": [],
+          "fieldConfidence": "verified-against-live-response",
+          "fieldsVerifiedOn": "2026-09-06",
+          "missingFields": []
+        },
+        {
+          "platform": "x",
+          "platformLabel": "X（Twitter）",
+          "id": "2092954539208880445",
+          "url": "https://x.com/nicht_tintin/status/2092954539208880445",
+          "author": "tintinweb",
+          "authorId": "nicht_tintin",
+          "publishedAt": "2026-08-27T12:37:02.000Z",
+          "title": "Dynamic Workflows. Now in @tintinweb/pi-subagents for @pidot",
+          "excerpt": "Dynamic Workflows. Now in @tintinweb/pi-subagents for @pidotdev ♥️. @claudeai Code-compatible. Highly underrated. Thank you for your attention to the matter of scriptable agent orchestration 🦅 `pi install npm:@tintinweb/pi-subagents` https://t.co/P2b7Ml9BIY https://t.co/nyi7x117RR",
+          "mentions": [],
+          "fieldConfidence": "verified-against-live-response",
+          "fieldsVerifiedOn": "2026-09-06",
+          "missingFields": []
+        },
+        {
+          "platform": "x",
+          "platformLabel": "X（Twitter）",
+          "id": "2094484911315194115",
+          "url": "https://x.com/Suryanshti777/status/2094484911315194115",
+          "author": "Suryansh Tiwari",
+          "authorId": "Suryanshti777",
+          "publishedAt": "2026-08-31T17:58:11.000Z",
+          "title": "I sat through a pip install this morning like it was 2016. W",
+          "excerpt": "I sat through a pip install this morning like it was 2016. Waited. Made coffee. Came back. Still resolving. Turns out I stopped needing to do that a while ago and nobody told me. It's called uv. A Python package manager written in Rust. The part that got me: it isn't just a faster pip. It replaces p…",
+          "mentions": [],
+          "fieldConfidence": "verified-against-live-response",
+          "fieldsVerifiedOn": "2026-09-06",
+          "missingFields": []
+        },
+        {
+          "platform": "x",
+          "platformLabel": "X（Twitter）",
+          "id": "2095892849678229790",
+          "url": "https://x.com/thisistonydang/status/2095892849678229790",
+          "author": "Tony Dang",
+          "authorId": "thisistonydang",
+          "publishedAt": "2026-09-04T15:12:49.000Z",
+          "title": "Been loving @pidotdev as my main terminal coding agent, so I",
+          "excerpt": "Been loving @pidotdev as my main terminal coding agent, so I made a Pi package for @neondatabase skills. It’s now live in the Pi package catalog. 😎 Neon + Pi 🤝 https://t.co/F6XPVJ16zq https://t.co/DJH3V90FeP",
+          "mentions": [],
+          "fieldConfidence": "verified-against-live-response",
+          "fieldsVerifiedOn": "2026-09-06",
+          "missingFields": []
+        },
+        {
+          "platform": "x",
+          "platformLabel": "X（Twitter）",
+          "id": "2069464131334451297",
+          "url": "https://x.com/mem0ai/status/2069464131334451297",
+          "author": "mem0",
+          "authorId": "mem0ai",
+          "publishedAt": "2026-06-23T16:54:32.000Z",
+          "title": "We gave Pi Code persistent memory with Mem0 Launching the Me",
+          "excerpt": "We gave Pi Code persistent memory with Mem0 Launching the Mem0 plugin for Pi Code: persistent, scoped, semantic memory across sessions and projects. It captures what matters, searches by meaning, and brings the right context back when your agent needs it. Try it out: pi install npm:@ mem0/pi-agent-p…",
+          "mentions": [
+            "Mem0"
+          ],
+          "fieldConfidence": "verified-against-live-response",
+          "fieldsVerifiedOn": "2026-09-06",
+          "missingFields": []
+        },
+        {
+          "platform": "x",
+          "platformLabel": "X（Twitter）",
+          "id": "2092366925770702962",
+          "url": "https://x.com/onusoz/status/2092366925770702962",
+          "author": "Onur Solmaz",
+          "authorId": "onusoz",
+          "publishedAt": "2026-08-25T21:42:04.000Z",
+          "title": "*autoplan* This is one of my most used workflows in pi now W",
+          "excerpt": "*autoplan* This is one of my most used workflows in pi now While working with AI agents, there is a mechanical process by which I mine the agent for ideas. This reduces an open-ended feature design or bugfixing problem to a multiple choice question Basically, I keep asking paraphrases of the questio…",
+          "mentions": [],
+          "fieldConfidence": "verified-against-live-response",
+          "fieldsVerifiedOn": "2026-09-06",
+          "missingFields": []
+        },
+        {
+          "platform": "x",
+          "platformLabel": "X（Twitter）",
+          "id": "2095344641868763163",
+          "url": "https://x.com/chasen_liao/status/2095344641868763163",
+          "author": "Chasen",
+          "authorId": "chasen_liao",
+          "publishedAt": "2026-09-03T02:54:26.000Z",
+          "title": "很多朋友好奇如何在 Pi 里面使用 Gemini 模型（有antigravity订阅的话） 其实很简单，就一个插件 👇",
+          "excerpt": "很多朋友好奇如何在 Pi 里面使用 Gemini 模型（有antigravity订阅的话） 其实很简单，就一个插件 👇 https://t.co/kQGkukfFn1 &gt; pi install npm:pi-antigravity Pi 里爽用，又快额度又多",
+          "mentions": [
+            "Gemini"
+          ],
+          "fieldConfidence": "verified-against-live-response",
+          "fieldsVerifiedOn": "2026-09-06",
+          "missingFields": []
+        },
+        {
+          "platform": "x",
+          "platformLabel": "X（Twitter）",
+          "id": "1543210144799940609",
+          "url": "https://x.com/luongha68/status/1543210144799940609",
+          "author": "Hà Lương",
+          "authorId": "luongha68",
+          "publishedAt": "2022-07-02T12:29:04.000Z",
+          "title": "when pi enters mainnet, and I pass kyc, the first thing I do",
+          "excerpt": "when pi enters mainnet, and I pass kyc, the first thing I do is buy 1000 old phones and install Pi and give it to 1000 poor people and teach them how to earn Pi.Let them put in their labor to get out of poverty, than buy rice, noodles, or food for them!Is it okay 😍?#PiNetwork https://t.co/Qo4hddUTH…",
+          "mentions": [
+            "PiNetwork"
+          ],
+          "fieldConfidence": "verified-against-live-response",
+          "fieldsVerifiedOn": "2026-09-06",
+          "missingFields": []
+        }
+      ],
+      "pages": [
+        {
+          "page": 1,
+          "received": 20
+        }
+      ]
+    },
+    {
+      "platform": "bilibili",
+      "platformLabel": "B站",
+      "records": [
+        {
+          "platform": "bilibili",
+          "platformLabel": "B站",
+          "id": "BV18S411F7jX",
+          "url": "https://www.bilibili.com/video/BV18S411F7jX",
+          "author": "淘毕设",
+          "authorId": "505299201",
+          "publishedAt": "2024-05-12T04:08:49.000Z",
+          "title": "【实用教程】cnpm下载依赖1-install.bat执行计算机毕业课程设计教程",
+          "excerpt": "【实用教程】cnpm下载依赖1-install.bat执行计算机毕业课程设计教程 cnpm下载依赖1-install.bat执行计算机毕业课程设计教程",
+          "mentions": [],
+          "fieldConfidence": "verified-against-live-response",
+          "fieldsVerifiedOn": "2026-09-06",
+          "missingFields": []
+        },
+        {
+          "platform": "bilibili",
+          "platformLabel": "B站",
+          "id": "BV1GZbX6LE15",
+          "url": "https://www.bilibili.com/video/BV1GZbX6LE15",
+          "author": "poaipaipi",
+          "authorId": "3546940509784399",
+          "publishedAt": "2026-08-20T10:00:00.000Z",
+          "title": "Pi 插件教程:pi-fff 模糊搜索",
+          "excerpt": "Pi 插件教程:pi-fff 模糊搜索 真实录屏 + 旁白讲解, pi-fff 上手: ✅ FFF 引擎模糊搜索, 快而准 ✅ 支持分页翻页 ✅ 记不清文件名也能找到 ✅ 安装: pi install npm:@ff-labs/pi-fff 关注我,",
+          "mentions": [],
+          "fieldConfidence": "verified-against-live-response",
+          "fieldsVerifiedOn": "2026-09-06",
+          "missingFields": []
+        },
+        {
+          "platform": "bilibili",
+          "platformLabel": "B站",
+          "id": "BV1qy3E6LEKb",
+          "url": "https://www.bilibili.com/video/BV1qy3E6LEKb",
+          "author": "晴天AI实战",
+          "authorId": "263554645",
+          "publishedAt": "2026-07-26T10:13:59.000Z",
+          "title": "Pi Agent 从安装到配置保姆级全流程指南",
+          "excerpt": "Pi Agent 从安装到配置保姆级全流程指南 拒绝黑箱——装完你就是自己的 Agent 主人。",
+          "mentions": [],
+          "fieldConfidence": "verified-against-live-response",
+          "fieldsVerifiedOn": "2026-09-06",
+          "missingFields": []
+        },
+        {
+          "platform": "bilibili",
+          "platformLabel": "B站",
+          "id": "BV1c7826VEfi",
+          "url": "https://www.bilibili.com/video/BV1c7826VEfi",
+          "author": "poaipaipi",
+          "authorId": "3546940509784399",
+          "publishedAt": "2026-08-22T23:00:00.000Z",
+          "title": "Pi 插件教程:pi-lens 给 AI 一双代码眼",
+          "excerpt": "Pi 插件教程:pi-lens 给 AI 一双代码眼 2026-08-23 07:00",
+          "mentions": [],
+          "fieldConfidence": "verified-against-live-response",
+          "fieldsVerifiedOn": "2026-09-06",
+          "missingFields": []
+        },
+        {
+          "platform": "bilibili",
+          "platformLabel": "B站",
+          "id": "BV13q826bEC8",
+          "url": "https://www.bilibili.com/video/BV13q826bEC8",
+          "author": "poaipaipi",
+          "authorId": "3546940509784399",
+          "publishedAt": "2026-08-24T03:00:00.000Z",
+          "title": "Pi 插件教程:pi-web-ui 把 Pi 变成网页聊天",
+          "excerpt": "Pi 插件教程:pi-web-ui 把 Pi 变成网页聊天 【Pi 插件教程 第31期】pi-web-ui: 把 Pi 变成网页聊天 一行命令启动, 浏览器里直接对话, 还能装成系统服务。 📦 安装: pi install npm:pi-web-ui 🔥 每天一个 Pi 插件深度教程: 真实安装、真实使用、准确讲解。关注我, 一起把 AI 编程用到极致! #Pi #AI编程 #插件 #效率工具",
+          "mentions": [],
+          "fieldConfidence": "verified-against-live-response",
+          "fieldsVerifiedOn": "2026-09-06",
+          "missingFields": []
+        },
+        {
+          "platform": "bilibili",
+          "platformLabel": "B站",
+          "id": "BV1iUbD6CEVY",
+          "url": "https://www.bilibili.com/video/BV1iUbD6CEVY",
+          "author": "poaipaipi",
+          "authorId": "3546940509784399",
+          "publishedAt": "2026-08-17T07:00:00.000Z",
+          "title": "Pi 插件教程:plan-mode 先规划再动手",
+          "excerpt": "Pi 插件教程:plan-mode 先规划再动手 真实录屏 + 旁白讲解, pi-plan-mode 上手: ✅ 只读规划模式: 先探索先提问, 不碰代码 ✅ 输出可执行计划: 目标/步骤/验收标准 ✅ 主动提问澄清模糊需求 ✅ 安装: pi install npm:@narumitw/pi-plan-mode 关注我,",
+          "mentions": [],
+          "fieldConfidence": "verified-against-live-response",
+          "fieldsVerifiedOn": "2026-09-06",
+          "missingFields": []
+        },
+        {
+          "platform": "bilibili",
+          "platformLabel": "B站",
+          "id": "BV13q826bELv",
+          "url": "https://www.bilibili.com/video/BV13q826bELv",
+          "author": "poaipaipi",
+          "authorId": "3546940509784399",
+          "publishedAt": "2026-08-23T23:00:00.000Z",
+          "title": "Pi 插件教程:pi-powerline-footer 终端也有状态栏",
+          "excerpt": "Pi 插件教程:pi-powerline-footer 终端也有状态栏 【Pi 插件教程 第30期】pi-powerline-footer: 终端也有状态栏 模型/供应商/会话/余额实时显示在编辑器顶边框。 📦 安装: pi install npm:pi-powerline-footer 🔥 每天一个 Pi 插件深度教程: 真实安装、真实使用、准确讲解。关注我, 一起把 AI 编程用到极致! #Pi #AI编程 #插件 #效率工具",
+          "mentions": [],
+          "fieldConfidence": "verified-against-live-response",
+          "fieldsVerifiedOn": "2026-09-06",
+          "missingFields": []
+        },
+        {
+          "platform": "bilibili",
+          "platformLabel": "B站",
+          "id": "BV1DV4f6QESX",
+          "url": "https://www.bilibili.com/video/BV1DV4f6QESX",
+          "author": "pisper-official",
+          "authorId": "98673882",
+          "publishedAt": "2026-08-28T00:00:00.000Z",
+          "title": "口袋里的 AI 助手：Pisper 让手机自己跑 Agent，不靠电脑",
+          "excerpt": "口袋里的 AI 助手：Pisper 让手机自己跑 Agent，不靠电脑 把助手，带在身边。 Pisper 是本地优先的多 Agent 助手，跨桌面、终端与手机： · 手机本机内置 Pisper Runtime，打开即用，不依赖电脑 · 会话、Provider 配置与工作区，全部保存在手机 App 私有目录 · 需要桌面能力时：发现 → 申请 → 桌面明确审批，连接由你开启 · 接续的是 Runtime、会话和上下文——换设备，不换上下文 Windows · macOS · Linux · Android · iOS · MIT 开源 官网与下载 → https://p",
+          "mentions": [],
+          "fieldConfidence": "verified-against-live-response",
+          "fieldsVerifiedOn": "2026-09-06",
+          "missingFields": []
+        }
+      ],
+      "pages": [
+        {
+          "page": 1,
+          "received": 20
+        }
+      ]
+    }
+  ]
+}

--- a/docs/research/2026-09-07-pi-package-ecosystem/tikhub/pi-install/tikhub-search.md
+++ b/docs/research/2026-09-07-pi-package-ecosystem/tikhub/pi-install/tikhub-search.md
@@ -1,0 +1,165 @@
+# TikHub 自媒体检索：「pi install」
+
+- 抓取时间：2026-09-07T01:17:54.175Z
+- 关键词：`pi install`
+- 平台：X（Twitter）(8) · B站(8)
+- 合计 16 条
+
+> 摘要是**原文前 300 字**，没有任何 AI 改写；`framework/tool` 是正则抽取的提及，不是判断。
+> 标 `best-effort-unverified` 的平台字段路径未经真实响应核对，读结论时以 URL 原文为准。
+
+## 本轮对账
+
+| 平台 | 状态 | 条数 | 页数 | 缺字段 | 字段路径 |
+|---|---|---|---|---|---|
+ | X（Twitter） | ✓ | 8 | 1 | （无） | 已核对 2026-09-06 | 
+ | B站 | ✓ | 8 | 1 | （无） | 已核对 2026-09-06 | 
+
+## X（Twitter）（8 条）
+
+### you know what time it is... introducing pi-monitor pi-monito
+
+- 出处：https://x.com/micLivs/status/2042357503854592103
+- 平台 / 作者：X（Twitter） · Michael Livs
+- 发布时间：2026-04-09T21:42:28.000Z
+- 提到的框架/工具：（无）
+
+> you know what time it is... introducing pi-monitor pi-monitor give @badlogicgames's pi a tool for running background bash commands and notify pi when its done. it writes outputs to @DanielGri's glimpse and also to disk in case the agent needs to investigate further. obviously awesome idea @noahzwebe…
+
+### Dynamic Workflows. Now in @tintinweb/pi-subagents for @pidot
+
+- 出处：https://x.com/nicht_tintin/status/2092954539208880445
+- 平台 / 作者：X（Twitter） · tintinweb
+- 发布时间：2026-08-27T12:37:02.000Z
+- 提到的框架/工具：（无）
+
+> Dynamic Workflows. Now in @tintinweb/pi-subagents for @pidotdev ♥️. @claudeai Code-compatible. Highly underrated. Thank you for your attention to the matter of scriptable agent orchestration 🦅 `pi install npm:@tintinweb/pi-subagents` https://t.co/P2b7Ml9BIY https://t.co/nyi7x117RR
+
+### I sat through a pip install this morning like it was 2016. W
+
+- 出处：https://x.com/Suryanshti777/status/2094484911315194115
+- 平台 / 作者：X（Twitter） · Suryansh Tiwari
+- 发布时间：2026-08-31T17:58:11.000Z
+- 提到的框架/工具：（无）
+
+> I sat through a pip install this morning like it was 2016. Waited. Made coffee. Came back. Still resolving. Turns out I stopped needing to do that a while ago and nobody told me. It's called uv. A Python package manager written in Rust. The part that got me: it isn't just a faster pip. It replaces p…
+
+### Been loving @pidotdev as my main terminal coding agent, so I
+
+- 出处：https://x.com/thisistonydang/status/2095892849678229790
+- 平台 / 作者：X（Twitter） · Tony Dang
+- 发布时间：2026-09-04T15:12:49.000Z
+- 提到的框架/工具：（无）
+
+> Been loving @pidotdev as my main terminal coding agent, so I made a Pi package for @neondatabase skills. It’s now live in the Pi package catalog. 😎 Neon + Pi 🤝 https://t.co/F6XPVJ16zq https://t.co/DJH3V90FeP
+
+### We gave Pi Code persistent memory with Mem0 Launching the Me
+
+- 出处：https://x.com/mem0ai/status/2069464131334451297
+- 平台 / 作者：X（Twitter） · mem0
+- 发布时间：2026-06-23T16:54:32.000Z
+- 提到的框架/工具：Mem0
+
+> We gave Pi Code persistent memory with Mem0 Launching the Mem0 plugin for Pi Code: persistent, scoped, semantic memory across sessions and projects. It captures what matters, searches by meaning, and brings the right context back when your agent needs it. Try it out: pi install npm:@ mem0/pi-agent-p…
+
+### *autoplan* This is one of my most used workflows in pi now W
+
+- 出处：https://x.com/onusoz/status/2092366925770702962
+- 平台 / 作者：X（Twitter） · Onur Solmaz
+- 发布时间：2026-08-25T21:42:04.000Z
+- 提到的框架/工具：（无）
+
+> *autoplan* This is one of my most used workflows in pi now While working with AI agents, there is a mechanical process by which I mine the agent for ideas. This reduces an open-ended feature design or bugfixing problem to a multiple choice question Basically, I keep asking paraphrases of the questio…
+
+### 很多朋友好奇如何在 Pi 里面使用 Gemini 模型（有antigravity订阅的话） 其实很简单，就一个插件 👇
+
+- 出处：https://x.com/chasen_liao/status/2095344641868763163
+- 平台 / 作者：X（Twitter） · Chasen
+- 发布时间：2026-09-03T02:54:26.000Z
+- 提到的框架/工具：Gemini
+
+> 很多朋友好奇如何在 Pi 里面使用 Gemini 模型（有antigravity订阅的话） 其实很简单，就一个插件 👇 https://t.co/kQGkukfFn1 &gt; pi install npm:pi-antigravity Pi 里爽用，又快额度又多
+
+### when pi enters mainnet, and I pass kyc, the first thing I do
+
+- 出处：https://x.com/luongha68/status/1543210144799940609
+- 平台 / 作者：X（Twitter） · Hà Lương
+- 发布时间：2022-07-02T12:29:04.000Z
+- 提到的框架/工具：PiNetwork
+
+> when pi enters mainnet, and I pass kyc, the first thing I do is buy 1000 old phones and install Pi and give it to 1000 poor people and teach them how to earn Pi.Let them put in their labor to get out of poverty, than buy rice, noodles, or food for them!Is it okay 😍?#PiNetwork https://t.co/Qo4hddUTH…
+
+## B站（8 条）
+
+### 【实用教程】cnpm下载依赖1-install.bat执行计算机毕业课程设计教程
+
+- 出处：https://www.bilibili.com/video/BV18S411F7jX
+- 平台 / 作者：B站 · 淘毕设
+- 发布时间：2024-05-12T04:08:49.000Z
+- 提到的框架/工具：（无）
+
+> 【实用教程】cnpm下载依赖1-install.bat执行计算机毕业课程设计教程 cnpm下载依赖1-install.bat执行计算机毕业课程设计教程
+
+### Pi 插件教程:pi-fff 模糊搜索
+
+- 出处：https://www.bilibili.com/video/BV1GZbX6LE15
+- 平台 / 作者：B站 · poaipaipi
+- 发布时间：2026-08-20T10:00:00.000Z
+- 提到的框架/工具：（无）
+
+> Pi 插件教程:pi-fff 模糊搜索 真实录屏 + 旁白讲解, pi-fff 上手: ✅ FFF 引擎模糊搜索, 快而准 ✅ 支持分页翻页 ✅ 记不清文件名也能找到 ✅ 安装: pi install npm:@ff-labs/pi-fff 关注我,
+
+### Pi Agent 从安装到配置保姆级全流程指南
+
+- 出处：https://www.bilibili.com/video/BV1qy3E6LEKb
+- 平台 / 作者：B站 · 晴天AI实战
+- 发布时间：2026-07-26T10:13:59.000Z
+- 提到的框架/工具：（无）
+
+> Pi Agent 从安装到配置保姆级全流程指南 拒绝黑箱——装完你就是自己的 Agent 主人。
+
+### Pi 插件教程:pi-lens 给 AI 一双代码眼
+
+- 出处：https://www.bilibili.com/video/BV1c7826VEfi
+- 平台 / 作者：B站 · poaipaipi
+- 发布时间：2026-08-22T23:00:00.000Z
+- 提到的框架/工具：（无）
+
+> Pi 插件教程:pi-lens 给 AI 一双代码眼 2026-08-23 07:00
+
+### Pi 插件教程:pi-web-ui 把 Pi 变成网页聊天
+
+- 出处：https://www.bilibili.com/video/BV13q826bEC8
+- 平台 / 作者：B站 · poaipaipi
+- 发布时间：2026-08-24T03:00:00.000Z
+- 提到的框架/工具：（无）
+
+> Pi 插件教程:pi-web-ui 把 Pi 变成网页聊天 【Pi 插件教程 第31期】pi-web-ui: 把 Pi 变成网页聊天 一行命令启动, 浏览器里直接对话, 还能装成系统服务。 📦 安装: pi install npm:pi-web-ui 🔥 每天一个 Pi 插件深度教程: 真实安装、真实使用、准确讲解。关注我, 一起把 AI 编程用到极致! #Pi #AI编程 #插件 #效率工具
+
+### Pi 插件教程:plan-mode 先规划再动手
+
+- 出处：https://www.bilibili.com/video/BV1iUbD6CEVY
+- 平台 / 作者：B站 · poaipaipi
+- 发布时间：2026-08-17T07:00:00.000Z
+- 提到的框架/工具：（无）
+
+> Pi 插件教程:plan-mode 先规划再动手 真实录屏 + 旁白讲解, pi-plan-mode 上手: ✅ 只读规划模式: 先探索先提问, 不碰代码 ✅ 输出可执行计划: 目标/步骤/验收标准 ✅ 主动提问澄清模糊需求 ✅ 安装: pi install npm:@narumitw/pi-plan-mode 关注我,
+
+### Pi 插件教程:pi-powerline-footer 终端也有状态栏
+
+- 出处：https://www.bilibili.com/video/BV13q826bELv
+- 平台 / 作者：B站 · poaipaipi
+- 发布时间：2026-08-23T23:00:00.000Z
+- 提到的框架/工具：（无）
+
+> Pi 插件教程:pi-powerline-footer 终端也有状态栏 【Pi 插件教程 第30期】pi-powerline-footer: 终端也有状态栏 模型/供应商/会话/余额实时显示在编辑器顶边框。 📦 安装: pi install npm:pi-powerline-footer 🔥 每天一个 Pi 插件深度教程: 真实安装、真实使用、准确讲解。关注我, 一起把 AI 编程用到极致! #Pi #AI编程 #插件 #效率工具
+
+### 口袋里的 AI 助手：Pisper 让手机自己跑 Agent，不靠电脑
+
+- 出处：https://www.bilibili.com/video/BV1DV4f6QESX
+- 平台 / 作者：B站 · pisper-official
+- 发布时间：2026-08-28T00:00:00.000Z
+- 提到的框架/工具：（无）
+
+> 口袋里的 AI 助手：Pisper 让手机自己跑 Agent，不靠电脑 把助手，带在身边。 Pisper 是本地优先的多 Agent 助手，跨桌面、终端与手机： · 手机本机内置 Pisper Runtime，打开即用，不依赖电脑 · 会话、Provider 配置与工作区，全部保存在手机 App 私有目录 · 需要桌面能力时：发现 → 申请 → 桌面明确审批，连接由你开启 · 接续的是 Runtime、会话和上下文——换设备，不换上下文 Windows · macOS · Linux · Android · iOS · MIT 开源 官网与下载 → https://p
+


### PR DESCRIPTION
## 为什么

2026-09-07 用户点名：「有调查 pi agent package 吗，类似他们的生态，可能对我们有帮助」。

pi 已经在仓库里，但我们只接了 agent loop 那一层——它的**包系统**没人打开过，而 [R29 的参考实现对照](https://github.com/aqm857886159/Nomi/blob/main/docs/research/2026-09-07-pi-reference-implementation-conformance.md)在层 7「扩展 API」正好留了一格「只用了 37 分之 1」。这份补上那一格里与「分发」有关的部分。

**只调研不改码，一行产品代码未动。**

## 包系统一句话

`package.json` 的 `pi` 键声明四类资源（extensions / skills / prompts / themes），`pi install` 装进 `~/.pi/agent/` 或 `.pi/`，**装完那段代码就以完整系统权限跑**（文档三处红字）。版本锁锁在 source 字符串里，**没有任何完整性或签名校验**。

## 生态规模（2026-09-07 实测，可复核）

| 指标 | 数字 |
|---|---|
| npm 带 `pi-package` 关键字的包 | **5 250**（分页去重实数；npm 自报的 `total: 9267` 是模糊值，不作数） |
| 官方目录 `pi.dev/packages` | 分页到第 106 页，量级一致 |
| 月度分布 | 2026-07: 712 · **08: 2 791** · 09（前 7 天）: 1 062 —— 这个生态是最近 60 天炸出来的 |
| 与 Nomi 同题的分桶 | MCP 桥 172 · 技能包 458 · 审批/权限 170 · UI 312 · 花费 245 · 图像视频 125（真做视频的 ≤6） |

下载量一律取 npm downloads API（窗口 2026-08-23→08-29）；**star 数在这个生态里不可信**，正文说明了理由，全文未使用。

## 三种价值

- **借**：代码一行不借（R20 + R28：pi 是信任本机用户的 CLI，Nomi 是握着用户密钥和钱包的桌面应用）。**格式要借成唯一 owner**——pi / Claude Code / Codex 已经收敛到 Agent Skills 的单文件 frontmatter，我们是唯一还多一份 `skill.json` 的（P1/P4）。真实摩擦是「从 Claude Code 拖一个技能目录进 Nomi 用不了」，不是「兼容 pi」。
- **发**：最短的路不是发包，是**给现有 MCP 一键接入加一个 pi 客户端档**（≈半天，完全同源，不新增任何契约）——pi 没有内置 MCP，但 `pi-mcp-adapter`（252k/wk，全生态第一）自动读标准 `.mcp.json`。skills-only 的 `@nomi/pi-skills` 值得做；**registering `nomi_*` 的 extension 包不做**（P1 并行版，工具契约会有两个 owner，正是 #546 的复发形状）。正文有四路结构对比表。
- **学**：10 条机制按 R29 三档判定，含 **2 条「没想到」**——① 资源发现在 pi 是事件（`resources_discover`），在我们是六个写死的根，**阶段 5 之前补**；② pi 在包路径上做了前缀断言、却在模型可达的工具路径上一点不做，**所以「上游不做」不能当作我们不做 S11 的理由**（沿用 conformance G-07 排期，阶段 2 之前）。

## 顺带一条

`@dietrichgebert/ponytail` 的 `keywords` 里就有 `pi-package`、`pi` 清单指向 `extensions` + `skills` —— **我们的 R25 提交闸每天都在用一个 pi 包**，只是没走 `pi install`。同一份技能资产已在 pi / opencode / Claude Code / Codex 四个宿主上分发，靠的正是那一份 frontmatter。§4.2 的「格式换 owner」不是理论。

## 要拍板的一个点

**要不要以 skills-only 的 `@nomi/pi-skills` 公开发布 Nomi 的创作方法论？** 取舍点一句话：把最容易被抄的东西（方法论）免费送进一个 5 250 包的生态，换一个 `pi install` 一行的入口。护城河在产物与工具，不在方法论；但公开发布不可逆。**我倾向发**，但按决策自治这属于「产品方向 + 不可逆」，停下来问。

## 验证

`pnpm run gates:contracts` —— **68 个门岗 · 68 通过 · 0 阻断失败 · 0 advisory 失败**（含 `check:research-sources`：自媒体来源一节 + TikHub 附件齐备）。纯文档改动，不触发 R16/R13。

## 没查成的（正文 §1 有表）

gallery 未逐页抓；GitHub topic 计数与 star 数不可信（已说明并弃用）；「Oh My Pi」发行版源仓未找到；Discord 未取样；下载量窗口是 08-23→08-29 不是最近 7 天。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
