### PR TITLE
docs(design): 登记 threeUI 为设计灵感源（灵感≠复用，只参考不搬码）

### DIFF
--- a/docs/design/nomi-design-flow-howto.md
+++ b/docs/design/nomi-design-flow-howto.md
@@ -21,6 +21,22 @@ hook 命中时会顶出一行「设计流程提示」，确保 AI 不跳步。
 | ④ 交付走读 | 逐屏逐件：这是什么 / 为什么 / 什么时候碰 | 用户拍不了板（统计表看不到决策理由） |
 | ⑤ 拍板后产契约 | `pnpm run check:mockup-contracts` 产 `.auto.mjs` + 手写 `.intent.mjs` | 实现漂移（骨架段跑到框外了，36 门全绿也发现不了） |
 
+## 外部参考来源（灵感 ≠ 复用）
+
+步骤②先分清两类外部来源，别混用：
+
+| 类型 | 来源 | 用途 | 边界 |
+|---|---|---|---|
+| **复用源**（可整件进代码） | Beautiful UI / AI Elements | 主工作台 React UI 整件复用 | 进代码前按 R20 过 build-vs-buy + 授权核，符合 token 门岗 |
+| **灵感源**（不搬码） | threeUI（`threeui.com/browse`） | Three.js/WebGL 特效组件与落地页商店：Hero、3D 场景、WebGL 背景、着色器按钮、文字动效、落地页整页 | 只参考，禁止把源码/CSS/GLSL/素材拷进 Nomi 仓库 |
+
+**threeUI 适用面**（2026-09-07 登记）：营销站 `nomiaqm.com` 首屏与背景氛围、scene3d / 3D 导演台的氛围与微动效节奏；**不适用**主工作台高密度 UI（面板/表格/节点/时间线/设置——其上无对应素材）。营销站不在 `src/` token 门岗覆盖范围，scene3d 走既有 three/R3F 栈。
+
+**使用规则**：
+1. 只借鉴结构、质感、动效节奏、光照语言 → 用 Nomi token 与既有组件**重画**成 mockup（回到步骤③），不照抄布局密度。
+2. 授权红线：Community（免费）未声明开源/商用授权；Pro（$99/年 或 $199 终身）条款明示源码不进公开产物、不得再分发。Nomi 是公开 AGPL 仓库 → **任何档位的 threeUI 代码/截图都不入库**，要引用只放外链。
+3. 任务涉及营销站或 3D 视觉时，步骤①先过一遍 `threeui.com/browse` 相关分类（Landing Pages / Hero / Backgrounds / Text Animation / Buttons）做结构参考，再动手。
+
 ## 依赖关系
 
 步骤⑤依赖 PR #395（`feat/design-conformance-unified-20260903`）提供的工具链：
@@ -44,3 +60,6 @@ hook 命中时会顶出一行「设计流程提示」，确保 AI 不跳步。
 
 **Q：「逐件走读」格式有没有范本？**
 有。参照 `docs/design/2026-09-02-agent-ui-v3-walkthrough.md`——那是经用户拍板认可的交付格式。
+
+**Q：看中 threeUI 某个效果，能不能直接用？**
+不能搬源（授权见「外部参考来源」红线）。要效果就走**手法自研**：分析它的结构/动效/光照语言 → 用 Nomi 已有 three/R3F 或 CSS 自己写一版，进 mockup 供拍板。Nomi 已有 three@0.184 + @react-three/fiber，自研成本可控，且完全绕开授权与 R1 并行版问题。


### PR DESCRIPTION
## 背景
threeui.com/browse 是 Three.js/WebGL 特效组件与落地页模板商店（Hero/3D 场景/WebGL 背景/着色器按钮/文字动效/落地页整页）。用户希望把它接入 Nomi 作为设计参考。

## 核实结论（为什么只登记为参考源）
- Nomi 是公开 AGPL 仓库；threeUI Community（免费）档未声明开源/商用授权，Pro（$99/年、$199 终身）条款明示源码不进公开产物、不得再分发 → **代码/截图一律不入库**，引用只放外链。
- 适配面：营销站 nomiaqm.com 首屏/背景、scene3d/3D 导演台氛围微动效；与主工作台高密度 UI 无关。

## 改动（1 文件 +19 行，纯文档）
docs/design/nomi-design-flow-howto.md：
1. 新增「外部参考来源（灵感 ≠ 复用）」节——把外部来源分复用源（Beautiful UI / AI Elements，可进代码）与灵感源（threeUI，不搬码），含适用面/不适用面/3 条使用规则；
2. FAQ 增补：看中效果走手法自研（three@0.184 + R3F），不进代码。

## 验证
- 纯文档改动：未触 src/、无 token/i18n/词汇表影响，无代码门岗需跑。
- pre-commit 安全门岗已过（1 staged 文件无敏感泄露）。
- --no-verify：Ponytail Codex 适配器本环境缺插件返回 0B fail-closed（与 PR #572 先例相同），用户拍板授权绕过；上游修复分支 fix/ponytail-runner-failed-0b-20260907 已在 main。

## 后续（非本 PR 范围）
- nomi-design-flow 技能本体（SKILL.md）当前 checkout 不在仓内（随运行时安装），如需同步登记待确认其安装来源。