### PR TITLE
feat(agent-lane): 阶段 3b · 花费/上下文/推理三行三态 + Model.tokenPricing + 价目门岗

### DIFF
--- a/docs/fixes/2026-09-07-absent-number-printed-as-zero.root-cause.json
+++ b/docs/fixes/2026-09-07-absent-number-printed-as-zero.root-cause.json
@@ -1,0 +1,180 @@
+{
+  "schema_version": 3,
+  "id": "2026-09-07-absent-number-printed-as-zero",
+  "problem_type": "「我们没有这个数」被编码成 0，于是屏幕上印出一个我们没资格下的断言",
+  "symptom": "Agent 面板顶部的花费 / 上下文 / 推理三行，在真实目录的对话模型上永远是空白或 0，而没有任何一层报错：单测全绿、门岗全绿、typecheck 全绿，只有用户看到一整排读不出东西的位置。花费那一行最刺眼——一个 $0.00 看起来像「这次没花钱」，而实际含义是「运行时对这个模型没有价目」。",
+  "direct_cause": "electron/agentLane/laneProjection.mts 里 `...(typeof cost === 'number' && Number.isFinite(cost) && cost > 0 ? { costUsd: cost } : {})` 拿「算出来的金额大于零」当「有没有价目」的判据。而它的上游 electron/harness/runtime/pi/model.mts:createNomiProvider 给每个模型无条件填 `cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }`（pi 的 `Model.cost` 不可选，见 pi-ai/dist/types.d.ts:729），于是 pi 的 `calculateCost` 老老实实算出 0，判据恒假，字段恒缺席。",
+  "class_root": "**用一个 in-band 的数值（0 / undefined）同时编码「量到了」「没量到」「对这里不适用」三种状态。** 三态挤进一个数值位之后，每个下游只能靠猜把它拆回来——而每种猜法都在某一态上是错的。这次的三行是同一个形状的三个实例：花费的 0 同时是「免费 / 还没花钱 / 没有价目」；上下文的 0 同时是「上下文是空的 / 刚压缩完还没重新结算 / 首轮」；推理的 0 同时是「没有思考 / 这个模型不会思考 / 供应商没报」。真正让它可能发生的结构缺口是：目录里**根本没有放 per-token 价的地方**（`Model.pricing` 是「生成一次图/一段视频扣多少点」，不是 per-token），所以连「有价目」这一态都无处声明，下游除了看那个算出来的 0 别无判据。",
+  "migration": "① `electron/catalog/types.ts` 新增 `Model.tokenPricing`（USD / 每百万 token，带结构化出处）与显式 `Model.free`，与 per-generation 的 `pricing` 语义分开并存；② `createNomiProvider` 由它派生 pi 的 `Model.cost`，并**另行返回** `NomiPricingBasis`（priced / free / unpriced）——判据来自配置，不从算出来的 0 反推；③ 契约层 `LaneUsage.costUsd?: number` 整体换成 `LaneMetric` 三态（known / unknown+reason / not-applicable+reason），上下文与推理两行同期改成同一个类型；④ `laneProjection.mts` 里那条 `cost > 0` 判断**同 commit 删除**（P1），没有留 fallback；⑤ 渲染层 `laneViewModel` 成为「绝不画 0」这条规则的唯一执行点：unknown → 占位符、not-applicable → 整行不渲染（花费行例外，它有「免费」这句更好的话）。旧的 `costUsd` 字段在契约里已不存在，不是并存。",
+  "affected_population": [
+    "所有用 Agent 主控（lane 通路）的用户：DeepSeek V3.2 / V3.1-terminus 这类目录里没有价目的模型，花费行原本印不出任何可读内容",
+    "魔搭三个免费 Qwen3 模型的用户：原本「免费」和「我们不知道」在屏幕上长得一模一样，看不出自己在不在花钱",
+    "刚触发过一次自动压缩的会话：上下文那一行会继续显示压缩前的 prompt 数字，那个数已经不回答「现在装了多少」",
+    "会思考的模型（推理档 > 1）：供应商没报 reasoning token 时，原本与「没有思考」不可区分"
+  ],
+  "scope_paths": [
+    "electron/agentLane/",
+    "electron/shared/agentLane/",
+    "electron/catalog/",
+    "electron/harness/runtime/",
+    "src/workbench/ai/lane/",
+    "scripts/check-archetype-sources.mjs"
+  ],
+  "entry_points": [
+    "electron/agentLane/laneProjection.mts:174（旧）—— `cost > 0 ? { costUsd: cost } : {}`，本次删除；花费三态的唯一决定点现为 `costMetric`",
+    "electron/agentLane/laneProjection.mts:139 `contextMetric` —— 上下文那一行的同形状缺口（累计 vs 末轮 prompt、刚压缩完）",
+    "electron/agentLane/laneProjection.mts:129 `reasoningMetric` —— 推理那一行的同形状缺口（不会思考 vs 供应商没报）",
+    "electron/harness/runtime/pi/model.mts:87 `modelCost` —— 把「没有价目」填成一份全零 `Model.cost` 的那一处（pi 类型不给「不填」这个选项），配套的 `pricingBasis` 就是为了让那份零不再被当作判据",
+    "electron/harness/runtime/pi/run.mts:24 `nomiUsage` —— 影子期仍在的旧通路的同类判断（`total > 0 ? total : undefined`）",
+    "electron/productionRun/shotPricing.ts:113 `deriveShotPrice` —— 另一个子系统里同一个类问题的既有解（`{ known: false }`，从不返回 0）"
+  ],
+  "invariants": [
+    "屏幕上的每个数字都是量到的：没有量到的位置显示占位符或整行不渲染，**任何情况下都不显示一个未经测量的 0**",
+    "「不可知」与「不适用」是两个可区分的态，各自带得出理由；两者都不得坍缩成同一个 `undefined`",
+    "`known` 的 0 照常显示——三态不是「把所有 0 都藏起来」，而是把编出来的 0 和量到的 0 分开",
+    "花费判据来自目录声明（`NomiPricingBasis`），永远不从 pi 算出来的金额反推",
+    "上下文占用的分子是末条已结算助手消息那次请求的 prompt（input + cacheRead + cacheWrite），不是会话累计；没有分母就不画环",
+    "推理档由 `getSupportedThinkingLevels(model)` derive，本仓不另列第二张档位表",
+    "每个 Agent 可选文本模型要么声明带官方出处的 `tokenPricing`，要么显式 `free: true`，两者互斥"
+  ],
+  "invariant_owner_layer": {
+    "layer": "electron/shared/agentLane/laneContracts.ts",
+    "tests": [
+      "tests/agent-runtime/lane-cost.test.mts",
+      "src/workbench/ai/lane/laneViewModel.test.ts",
+      "src/workbench/ai/lane/laneViewModel.fixture.test.ts"
+    ],
+    "why": "「屏幕上的每个数字都是量到的」这条不变量归**契约类型层**管，不归任何一处判断管。`LaneMetric` 是可辨识联合：没量到的那两个分支上不存在 value 属性，所以违反它的写法在这一层根本表达不出来（R28：能让编译器拦的别留给门岗）。这一层有两侧的真实测试——lane-cost.test.mts 证明「投影在各种处境下产出哪一态」（含刚压缩完、首轮、无价目、免费四个夹具，每条都配阳性对照），laneViewModel*.test.ts 证明「拿到那一态时屏幕上出现什么」（unknown → 占位符、not-applicable → 整行不画或说「免费」、known 的 0 照印）。两侧分开是因为「投影说 unknown」和「面板印了一个 0」可以同时成立，中间这一层就是它们分家的地方。"
+  },
+  "regression_tests": [
+    "tests/agent-runtime/lane-cost.test.mts",
+    "tests/agent-runtime/lane-shadow-parity.test.mts",
+    "src/workbench/ai/lane/laneViewModel.test.ts",
+    "src/workbench/ai/lane/laneViewModel.fixture.test.ts",
+    "src/workbench/ai/lane/laneClient.test.ts"
+  ],
+  "residual_risks": [
+    "APIMart 是中转，用户实际付的是中转价；其公开文档不列单价，所以目录里记的是模型一手厂商的官网价——量级对得上，逐分未必对得上。面板上那个金额是估算，不是账单，这条限制写在 electron/catalog/apimartTexts.ts 的注释里。",
+    "DeepSeek 自 2026-08-16 起分时计价（峰/谷两价），而 pi 的 `Model.cost` 只有一个平价、没有时间维度。目录取峰价：谷时段会高估，宁可高估不低估。",
+    "Agnes 两条 flash 官网当前促销到 $0/M（划线价 $0.03 / $0.15）。目录记划线价，所以促销期间会高估；记成 `free: true` 是错的——那个字段说的是「不按 token 计费」，而它们是按 token 计费、只是眼下打折。",
+    "`NomiModelConfig.reasoning` 今天目录还没有一处声明，生产路径恒为 `false`，于是真实模型上推理那一行会落到「不适用」。填它需要逐个模型抓官方文档（R5），不在本阶段范围——这是**已知遗留**，不是设计。",
+    "`contextWindow` 同样没有一个对话模型声明（2026-09-06 打包版实测），所以环仍不画，钮上退回「已用 N」。这是本次三态**正确表达**出来的缺口，不是本次引入的。",
+    "价目会过期。门岗只检查「有没有出处 + 出处格式对不对」，检查不了「这个价今天还准不准」；`checkedAt` 是给下一次模型雷达复核用的锚点。"
+  ],
+  "external_sources": [
+    {
+      "kind": "official-doc",
+      "url": "https://api-docs.deepseek.com/quick_start/pricing/",
+      "checked_at": "2026-09-07",
+      "purpose": "取 DeepSeek v4-flash / v4-pro 的峰谷两档 per-1M-token 价；同时证明 V3.2 与 V3.1-terminus 已不在定价表里——那两条因此留白并登记进棘轮，而不是编一个数字"
+    },
+    {
+      "kind": "official-doc",
+      "url": "https://ai.google.dev/gemini-api/docs/pricing",
+      "checked_at": "2026-09-07",
+      "purpose": "取 Gemini 3.5 Flash 付费档输入 $1.50 / 输出 $9.00（页面明写 including thinking tokens）/ 缓存读 $0.15"
+    },
+    {
+      "kind": "official-doc",
+      "url": "https://agnes-ai.com/zh-Hans/docs/pricing",
+      "checked_at": "2026-09-07",
+      "purpose": "取 Agnes 五条模型的 list price 与缓存命中价；同时确认 flash 两条的 $0/M 是促销而非「不按 token 计费」，所以记划线价而不是 free"
+    },
+    {
+      "kind": "source-code",
+      "url": "https://github.com/earendil-works/pi/blob/main/packages/pi-ai/src/models.ts",
+      "checked_at": "2026-09-07",
+      "purpose": "核实 `calculateCost` 写死 `rates.input / 1_000_000 * tokens`（dist/models.js:543-547），据此把 `tokenPricing` 的单位钉死为「每百万 token」；并核实 `getSupportedThinkingLevels` 会剔掉 `thinkingLevelMap[level] === null` 的档（dist/models.js:551-562），据此不在本仓另列档位表"
+    }
+  ],
+  "recurrence": {
+    "classification": "recurring",
+    "reason": "同一个形状在这一次改动里就出现了三个实例（花费 / 上下文 / 推理），而且它们是各自独立写出来的——说明产生它的不是某一次手滑，而是「类型允许一个数值位承载三种含义」这个结构条件。只要那个条件还在，下一个用量字段（缓存写入、工具耗时、预算余额）会以同样的方式再长一个出来。全仓实扫还在 `electron/harness/runtime/pi/run.mts:24` 与 `electron/productionRun/shotPricing.ts:113` 各找到一个同类现场，一个用 `> 0` 判据、一个已经用 `{ known: false }` 解决——同一个类问题在两个子系统里各被处理过一次，这就是复发的直接证据。",
+    "same_class_scan": [
+      "electron/harness/runtime/pi/run.mts:24-26 `nomiUsage` —— `total > 0 ? total : undefined`，与本次删掉的那条判据逐字同形",
+      "electron/productionRun/shotPricing.ts:113-127 `deriveShotPrice` —— 同一个类问题的既有解：返回 `{ known: false }`，注释明写 never 0",
+      "src/workbench/ai/v4/agentPanelV4Projection.ts:543-549 `projectV4Context` —— 影子期旧投影，用「字段缺席」表达不可知（不印 0），但表达不了「免费」",
+      "src/workbench/ai/v4/AgentPanelV4Context.tsx:70-82 `V4ContextRing` —— 渲染侧同一条纪律的既有落点：没有分母就不画环，因为一个恒定的灰圈和「用量为 0」长得一样",
+      "electron/projectAgentHost/projectAgentStateValidationPrimitives.ts:64-75 —— 持久化侧对 `costUsd` 只校验「有就必须是有限非负数」，不把缺席补成 0，与本次方向一致"
+    ]
+  },
+  "generality_proof": "修在类型上，而不是修在三处判断上。`LaneMetric` 是一个可辨识联合：`known` 才带 `value`，`unknown` / `not-applicable` 各自带 reason 而**没有** `value` 字段。于是「拿一个没量到的位置去当数字用」在这一层不再是一个会算错的表达式，而是一个取不到的属性——编译器在写下去的那一刻就拦住（R28：能让编译器拦的别留给门岗）。三行共用同一个类型，第四个用量字段接进来时只能沿用它，不存在「这一行忘了做三态」这条路。类型只管「表达得出来」，管不了「有没有人去填价目」，所以配一道静态门岗（`check:archetype-sources` 的文本模型价目段）守住另一半：每个 Agent 可选文本模型要么有带官方出处的价目、要么显式 free，查不到价的存量条目登记进只减不增的棘轮。两道防线各自覆盖类根因的一半——类型让「不可知」表达得出来，门岗让「有价目」这一态真的有人填。",
+  "shared_boundaries": [
+    {
+      "path": "electron/shared/agentLane/laneContracts.ts",
+      "symbol": "LaneMetric",
+      "responsibility": "让「没量到」与「不适用」成为可表达、可辨识、且**取不出数字**的状态。三行共用它，所以任何一行想印一个未经测量的数，都得先绕过类型系统"
+    },
+    {
+      "path": "electron/agentLane/laneProjection.mts",
+      "symbol": "projectLaneSnapshot",
+      "responsibility": "三个状态在这里被决定一次。判据来自目录声明与转录事实，不从算出来的 0 反推；下游（含渲染层）不再有第二处做这个判断"
+    },
+    {
+      "path": "scripts/check-archetype-sources.mjs",
+      "symbol": "文本模型价目段",
+      "responsibility": "拦住「类型加了但没人填」：每个 curated 文本模型必须声明带 https 官方出处 + ISO 日期的 tokenPricing，或显式 free；两者互斥，查不到价的存量条目走只减不增的棘轮"
+    }
+  ],
+  "same_class_entry_points": [
+    {
+      "path": "electron/agentLane/laneProjection.mts",
+      "entry_point": "costMetric",
+      "disposition": "enforced",
+      "evidence": "旧的 `cost > 0` 判断已在同 commit 删除（P1，无 fallback）；现在读 `NomiPricingBasis` 返回三态，返回类型是 `LaneMetric`，`unknown` / `not-applicable` 分支上根本没有 value 可填。tests/agent-runtime/lane-cost.test.mts 的三条 G3d 各自 deepEqual 到具体的 state+reason，其中「无价目」那条另配阳性对照（同一轮的 contextTokens 必须 > 0），所以一个「什么都报不可知」的实现过不了。"
+    },
+    {
+      "path": "electron/catalog/apimartTexts.ts",
+      "entry_point": "APIMART_TEXT_MODELS",
+      "disposition": "enforced",
+      "evidence": "`check:archetype-sources` 的价目段逐条 AST 扫这个数组：缺 tokenPricing 且不在棘轮里 → 红；tokenPricing 与 free 同时出现 → 红；出处非 https 或 checkedAt 非 YYYY-MM-DD → 红。七次变异实测（去价目 / 改 http / 价目+free 并存 / 删 free / 棘轮陈旧 / promptRefineOnly 声明价目 / checkedAt 写成 'Sept 2026'）逐个先红后绿，还原后 exit 0。"
+    },
+    {
+      "path": "electron/harness/runtime/pi/run.mts",
+      "entry_point": "nomiUsage",
+      "disposition": "not-affected",
+      "evidence": "逐行读过：它把 `total === 0` 映射成 `undefined`，而消费方 src/workbench/ai/v4/agentPanelV4Projection.ts:548 在 cost 为 undefined 时整个字段不产出，V4ContextRing:112 再据此整行不渲染。所以这条旧通路**从不印一个未经测量的数字**——本合同的不变量它满足，只是用的是更粗的办法（把三态压成两态）。它表达不了「免费」，那是保真度缺口而非不变量违反，已记进 residual_risks；这条通路整体由阶段 4 删除（tests/agent-runtime/lane-shadow-parity.test.mts 正是为此对照两条通路），在此之前不动它，避免与并行任务改同一批文件。"
+    },
+    {
+      "path": "electron/productionRun/shotPricing.ts",
+      "entry_point": "deriveShotPrice",
+      "disposition": "not-affected",
+      "evidence": "另一个子系统里同一个类问题的既有解，方向与本次一致且更早：函数签名注释明写 `Returns { known: false } (never 0) when the price cannot be honestly established`，第 115 行在价目缺席/未启用/非有限非负时直接返回 `{ known: false }`，不经过任何数值位。它不需要接入 LaneMetric——那是 lane 投影的契约类型，跨子系统共用会把生成侧的点数语义和对话侧的 per-token 语义并进一个类型（正是本次要分开的那两件事）。它在这里的作用是**先例**：同一个 known/unknown 可辨识形状在本仓已被独立采用过一次，这是 generality_proof 的经验依据。"
+    }
+  ],
+  "prevention": {
+    "kind": "type-system",
+    "enforcement_path": "electron/shared/agentLane/laneContracts.ts",
+    "invariant": "一个没有被测量的用量位取不出数字：`LaneMetric` 的 `unknown` / `not-applicable` 分支上不存在 `value` 属性，所以「把缺失当成 0 印出去」在这一层写不出来，只能在 `state === 'known'` 的窄化之后才拿得到数",
+    "failure_mode": "编译期失败：`pnpm run typecheck` 与 `pnpm run check:test-types` 在访问未窄化的 `.value` 处报 TS2339 / 在遗漏三态字段处报 TS2739，红在写代码的那一刻，不用等门岗、更不用等用户截图。本次改动落地时这道防线已经真实触发过一次——三个渲染层测试文件因为 `LaneUsage` 少了 cost/contextTokens/reasoningTokens 而当场 TS2739。",
+    "exception_policy": "none",
+    "strategy": "把三态搬进类型系统，让「没有数」不可能被当成数用；再配一道静态门岗守住「有没有人去填价目」这另一半（R28：能让编译器拦的别留给门岗，能让门岗拦的别留给人）",
+    "artifacts": [
+      "electron/shared/agentLane/laneContracts.ts",
+      "electron/agentLane/laneProjection.mts",
+      "electron/catalog/types.ts",
+      "electron/harness/runtime/pi/model.mts",
+      "scripts/check-archetype-sources.mjs",
+      "scripts/archetype-sources-baseline.json"
+    ]
+  },
+  "class_regression_tests": [
+    "tests/agent-runtime/lane-cost.test.mts",
+    "src/workbench/ai/lane/laneViewModel.test.ts",
+    "src/workbench/ai/lane/laneViewModel.fixture.test.ts"
+  ],
+  "legacy_paths": {
+    "status": "removed",
+    "removed_paths": [
+      "electron/agentLane/laneProjection.mts",
+      "electron/shared/agentLane/laneContracts.ts",
+      "src/workbench/ai/lane/laneViewModel.ts"
+    ],
+    "rationale": "P1 加新必删旧：三态是替代品不是补充品。三处删掉的具体旧写法——laneProjection.mts 里 `cost > 0 ? { costUsd: cost } : {}`（用「金额大于零」当「有没有价目」判据）；laneContracts.ts 里 `LaneUsage.costUsd?: number`（用「字段缺席」编码不可知的旧表达）；laneViewModel.ts 里 `usage.costUsd === undefined ? {} : { cost: format(...) }`（渲染侧读旧字段的那一条）。旧的 `costUsd?: number` 若与新的 `cost: LaneMetric` 并存，两个字段会在某个时刻给出不同答案，而下游没有判据决定信哪个——那正是本次要消除的那种含糊。契约层字段直接改名换型（而不是 deprecate 后保留），是为了让所有读旧字段的地方在编译期一次性暴露：本次它确实一次性暴露了三个渲染层测试文件与一条影子对照测试。"
+  },
+  "dependency_lifecycle": {
+    "decision": "not-applicable",
+    "rationale": "本次不引入、不升级、不保留任何第三方依赖。pi 0.85.1 是既有依赖，改动只是**更完整地使用它已经提供的能力**（`Model.cost` 与 `getSupportedThinkingLevels`），没有另写一份等价实现，也没有绕过它的任何版本约束（R29 框架边界）。",
+    "exit_criteria": []
+  }
+}

--- a/electron/agentLane/laneHost.mts
+++ b/electron/agentLane/laneHost.mts
@@ -21,7 +21,7 @@ import type { OpenLane, OpenLaneOptions } from './laneRuntimePort.js';
 import { composeLaneSystemPrompt } from './lanePromptSections.js';
 import { openLaneSession } from './laneSession.mjs';
 import { createLaneTools } from './laneTools.mjs';
-import { projectLaneSnapshot } from './laneProjection.mjs';
+import { projectLaneSnapshot, type LaneModelFacts } from './laneProjection.mjs';
 
 /** 阶段 1 的观测：pi 每个 delta 自报的 `contentIndex`，与我们从 content 数组下标推出来的那个。 */
 export interface LaneOrderObservation {
@@ -63,7 +63,11 @@ export const openLane: OpenLane = async (options: OpenLaneOptions): Promise<Lane
   }
 
   async function assemble(): Promise<LaneHandleWithObservations> {
-  const { provider, model, credentials } = await createNomiProvider(options.model);
+  const { provider, model, credentials, pricingBasis } = await createNomiProvider(options.model);
+  // 三行（花费/上下文/推理）需要的**模型侧事实**，在这里定死一次，投影层不再回头问任何人。
+  // `contextWindow` 只收显式声明的那个：provider 内部的 128k 兜底是给 pi 的类型用的，不是分母。
+  const modelFacts: LaneModelFacts = { model, pricing: pricingBasis,
+    ...(options.model.contextWindow === undefined ? {} : { contextWindow: options.model.contextWindow }) };
   const models = createModels({ credentials });
   models.setProvider(provider);
   const tools = createLaneTools(options.tools);
@@ -112,10 +116,10 @@ export const openLane: OpenLane = async (options: OpenLaneOptions): Promise<Lane
 
   const watch = await lane.watch(context);
   let snapshot: LaneSnapshot = watch.snapshot;
-  let projection: LaneProjection = projectLaneSnapshot(snapshot);
+  let projection: LaneProjection = projectLaneSnapshot(snapshot, modelFacts);
   const listeners = new Set<(next: LaneProjection) => void>();
   const publish = () => {
-    projection = projectLaneSnapshot(snapshot);
+    projection = projectLaneSnapshot(snapshot, modelFacts);
     for (const listener of listeners) listener(projection);
   };
   watch.start((event, eventContext) => {

--- a/electron/agentLane/laneProjection.mts
+++ b/electron/agentLane/laneProjection.mts
@@ -8,8 +8,11 @@
 // 对照今天：`agentPanelV4Projection.sortedItems()` 拿 `createdAt` 加数组下标排一遍，
 // 是因为宿主那边的记录本来就没有可信顺序。那个 `sort` 在阶段 4 会被整个删掉。
 import type { LaneSnapshot } from '@earendil-works/pi-agent-core';
-import type { AssistantMessage } from '@earendil-works/pi-ai';
-import type { LanePart, LaneProjection } from '../shared/agentLane/laneContracts.js';
+import { getSupportedThinkingLevels } from '@earendil-works/pi-ai';
+import type { Api, AssistantMessage, Model, Usage } from '@earendil-works/pi-ai';
+import type { NomiPricingBasis } from '../harness/runtime/pi/model.mjs';
+import type { LaneMetric, LanePart, LaneProjection, LaneThinking, LaneThinkingLevel }
+  from '../shared/agentLane/laneContracts.js';
 
 function textOf(content: unknown): string {
   if (typeof content === 'string') return content;
@@ -50,7 +53,90 @@ function pushAssistantParts(
  * `residentToolProjection` 把工具正文写进 localStorage 的那条路（清浏览器存储 =
  * 历史收据静默清空）。
  */
-export function projectLaneSnapshot(snapshot: LaneSnapshot): LaneProjection {
+export interface LaneModelFacts {
+  /** pi 的模型定义（`createNomiProvider` 造的那一份）。推理档从它 derive，不另列表。 */
+  readonly model: Model<Api>;
+  /** 目录声明的计费三态。**不从 `model.cost` 反推**——那份全零同时长得像三件事。 */
+  readonly pricing: NomiPricingBasis;
+  /**
+   * 上下文窗口。只收**显式声明**的那个：`createNomiProvider` 为了满足 pi 的类型给了 128k 兜底，
+   * 拿它当分母会画出一个我们没量过的百分比（2026-09-06 打包版实测：真实目录里的对话模型
+   * 一个都没写 contextWindow）。
+   */
+  readonly contextWindow?: number;
+}
+
+const KNOWN = (value: number): LaneMetric => ({ state: 'known', value });
+
+/**
+ * 上下文占用 + 推理 token，从**转录本身**取。
+ *
+ * 为什么不能用 `snapshot.stats.usage`：那是**会话累计**（`SessionStats.usage`），累加会随聊天
+ * 次数一路涨到超过窗口；而且它在并的时候把 `reasoning` 丢掉了（pi `core/usage-totals.js`）。
+ * 每条助手消息自己带着那次请求的 `usage`（`pi-ai` `AssistantMessage.usage`），走一遍转录就都有了。
+ *
+ * 「刚压缩完」的判据是**位置**不是内容：压缩条目出现在最后一条结算助手消息之后，就说明那条消息
+ * 的 prompt 描述的是压缩前的上下文——数字还在，但它已经不回答「现在装了多少」这个问题了。
+ */
+function walkUsage(snapshot: LaneSnapshot): {
+  lastPrompt?: number; compactedAfterLastTurn: boolean; reasoning?: number; sawSettledTurn: boolean;
+} {
+  let lastPrompt: number | undefined;
+  let compactedAfterLastTurn = false;
+  let reasoning: number | undefined;
+  let sawSettledTurn = false;
+  for (const entry of snapshot.transcript) {
+    if (entry.type === 'compaction') { compactedAfterLastTurn = true; continue; }
+    if (entry.type !== 'message' || entry.message.role !== 'assistant') continue;
+    const usage: Usage = entry.message.usage;
+    sawSettledTurn = true;
+    compactedAfterLastTurn = false;
+    // pi 自己对「输入」的定义就是这三列之和（`calculateCost` 第一行），照抄，不另立一份。
+    lastPrompt = usage.input + usage.cacheRead + usage.cacheWrite;
+    if (typeof usage.reasoning === 'number' && Number.isFinite(usage.reasoning)) {
+      reasoning = (reasoning ?? 0) + usage.reasoning;
+    }
+  }
+  return { ...(lastPrompt === undefined ? {} : { lastPrompt }), compactedAfterLastTurn,
+    ...(reasoning === undefined ? {} : { reasoning }), sawSettledTurn };
+}
+
+function costMetric(snapshot: LaneSnapshot, pricing: NomiPricingBasis, sawSettledTurn: boolean): LaneMetric {
+  if (pricing === 'free') return { state: 'not-applicable', reason: 'model-is-free' };
+  if (pricing === 'unpriced') return { state: 'unknown', reason: 'model-has-no-pricing' };
+  // 有价目、但一条回合都还没结算：那个 0 是「还没开始」，不是「花了 0 块」。
+  if (!sawSettledTurn) return { state: 'unknown', reason: 'no-settled-turn' };
+  const total = snapshot.stats.usage.cost?.total;
+  return typeof total === 'number' && Number.isFinite(total)
+    ? KNOWN(total) : { state: 'unknown', reason: 'no-settled-turn' };
+}
+
+function reasoningMetric(model: Model<Api>, walk: ReturnType<typeof walkUsage>): LaneMetric {
+  // 「这个模型有没有推理这回事」由 pi 判，我们不看名字也不看档位表。
+  const levels = getSupportedThinkingLevels(model);
+  if (levels.length <= 1) return { state: 'not-applicable', reason: 'model-has-no-reasoning' };
+  if (!walk.sawSettledTurn) return { state: 'unknown', reason: 'no-settled-turn' };
+  // 会思考，但供应商这一轮一个 reasoning 字段都没报——那是「没告诉我们」，不是「思考了 0 个 token」。
+  return walk.reasoning === undefined
+    ? { state: 'unknown', reason: 'provider-omits-reasoning' } : KNOWN(walk.reasoning);
+}
+
+function contextMetric(walk: ReturnType<typeof walkUsage>): LaneMetric {
+  if (!walk.sawSettledTurn) return { state: 'unknown', reason: 'no-settled-turn' };
+  if (walk.compactedAfterLastTurn) return { state: 'unknown', reason: 'just-compacted' };
+  return walk.lastPrompt === undefined ? { state: 'unknown', reason: 'no-settled-turn' } : KNOWN(walk.lastPrompt);
+}
+
+function projectThinking(snapshot: LaneSnapshot, model: Model<Api>): LaneThinking {
+  const supportedLevels = getSupportedThinkingLevels(model) as readonly LaneThinkingLevel[];
+  return {
+    supportedLevels,
+    level: snapshot.configuration.thinkingLevel as LaneThinkingLevel,
+    canTurnOff: supportedLevels.includes('off'),
+  };
+}
+
+export function projectLaneSnapshot(snapshot: LaneSnapshot, facts: LaneModelFacts): LaneProjection {
   const parts: LanePart[] = [];
   const running = snapshot.operation?.runningTools ?? [];
   const runningToolCallIds = new Set(running.filter((tool) => tool.status === 'running').map((tool) => tool.toolCallId));
@@ -85,7 +171,7 @@ export function projectLaneSnapshot(snapshot: LaneSnapshot): LaneProjection {
     pushAssistantParts(streaming, nextSeq, true, runningToolCallIds, parts);
   }
   const usage = snapshot.stats.usage;
-  const cost = usage.cost?.total;
+  const walk = walkUsage(snapshot);
   return {
     lane: snapshot.lane,
     parts,
@@ -97,9 +183,11 @@ export function projectLaneSnapshot(snapshot: LaneSnapshot): LaneProjection {
       cacheReadTokens: usage.cacheRead,
       cacheWriteTokens: usage.cacheWrite,
       totalTokens: usage.totalTokens,
-      // 0 不是「免费」，是「运行时对这个模型没有价目」。把它当数字印出去就是一个
-      // 我们没资格下的断言（同 `run.mts:20-30` 的判断，一字不差地保持一致）。
-      ...(typeof cost === 'number' && Number.isFinite(cost) && cost > 0 ? { costUsd: cost } : {}),
+      cost: costMetric(snapshot, facts.pricing, walk.sawSettledTurn),
+      contextTokens: contextMetric(walk),
+      reasoningTokens: reasoningMetric(facts.model, walk),
+      ...(facts.contextWindow === undefined ? {} : { contextWindow: facts.contextWindow }),
     },
+    thinking: projectThinking(snapshot, facts.model),
   };
 }

--- a/electron/catalog/agnesTexts.ts
+++ b/electron/catalog/agnesTexts.ts
@@ -1,16 +1,50 @@
 // Source: https://agnes-ai.com/zh-Hans/docs/agnes-{20-flash,25-flash,25-pro-alpha,25-pro-beta,25-pro}
 // Checked 2026-08-26. All five use the existing OpenAI-compatible chat SDK path,
 // including streaming/tools and image_url input. Public coverage is not account eligibility.
+import type { Model } from "./types";
+
 export type AgnesTextModel = {
   modelKey: string;
   labelZh: string;
   meta: { supportsImageInput: true };
+  /** 按 token 计费的价目（USD / 每百万 token）。见 `Model.tokenPricing`。 */
+  tokenPricing: NonNullable<Model["tokenPricing"]>;
 };
 
+/**
+ * 价目出处：Agnes 官方定价页，2026-09-07 实查。
+ *
+ * **记的是 list price，不是当下的促销价。** flash 两条官网当前写「$0 / M」促销、
+ * 划线价 $0.03 / $0.15；促销随时会停，而目录里的价目是要长期跑的。记划线价 =
+ * 宁可高估不低估（与 apimartTexts 那条峰谷取高同一条纪律）。它也不能记成 `free: true`——
+ * 那个字段说的是「这个模型不按 token 计费」，而 Agnes flash 是按 token 计费、只是眼下打折到零。
+ *
+ * 官网只给 pro 三条列了「缓存命中」价；flash 两条没列，`cacheReadPerMTokUsd` 就不写，
+ * 缺省即与输入同价（`Model.tokenPricing` 的注释）——不是 0。
+ */
+const AGNES_PRICING_SOURCE = { url: "https://agnes-ai.com/zh-Hans/docs/pricing", checkedAt: "2026-09-07" } as const;
+
+const VISION: { supportsImageInput: true } = { supportsImageInput: true };
+
 export const AGNES_TEXT_MODELS: AgnesTextModel[] = [
-  ["agnes-2.0-flash", "Agnes 2.0 Flash"],
-  ["agnes-2.5-flash", "Agnes 2.5 Flash"],
-  ["agnes-2.5-pro-alpha", "Agnes 2.5 Pro Alpha"],
-  ["agnes-2.5-pro-beta", "Agnes 2.5 Pro Beta"],
-  ["agnes-2.5-pro", "Agnes 2.5 Pro"],
-].map(([modelKey, labelZh]) => ({ modelKey, labelZh, meta: { supportsImageInput: true } }));
+  {
+    modelKey: "agnes-2.0-flash", labelZh: "Agnes 2.0 Flash", meta: VISION,
+    tokenPricing: { inputPerMTokUsd: 0.03, outputPerMTokUsd: 0.15, source: AGNES_PRICING_SOURCE },
+  },
+  {
+    modelKey: "agnes-2.5-flash", labelZh: "Agnes 2.5 Flash", meta: VISION,
+    tokenPricing: { inputPerMTokUsd: 0.03, outputPerMTokUsd: 0.15, source: AGNES_PRICING_SOURCE },
+  },
+  {
+    modelKey: "agnes-2.5-pro-alpha", labelZh: "Agnes 2.5 Pro Alpha", meta: VISION,
+    tokenPricing: { inputPerMTokUsd: 0.45, outputPerMTokUsd: 0.9, cacheReadPerMTokUsd: 0.045, source: AGNES_PRICING_SOURCE },
+  },
+  {
+    modelKey: "agnes-2.5-pro-beta", labelZh: "Agnes 2.5 Pro Beta", meta: VISION,
+    tokenPricing: { inputPerMTokUsd: 0.1, outputPerMTokUsd: 0.3, cacheReadPerMTokUsd: 0.01, source: AGNES_PRICING_SOURCE },
+  },
+  {
+    modelKey: "agnes-2.5-pro", labelZh: "Agnes 2.5 Pro", meta: VISION,
+    tokenPricing: { inputPerMTokUsd: 0.45, outputPerMTokUsd: 0.9, cacheReadPerMTokUsd: 0.045, source: AGNES_PRICING_SOURCE },
+  },
+];

--- a/electron/catalog/apimartTexts.ts
+++ b/electron/catalog/apimartTexts.ts
@@ -1,4 +1,4 @@
-import type { HttpOperation, ProfileKind } from "./types";
+import type { HttpOperation, Model, ProfileKind } from "./types";
 import { APIMART_CREATE_TASK_ID_PATH, APIMART_STATUS_MAPPING } from "./apimartVendor";
 
 // apimart 文本模型（创作助手 / 拆镜头的「大脑」）的 curated 种子。
@@ -25,7 +25,25 @@ export type ApimartTextModel = {
   labelZh: string;
   /** 合并进 Model.meta；`supportsImageInput` 供 chooseTextModel 的 imageInputRank 选型（显式声明优先于名字正则）。 */
   meta?: Record<string, unknown>;
+  /** 按 token 计费的价目（USD / 每百万 token）。见 `Model.tokenPricing`。 */
+  tokenPricing?: Model["tokenPricing"];
+  /** 显式不按 token 计费。 */
+  free?: true;
 };
+
+/**
+ * 价目取值的两条纪律（2026-09-07 定，落成注释是因为下一个填价的人会碰到同样的岔路）：
+ *
+ * ① **峰谷两价取高的那个。** DeepSeek 自 2026-08-16 起分时计价（峰：UTC 周一至周五
+ *    01:00–04:00 与 06:00–10:00；其余为谷），而 pi 的 `Model.cost` 只有一个平价、没有时间维度
+ *    （`pi-ai/dist/types.d.ts:712-715` 的 tiers 是按输入量分档，不是按时段）。二选一时取峰价：
+ *    宁可高估也不低估——面板上一个偏高的金额只是保守，一个偏低的金额会让用户按它做决定。
+ * ② **中转价查不到就记一手价。** APIMart 是中转，用户实际付的是 APIMart 的价，但它的公开文档
+ *    （`https://docs.apimart.ai/en/api-reference/texts/general/chat-completions`，2026-09-07 实查）
+ *    只列模型名、不列单价。所以这里记的是**模型一手厂商**的官网价，量级对得上、逐分未必对得上——
+ *    这条限制写在这里，不许把它当成账单。
+ */
+const DEEPSEEK_PRICING_SOURCE = { url: "https://api-docs.deepseek.com/quick_start/pricing/", checkedAt: "2026-09-07" } as const;
 
 /**
  * apimart 的 curated 文本模型（单源）。DeepSeek IDs 来自 2026-08-21
@@ -51,11 +69,33 @@ export type ApimartTextModel = {
  *      单镜分镜提取实测：1178 token 进（图片占 1058）/ 1160 出 / 10.4s。
  */
 export const APIMART_TEXT_MODELS: ApimartTextModel[] = [
-  { modelKey: "deepseek-v4-pro", labelZh: "DeepSeek V4 Pro" },
-  { modelKey: "deepseek-v4-flash", labelZh: "DeepSeek V4 Flash" },
+  {
+    modelKey: "deepseek-v4-pro", labelZh: "DeepSeek V4 Pro",
+    // 峰价：cache miss 输入 $1.32 / 输出 $3.96 / cache hit $0.044（谷价为其一半）。
+    tokenPricing: { inputPerMTokUsd: 1.32, outputPerMTokUsd: 3.96, cacheReadPerMTokUsd: 0.044,
+      source: DEEPSEEK_PRICING_SOURCE },
+  },
+  {
+    modelKey: "deepseek-v4-flash", labelZh: "DeepSeek V4 Flash",
+    // 峰价：cache miss 输入 $0.44 / 输出 $1.32 / cache hit $0.014（谷价为其一半）。
+    tokenPricing: { inputPerMTokUsd: 0.44, outputPerMTokUsd: 1.32, cacheReadPerMTokUsd: 0.014,
+      source: DEEPSEEK_PRICING_SOURCE },
+  },
+  // V3 两条**故意留白**：2026-09-07 实查 DeepSeek 官方定价页，表里只有 v4-flash / v4-pro /
+  // v4-flash-vision-exp 三行，V3.2 与 V3.1-terminus 一个字都没有。查不到就不填——
+  // 编一个「大概和 flash 差不多」的数字，面板上会印出一个看起来很确定的金额。
+  // 它们在运行时落到「花费不可知」那一态，并登记在 scripts/archetype-sources-baseline.json 的棘轮里。
   { modelKey: "deepseek-v3.2", labelZh: "DeepSeek V3.2" },
   { modelKey: "deepseek-v3.1-terminus", labelZh: "DeepSeek V3.1 Terminus" },
-  { modelKey: "gemini-3.5-flash", labelZh: "Gemini 3.5 Flash", meta: { supportsImageInput: true } },
+  {
+    modelKey: "gemini-3.5-flash", labelZh: "Gemini 3.5 Flash", meta: { supportsImageInput: true },
+    // Google 付费档：输入 $1.50 / 输出 $9.00（含 thinking token）/ 上下文缓存读 $0.15。
+    tokenPricing: { inputPerMTokUsd: 1.5, outputPerMTokUsd: 9, cacheReadPerMTokUsd: 0.15,
+      source: { url: "https://ai.google.dev/gemini-api/docs/pricing", checkedAt: "2026-09-07" } },
+  },
+  // Context-IR 不是 chat 模型：它走 /v1/videos/generations 的异步任务，`textBrainResolver`
+  // 的 `isPromptRefineOnlyModel` 明确把它挡在 Agent 主控之外（electron/ai/textBrainResolver.ts:26-31）。
+  // 不按 token 计费也不是「免费」，所以两个字段都不声明——价目门岗按同一个生产判据豁免它。
   { modelKey: "MiniMax-H3-Context-IR", labelZh: "MiniMax H3 · Context-IR 提示词增强", meta: { promptRefineOnly: true } },
 ];
 

--- a/electron/catalog/modelscopeTexts.ts
+++ b/electron/catalog/modelscopeTexts.ts
@@ -13,10 +13,19 @@
 // kind=text 无 mapping：走 buildLanguageModelForVendor 直连 /v1/chat/completions(魔搭 baseUrl
 // 已是 api-inference.modelscope.cn，默认 openai-compatible)。modelKey = 魔搭 hub 路径。
 
-export type ModelscopeTextModel = { modelKey: string; labelZh: string };
+export type ModelscopeTextModel = {
+  modelKey: string;
+  labelZh: string;
+  /**
+   * 显式「不按 token 计费」。魔搭 api-inference 是**免费额度制**（每日 2000 次调用），
+   * 没有 per-token 单价——所以它不是「我们查不到价目」，是「按 token 算钱这件事在这里不存在」。
+   * 两者在面板上是两句不同的话：这里印「免费」，查不到的那种印「不可知」（方案 §1.7）。
+   */
+  free: true;
+};
 
 export const MODELSCOPE_TEXT_MODELS: ModelscopeTextModel[] = [
-  { modelKey: "Qwen/Qwen3-Next-80B-A3B-Instruct", labelZh: "Qwen3 Next 80B（免费）" },
-  { modelKey: "Qwen/Qwen3-30B-A3B", labelZh: "Qwen3 30B（免费）" },
-  { modelKey: "Qwen/Qwen3-8B", labelZh: "Qwen3 8B（免费）" },
+  { modelKey: "Qwen/Qwen3-Next-80B-A3B-Instruct", labelZh: "Qwen3 Next 80B（免费）", free: true },
+  { modelKey: "Qwen/Qwen3-30B-A3B", labelZh: "Qwen3 30B（免费）", free: true },
+  { modelKey: "Qwen/Qwen3-8B", labelZh: "Qwen3 8B（免费）", free: true },
 ];

--- a/electron/catalog/seedBuiltins.ts
+++ b/electron/catalog/seedBuiltins.ts
@@ -11,6 +11,8 @@
 // （P1：不开并行版）。GPT Image 2 的视频形状坏 mapping repair 是 kie 历史包袱，仍 kie 专属。
 
 import type { CatalogState, HttpOperation, Mapping, Model, Vendor } from "./types";
+// 身份与分档表住在隔壁（表随模型雷达增删，对账逻辑几乎不动 —— 两者变更理由不同）。
+import { CANONICAL_MODEL_IDS, curatedCatalogLifecycle } from "./seedModelIdentity";
 import {
   KIE_VENDOR_SEED,
   SEEDANCE_2_CREATE_OP,
@@ -88,8 +90,11 @@ type CuratedModel = {
   archetypeId?: string;
   /** 代码所有的额外 meta（如 ComfyUI 长尾 workflow 的 parameters 动态控件）；与 archetypeId 合并进 meta。 */
   meta?: Record<string, unknown>;
+  /** 按 token 计费的价目（USD / 每百万 token）。代码所有，随 seed 对账自愈。 */
+  tokenPricing?: Model["tokenPricing"];
+  /** 显式不按 token 计费。与 `tokenPricing` 互斥（`check:archetype-sources` 的价目段守着）。 */
+  free?: true;
 };
-type CatalogLifecycle = "flagship" | "value" | "companion" | "legacy";
 type CuratedMapping = {
   id: string;
   taskKind: Mapping["taskKind"];
@@ -183,6 +188,8 @@ const APIMART_CURATED_MODELS: CuratedModel[] = [
     labelZh: m.labelZh,
     kind: "text" as const,
     ...(m.meta ? { meta: m.meta } : {}),
+    ...(m.tokenPricing ? { tokenPricing: m.tokenPricing } : {}),
+    ...(m.free ? { free: m.free } : {}),
   })),
   ...APIMART_IMAGE_MODELS.map((m) => ({ modelKey: m.modelKey, labelZh: m.labelZh, kind: "image" as const, archetypeId: m.archetypeId })),
   ...APIMART_VIDEO_MODELS.map((m) => ({ modelKey: m.modelKey, labelZh: m.labelZh, kind: "video" as const, archetypeId: m.archetypeId })),
@@ -217,7 +224,7 @@ const APIMART_CURATED_MAPPINGS: CuratedMapping[] = [
 /** Agnes AI 公开模型 curated 种子；实际调用权限和费用由账户决定。文本(无 mapping，直连 chat)；
  *  图片：同步 create(无 query)；视频：异步 create→poll(query 参数版轮询，见 agnesVendor)。 */
 const AGNES_CURATED_MODELS: CuratedModel[] = [
-  ...AGNES_TEXT_MODELS.map((m) => ({ modelKey: m.modelKey, labelZh: m.labelZh, kind: "text" as const, meta: m.meta })),
+  ...AGNES_TEXT_MODELS.map((m) => ({ modelKey: m.modelKey, labelZh: m.labelZh, kind: "text" as const, meta: m.meta, tokenPricing: m.tokenPricing })),
   ...AGNES_IMAGE_MODELS.map((m) => ({ modelKey: m.modelKey, labelZh: m.labelZh, kind: "image" as const, archetypeId: m.archetypeId })),
   ...AGNES_VIDEO_MODELS.map((m) => ({ modelKey: m.modelKey, labelZh: m.labelZh, kind: "video" as const, archetypeId: m.archetypeId })),
 ];
@@ -238,7 +245,7 @@ const AGNES_CURATED_MAPPINGS: CuratedMapping[] = [
 /** 魔搭社区（官方原生）curated 模型 + mapping。图片：async create→poll；文本：免费 LLM(无 mapping，直连 chat)。 */
 const MODELSCOPE_CURATED_MODELS: CuratedModel[] = [
   // 免费文本大脑（Qwen3 系，真实验证 chat+tool_use 双通）：补 Issue #9，给没付费用户免费大脑。
-  ...MODELSCOPE_TEXT_MODELS.map((m) => ({ modelKey: m.modelKey, labelZh: m.labelZh, kind: "text" as const })),
+  ...MODELSCOPE_TEXT_MODELS.map((m) => ({ modelKey: m.modelKey, labelZh: m.labelZh, kind: "text" as const, free: m.free })),
   ...MODELSCOPE_IMAGE_MODELS.map((m) => ({ modelKey: m.modelKey, labelZh: m.labelZh, kind: "image" as const, archetypeId: m.archetypeId })),
 ];
 const MODELSCOPE_CURATED_MAPPINGS: CuratedMapping[] = MODELSCOPE_IMAGE_MODELS.flatMap((m) =>
@@ -391,208 +398,6 @@ function seedVendor(vendors: Vendor[], seed: VendorSeed, now: string): boolean {
  * 某供应商的 curated 模型 insert + 启动对账（供应商无关）。代码所有：kind + meta.archetypeId（漂移强制对账，
  * 否则模型套错能力）；用户所有：enabled/labelZh/createdAt 保留。返回是否变更。
  */
-/**
- * 跨供应商同一逻辑模型的**版本级** canonical 身份（modelKey → canonicalModelId，全局无键冲突）。
- * 消费方：src/config/modelIdentity.deriveCanonicalModelId（priority-1 去重键）——填了它，节点模型
- * 下拉的「同模型多家合并成一条 + N 家」不再赌 labelZh 字符串（label 漂移=不合并、撞名=错合并的根因）。
- * 纪律：
- *  - **版本级**（seedream 4.5 ≠ 5.0 ≠ 4.0），绝不用 archetype 家族级；
- *  - 单家独有的模型（happyhorse/agnes/imagen…）不填——无叠加可治，缺省走 label 归一化回退；
- *  - **值刻意 = normalizeModelLabel(labelZh) 的产物**（小写、空格分隔）：没进表的同名模型
- *    （静态表条目 / 未来新家）走 label 回退会得到同一个键 → 永不把现有合并组拆开；
- *    显式填表的价值只在「对抗 label 改名/漂移」，不在换一套 id 风格。
- */
-const CANONICAL_MODEL_IDS: Record<string, string> = {
-  // Seedream 4.5（kie / apimart / 火山 / RunningHub 四家）
-  "seedream": "seedream 4.5",
-  "doubao-seedream-4.5": "seedream 4.5",
-  "doubao-seedream-4-5-251128": "seedream 4.5",
-  "seedream-v4.5": "seedream 4.5",
-  // Seedance 2.0（kie / apimart / 火山 / RunningHub；即梦 label 为「即梦 Seedance 2.0（会员）」本就独立，不填）
-  "bytedance/seedance-2": "seedance 2.0",
-  "doubao-seedance-2.0": "seedance 2.0",
-  "doubao-seedance-2-0-260128": "seedance 2.0",
-  "bytedance/seedance-2.0-global": "seedance 2.0",
-  // Nano Banana（kie / apimart / RunningHub；静态 gemini 表同名条目走 label 回退同键）
-  "nano-banana": "nano banana",
-  "gemini-2.5-flash-image-preview": "nano banana",
-  "rhart-image-v1": "nano banana",
-  // Nano Banana 2（kie 主款 / apimart；**版本级**故与上面 2.5 代的 "nano banana" 分键，绝不合并）
-  // Lite 是独立档次（更快更便宜、参考图上限 10 而非 14）→ 自己一个键，不与主款合并成一条。
-  "nano-banana-2": "nano banana 2",
-  "gemini-3.1-flash-image-preview": "nano banana 2",
-  "nano-banana-2-lite": "nano banana 2 lite",
-  // Seedream 5.0（kie 的 pro / lite 两档 + apimart pro + 火山 pro；lite 与 pro 是不同档次故分键）
-  "seedream/5-pro-text-to-image": "seedream 5.0 pro",
-  "doubao-seedream-5-0-pro": "seedream 5.0 pro",
-  "doubao-seedream-5-0-pro-260628": "seedream 5.0 pro",
-  "seedream/5-lite-text-to-image": "seedream 5.0 lite",
-  // GPT Image 2（kie 拆「· 文生图 / · 图生图」两行 / apimart / RunningHub → 同一 canonical 合并成一条）
-  "gpt-image-2-text-to-image": "gpt image 2",
-  "gpt-image-2-image-to-image": "gpt image 2",
-  "gpt-image-2": "gpt image 2",
-  "rhart-image-g-2-official": "gpt image 2",
-  // 可灵 3.0（kie / apimart / RunningHub）
-  "kling-3.0": "可灵 3.0",
-  "kling-v3": "可灵 3.0",
-  "kling-v3.0-pro": "可灵 3.0",
-  // Qwen-Image 2.0（apimart / RunningHub）
-  "qwen-image-2.0": "qwen-image 2.0",
-  "rh-qwen-image-2.0": "qwen-image 2.0",
-  // Qwen-Image 3.0（apimart 独家；**版本级**故与 2.0 分键）
-  "qwen-image-3.0": "qwen-image 3.0",
-  // Veo 3.1（apimart / RunningHub）
-  "veo3.1-fast": "veo 3.1",
-  "rhart-video-v3.1-pro-official": "veo 3.1",
-  // Sora 2（apimart / RunningHub）
-  "sora-2": "sora 2",
-  "rhart-video-s-official": "sora 2",
-  // Wan 2.7（apimart / RunningHub）
-  "wan2.7": "wan 2.7",
-  "rh-wan-2.7": "wan 2.7",
-  // Hailuo 2.3（apimart / RunningHub）
-  "MiniMax-Hailuo-2.3": "hailuo 2.3",
-  "rh-hailuo-2.3": "hailuo 2.3",
-  "suno-v5-5": "suno v5.5",
-  "suno-v5.5": "suno v5.5",
-  "suno-sounds-v5-5": "suno sounds v5.5",
-  "suno-sounds-v5.5": "suno sounds v5.5",
-};
-
-/**
- * Curated lifecycle is an explicit product decision, never a version/name heuristic.
- * Models omitted from these reviewed sets remain useful companion routes. Keeping the
- * table keyed by exact upstream model id also makes a future radar update auditable.
- */
-const FLAGSHIP_MODEL_KEYS = new Set([
-  // Current text and multimodal leaders.
-  "deepseek-v4-pro",
-  "gemini-3.5-flash",
-  // Current image leaders.
-  "gpt-image-2-text-to-image",
-  "gpt-image-2-image-to-image",
-  "gpt-image-2",
-  "nano-banana-2",
-  "gemini-3.1-flash-image-preview",
-  "seedream/5-pro-text-to-image",
-  "doubao-seedream-5-0-pro",
-  "doubao-seedream-5-0-pro-260628",
-  "flux-2/pro-text-to-image",
-  "qwen-image-3.0",
-  // Current video leaders.
-  "bytedance/seedance-2-5",
-  "doubao-seedance-2.5",
-  "doubao-seedance-2-5-260628",
-  "kling-3.0",
-  "kling-3.0-turbo",
-  "kling-v3",
-  "kling-v3.0-pro",
-  "minimax-h3",
-  "MiniMax-H3",
-  "MiniMax-M3",
-  "wan/3-0-video",
-  "wan3.0-video",
-  "viduq3",
-  "grok-imagine-1.5-video-apimart",
-  // Current 3D leader already available through the aggregate route.
-  "hunyuan3d-v3.1",
-  "google/gemini-omni-flash-1-1",
-  "suno-v5.5",
-  "suno-sounds-v5.5",
-  "suno-sounds-v5-5",
-  "flowmusic-lyria-3.5",
-  "speech-2.8-hd",
-  "eleven_v3",
-  "music_v2",
-  "eleven_text_to_sound_v2",
-  "scribe_v2",
-  "meshy-7",
-  "fal-ai/nano-banana-2",
-  "openai/gpt-image-2",
-  "bytedance/seedream/v5/pro",
-  "minimax/h3-max",
-  "bytedance/seedance-2.5",
-  "fal-ai/kling-video/v3/pro",
-  "google/gemini-omni-flash/v1.1",
-  "minimax/music-3",
-  "fal-ai/elevenlabs/sound-effects/v2",
-  "hitem3d/hi3d/v3.0",
-  // Runway Dev official catalog (video + image families; exact ids are from
-  // the 2024-11-06 OpenAPI discriminator, not name heuristics).
-  "gen4.5",
-  "gen4_turbo",
-  "seedance2_5",
-  "seedance2",
-  "seedance2_fast",
-  "seedance2_mini",
-  "wan3",
-  "grok_imagine_1_5",
-  "hailuo3",
-  "veo3.1",
-  "veo3.1_fast",
-  "gemini_omni_flash",
-  "muse_image",
-  "grok_imagine_image_2",
-  "seedream5_pro",
-  "seedream5_lite",
-  "gen4_image",
-  "gen4_image_turbo",
-  "gemini_image3_pro",
-  "gemini_image3.1_flash",
-  "gpt_image_2",
-  "gemini_2.5_flash",
-]);
-
-const VALUE_MODEL_KEYS = new Set([
-  "deepseek-v4-flash",
-  "nano-banana-2-lite",
-  "seedream/5-lite-text-to-image",
-  "doubao-seedream-5-0-260128",
-  "z-image-turbo",
-  "Tongyi-MAI/Z-Image-Turbo",
-  "Qwen/Qwen3-Next-80B-A3B-Instruct",
-  "Qwen/Qwen3-30B-A3B",
-  "Qwen/Qwen3-8B",
-  "agnes-2.5-flash",
-  "agnes-video-2.5-flash",
-  "speech-2.8-turbo",
-]);
-
-const LEGACY_MODEL_KEYS = new Set([
-  "happyhorse",
-  "seedream",
-  "doubao-seedream-4.5",
-  "doubao-seedream-4-5-251128",
-  "doubao-seedream-4-0-250828",
-  "seedream-v4.5",
-  "nano-banana",
-  "gemini-2.5-flash-image-preview",
-  "rhart-image-v1",
-  "bytedance/seedance-2",
-  "doubao-seedance-2.0",
-  "doubao-seedance-2-0-260128",
-  "bytedance/seedance-2.0-global",
-  "agnes-2.0-flash",
-  "agnes-image-2.0-flash",
-  "agnes-video-v2.0",
-  "meshy6",
-  "deepseek-v3.2",
-  "deepseek-v3.1-terminus",
-  "qwen-image-2.0",
-  "rh-qwen-image-2.0",
-  "wan2.7",
-  "rh-wan-2.7",
-  "Omni-Flash-Ext",
-  "nomi-audio",
-]);
-
-function curatedCatalogLifecycle(modelKey: string): CatalogLifecycle {
-  if (FLAGSHIP_MODEL_KEYS.has(modelKey)) return "flagship";
-  if (VALUE_MODEL_KEYS.has(modelKey)) return "value";
-  if (LEGACY_MODEL_KEYS.has(modelKey)) return "legacy";
-  return "companion";
-}
-
 function reconcileModels(models: Model[], vendorKey: string, curated: CuratedModel[], now: string): boolean {
   let changed = false;
   for (const c of curated) {
@@ -604,11 +409,18 @@ function reconcileModels(models: Model[], vendorKey: string, curated: CuratedMod
       ...(c.meta || {}),
       catalogLifecycle: curatedCatalogLifecycle(c.modelKey),
     };
+    // 价目是**代码所有**的事实（和 kind / archetypeId 同级），不是用户配置：官网调价后老装机
+    // 必须跟着自愈，否则面板上会长期印一个过期金额，而过期金额比没有金额更难发现。
+    const curatedPricing = {
+      ...(c.tokenPricing ? { tokenPricing: c.tokenPricing } : {}),
+      ...(c.free ? { free: c.free } : {}),
+    } as Pick<Model, "tokenPricing" | "free">;
     const i = models.findIndex((m) => m.modelKey === c.modelKey && m.vendorKey === vendorKey);
     if (i < 0) {
       models.push({
         modelKey: c.modelKey, vendorKey, labelZh: c.labelZh, kind: c.kind, enabled: true,
         ...(Object.keys(curatedMeta).length > 0 ? { meta: curatedMeta } : {}),
+        ...curatedPricing,
         createdAt: now, updatedAt: now,
       });
       changed = true;
@@ -619,12 +431,17 @@ function reconcileModels(models: Model[], vendorKey: string, curated: CuratedMod
     // Compare every code-owned capability, including supportsImageInput added to existing text rows.
     // Unrelated user metadata is not compared or removed.
     const metaDrift = Object.entries(curatedMeta).some(([key, value]) => JSON.stringify(exMeta[key]) !== JSON.stringify(value));
-    const drift = ex.kind !== c.kind || metaDrift;
+    // 撤价（curated 不再声明）也算漂移：留着一份没人维护的旧价目就是留一个会说谎的数字。
+    const pricingDrift = JSON.stringify(ex.tokenPricing) !== JSON.stringify(c.tokenPricing)
+      || JSON.stringify(ex.free) !== JSON.stringify(c.free);
+    const drift = ex.kind !== c.kind || metaDrift || pricingDrift;
     if (drift) {
       const nextMeta = { ...exMeta, ...curatedMeta };
+      const { tokenPricing: _stalePricing, free: _staleFree, ...rest } = ex;
       models[i] = {
-        ...ex, kind: c.kind,
+        ...rest, kind: c.kind,
         ...(Object.keys(nextMeta).length > 0 ? { meta: nextMeta } : {}),
+        ...curatedPricing,
         updatedAt: now,
       };
       changed = true;

--- a/electron/catalog/seedModelIdentity.ts
+++ b/electron/catalog/seedModelIdentity.ts
@@ -1,0 +1,212 @@
+// 目录 curated 种子的**身份与分档表**：跨供应商同一逻辑模型的 canonical id，
+// 以及「旗舰 / 性价比 / 陪跑 / 退役」四档的显式名单。
+//
+// 为什么从 `seedBuiltins.ts` 分出来：那个文件做的是**对账**（把 curated 声明 reconcile 进
+// 用户目录），而这里是一张**查找表**——两者变更的理由完全不同。表随每次模型雷达增删，
+// 对账逻辑几乎不动；混在一个文件里，读对账那 60 行要先翻过 200 行模型名。
+// 分档判据本身没变一个字：`curatedCatalogLifecycle` 仍是这三张 Set 的唯一读取者。
+
+/** curated 模型的产品分档。明确的产品决定，**不是**从版本号或名字猜出来的。 */
+export type CatalogLifecycle = "flagship" | "value" | "companion" | "legacy";
+
+/**
+ * 跨供应商同一逻辑模型的**版本级** canonical 身份（modelKey → canonicalModelId，全局无键冲突）。
+ * 消费方：src/config/modelIdentity.deriveCanonicalModelId（priority-1 去重键）——填了它，节点模型
+ * 下拉的「同模型多家合并成一条 + N 家」不再赌 labelZh 字符串（label 漂移=不合并、撞名=错合并的根因）。
+ * 纪律：
+ *  - **版本级**（seedream 4.5 ≠ 5.0 ≠ 4.0），绝不用 archetype 家族级；
+ *  - 单家独有的模型（happyhorse/agnes/imagen…）不填——无叠加可治，缺省走 label 归一化回退；
+ *  - **值刻意 = normalizeModelLabel(labelZh) 的产物**（小写、空格分隔）：没进表的同名模型
+ *    （静态表条目 / 未来新家）走 label 回退会得到同一个键 → 永不把现有合并组拆开；
+ *    显式填表的价值只在「对抗 label 改名/漂移」，不在换一套 id 风格。
+ */
+export const CANONICAL_MODEL_IDS: Record<string, string> = {
+  // Seedream 4.5（kie / apimart / 火山 / RunningHub 四家）
+  "seedream": "seedream 4.5",
+  "doubao-seedream-4.5": "seedream 4.5",
+  "doubao-seedream-4-5-251128": "seedream 4.5",
+  "seedream-v4.5": "seedream 4.5",
+  // Seedance 2.0（kie / apimart / 火山 / RunningHub；即梦 label 为「即梦 Seedance 2.0（会员）」本就独立，不填）
+  "bytedance/seedance-2": "seedance 2.0",
+  "doubao-seedance-2.0": "seedance 2.0",
+  "doubao-seedance-2-0-260128": "seedance 2.0",
+  "bytedance/seedance-2.0-global": "seedance 2.0",
+  // Nano Banana（kie / apimart / RunningHub；静态 gemini 表同名条目走 label 回退同键）
+  "nano-banana": "nano banana",
+  "gemini-2.5-flash-image-preview": "nano banana",
+  "rhart-image-v1": "nano banana",
+  // Nano Banana 2（kie 主款 / apimart；**版本级**故与上面 2.5 代的 "nano banana" 分键，绝不合并）
+  // Lite 是独立档次（更快更便宜、参考图上限 10 而非 14）→ 自己一个键，不与主款合并成一条。
+  "nano-banana-2": "nano banana 2",
+  "gemini-3.1-flash-image-preview": "nano banana 2",
+  "nano-banana-2-lite": "nano banana 2 lite",
+  // Seedream 5.0（kie 的 pro / lite 两档 + apimart pro + 火山 pro；lite 与 pro 是不同档次故分键）
+  "seedream/5-pro-text-to-image": "seedream 5.0 pro",
+  "doubao-seedream-5-0-pro": "seedream 5.0 pro",
+  "doubao-seedream-5-0-pro-260628": "seedream 5.0 pro",
+  "seedream/5-lite-text-to-image": "seedream 5.0 lite",
+  // GPT Image 2（kie 拆「· 文生图 / · 图生图」两行 / apimart / RunningHub → 同一 canonical 合并成一条）
+  "gpt-image-2-text-to-image": "gpt image 2",
+  "gpt-image-2-image-to-image": "gpt image 2",
+  "gpt-image-2": "gpt image 2",
+  "rhart-image-g-2-official": "gpt image 2",
+  // 可灵 3.0（kie / apimart / RunningHub）
+  "kling-3.0": "可灵 3.0",
+  "kling-v3": "可灵 3.0",
+  "kling-v3.0-pro": "可灵 3.0",
+  // Qwen-Image 2.0（apimart / RunningHub）
+  "qwen-image-2.0": "qwen-image 2.0",
+  "rh-qwen-image-2.0": "qwen-image 2.0",
+  // Qwen-Image 3.0（apimart 独家；**版本级**故与 2.0 分键）
+  "qwen-image-3.0": "qwen-image 3.0",
+  // Veo 3.1（apimart / RunningHub）
+  "veo3.1-fast": "veo 3.1",
+  "rhart-video-v3.1-pro-official": "veo 3.1",
+  // Sora 2（apimart / RunningHub）
+  "sora-2": "sora 2",
+  "rhart-video-s-official": "sora 2",
+  // Wan 2.7（apimart / RunningHub）
+  "wan2.7": "wan 2.7",
+  "rh-wan-2.7": "wan 2.7",
+  // Hailuo 2.3（apimart / RunningHub）
+  "MiniMax-Hailuo-2.3": "hailuo 2.3",
+  "rh-hailuo-2.3": "hailuo 2.3",
+  "suno-v5-5": "suno v5.5",
+  "suno-v5.5": "suno v5.5",
+  "suno-sounds-v5-5": "suno sounds v5.5",
+  "suno-sounds-v5.5": "suno sounds v5.5",
+};
+
+/**
+ * Curated lifecycle is an explicit product decision, never a version/name heuristic.
+ * Models omitted from these reviewed sets remain useful companion routes. Keeping the
+ * table keyed by exact upstream model id also makes a future radar update auditable.
+ */
+const FLAGSHIP_MODEL_KEYS = new Set([
+  // Current text and multimodal leaders.
+  "deepseek-v4-pro",
+  "gemini-3.5-flash",
+  // Current image leaders.
+  "gpt-image-2-text-to-image",
+  "gpt-image-2-image-to-image",
+  "gpt-image-2",
+  "nano-banana-2",
+  "gemini-3.1-flash-image-preview",
+  "seedream/5-pro-text-to-image",
+  "doubao-seedream-5-0-pro",
+  "doubao-seedream-5-0-pro-260628",
+  "flux-2/pro-text-to-image",
+  "qwen-image-3.0",
+  // Current video leaders.
+  "bytedance/seedance-2-5",
+  "doubao-seedance-2.5",
+  "doubao-seedance-2-5-260628",
+  "kling-3.0",
+  "kling-3.0-turbo",
+  "kling-v3",
+  "kling-v3.0-pro",
+  "minimax-h3",
+  "MiniMax-H3",
+  "MiniMax-M3",
+  "wan/3-0-video",
+  "wan3.0-video",
+  "viduq3",
+  "grok-imagine-1.5-video-apimart",
+  // Current 3D leader already available through the aggregate route.
+  "hunyuan3d-v3.1",
+  "google/gemini-omni-flash-1-1",
+  "suno-v5.5",
+  "suno-sounds-v5.5",
+  "suno-sounds-v5-5",
+  "flowmusic-lyria-3.5",
+  "speech-2.8-hd",
+  "eleven_v3",
+  "music_v2",
+  "eleven_text_to_sound_v2",
+  "scribe_v2",
+  "meshy-7",
+  "fal-ai/nano-banana-2",
+  "openai/gpt-image-2",
+  "bytedance/seedream/v5/pro",
+  "minimax/h3-max",
+  "bytedance/seedance-2.5",
+  "fal-ai/kling-video/v3/pro",
+  "google/gemini-omni-flash/v1.1",
+  "minimax/music-3",
+  "fal-ai/elevenlabs/sound-effects/v2",
+  "hitem3d/hi3d/v3.0",
+  // Runway Dev official catalog (video + image families; exact ids are from
+  // the 2024-11-06 OpenAPI discriminator, not name heuristics).
+  "gen4.5",
+  "gen4_turbo",
+  "seedance2_5",
+  "seedance2",
+  "seedance2_fast",
+  "seedance2_mini",
+  "wan3",
+  "grok_imagine_1_5",
+  "hailuo3",
+  "veo3.1",
+  "veo3.1_fast",
+  "gemini_omni_flash",
+  "muse_image",
+  "grok_imagine_image_2",
+  "seedream5_pro",
+  "seedream5_lite",
+  "gen4_image",
+  "gen4_image_turbo",
+  "gemini_image3_pro",
+  "gemini_image3.1_flash",
+  "gpt_image_2",
+  "gemini_2.5_flash",
+]);
+
+const VALUE_MODEL_KEYS = new Set([
+  "deepseek-v4-flash",
+  "nano-banana-2-lite",
+  "seedream/5-lite-text-to-image",
+  "doubao-seedream-5-0-260128",
+  "z-image-turbo",
+  "Tongyi-MAI/Z-Image-Turbo",
+  "Qwen/Qwen3-Next-80B-A3B-Instruct",
+  "Qwen/Qwen3-30B-A3B",
+  "Qwen/Qwen3-8B",
+  "agnes-2.5-flash",
+  "agnes-video-2.5-flash",
+  "speech-2.8-turbo",
+]);
+
+const LEGACY_MODEL_KEYS = new Set([
+  "happyhorse",
+  "seedream",
+  "doubao-seedream-4.5",
+  "doubao-seedream-4-5-251128",
+  "doubao-seedream-4-0-250828",
+  "seedream-v4.5",
+  "nano-banana",
+  "gemini-2.5-flash-image-preview",
+  "rhart-image-v1",
+  "bytedance/seedance-2",
+  "doubao-seedance-2.0",
+  "doubao-seedance-2-0-260128",
+  "bytedance/seedance-2.0-global",
+  "agnes-2.0-flash",
+  "agnes-image-2.0-flash",
+  "agnes-video-v2.0",
+  "meshy6",
+  "deepseek-v3.2",
+  "deepseek-v3.1-terminus",
+  "qwen-image-2.0",
+  "rh-qwen-image-2.0",
+  "wan2.7",
+  "rh-wan-2.7",
+  "Omni-Flash-Ext",
+  "nomi-audio",
+]);
+
+export function curatedCatalogLifecycle(modelKey: string): CatalogLifecycle {
+  if (FLAGSHIP_MODEL_KEYS.has(modelKey)) return "flagship";
+  if (VALUE_MODEL_KEYS.has(modelKey)) return "value";
+  if (LEGACY_MODEL_KEYS.has(modelKey)) return "legacy";
+  return "companion";
+}

--- a/electron/catalog/types.ts
+++ b/electron/catalog/types.ts
@@ -280,6 +280,45 @@ export type Model = {
     specCosts: Array<{ specKey: string; cost: number; enabled: boolean; createdAt?: string; updatedAt?: string }>;
   };
   /**
+   * 按 token 计费的价目，**单位一律「美元 / 每百万 token」**（USD per 1M tokens）。
+   *
+   * **和上面的 `pricing` 是两件事，永远不要混**：`pricing` 是「生成一次图 / 一段视频扣多少点」
+   * （per-generation，见 `shotPricing.ts`），只对 image / video / audio 那几类模型有意义；
+   * `tokenPricing` 是对话模型（`kind: "text"`）按 token 结算的单价，是 Agent 花费那一行的唯一来源。
+   * 一个模型不会同时用到两者——把两个数放进同一个字段，第一次就会印出一个差几个数量级的金额。
+   *
+   * **为什么必须是「每百万」而不是「每千」或「每个」**：下游 `createNomiProvider` 把它原样交给
+   * pi 的 `Model.cost`，而 pi 的 `calculateCost` 写死 `rates.input / 1_000_000 * tokens`
+   * （`pi-ai/dist/models.js:543-547`）。单位选错不会报错，只会让面板上的金额差 1000 倍——
+   * 这正是 `tests/agent-runtime/lane-cost.test.mts` 那条手算对账要钉住的东西。
+   *
+   * 缺席 = 「我们没有这个模型的价目」，**不是 0**。运行时据此把花费那一行渲染成「不可知」
+   * 而不是一个 ¥0.00（方案 §1.7）。真正不花钱的模型走下面的 `free`。
+   */
+  tokenPricing?: {
+    /** 未命中缓存的输入单价（USD / 1M tokens）。 */
+    inputPerMTokUsd: number;
+    /** 输出单价（USD / 1M tokens）。思考型模型的 thinking token 计在输出里。 */
+    outputPerMTokUsd: number;
+    /** 命中缓存前缀的输入单价。缺省 = 与 `inputPerMTokUsd` 同价（供应商不单列时的真实行为）。 */
+    cacheReadPerMTokUsd?: number;
+    /** 写入缓存前缀的单价。缺省 = 与 `inputPerMTokUsd` 同价。 */
+    cacheWritePerMTokUsd?: number;
+    /**
+     * 出处。**必填**，与 `ModelArchetype.sources` 同一条纪律（`check:archetype-sources`）：
+     * 注释可以写「已对过官网」而没人能反证，结构化出处才检查得了。
+     */
+    source: { url: string; checkedAt: string };
+  };
+  /**
+   * 显式「这个模型不按 token 计费」（例如魔搭的免费推理额度）。**只对 `kind: "text"` 有意义**，
+   * 和生成模型的点数（`pricing`）无关。
+   *
+   * 它和「没有 `tokenPricing`」是两件不同的事：前者是我们查过、答案是不花钱；后者是我们不知道。
+   * 面板上前者印「免费」，后者印「不可知」——两者都不许印 ¥0.00。
+   */
+  free?: true;
+  /**
    * Catalog v2+: present when this model was produced by the onboarding agent.
    * Carries the doc-quote evidence per parameter so we can audit / re-trial later.
    */

--- a/electron/harness/runtime/pi/model.mts
+++ b/electron/harness/runtime/pi/model.mts
@@ -20,7 +20,21 @@ export const modelConfigSchema = z.object({
   contextWindow: z.number().int().positive().optional(),
   maxOutputTokens: z.number().int().positive().optional(),
   temperature: z.number().finite().optional(),
+  tokenPricing: z.object({
+    inputPerMTokUsd: z.number().finite().nonnegative(),
+    outputPerMTokUsd: z.number().finite().nonnegative(),
+    cacheReadPerMTokUsd: z.number().finite().nonnegative().optional(),
+    cacheWritePerMTokUsd: z.number().finite().nonnegative().optional(),
+  }).optional(),
+  free: z.literal(true).optional(),
+  reasoning: z.boolean().optional(),
+  thinkingLevelMap: z.record(z.string().nullable()).optional(),
 }).superRefine((model, ctx) => {
+  // 一个模型不能既有价目又声明免费：那样「花费」这一行有两个互相矛盾的答案，
+  // 而下游必须在两者之间挑一个——挑哪个都是我们在替用户猜。
+  if (model.tokenPricing && model.free) {
+    ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'tokenPricing and free are mutually exclusive' });
+  }
   if (model.authType === 'none' && model.kind !== 'openai-compatible') {
     ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'auth:none is supported only by openai-compatible' });
   }
@@ -56,6 +70,37 @@ function anthropicFetch(baseURL: string, fetchRequest: NonNullable<StreamOptions
 }
 
 /**
+ * 这个模型在「按 token 花了多少钱」这件事上的**三态**，`createNomiProvider` 一并返回。
+ *
+ * 为什么必须单独返回、不能从 pi 的 `Model.cost` 反推：pi 的 `cost` **不是可选的**
+ * （`pi-ai/dist/types.d.ts:729`），没有价目的模型只能填一份全零，于是 `cost.total` 恒 0——
+ * 而 0 同时长得像「免费」「还没花钱」和「我们没有价目」三件事。三者在面板上是三句不同的话
+ * （方案 §1.7），所以判据必须来自配置，不能来自算出来的那个 0。
+ */
+export type NomiPricingBasis =
+  /** 目录里有 per-token 价目 → pi 算出来的金额可信。 */
+  | 'priced'
+  /** 目录明说这个模型不按 token 计费 → 花费那一行印「免费」。 */
+  | 'free'
+  /** 我们没有这个模型的价目 → 花费那一行印「不可知」，绝不印 0。 */
+  | 'unpriced';
+
+/** 每百万 token 的美元价 → pi `ModelCost` 的每百万单价（`calculateCost` 自己除以 1e6）。 */
+function modelCost(config: NomiModelConfig): Model<Api>['cost'] {
+  const pricing = config.tokenPricing;
+  // 没有价目就填零——pi 的类型不给我们「不填」这个选项。零在这里**不是一个断言**，
+  // 是一个占位；真正的断言由 `pricingBasis` 带出去，投影层只信它。
+  if (!pricing) return { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
+  return {
+    input: pricing.inputPerMTokUsd,
+    output: pricing.outputPerMTokUsd,
+    // 供应商不单列缓存价时，缓存读写就是按输入价结算的——`?? 0` 会把它白送出去。
+    cacheRead: pricing.cacheReadPerMTokUsd ?? pricing.inputPerMTokUsd,
+    cacheWrite: pricing.cacheWritePerMTokUsd ?? pricing.inputPerMTokUsd,
+  };
+}
+
+/**
  * Provider assembly, extracted so the two Nomi call sites build **one** pi provider
  * instead of two lookalikes: the legacy `createAgentSession` path (below) and the
  * `AgentHarness` lane (`electron/agentLane/`), which needs a `Models` rather than a
@@ -74,8 +119,13 @@ export async function createNomiProvider(input: NomiModelConfig) {
   const baseUrl = config.baseURL.replace(/\/+$/, '');
   const model: Model<Api> = {
     provider: config.providerId, id: config.modelId, name: config.modelId,
-    api: protocol.api, baseUrl, reasoning: false, input: ['text', 'image'],
-    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    api: protocol.api, baseUrl, reasoning: config.reasoning ?? false, input: ['text', 'image'],
+    // 契约层不认识 pi 的 `ThinkingLevelMap`（它是 `Partial<Record<ModelThinkingLevel, …>>`），
+    // 键的合法性由 pi 自己在 `getSupportedThinkingLevels` 里过滤：认不出的键被忽略、
+    // 值为 null 的档被剔掉。这里只负责原样递过去，不在两侧各维护一份档位清单。
+    ...(config.thinkingLevelMap
+      ? { thinkingLevelMap: config.thinkingLevelMap as Model<Api>['thinkingLevelMap'] } : {}),
+    cost: modelCost(config),
     // Internal SDK accounting only; onPayload below preserves Nomi's actual
     // configured output cap, or absence of one, instead of sending this bound.
     contextWindow: config.contextWindow ?? 128_000, maxTokens: config.maxOutputTokens ?? 16_384,
@@ -124,7 +174,8 @@ export async function createNomiProvider(input: NomiModelConfig) {
         : credential?.key ? { auth: { apiKey: credential.key, headers }, source: 'Nomi memory credential' } : undefined,
     } },
   });
-  return { provider, model, credentials };
+  const pricingBasis: NomiPricingBasis = config.tokenPricing ? 'priced' : config.free ? 'free' : 'unpriced';
+  return { provider, model, credentials, pricingBasis };
 }
 
 /** The legacy `createAgentSession` seam. Unchanged behaviour; it just no longer owns the assembly. */

--- a/electron/harness/runtime/runtimePort.ts
+++ b/electron/harness/runtime/runtimePort.ts
@@ -13,6 +13,32 @@ export interface NomiModelConfig {
   contextWindow?: number
   maxOutputTokens?: number
   temperature?: number
+  /**
+   * 按 token 计费的价目，**单位一律「美元 / 每百万 token」**（与 `Model.tokenPricing` 同一个单位）。
+   * 缺席 = 我们没有这个模型的价目 → 运行时把花费那一行渲染成「不可知」，**不是 0**。
+   * 出处（url/checkedAt）留在目录里，不过这道门：wire 配置只需要数字。
+   */
+  tokenPricing?: {
+    inputPerMTokUsd: number
+    outputPerMTokUsd: number
+    /** 缺省 = 与 `inputPerMTokUsd` 同价。 */
+    cacheReadPerMTokUsd?: number
+    /** 缺省 = 与 `inputPerMTokUsd` 同价。 */
+    cacheWritePerMTokUsd?: number
+  }
+  /** 显式「这个模型不按 token 计费」。与 `tokenPricing` 互斥；面板据此印「免费」而不是「不可知」。 */
+  free?: true
+  /**
+   * 这个模型会不会思考。pi 的 `getSupportedThinkingLevels(model)` 直接读它：`false` → 只有 `off`
+   * 一档（推理那一行「不适用」）。今天目录还没有一处声明它，所以生产路径恒为 `false`——
+   * 这是**已知遗留**，不是设计：填它需要逐个模型抓官方文档（R5），不在阶段 3b 的范围里。
+   */
+  reasoning?: boolean
+  /**
+   * 各思考档到供应商原生取值的映射。`null` = 这一档这个模型不支持，pi 会把它从
+   * `getSupportedThinkingLevels` 里剔掉；`off: null` 就是「关不掉思考」。
+   */
+  thinkingLevelMap?: Record<string, string | null>
 }
 
 export interface RuntimeToolDescriptor {

--- a/electron/shared/agentLane/laneContracts.ts
+++ b/electron/shared/agentLane/laneContracts.ts
@@ -58,6 +58,41 @@ export type LanePart =
 
 export type LanePartKind = LanePart['kind']
 
+/**
+ * 一个数字的**三态**。三行（花费 / 上下文 / 推理）共用它，因为三行踩的是同一个坑：
+ * 「没有数」被当成「数是 0」印出去。
+ *
+ * · `known`          —— 我们量到了这个数。
+ * · `unknown`        —— 这个数**现在**拿不到（首轮还没结算、刚压缩完、模型没价目…）。
+ *                       面板上印占位符，**绝不印 0**：0 是「几乎没花钱 / 几乎没用上下文」这个断言，
+ *                       而那一刻我们其实是「不知道」。
+ * · `not-applicable` —— 这个数**对这个模型不存在**（免费模型没有花费、不会思考的模型没有推理 token）。
+ *                       它是一个真答案，不是缺失——所以和 `unknown` 分开，面板上说的是两句不同的话。
+ *
+ * 为什么不用 `number | undefined`：那样 `unknown` 和 `not-applicable` 会坍缩成同一个 `undefined`，
+ * 下游只能靠猜决定印「—」还是印「免费」；而「有没有理由」这件事也就丢了，报错时没人知道数为什么没有。
+ */
+export type LaneMetric =
+  | { readonly state: 'known'; readonly value: number }
+  | { readonly state: 'unknown'; readonly reason: LaneMetricUnknownReason }
+  | { readonly state: 'not-applicable'; readonly reason: LaneMetricNotApplicableReason }
+
+export type LaneMetricUnknownReason =
+  /** 一条结算过的助手回复都还没有（首轮）。此时任何数都还没产生，估算又不含系统提示词与工具 schema。 */
+  | 'no-settled-turn'
+  /** 刚压缩完，下一条助手回复之前：旧的用量数字描述的是压缩前的上下文，拿它当「现在装了多少」是错的。 */
+  | 'just-compacted'
+  /** 目录里这个模型没有 per-token 价目（`Model.tokenPricing` 缺席）。 */
+  | 'model-has-no-pricing'
+  /** 模型会思考，但供应商这一轮没报推理 token（pi 的 `Usage.reasoning` 是可选的）。 */
+  | 'provider-omits-reasoning'
+
+export type LaneMetricNotApplicableReason =
+  /** 目录明说这个模型不按 token 计费。 */
+  | 'model-is-free'
+  /** `getSupportedThinkingLevels(model)` 只返回 `["off"]` —— 这个模型没有推理这回事。 */
+  | 'model-has-no-reasoning'
+
 /** 这条 lane 到此为止的用量。数字全部来自 pi 的 `SessionStats`，本层不做第二次换算（不变量 I3）。 */
 export interface LaneUsage {
   readonly inputTokens: number
@@ -76,8 +111,53 @@ export interface LaneUsage {
   /** 写进缓存前缀的 token（`Usage.cacheWrite`）。一条新 lane 的第一轮几乎全在这一列。 */
   readonly cacheWriteTokens: number
   readonly totalTokens: number
-  /** 运行时对这个模型没有价目时**整个字段不存在**——不是 0。0 会印成一个我们没资格下的断言。 */
-  readonly costUsd?: number
+  /**
+   * 本条 lane 到此为止的花费（美元），三态。
+   *
+   * **不是 `costUsd?: number`。** pi 的 `Usage.cost` 不可选：没有价目的模型照样产出一份全零
+   * （`pi-ai/dist/models.js:543-547` 拿 `Model.cost` 直接乘），所以 `cost.total === 0` 同时长得像
+   * 「免费」「还没花钱」和「我们没有价目」。用 `> 0` 去分辨它们是猜——那条判断 2026-09-07 删掉了，
+   * 判据改为目录声明的 `NomiPricingBasis`（`electron/harness/runtime/pi/model.mts`）。
+   */
+  readonly cost: LaneMetric
+  /**
+   * 「现在上下文里装了多少 token」，三态。**不是累计用量**：累计会随聊天次数一路涨到超过窗口，
+   * 画出一个 300% 的环（`agentPanelV4Projection.projectV4Context` 早就把这条写在注释里了）。
+   * 取的是最后一条**结算过**的助手消息那次请求的 prompt（`input + cacheRead + cacheWrite`，
+   * 与 pi `calculateCost` 对「输入」的定义一字不差）。
+   */
+  readonly contextTokens: LaneMetric
+  /**
+   * 推理（thinking）token，三态。**逐消息累加**：pi 的会话总计把 `reasoning` 丢掉了
+   * （`core/usage-totals.js` 只并 input/output/cacheRead/cacheWrite），所以它只能从转录里的
+   * 每条助手消息上取。它是 `output` 的**子集**，不是另加的一份。
+   */
+  readonly reasoningTokens: LaneMetric
+  /**
+   * 这个模型的上下文窗口（分母）。**缺就是缺**——没有分母就不画环，也不拿一个默认值凑
+   * （`createNomiProvider` 内部为了满足 pi 的类型给了 128k 兜底，那个数不许上屏）。
+   */
+  readonly contextWindow?: number
+}
+
+/** pi 的思考档（`ModelThinkingLevel`）。中立层复述一遍，是因为 `src/` 那侧 import 不到 pi。 */
+export type LaneThinkingLevel = 'off' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh' | 'max'
+
+/**
+ * 推理档位。**全部由 `getSupportedThinkingLevels(model)` derive**，不在我们这侧另列一张表：
+ * pi 已经把「`thinkingLevelMap[level] === null` 的档不支持」这条规则写进那个函数
+ * （`pi-ai/dist/models.js:551-562`），再抄一份就是两把尺子。
+ */
+export interface LaneThinking {
+  /** 这个模型真正可选的档。UI 只许画这几个——画一个点不动的档比不画更糟。 */
+  readonly supportedLevels: readonly LaneThinkingLevel[]
+  /** 当前档（`LaneSnapshot.configuration.thinkingLevel`）。 */
+  readonly level: LaneThinkingLevel
+  /**
+   * 能不能关掉思考。`off` 被模型标成 `null` 时它是 `false`——那种模型**关不掉思考**，
+   * UI 不能给一个按下去不生效的「关闭」。
+   */
+  readonly canTurnOff: boolean
 }
 
 /** 一次推送 = lane 当前的全部有序段。阶段 1 走全量快照；增量是阶段 3 的事。 */
@@ -87,6 +167,7 @@ export interface LaneProjection {
   /** 这条 lane 现在有没有在跑（`LaneSnapshot.operation !== null`）。 */
   readonly running: boolean
   readonly usage: LaneUsage
+  readonly thinking: LaneThinking
 }
 
 /** 宿主审批记录的 custom entry 类型名。渲染层按它认出「这是策略拒收，不是工具坏了」。 */

--- a/scripts/archetype-sources-baseline.json
+++ b/scripts/archetype-sources-baseline.json
@@ -37,5 +37,10 @@
     "viduQ3.ts",
     "wan27.ts",
     "zImage.ts"
+  ],
+  "_whyTokenPricing": "2026-09-07：Agent 可选文本模型必须声明 per-token 价目或显式 free。这里登记的是官方定价页上**查不到价**的存量模型——编一个数字比留一个「不可知」更糟（DeepSeek 官方定价页 2026-09-07 实查只列 v4-flash / v4-pro / v4-flash-vision-exp 三行）。棘轮：只减不增。",
+  "textModelsWithoutTokenPricing": [
+    "apimartTexts.ts:deepseek-v3.1-terminus",
+    "apimartTexts.ts:deepseek-v3.2"
   ]
 }

--- a/scripts/check-archetype-sources.mjs
+++ b/scripts/check-archetype-sources.mjs
@@ -11,6 +11,7 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
+import ts from 'typescript'
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
 const archetypeDirs = [
@@ -68,6 +69,123 @@ for (const file of stale) {
   problems.push(`✗ ${file}: 已补出处但仍留在白名单里 —— 从 ${path.relative(repoRoot, baselinePath)} 删掉这行（棘轮只减不增）`)
 }
 
+// ── 第二段：Agent 可选文本模型的 token 价目出处 ────────────────────────────────
+//
+// 同一条纪律的另一个实例（方案 §1.7 / P4）：**面板上那个金额也是一个契约数字**。
+// 病史：`createNomiProvider` 给每个模型填 `cost: {input:0, output:0, …}`，于是 pi 算出来的
+// 花费恒为 0；面板拿 `> 0` 当「有没有价目」的判据，结果「免费」「还没花钱」「我们没有价目」
+// 三件事印出来一模一样——都是空白。根因是**目录里根本没有放 per-token 价的地方**
+// （`Model.pricing` 是每次生成扣多少点，不是 per-token）。2026-09-07 补上 `Model.tokenPricing` 后，
+// 这道门保证它不会又变成一个「写了类型但没人填」的字段。
+//
+// 判据：每个 curated 文本模型（= Agent 主控能选中的那批）要么声明 `tokenPricing`（带 https 出处
+// + ISO 对账日期），要么显式 `free: true`。两者互斥。
+// 豁免：`meta.promptRefineOnly` 的条目——`textBrainResolver.isPromptRefineOnlyModel`
+// （electron/ai/textBrainResolver.ts:26-31）明确把它们挡在 Agent 主控之外，它们不按 token 计费
+// 也不是「免费」，两个字段都不该有。豁免判据与生产判据是同一个字段名，不是另立一套。
+//
+// 棘轮：官方定价页上查不到价的存量模型登记在基线里，**只减不增**（补一个删一行）。
+// 这不是偷懒：DeepSeek 官方定价页 2026-09-07 实查只列 v4 三行，V3.2 / V3.1-terminus 一个字没有——
+// 编一个数字比留一个「不可知」更糟。
+const textSeedFiles = ['apimartTexts.ts', 'agnesTexts.ts', 'modelscopeTexts.ts']
+const allowedUnpriced = new Set(baseline.textModelsWithoutTokenPricing ?? [])
+const unpriced = []
+
+/** 对象字面量里某个属性的初始化表达式。找不到返回 undefined。 */
+const prop = (node, name) => node.properties.find((p) =>
+  ts.isPropertyAssignment(p) && ts.isIdentifier(p.name) && p.name.text === name)?.initializer
+
+const literalText = (node) => (node && (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)))
+  ? node.text : undefined
+
+for (const file of textSeedFiles) {
+  const abs = path.join(repoRoot, 'electron/catalog', file)
+  const source = ts.createSourceFile(abs, fs.readFileSync(abs, 'utf8'), ts.ScriptTarget.Latest, true)
+  // 出处常量会被抽成 `const X_PRICING_SOURCE = {...}` 复用；先把它们收下来，
+  // 否则每个模型的 `source: X` 都会被误判成「没有 url」。
+  const sourceConsts = new Map()
+  const visitConsts = (node) => {
+    if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.initializer) {
+      let init = node.initializer
+      if (ts.isAsExpression(init)) init = init.expression
+      if (ts.isObjectLiteralExpression(init) && prop(init, 'url')) sourceConsts.set(node.name.text, init)
+    }
+    ts.forEachChild(node, visitConsts)
+  }
+  visitConsts(source)
+
+  // **只扫 `*_TEXT_MODELS` 那个数组**。同一个文件里 `*_TEXT_MAPPINGS` 的条目也带 `modelKey`
+  // （它指的是「这条 mapping 服务哪个模型」），把它们一起扫进来会对同一个模型报两遍、
+  // 还会要求一条 mapping 声明价目 —— 门岗自己制造的假红比没有门岗更贵。
+  const models = []
+  const visitModels = (node) => {
+    if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && /_TEXT_MODELS$/.test(node.name.text)
+        && node.initializer && ts.isArrayLiteralExpression(node.initializer)) {
+      for (const element of node.initializer.elements) {
+        if (!ts.isObjectLiteralExpression(element)) {
+          problems.push(`✗ ${file}: ${node.name.text} 里有一个不是对象字面量的条目 —— 门岗读不了算出来的模型表`)
+          continue
+        }
+        const key = literalText(prop(element, 'modelKey'))
+        if (key === undefined) problems.push(`✗ ${file}: ${node.name.text} 里有一个条目没有字面量 modelKey`)
+        else models.push({ key, node: element })
+      }
+    }
+    ts.forEachChild(node, visitModels)
+  }
+  visitModels(source)
+  if (models.length === 0) problems.push(`✗ ${file}: 一个 *_TEXT_MODELS 条目都没扫到 —— 种子文件的形状变了，门岗先红再说`)
+
+  for (const { key, node } of models) {
+    const identity = `${file}:${key}`
+    // 不是 chat 模型的那批：生产侧同一个字段把它们挡在 Agent 主控之外。
+    const meta = prop(node, 'meta')
+    const refineOnly = meta && ts.isObjectLiteralExpression(meta)
+      && prop(meta, 'promptRefineOnly')?.kind === ts.SyntaxKind.TrueKeyword
+    const pricing = prop(node, 'tokenPricing')
+    const free = prop(node, 'free')?.kind === ts.SyntaxKind.TrueKeyword
+    if (refineOnly) {
+      if (pricing || free) {
+        problems.push(`✗ ${identity}: promptRefineOnly 的条目不按 token 计费，也不是「免费」—— 两个字段都不该声明`)
+      }
+      continue
+    }
+    if (pricing && free) {
+      problems.push(`✗ ${identity}: tokenPricing 与 free 互斥 —— 花费那一行不能有两个互相矛盾的答案`)
+      continue
+    }
+    if (free) continue
+    if (!pricing) {
+      unpriced.push(identity)
+      if (!allowedUnpriced.has(identity)) {
+        problems.push(`✗ ${identity}: 缺 tokenPricing —— Agent 可选文本模型必须声明 per-token 价目（USD/每百万 token，带官方出处）或显式 free: true`)
+      }
+      continue
+    }
+    if (!ts.isObjectLiteralExpression(pricing)) {
+      problems.push(`✗ ${identity}: tokenPricing 必须是就地写死的对象字面量（门岗读不了算出来的价）`)
+      continue
+    }
+    for (const field of ['inputPerMTokUsd', 'outputPerMTokUsd']) {
+      if (!prop(pricing, field)) problems.push(`✗ ${identity}: tokenPricing 缺 ${field}`)
+    }
+    let src = prop(pricing, 'source')
+    if (src && ts.isIdentifier(src)) src = sourceConsts.get(src.text)
+    if (!src || !ts.isObjectLiteralExpression(src)) {
+      problems.push(`✗ ${identity}: tokenPricing 缺 source —— 注释写「已对过官网」没人能反证，结构化出处才检查得了`)
+      continue
+    }
+    const url = literalText(prop(src, 'url'))
+    const checkedAt = literalText(prop(src, 'checkedAt'))
+    if (!url || !/^https:\/\//.test(url)) problems.push(`✗ ${identity}: 价目出处必须是 https 官方定价页，收到 ${url}`)
+    if (!checkedAt || !/^\d{4}-\d{2}-\d{2}$/.test(checkedAt)) problems.push(`✗ ${identity}: 价目 checkedAt 必须是 YYYY-MM-DD，收到 ${checkedAt}`)
+  }
+}
+
+for (const staleKey of [...allowedUnpriced].filter((k) => !unpriced.includes(k))) {
+  problems.push(`✗ ${staleKey}: 已补价目（或已下架）但仍留在 textModelsWithoutTokenPricing 里 —— 删掉这行（棘轮只减不增）`)
+}
+
 if (problems.length > 0) {
   console.error('档案出处门岗未通过（规则 G1/G3）：')
   for (const p of problems) console.error(p)
@@ -77,3 +195,4 @@ if (problems.length > 0) {
 }
 
 console.log(`✓ 档案出处门岗通过：扫 ${files.length} 个档案文件，${files.length - unsourced.length} 个已登记出处，${unsourced.length} 个待补（棘轮基线 ${allowed.size}）。`)
+console.log(`✓ 文本模型价目门岗通过：扫 ${textSeedFiles.length} 个种子文件，${unpriced.length} 个模型无 per-token 价目（棘轮基线 ${allowedUnpriced.size}）。`)

--- a/scripts/vocabularies-baseline.json
+++ b/scripts/vocabularies-baseline.json
@@ -193,14 +193,14 @@
       "reason": "OutboundStage 回答的是「这次出站被拦时，用户的钱怎么样了」——不是任务状态，也不是流程阶段，所以不复用 GenerationProviderTaskState / McpGenerationPhase 那些既有词表（它们描述上游任务走到哪一步，而这里上游根本没被请求到）。submit 表示判据跑在 fetchVendorWithBaseFallback 之前、连接一次都没建立，故供应商必然未计费、也不存在可找回的 taskId，用户的下一步是修好网络重新生成；retrieval 表示提交已成功、上游多半已出片、钱已经付过，丢的只是那一次下载，下一步是免费重新拉取。两者共用一句话就会说反方向，因此成员集只此一处定义，networkOutboundMessage 的文案分支与 nomiErrorCodes 的 outbound-blocked / outbound-blocked-submit 两个码都从它 derive。"
     },
     {
-      "site": "electron/catalog/seedBuiltins.ts::type:CatalogLifecycle/type-union",
+      "site": "electron/catalog/seedModelIdentity.ts::type:CatalogLifecycle/type-union",
       "members": [
         "companion",
         "flagship",
         "legacy",
         "value"
       ],
-      "reason": "seedBuiltins 的 CatalogLifecycle 是主进程内置目录的产品分层标签：flagship、companion、legacy 与 value 决定种子发布和兼容策略，和 renderer 的排序投影保持边界分离。"
+      "reason": "seedModelIdentity 的 CatalogLifecycle 是主进程内置目录的产品分层标签：flagship、companion、legacy 与 value 决定种子发布和兼容策略，和 renderer 的排序投影保持边界分离。2026-09-07 从 seedBuiltins.ts 原样搬到这里（成员一个没改）：那个文件做的是对账，这里是一张随模型雷达增删的查找表，两者变更理由不同；唯一读取者仍是同文件的 curatedCatalogLifecycle。"
     },
     {
       "site": "electron/harness/context/contextStore.ts::interface:StoredAgentContext/property:state/type-union",

--- a/src/workbench/ai/lane/laneClient.test.ts
+++ b/src/workbench/ai/lane/laneClient.test.ts
@@ -17,7 +17,15 @@ function fakeBridge() {
 const projection = (text: string): LaneProjection => ({
   lane: 'main', running: false,
   parts: [{ sequence: 0, entrySeq: 0, contentIndex: 0, kind: 'user', text }],
-  usage: { inputTokens: 1, outputTokens: 1, cacheReadTokens: 0, cacheWriteTokens: 0, totalTokens: 2 },
+  usage: {
+    inputTokens: 1, outputTokens: 1, cacheReadTokens: 0, cacheWriteTokens: 0, totalTokens: 2,
+    // 三行三态。这份夹具只关心「订阅有没有偷偷记账」，所以三行都停在「还没结算」那一态——
+    // 但它们**必须存在**：`LaneUsage` 里没有「省略即 0」这条路了。
+    cost: { state: 'unknown', reason: 'no-settled-turn' },
+    contextTokens: { state: 'unknown', reason: 'no-settled-turn' },
+    reasoningTokens: { state: 'unknown', reason: 'no-settled-turn' },
+  },
+  thinking: { supportedLevels: ['off'], level: 'off', canTurnOff: true },
 })
 
 describe('laneClient', () => {

--- a/src/workbench/ai/lane/laneClient.ts
+++ b/src/workbench/ai/lane/laneClient.ts
@@ -37,12 +37,24 @@ export function resolveLaneBridge(host: LaneBridgeHost | undefined = globalThis 
   return host?.nomiDesktop?.agentLane
 }
 
-/** 桥没接上时订阅者看到的东西。空投影不是「出错了」，是「这条 lane 还没有内容」。 */
+/**
+ * 桥没接上时订阅者看到的东西。空投影不是「出错了」，是「这条 lane 还没有内容」。
+ *
+ * 三行**全部是「不可知」**，不是 0：桥没接上时我们连模型是谁都不知道，更不知道花了多少钱。
+ * token 那四列留 0 是因为它们说的是「这条 lane 到此为止累计用了多少」，而答案确实是零——
+ * 一件事都还没发生过。两者的区别就是「量到的 0」和「没量」，这一层不许把后者写成前者。
+ */
 export const EMPTY_LANE_PROJECTION: LaneProjection = Object.freeze({
   lane: 'main',
   parts: Object.freeze([]),
   running: false,
-  usage: Object.freeze({ inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0, totalTokens: 0 }),
+  usage: Object.freeze({
+    inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0, totalTokens: 0,
+    cost: Object.freeze({ state: 'unknown', reason: 'no-settled-turn' }),
+    contextTokens: Object.freeze({ state: 'unknown', reason: 'no-settled-turn' }),
+    reasoningTokens: Object.freeze({ state: 'unknown', reason: 'no-settled-turn' }),
+  }),
+  thinking: Object.freeze({ supportedLevels: Object.freeze(['off' as const]), level: 'off', canTurnOff: true }),
 })
 
 export interface LaneClient {

--- a/src/workbench/ai/lane/laneViewModel.fixture.test.ts
+++ b/src/workbench/ai/lane/laneViewModel.fixture.test.ts
@@ -18,6 +18,8 @@ const labels: LaneViewModelLabels = {
   thinkingLabel: '[thinking]',
   formatTokens: (value) => `${value}t`,
   formatCost: (usd) => `$${usd.toFixed(4)}`,
+  unknown: '[unknown]',
+  free: '[free]',
 }
 
 describe('laneViewModel against a projection a real pi lane produced', () => {
@@ -48,8 +50,15 @@ describe('laneViewModel against a projection a real pi lane produced', () => {
     const model = laneViewModel(fixture as unknown as LaneProjection, labels)
     expect(model.usage.input).toBe('30t')
     expect(model.usage.output).toBe('12t')
-    // 这个夹具的模型没有价目，所以花费那一行**不渲染**——不是印一个 ¥0.00。
-    expect(model.usage.cost).toBeUndefined()
+    // 这个夹具的模型没有价目（真 pi 跑出来的那一份就是 `unknown / model-has-no-pricing`），
+    // 所以花费那一行印占位符——**不是** ¥0.00。这条断言的价值在于夹具是上游产的：
+    // 哪天投影又开始把那个 0 当金额发下来，这里会立刻变成 '$0.0000'。
+    expect(model.usage.cost).toBe('[unknown]')
+    expect(model.usage.cost).not.toBe('$0.0000')
+    // 这个模型不会思考 → 推理那一行整行不画。
+    expect(model.usage.reasoning).toBeUndefined()
+    // 分母没量过就不画环；分子来自那一轮真实的 prompt（10），不是累计的 42。
     expect(model.usage.max).toBeUndefined()
+    expect(model.usage.used).toBe(10)
   })
 })

--- a/src/workbench/ai/lane/laneViewModel.test.ts
+++ b/src/workbench/ai/lane/laneViewModel.test.ts
@@ -4,7 +4,9 @@
 // 「不做什么」很难用正面断言证，所以每条都配一个会暴露它的场景。
 import { describe, expect, it } from 'vitest'
 
-import type { LanePart, LaneProjection } from '../../../../electron/shared/agentLane/laneContracts'
+import type {
+  LaneMetric, LaneMetricUnknownReason, LanePart, LaneProjection, LaneUsage,
+} from '../../../../electron/shared/agentLane/laneContracts'
 import { LANE_APPROVAL_NOTE_TYPE } from '../../../../electron/shared/agentLane/laneContracts'
 import { laneViewModel, type LaneViewModelLabels } from './laneViewModel'
 
@@ -13,18 +15,33 @@ const labels: LaneViewModelLabels = {
   thinkingLabel: '[thinking]',
   formatTokens: (value) => `${value}t`,
   formatCost: (usd) => `$${usd.toFixed(4)}`,
+  // 这两句在生产里是 i18n 的 `contextUnknown` / `contextCostFree`。测试里写成醒目的假串，
+  // 是为了让「本层自己编了一个字」当场露馅——占位符长什么样是调用方的事，不是这一层的。
+  unknown: '[unknown]',
+  free: '[free]',
 }
+
+/** 三态的常用取值。写成构件是因为下面几乎每条都要摆一次。 */
+const UNKNOWN = (reason: LaneMetricUnknownReason): LaneMetric => ({ state: 'unknown', reason })
+const KNOWN = (value: number): LaneMetric => ({ state: 'known', value })
+
+/** 一份「什么都还没量到」的用量：三行全是 `unknown`，token 那几列是真实累计。 */
+const usageOf = (overrides: Partial<LaneUsage> = {}): LaneUsage => ({
+  inputTokens: 120, outputTokens: 40, cacheReadTokens: 900, cacheWriteTokens: 0, totalTokens: 160,
+  cost: UNKNOWN('no-settled-turn'),
+  contextTokens: UNKNOWN('no-settled-turn'),
+  reasoningTokens: UNKNOWN('no-settled-turn'),
+  ...overrides,
+})
+
+const THINKING: LaneProjection['thinking'] = { supportedLevels: ['off'], level: 'off', canTurnOff: true }
 
 let next = 0
 const part = (input: Omit<LanePart, 'sequence' | 'entrySeq' | 'contentIndex'> & Partial<LanePart>): LanePart =>
   ({ sequence: next++, entrySeq: next, contentIndex: 0, ...input }) as LanePart
 
 function projection(parts: LanePart[], overrides: Partial<LaneProjection> = {}): LaneProjection {
-  return {
-    lane: 'main', parts, running: false,
-    usage: { inputTokens: 120, outputTokens: 40, cacheReadTokens: 900, cacheWriteTokens: 0, totalTokens: 160 },
-    ...overrides,
-  }
+  return { lane: 'main', parts, running: false, usage: usageOf(), thinking: THINKING, ...overrides }
 }
 
 describe('laneViewModel', () => {
@@ -108,20 +125,80 @@ describe('laneViewModel', () => {
     expect(model.items).toEqual([])
   })
 
-  it('leaves cost and context ceiling absent when nobody measured them', () => {
+  // ── G3d · 三行三态的**渲染这一半** ───────────────────────────────────────────
+  //
+  // 上游那一半（投影产出什么态）在 `tests/agent-runtime/lane-cost.test.mts`。这里问的是
+  // 另一个问题：**拿到「不可知」的时候，屏幕上出现的是什么。** 两者分开是因为
+  // 「投影说 unknown」和「面板印了一个 0」可以同时成立——中间这一层就是它们分家的地方。
+  it('G3d · 不可知：印占位符，绝不印 0——那三种「没有数」在屏幕上都不许长成一个数字', () => {
     next = 0
-    const withoutCost = laneViewModel(projection([]), labels)
-    expect(withoutCost.usage.cost).toBeUndefined()
-    expect(withoutCost.usage.max).toBeUndefined()
-    expect(withoutCost.usage.input).toBe('120t')
+    // 三夹具之一：**首轮**（一条回合都还没结算）。
+    const firstTurn = laneViewModel(projection([]), labels)
+    expect(firstTurn.usage.cost).toBe('[unknown]')
+    expect(firstTurn.usage.reasoning).toBe('[unknown]')
+    // 环的分子也必须缺席：`used: 0` 会画出一个「上下文是空的」的断言，而我们只是没量。
+    expect(firstTurn.usage.used).toBeUndefined()
+    expect(firstTurn.usage.max).toBeUndefined()
+    // 阳性对照：同一次调用里 token 那几列**确实有数**。少了这一行，一个「什么都印占位符」
+    // 的实现也能全绿。
+    expect(firstTurn.usage.input).toBe('120t')
     // 缓存命中单独一列：并进 input 就看不出前缀合同有没有被自己抖坏。
-    expect(withoutCost.usage.cache).toBe('900t')
+    expect(firstTurn.usage.cache).toBe('900t')
 
     next = 0
-    const withCost = laneViewModel(projection([], {
-      usage: { inputTokens: 120, outputTokens: 40, cacheReadTokens: 900, cacheWriteTokens: 0, totalTokens: 160, costUsd: 0.0123 },
+    // 三夹具之二：**刚压缩完**。上下文那一行的旧数字描述的是压缩前，不能拿来回答「现在装了多少」。
+    const compacted = laneViewModel(projection([], {
+      usage: usageOf({ cost: KNOWN(0.0123), contextTokens: UNKNOWN('just-compacted') }),
     }), labels)
-    expect(withCost.usage.cost).toBe('$0.0123')
+    expect(compacted.usage.used).toBeUndefined()
+    // 花费这一行不受压缩影响——它是累计的，压缩不会把已经花掉的钱变回来。
+    expect(compacted.usage.cost).toBe('$0.0123')
+
+    next = 0
+    // 三夹具之三：**这个模型没有价目**。花费印占位符，不是 $0.0000。
+    const unpriced = laneViewModel(projection([], {
+      usage: usageOf({ cost: UNKNOWN('model-has-no-pricing'), contextTokens: KNOWN(1_024) }),
+    }), labels)
+    expect(unpriced.usage.cost).toBe('[unknown]')
+    expect(unpriced.usage.cost).not.toBe('$0.0000')
+    expect(unpriced.usage.used).toBe(1_024)
+  })
+
+  it('G3d · 不适用：免费模型说「免费」，不会思考的模型整行不画——两者都不是「不可知」', () => {
+    next = 0
+    const model = laneViewModel(projection([], {
+      usage: usageOf({
+        cost: { state: 'not-applicable', reason: 'model-is-free' },
+        reasoningTokens: { state: 'not-applicable', reason: 'model-has-no-reasoning' },
+      }),
+    }), labels)
+    // 「查过了，不花钱」是一个答案，和「我们不知道」是两句不同的话。
+    expect(model.usage.cost).toBe('[free]')
+    // 推理没有这么一句更好的话可说，所以整行不渲染——画一个永远是 `—` 的行只会占地方。
+    expect(model.usage.reasoning).toBeUndefined()
+  })
+
+  it('G3d · known 的 0 照印——那是量到的，不是编的', () => {
+    next = 0
+    // 这一条守的是反向：三态不是「把所有 0 都藏起来」。真花了不到半分钱、真没思考，
+    // 屏幕上就该出现那个 0；藏掉它等于把「便宜」也说成「不知道」。
+    const model = laneViewModel(projection([], {
+      usage: usageOf({ cost: KNOWN(0), reasoningTokens: KNOWN(0), contextTokens: KNOWN(0) }),
+    }), labels)
+    expect(model.usage.cost).toBe('$0.0000')
+    expect(model.usage.reasoning).toBe('0t')
+    expect(model.usage.used).toBe(0)
+  })
+
+  it('G3d · 上下文的分子是「现在装了多少」，不是累计用量', () => {
+    next = 0
+    // 累计（totalTokens: 160）会随聊天次数一路涨到超过窗口，画出一个 300% 的环。
+    // 这里刻意让两者不相等，好让「不小心又拿了累计」当场翻红。
+    const model = laneViewModel(projection([], {
+      usage: usageOf({ contextTokens: KNOWN(4_096), contextWindow: 128_000 }),
+    }), labels)
+    expect(model.usage.used).toBe(4_096)
+    expect(model.usage.max).toBe(128_000)
   })
 
   it('maps a known capability alias to its icon family, and refuses to guess for an unknown one', () => {

--- a/src/workbench/ai/lane/laneViewModel.ts
+++ b/src/workbench/ai/lane/laneViewModel.ts
@@ -17,6 +17,7 @@
 // 终于按发生顺序出现。
 import type {
   LaneApprovalNote,
+  LaneMetric,
   LanePart,
   LaneProjection,
 } from '../../../../electron/shared/agentLane/laneContracts'
@@ -47,6 +48,36 @@ export interface LaneViewModelLabels {
   /** 数字格式化：token 数、金额。缺省不印，不是印 0。 */
   formatTokens(value: number): string
   formatCost(usd: number): string
+  /**
+   * 「这个数我们没有」的占位（面板上那个 `—`）。三态里的 `unknown` 走它——
+   * **整行留着、数字位写占位符**，让用户看见「这一项存在但拿不到」，而不是看见一个 0，
+   * 也不是让整行凭空消失（消失会让人以为这一项不存在）。
+   */
+  unknown: string
+  /**
+   * 「这个模型不按 token 计费」那句话。三态里的 `not-applicable` 走它（花费行）。
+   *
+   * **本层不给它默认值，也不在 i18n 里预先放一条词条。** 影子期没有任何生产调用方接到
+   * `laneViewModel`（`laneShadowStructure.test.ts` 正是在钉这件事），所以此刻往
+   * `agentPanelV4.*` 里写一条 `contextCostFree` 就是一个谁也到不了的死键——
+   * `check:i18n` 的死键门会直接拦下来，而它拦得对：预先摆一条没人能用的词条，
+   * 和预先摆一段没人调用的代码是同一件事（P1）。接线那一刻由调用方从 i18n 取词传进来，
+   * 与旁边的 `unknown`（今天已经是活的 `agentPanelV4.contextUnknown`）走同一条路。
+   */
+  free: string
+}
+
+/**
+ * 三态 → 一个字符串或「整行不要」。**这里是「绝不画 0」那条规则唯一的执行点。**
+ *
+ * · `known`          → 格式化那个数（真是 0 就印 0 —— 那是量到的，不是编的）
+ * · `unknown`        → 占位符（`—`）
+ * · `not-applicable` → `undefined`，调用方整行不渲染；花费行例外，它有一句更好的话（「免费」）
+ */
+function metricText(metric: LaneMetric, format: (value: number) => string, unknown: string): string | undefined {
+  if (metric.state === 'known') return format(metric.value)
+  if (metric.state === 'unknown') return unknown
+  return undefined
 }
 
 export interface LaneViewModel {
@@ -160,21 +191,31 @@ export function laneViewModel(projection: LaneProjection, labels: LaneViewModelL
     }
   }
 
+  const { usage } = projection
+  // 花费的 `not-applicable` 有一句比「不渲染」更有用的话：这个模型免费。其余两行没有。
+  const cost = usage.cost.state === 'not-applicable'
+    ? labels.free : metricText(usage.cost, labels.formatCost, labels.unknown)
+  const reasoning = metricText(usage.reasoningTokens, labels.formatTokens, labels.unknown)
   return {
     items,
     running: projection.running,
     usage: {
-      used: projection.usage.totalTokens,
-      input: labels.formatTokens(projection.usage.inputTokens),
-      output: labels.formatTokens(projection.usage.outputTokens),
+      // 环的分子是「现在上下文里装了多少」，不是累计用量——累计会画出一个 300% 的环。
+      // 三态里只有 `known` 能当分子；`unknown` 时**连 `used` 都不给**，钮上退回 `—`。
+      ...(usage.contextTokens.state === 'known' ? { used: usage.contextTokens.value } : {}),
+      // 分母缺就是缺。`?? 0` 会在环上画一个我们没量过的百分比
+      //（`agentPanelV4Types.ContextUsage` 的注释已经把这条钉死，这里只是遵守它）。
+      ...(usage.contextWindow === undefined ? {} : { max: usage.contextWindow }),
+      input: labels.formatTokens(usage.inputTokens),
+      output: labels.formatTokens(usage.outputTokens),
       // 缓存命中那一列。它不是装饰：前缀合同（工具定义顺序 + 系统提示词）一旦被自己抖坏，
       // 症状就是这个数塌到 0 而 `input` 猛涨——不单独印出来就只能等账单来告诉我们。
       // 写入那一列留在契约里不上屏：一条 lane 的第一轮几乎全是写入，印出来只会误导。
-      cache: labels.formatTokens(projection.usage.cacheReadTokens),
-      // `max` / `cost` 缺就是缺。`?? 0` 会在环上画一个我们没量过的百分比，
-      // 在花费那一行印一个我们没资格下的 ¥0.00（`agentPanelV4Types.ContextUsage` 的注释
-      // 已经把这条钉死，这里只是遵守它）。
-      ...(projection.usage.costUsd === undefined ? {} : { cost: labels.formatCost(projection.usage.costUsd) }),
+      cache: labels.formatTokens(usage.cacheReadTokens),
+      // 推理：模型不会思考就整行不渲染（`not-applicable`）；会思考但供应商没报，
+      // 印占位符——那一行存在，只是这一轮没数。
+      ...(reasoning === undefined ? {} : { reasoning }),
+      ...(cost === undefined ? {} : { cost }),
     },
   }
 }

--- a/tests/agent-runtime/__fixtures__/lane-projection.json
+++ b/tests/agent-runtime/__fixtures__/lane-projection.json
@@ -65,6 +65,25 @@
     "outputTokens": 12,
     "cacheReadTokens": 0,
     "cacheWriteTokens": 0,
-    "totalTokens": 42
+    "totalTokens": 42,
+    "cost": {
+      "state": "unknown",
+      "reason": "model-has-no-pricing"
+    },
+    "contextTokens": {
+      "state": "known",
+      "value": 10
+    },
+    "reasoningTokens": {
+      "state": "not-applicable",
+      "reason": "model-has-no-reasoning"
+    }
+  },
+  "thinking": {
+    "supportedLevels": [
+      "off"
+    ],
+    "level": "off",
+    "canTurnOff": true
   }
 }

--- a/tests/agent-runtime/lane-cost.test.mts
+++ b/tests/agent-runtime/lane-cost.test.mts
@@ -1,0 +1,262 @@
+// 三行（花费 / 上下文 / 推理）的三态门：方案 §1.7 与验收门 G3d，以及探针 P4 的单位对账。
+//
+// **这一族缺陷的形状**：面板上那三行永远是空的，而没有任何一层报错。根因链是三段：
+//   ① 目录里没有放 per-token 价的地方（`Model.pricing` 是「生成一次扣多少点」，不是 per-token）；
+//   ② 于是 `createNomiProvider` 给 pi 填 `cost: {input:0, …}`，pi 老老实实算出 0；
+//   ③ 于是宿主拿 `cost.total > 0` 当「有没有价目」的判据 —— 而 0 同时长得像
+//      「免费」「还没花钱」「我们没有价目」三件事。
+// 三段各自都自洽、单测全绿、门岗全绿，只有用户会看到一整排空白。所以这里钉的是**三态本身**：
+// 每个「不可知」都要说得出理由，每个「有值」都要和手算相等。
+//
+// 单位（P4 的核心）：`Model.tokenPricing` 是 **USD / 每百万 token**，因为 pi 的 `calculateCost`
+// 写死 `rates.input / 1_000_000 * tokens`（`pi-ai/dist/models.js:543-547`）。写成「每千」不会报错，
+// 只会让金额差 1000 倍 —— 下面那条手算断言就是为了让那种错当场翻红。
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import type { LaneSnapshot } from '@earendil-works/pi-agent-core';
+import { openLane } from '../../electron/agentLane/laneHost.mjs';
+import { projectLaneSnapshot, type LaneModelFacts } from '../../electron/agentLane/laneProjection.mjs';
+import type { LaneMetric, LaneUsage } from '../../electron/shared/agentLane/laneContracts.js';
+import { createLaneFixture } from './laneFixture.mjs';
+import type { FixtureReply } from './httpFixture.mjs';
+
+/**
+ * DeepSeek V4 Flash 官网价（峰价档），2026-09-07 实查
+ * <https://api-docs.deepseek.com/quick_start/pricing/>：
+ *   cache miss 输入 $0.44 / 1M · 输出 $1.32 / 1M · cache hit 输入 $0.014 / 1M。
+ * 与 `electron/catalog/apimartTexts.ts` 里那条 curated 种子逐字相同 —— 两处一起改才算改对。
+ */
+const V4_FLASH = { inputPerMTokUsd: 0.44, outputPerMTokUsd: 1.32, cacheReadPerMTokUsd: 0.014 } as const;
+
+const SAY_HI: FixtureReply[] = [{ type: 'text', text: 'Done.' }];
+
+function metricOf(usage: LaneUsage, line: 'cost' | 'contextTokens' | 'reasoningTokens'): LaneMetric {
+  return usage[line];
+}
+
+/** 三态里那个数；不是 `known` 就抛 —— 让「我以为它有值」当场变成一条失败而不是一个 NaN。 */
+function knownValue(metric: LaneMetric, what: string): number {
+  assert.equal(metric.state, 'known', `${what} should be known, got ${JSON.stringify(metric)}`);
+  return metric.state === 'known' ? metric.value : Number.NaN;
+}
+
+// ── P4 · 单位对账 ─────────────────────────────────────────────────────────────
+
+test('P4 · a priced model yields a cost that equals the hand-computed per-million-token amount', async (t) => {
+  // 一次回合的用量由假端点自己说了算（`httpFixture` 把它原样发成供应商报文），
+  // 所以「模型报了多少」和「我们算了多少」是两个独立来源，不是同一个数字自证。
+  const usage = { input: 12_000, output: 3_000, cacheRead: 8_000, cacheWrite: 0 };
+  const fixture = await createLaneFixture(t, [{ type: 'text', text: 'Done.', usage }]);
+  const lane = await openLane({ ...fixture.options,
+    model: { ...fixture.options.model, tokenPricing: V4_FLASH } });
+  t.after(() => lane.close());
+  await lane.execute({ kind: 'prompt', text: 'Say done.' });
+
+  const cost = knownValue(metricOf(lane.projection().usage, 'cost'), 'cost');
+  // 手算：(12000 × 0.44 + 3000 × 1.32 + 8000 × 0.014) / 1e6
+  //     = (5280 + 3960 + 112) / 1e6 = 0.009352 美元。
+  const expected = (usage.input * V4_FLASH.inputPerMTokUsd
+    + usage.output * V4_FLASH.outputPerMTokUsd
+    + usage.cacheRead * V4_FLASH.cacheReadPerMTokUsd) / 1_000_000;
+  assert.equal(expected.toFixed(6), '0.009352', 'the hand-computed amount is the one written in the comment');
+  assert.ok(Math.abs(cost - expected) < 1e-12, `cost ${cost} should equal the hand-computed ${expected}`);
+  // 量级闸：单位写成「每千」会得到 $9.35，写成「每个 token」会得到 $9352。
+  // 这条断言比上面那条等式更耐改 —— 它拦的是「把两边一起改错」。
+  assert.ok(cost > 1e-6 && cost < 1e-2, `a one-turn cost must land between $1e-6 and $1e-2, got ${cost}`);
+});
+
+/**
+ * 用量刻意压在 10 万以内：喂一个超过 `contextWindow` 的数字会让 pi 走溢出恢复 + 重试退避，
+ * 一条本来 90ms 的测试要空等 7 秒 —— 而它证明的东西一个字都没多。
+ */
+const CACHE_TOKENS = 100_000;
+
+test('P4 · cache reads are billed at the cache rate, not the input rate', async (t) => {
+  // 为什么单独一条：`cacheRead` 便宜一个数量级，把它按输入价算会让金额悄悄高一截 ——
+  // 高一截不会像 1000 倍那样显眼，所以需要一条只盯着它的断言。
+  const fixture = await createLaneFixture(t, [
+    { type: 'text', text: 'Done.', usage: { input: 0, output: 0, cacheRead: CACHE_TOKENS, cacheWrite: 0 } }]);
+  const lane = await openLane({ ...fixture.options,
+    model: { ...fixture.options.model, tokenPricing: V4_FLASH } });
+  t.after(() => lane.close());
+  await lane.execute({ kind: 'prompt', text: 'Say done.' });
+
+  const cost = knownValue(metricOf(lane.projection().usage, 'cost'), 'cost');
+  const atCacheRate = (CACHE_TOKENS * V4_FLASH.cacheReadPerMTokUsd) / 1_000_000;
+  const atInputRate = (CACHE_TOKENS * V4_FLASH.inputPerMTokUsd) / 1_000_000;
+  assert.ok(Math.abs(cost - atCacheRate) < 1e-12,
+    `cache-read tokens must bill at the cache rate ($${atCacheRate}), not the input rate ($${atInputRate}); got ${cost}`);
+});
+
+test('P4 · an omitted cache rate falls back to the input rate, never to free', async (t) => {
+  // 供应商不单列缓存价时，缓存读写就是按输入价结算的。`?? 0` 会把它白送出去 ——
+  // 那是一个我们没资格给用户的折扣。
+  const fixture = await createLaneFixture(t, [
+    { type: 'text', text: 'Done.', usage: { input: 0, output: 0, cacheRead: CACHE_TOKENS, cacheWrite: 0 } }]);
+  const lane = await openLane({ ...fixture.options, model: { ...fixture.options.model,
+    tokenPricing: { inputPerMTokUsd: V4_FLASH.inputPerMTokUsd, outputPerMTokUsd: V4_FLASH.outputPerMTokUsd } } });
+  t.after(() => lane.close());
+  await lane.execute({ kind: 'prompt', text: 'Say done.' });
+
+  const cost = knownValue(metricOf(lane.projection().usage, 'cost'), 'cost');
+  const atInputRate = (CACHE_TOKENS * V4_FLASH.inputPerMTokUsd) / 1_000_000;
+  assert.ok(Math.abs(cost - atInputRate) < 1e-12,
+    `an omitted cache rate must bill at the input rate ($${atInputRate}), got ${cost}`);
+});
+
+// ── G3d · 三态：不可知 ≠ 0 ────────────────────────────────────────────────────
+
+test('G3d · 首轮：一条回合都还没结算时，三行全部「不可知」，一个 0 都不画', async (t) => {
+  const fixture = await createLaneFixture(t, SAY_HI);
+  const lane = await openLane({ ...fixture.options,
+    model: { ...fixture.options.model, tokenPricing: V4_FLASH, reasoning: true } });
+  t.after(() => lane.close());
+
+  // 刻意**不发**任何提示词：这就是用户打开面板的第一眼。
+  const { usage } = lane.projection();
+  assert.deepEqual(usage.cost, { state: 'unknown', reason: 'no-settled-turn' },
+    '有价目、但一分钱都还没花：那个 0 是「还没开始」，不是「花了 0 块」');
+  assert.deepEqual(usage.contextTokens, { state: 'unknown', reason: 'no-settled-turn' },
+    '首轮估算不含系统提示词与工具 schema，低估几千 token —— 与其画一个低估值，不如说不知道');
+  assert.deepEqual(usage.reasoningTokens, { state: 'unknown', reason: 'no-settled-turn' });
+});
+
+test('G3d · 无价目模型：花费「不可知」，不是 $0.00；token 那几列照常有数', async (t) => {
+  const fixture = await createLaneFixture(t, SAY_HI);
+  // 目录里没有这个模型的 per-token 价（DeepSeek V3.2 / V3.1-terminus 就是这种）。
+  const lane = await openLane(fixture.options);
+  t.after(() => lane.close());
+  await lane.execute({ kind: 'prompt', text: 'Say done.' });
+
+  const { usage } = lane.projection();
+  assert.deepEqual(usage.cost, { state: 'unknown', reason: 'model-has-no-pricing' });
+  // 阳性对照：这一轮**确实**烧了 token。少了这条，一个「什么都报不可知」的实现也能全绿。
+  assert.ok(knownValue(usage.contextTokens, 'contextTokens') > 0,
+    'the same turn must still report a real context number — only the money is unknown');
+});
+
+test('G3d · 免费模型：花费是「不适用」，和「不可知」不是同一句话', async (t) => {
+  const fixture = await createLaneFixture(t, SAY_HI);
+  const lane = await openLane({ ...fixture.options, model: { ...fixture.options.model, free: true } });
+  t.after(() => lane.close());
+  await lane.execute({ kind: 'prompt', text: 'Say done.' });
+
+  assert.deepEqual(lane.projection().usage.cost, { state: 'not-applicable', reason: 'model-is-free' },
+    '「查过了，不花钱」和「我们不知道花了多少」是两个答案，面板上说的是两句不同的话');
+});
+
+test('G3d · 刚压缩完：上下文「不可知」，因为旧数字描述的是压缩前的上下文', async (t) => {
+  // **这一条为什么是纯函数级的**：`lane.compact()` 住在 pi 的 `AgentLane` 上，而阶段 3b 的
+  // `LaneHandle` 只暴露 prompt / abort（面板还没有「压缩」这个动作，为一条测试加一个没有 UI
+  // 的命令就是留一段死代码）。所以这里先用真 lane 跑出一份**真快照形状**，再往转录尾巴上
+  // 放一条真类型的 `CompactionEntry` —— 合成的只有那一条标记，其余全是 pi 自己产的。
+  const fixture = await createLaneFixture(t, SAY_HI);
+  const lane = await openLane({ ...fixture.options,
+    model: { ...fixture.options.model, tokenPricing: V4_FLASH } });
+  t.after(() => lane.close());
+  await lane.execute({ kind: 'prompt', text: 'Say done.' });
+
+  const facts: LaneModelFacts = { model: laneModel(), pricing: 'priced' };
+  const settled = snapshotWith([
+    { id: 'e1', parentId: null, seq: 1, timestamp: 1, type: 'message',
+      message: assistant({ input: 900, output: 100, cacheRead: 0, cacheWrite: 0 }) },
+  ]);
+  // 阳性对照先跑：同一份转录**没有**压缩条目时必须是 `known`。缺了它，一个
+  // 「上下文永远不可知」的实现在下面那条断言上也是绿的。
+  assert.equal(knownValue(projectLaneSnapshot(settled, facts).usage.contextTokens, 'contextTokens'), 900);
+
+  const compacted = snapshotWith([
+    ...settled.transcript,
+    { id: 'e2', parentId: 'e1', seq: 2, timestamp: 2, type: 'compaction',
+      summary: 'earlier conversation', retainedTail: [], tokensBefore: 900, fromHook: false },
+  ]);
+  assert.deepEqual(projectLaneSnapshot(compacted, facts).usage.contextTokens,
+    { state: 'unknown', reason: 'just-compacted' },
+    '压缩之后到下一条助手回复之前，上一轮的 prompt 数字已经不回答「现在装了多少」这个问题');
+
+  // 压缩之后又跑了一轮 → 重新有数。这条钉的是「不可知」是**一段状态**，不是一个粘住的开关。
+  const resumed = snapshotWith([
+    ...compacted.transcript,
+    { id: 'e3', parentId: 'e2', seq: 3, timestamp: 3, type: 'message',
+      message: assistant({ input: 120, output: 30, cacheRead: 0, cacheWrite: 0 }) },
+  ]);
+  // 120 = input 120 + cacheRead 0 + cacheWrite 0。**输出不算在里面**：上下文占用问的是
+  // 「下一次请求要带多少进去」，而 pi 对「输入」的定义就是那三列之和（`calculateCost` 第一行）。
+  assert.equal(knownValue(projectLaneSnapshot(resumed, facts).usage.contextTokens, 'contextTokens'), 120);
+});
+
+// ── 推理那一行 ────────────────────────────────────────────────────────────────
+
+test('推理：不会思考的模型「不适用」；会思考但供应商没报的「不可知」；报了的才有数', async (t) => {
+  const withReasoning = await createLaneFixture(t, [
+    { type: 'text', text: 'Done.', usage: { input: 10, output: 40, reasoning: 25 } }]);
+  const thinking = await openLane({ ...withReasoning.options,
+    model: { ...withReasoning.options.model, reasoning: true } });
+  t.after(() => thinking.close());
+  await thinking.execute({ kind: 'prompt', text: 'Think then answer.' });
+  assert.equal(knownValue(thinking.projection().usage.reasoningTokens, 'reasoningTokens'), 25,
+    '推理 token 只在逐条助手消息上有 —— pi 的会话总计把它丢掉了，所以必须走转录');
+
+  const plain = await createLaneFixture(t, SAY_HI);
+  const noThinking = await openLane(plain.options);
+  t.after(() => noThinking.close());
+  await noThinking.execute({ kind: 'prompt', text: 'Say done.' });
+  assert.deepEqual(noThinking.projection().usage.reasoningTokens,
+    { state: 'not-applicable', reason: 'model-has-no-reasoning' },
+    'getSupportedThinkingLevels 只返回 ["off"] 的模型没有推理这回事 —— 那一行整行不画');
+});
+
+test('推理档由 getSupportedThinkingLevels derive；off 被标 null 的模型关不掉思考', async (t) => {
+  const plain = await createLaneFixture(t, SAY_HI);
+  const off = await openLane(plain.options);
+  t.after(() => off.close());
+  assert.deepEqual(off.projection().thinking.supportedLevels, ['off'],
+    'reasoning:false 的模型只有一档 —— 面板不许给它画一排点不动的档位');
+
+  const gated = await createLaneFixture(t, SAY_HI);
+  const lane = await openLane({ ...gated.options, model: { ...gated.options.model,
+    // `null` = 这一档这个模型不支持。`off: null` 就是「关不掉思考」。
+    reasoning: true, thinkingLevelMap: { off: null, minimal: null, low: 'low', medium: 'medium', high: 'high' } } });
+  t.after(() => lane.close());
+  const { thinking } = lane.projection();
+  assert.deepEqual([...thinking.supportedLevels], ['low', 'medium', 'high'],
+    'thinkingLevelMap[level] === null 的档由 pi 自己剔掉，我们不另列一张表');
+  assert.equal(thinking.canTurnOff, false,
+    '关不掉思考的模型必须有对应态 —— 画一个按下去不生效的「关闭」比不画更糟');
+});
+
+// ── 上面几条共用的最小构件 ────────────────────────────────────────────────────
+
+function assistant(usage: { input: number; output: number; cacheRead: number; cacheWrite: number }) {
+  return {
+    role: 'assistant' as const, content: [{ type: 'text' as const, text: 'ok' }],
+    api: 'openai-completions' as const, provider: 'nomi-lane', model: 'chosen-model',
+    usage: { ...usage, totalTokens: usage.input + usage.output + usage.cacheRead + usage.cacheWrite,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } },
+    stopReason: 'stop' as const, timestamp: 1,
+  };
+}
+
+function laneModel() {
+  return {
+    provider: 'nomi-lane', id: 'chosen-model', name: 'chosen-model',
+    api: 'openai-completions' as const, baseUrl: 'http://127.0.0.1/v1', reasoning: false,
+    input: ['text' as const], cost: { input: 0.44, output: 1.32, cacheRead: 0.014, cacheWrite: 0.44 },
+    contextWindow: 128_000, maxTokens: 4096,
+  };
+}
+
+function snapshotWith(transcript: LaneSnapshot['transcript']): LaneSnapshot {
+  const usage = transcript.reduce((sum, entry) => entry.type === 'message' && entry.message.role === 'assistant'
+    ? sum + entry.message.usage.input + entry.message.usage.output : sum, 0);
+  return {
+    lane: 'main', transcript, tipId: transcript.at(-1)?.id ?? null,
+    configuration: { model: { provider: 'nomi-lane', modelId: 'chosen-model' },
+      thinkingLevel: 'medium', activeToolNames: [] },
+    stats: { messageCount: transcript.length,
+      usage: { input: usage, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: usage,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0.0001 } } },
+    operation: null, queues: [], faulted: false,
+  };
+}

--- a/tests/agent-runtime/lane-shadow-parity.test.mts
+++ b/tests/agent-runtime/lane-shadow-parity.test.mts
@@ -113,8 +113,11 @@ async function runNewPath(t: TestContext): Promise<{ beats: Beat[]; promptTokens
     if (part.kind === 'tool-call') { beats.push(`call:${part.toolName}:${JSON.stringify(part.args)}`); continue; }
     if (part.kind === 'tool-result') { beats.push(`result:${part.toolName}:${part.isError ? 'error' : 'ok'}`); }
   }
+  // 花费在新通路上是**三态**（`LaneMetric`），不是一个可选数字：这条影子对照只关心
+  // 「两边都拿不到金额」这件事对不对得上，所以只在 `known` 时才给出数字。
+  const cost = projection.usage.cost;
   return { beats, promptTokens: projection.usage.inputTokens, completionTokens: projection.usage.outputTokens,
-    ...(projection.usage.costUsd === undefined ? {} : { costUsd: projection.usage.costUsd }), text: texts.join('') };
+    ...(cost.state === 'known' ? { costUsd: cost.value } : {}), text: texts.join('') };
 }
 
 test('shadow parity · the two paths see the same beats, in the same order', async (t) => {


### PR DESCRIPTION
阶段 3b。方案 `docs/plan/2026-09-07-agent-rebuild-stage3-5-deep-plan.md` §1.7（三行三态）、§1.8 验收门 G3d、§4.3 探针 P4。**开 PR 不合并**，等 Fable 评审。

## 这一族缺陷的形状

面板顶部的花费 / 上下文 / 推理三行，在真实目录的模型上永远空白或印 0，而**没有任何一层报错**：单测全绿、门岗全绿、typecheck 全绿，只有用户看到一排读不出东西的位置。

根因链三段，每段单看都自洽：① 目录里根本没有放 per-token 价的地方（`Model.pricing` 是「生成一次扣多少点」，不是 per-token）；② 于是 `createNomiProvider` 只能给 pi 填一份全零 `Model.cost`（pi 的 `Model.cost` 不可选），pi 老实算出 0;③ 于是投影拿 `cost.total > 0` 当「有没有价目」的判据 —— 而 0 同时长得像「免费」「还没花钱」「我们没有价目」三件事。

类根因是**用一个 in-band 的数值同时编码「量到了 / 没量到 / 不适用」三种状态**。这次一口气出现三个实例，所以修在类型上而不是三处判断上。

## 验收门逐条

| 门 | 结果 | 证据 |
|---|---|---|
| P4 · 单位对账 | ✅ | DeepSeek V4 Flash 官网峰价（0.44 / 1.32 / cache 0.014）。12000 输入 + 3000 输出 + 8000 缓存读 → 手算 `(5280+3960+112)/1e6 = $0.009352`，实测逐位相等（差 < 1e-12）。另加量级闸 `$1e-6 < cost < $1e-2`：单位写成「每千」会得 $9.35、写成「每个 token」会得 $9352，两者都被这条拦下 |
| P4 · 缓存价 | ✅ | 缓存读按缓存价而非输入价结算（10 万 token：$0.0014 而非 $0.044）；缓存价缺省时**回落到输入价，不是 0**（`?? 0` 会白送一个我们没资格给的折扣） |
| G3d · 首轮 | ✅ | 一条回合都没结算 → 三行全 `unknown / no-settled-turn`，`used` 连分子都不给。渲染侧印占位符 |
| G3d · 无价目 | ✅ | `unknown / model-has-no-pricing`，**不是 $0.00**。阳性对照：同一轮 `contextTokens > 0`（少了它，一个「什么都报不可知」的实现也能全绿） |
| G3d · 刚压缩完 | ✅ | 上下文 `unknown / just-compacted`。前有阳性对照（同一份转录没有压缩条目时必须 `known` = 900），后有恢复对照（压缩后再跑一轮 → 重新 `known` = 120），钉死「不可知是一段状态，不是粘住的开关」 |
| G3d · 免费模型 | ✅ | `not-applicable / model-is-free`，与「不可知」是两句不同的话 |
| 推理三态 | ✅ | 不会思考 → `not-applicable`；会思考但供应商没报 → `unknown / provider-omits-reasoning`；报了 → 逐条助手消息累加（pi 的会话总计把 `reasoning` 丢掉了，只能走转录） |
| 推理档 derive | ✅ | 全部来自 `getSupportedThinkingLevels(model)`，本仓不另列档位表；`thinkingLevelMap.off === null` 的模型 `canTurnOff: false`（关不掉思考的模型不能给一个按下去不生效的「关闭」） |
| 门岗先红后绿 | ✅ | 见下 |
| `pnpm run gates` | ✅ | 72 个门岗 · 72 通过 · 0 阻断失败 |

## 门岗先红后绿（R17）

`check:archetype-sources` 新增「文本模型价目」段：每个 curated 文本模型要么声明带 https 官方出处 + ISO 日期的 `tokenPricing`，要么显式 `free: true`，两者互斥。七次变异逐个实测，每次单独还原后回绿：

| 变异 | 结果 |
|---|---|
| 去掉 gemini-3.5-flash 的 `tokenPricing` | ✗ 缺 tokenPricing（exit 1） |
| 出处改成 `http://` | ✗ 必须是 https 官方定价页 |
| 同时声明 `tokenPricing` 与 `free` | ✗ 两者互斥 |
| 删掉魔搭 Qwen3-8B 的 `free` | ✗ 缺 tokenPricing |
| 棘轮里留一条已补价目的陈旧登记 | ✗ 删掉这行（只减不增） |
| `promptRefineOnly` 条目声明 `free` | ✗ 两个字段都不该声明 |
| `checkedAt` 写成 `Sept 2026` | ✗ 必须是 YYYY-MM-DD |

还原后：`✓ 扫 3 个种子文件，2 个模型无 per-token 价目（棘轮基线 2）`。

豁免判据与生产判据是**同一个字段**（`meta.promptRefineOnly`，`textBrainResolver.isPromptRefineOnlyModel` 用它把 Context-IR 挡在 Agent 主控之外），不是另立一套。

## 价目逐条对过官网（R5，2026-09-07 实查）

| 模型 | 价（USD / 1M） | 出处 |
|---|---|---|
| DeepSeek V4 Flash | 0.44 / 1.32 / cache 0.014 | api-docs.deepseek.com |
| DeepSeek V4 Pro | 1.32 / 3.96 / cache 0.044 | 同上 |
| Gemini 3.5 Flash | 1.5 / 9（含 thinking token）/ cache 0.15 | ai.google.dev |
| Agnes 五条 | flash 0.03 / 0.15；pro 与 pro-alpha 0.45 / 0.9 / cache 0.045；pro-beta 0.1 / 0.3 / cache 0.01 | agnes-ai.com |
| 魔搭 Qwen3 三条 | `free: true` | 免费额度制，不按 token 计费 |

两条取值纪律写进代码注释：**峰谷两价取高的那个**（pi 的 `Model.cost` 没有时间维度，宁可高估不低估）；**Agnes flash 记划线价不记促销价**（$0/M 是促销，不是「不按 token 计费」；记成 `free` 是错的）。

**V3.2 / V3.1-terminus 刻意留白**：2026-09-07 官方定价表只有 v4 三行，这两条一个字都没有。编一个「大概和 flash 差不多」的数字，面板上会印出一个看起来很确定的金额 —— 所以它们落到「花费不可知」，并登记进只减不增的棘轮。

## 删旧清单（P1，同 commit）

- `laneProjection.mts` —— `cost > 0 ? { costUsd: cost } : {}`，用「金额大于零」当「有没有价目」判据的那一条
- `laneContracts.ts` —— `LaneUsage.costUsd?: number`，用「字段缺席」编码不可知的旧表达，整体换成 `cost: LaneMetric`
- `laneViewModel.ts` —— 渲染侧读 `costUsd` 的那一条，改由 `metricText` 统一处置三态

契约层字段直接改名换型（而不是 deprecate 后保留），让所有读旧字段的地方在编译期一次性暴露 —— 本次确实一次性暴露了三个渲染层测试文件与一条影子对照测试。无 fallback、无并存、无 env 开关。

## R30 数字

**本 PR 无真实模型数字**：这一阶段的改动全在投影与目录声明层，不碰工具契约与回合编排，工具写对率 / 回合成功率不会被它移动。零额度 loopback 夹具覆盖全部验收门（`tests/agent-runtime/lane-cost.test.mts` 9 条 + 渲染侧 4 条）。真实模型上真正会变的是「三行印出什么」，那属于 R13 走查而非 R30 计数，留给面板接线那一阶段（今天 `laneViewModel` 还没有任何生产调用方，`laneShadowStructure.test.ts` 正在钉这件事）。

## 与方案不一致处 / 遗留

1. **`contextCostFree` 这条 i18n 词条没有加**（方案第 5 项写了 i18n zh-CN/en）。影子期没有任何生产调用方接到 `laneViewModel`，加了就是一条谁也到不了的死键，`check:i18n` 的死键门会拦 —— 而它拦得对：预先摆一条没人能用的词条和预先摆一段没人调用的代码是同一件事。接线那一刻由调用方从 i18n 取词传进来，与旁边的 `unknown`（今天已是活的 `agentPanelV4.contextUnknown`）走同一条路。理由写在 `LaneViewModelLabels.free` 的注释里。
2. **`seedBuiltins.ts` 拆了一刀**（方案没提）。新增价目字段后它 818 行 > 800，`check:filesize` 红。把身份与分档查找表原样搬进 `electron/catalog/seedModelIdentity.ts`（成员一个没改，`curatedCatalogLifecycle` 仍是三张 Set 的唯一读取者），词表 owner 登记同步更新。分的理由不是凑行数：那个文件做的是**对账**，这里是一张**随模型雷达增删的查找表**，两者变更理由不同。
3. **`NomiModelConfig.reasoning` 今天目录一处都没声明**，生产路径恒 `false`，于是真实模型上推理那一行会落到「不适用」。填它需要逐个模型抓官方文档（R5），不在本阶段范围 —— **已知遗留，不是设计**。
4. **`contextWindow` 同样没有一个对话模型声明**（2026-09-06 打包版实测），所以环仍不画、钮上退回「已用 N」。这是本次三态**正确表达**出来的既有缺口，不是本次引入的。
5. **`pi/run.mts:24` 的同类判断没动**。逐行读过：它把 `total === 0` 映射成 `undefined`，消费方据此整行不渲染 —— 所以它**从不印一个未经测量的数字**，本合同的不变量它满足，只是用更粗的办法（三态压成两态），表达不了「免费」。这条通路整体由阶段 4 删除（`lane-shadow-parity.test.mts` 正是为此对照两条通路），在此之前不动，避免与并行任务改同一批文件。
6. **价目会过期**。门岗只检查「有没有出处 + 格式对不对」，检查不了「这个价今天还准不准」；`checkedAt` 是给下一次模型雷达复核用的锚点。APIMart 是中转，目录记的是一手厂商价 —— 量级对得上，逐分未必，面板上那个金额是估算不是账单。

## 根因合同

`docs/fixes/2026-09-07-absent-number-printed-as-zero.root-cause.json`（schema v3，`recurring`）。`invariant_owner_layer` = `electron/shared/agentLane/laneContracts.ts`：这条不变量归**类型层**管，不归任何一处判断管 —— `LaneMetric` 的 `unknown` / `not-applicable` 分支上不存在 `value`，违反它的写法在这一层根本表达不出来（R28）。本次落地时这道防线真实触发过一次：三个渲染层测试文件因 `LaneUsage` 少了三个字段当场 TS2739。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
