### PR TITLE
chore(docs-gates): 手工补齐 docs-autosync 的索引/状态回写（workflow 无权开 PR）

### DIFF
--- a/docs/plan/2026-09-07-skill-import-real-use.md
+++ b/docs/plan/2026-09-07-skill-import-real-use.md
@@ -1,5 +1,7 @@
 # 方案：把「导进来的技能」一路接到 Agent 里能真用上（2026-09-07）
 
+> 📋 方案待拍板 · 状态由 docs-autosync 自动登记，作者请按实修改
+
 - 状态：实施中（分支 `fix/skill-import-real-use-20260907`，PR #582）
 - 「先查别人」报告：[`docs/research/2026-09-07-skill-import-real-use/prior-art.md`](../research/2026-09-07-skill-import-real-use/prior-art.md)
 

--- a/docs/plan/INDEX.md
+++ b/docs/plan/INDEX.md
@@ -271,3 +271,10 @@
 - [2026-09-03 画布连线回归调查与修复](2026-09-03-canvas-connect-regression.md)
 
 - [2026-09-05] [第三刀·投影清零方案](2026-09-05-storyboard-projection-cleanup.md) — 分镜唯一 owner、旧字段一次迁移后丢弃、取证 runner 读 Host snapshot。
+
+## 🤖 自动收录（待人工归位）
+
+> 这些链接由 `.github/workflows/docs-autosync.yml` 在 main 上自动补登，只保证「能被搜到」，
+> 不代表已归好类。顺手把某一行挪进上面对应主题的表里即可——挪走后本区自然变短。
+
+- [2026-09-07-skill-import-real-use](2026-09-07-skill-import-real-use.md)


### PR DESCRIPTION
## 为什么
`Docs Gate Autosync` 在 main 上每次合并后都跑到「Open a docs repair pull request」这步失败：仓库 Actions 设置 `can_approve_pull_request_reviews=false`，GitHub 拒绝 Actions 创建 PR。`gh pr list --search head:docs/autosync` 为空 —— 历史上从未有一条 autosync PR 合入过，CLAUDE.md 里「合入 main 后由 docs-autosync 自动补齐回写」这条从未真正生效。

## 这个 PR
workflow 自动生成、推到 `docs/autosync-245fe6f3…` 的提交 c18880b 原样 cherry-pick，去掉 `[skip ci]` 让它走正常门岗。docs-only。

## 根因（需仓库所有者动手）
Settings → Actions → General → Workflow permissions → 勾选「Allow GitHub Actions to create and approve pull requests」，或：
```
gh api -X PUT repos/aqm857886159/Nomi/actions/permissions/workflow -f default_workflow_permissions=read -F can_approve_pull_request_reviews=true
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)