### PR TITLE
test(agent-lane): 阶段 3 前置探针 P1/P2/P3/P5/P6（含阳性对照）+ 裁决记录

### DIFF
--- a/docs/research/2026-09-07-agent-lane-stage3-probes.md
+++ b/docs/research/2026-09-07-agent-lane-stage3-probes.md
@@ -1,0 +1,162 @@
+# Agent lane · 阶段 3 前置探针实跑记录（P1 / P2 / P3 / P5 / P6）
+
+> 状态：✅ 已完成（探针进仓库当阳性对照；本文只记实跑结果与裁决，不改产品代码——P6 的一处投影修正除外，见 §6）
+> 对应：[`docs/plan/2026-09-07-agent-rebuild-stage3-5-deep-plan.md`](../plan/2026-09-07-agent-rebuild-stage3-5-deep-plan.md) §4.3「最可能逼我们再返工的五处 + 便宜探针」。P4（花费行）不在本轮。
+> 基线：`origin/main@4f55e2a36`（#591 已合）。pi 锁定 `0.85.1`，file:line 相对 `node_modules/@earendil-works/`。
+
+日期：2026-09-07 · 性质：探针 + 裁决（零额度为主；P5 ③ 花了真实模型 8 次请求，见 §4）
+服务对象：阶段 3（闸与三行）开工前的两条岔路——3a「审批停在钩子里等」与 3c「看门狗归一」——以及阶段 4 迁移、阶段 2 扁平 schema 的返工判断。
+
+## 0. 一句话结论
+
+| 探针 | 结果 | 一句话裁决 |
+|---|---|---|
+| **P1 ①** 等待期状态 | 🟡 绿但**词表不同** | pi 快照**从不**产出 `"running"`；等待期 `operation.status === "open"`、`runningTools` 空、`queues` 里能看到 `write`/`steer`、零模型请求在飞。**不翻方案 B**，方案 §1.2 / §4.3 把 `running` 改成 `open`，「在等你」由宿主投影（同 §1.2 已写的 `LaneProjection.pending`） |
+| **P1 ②** abort 穿透 | ✅ | `lane.abort()` 打断钩子里的 race；resolve 那一臂得到 pi 自己的 `abortedOutcome`（"Tool execution was cancelled before completion."）；`AbortResult.steer` 带回未消费的插话。**reject 那一臂不能用**：异常被 `hooks.js:121-125` 洗成 `block.reason`，模型看到的是 `signal.reason.message`（"Abort requested"）。宿主 gate 必须 **resolve-on-abort** |
+| **P1 ③** 崩溃恢复 | 🔴 **与方案 §1.5 相反** | 真崩溃（子进程 SIGKILL）后 `resume()` **不合成 interruptedOutcome**：停在预检里的调用还在 `planned`（intent 没发布），`runSequential` 走 `startToolInvocation`（`drive/tools.js:376-386`）→ `before_tool` **再问一次**，钩子放行就真的跑了。恢复文案改：不是「重启前等你确认的动作没有执行」，而是**重启后这张确认卡会再弹一次**（或宿主在 resume 前把它 block 掉） |
+| **P1 ⊕** 钩子抛异常 | ✅ 阳性对照 | `hooks.js:113-118`：抛 = block，工具没跑，`error.message` 逐字进 tool result、逐字到下一次请求 |
+| **P2** 旧对话回填 | ✅ | 生产写入路径落的真实 v1 文件（6 条：model_change / thinking_level_change / user / assistant(toolCall) / toolResult / assistant）逐条 `appendMessage`/`appendCustomEntry` → close → 重开：**段数与顺序 = 源**；再跑一轮，供应商收到的历史里 `tool` 消息紧跟带 `tool_calls` 的 assistant。**pi 不校验成对**（阳性对照：toolResult 排在 toolCall 前照单全收）——成对与否是迁移脚本自己的责任 |
+| **P3 ①** 无看门狗 | 🔴（预期中的红） | 首字节永不返回 → 5 s 后回合仍挂着、`projection().running === true`、只有用户按停能结束。G3c 的「今天会红」坐实 |
+| **P3 ②** 超时归一 | 🟢 **方案 §1.6 的预测被推翻** | `observeNativeStream` 挂到 provider 上后：超时**不是** `aborted`。它自己以 `NativeStreamTimeout` 拒绝 `result()`，harness 记成 `stopReason:"error"` + 含 "timeout" 的文本，`isRetryableAssistantError` 认它 → `retry_scheduled` 触发、第二次请求成功、无 fault。3c **不需要**在 provider 适配器里另做归一 |
+| **P5 ①** 扁平 schema 大小 | 🔴 | pi 字符启发式 ≈ **1 892** tokens；DeepSeek V4 Flash 真实 tokenizer（带/不带该工具的 prompt_tokens 之差）= **2 170** tokens。方案写的 ≤ 1 200 **红** |
+| **P5 ②** 畸形参数 | ✅ | 三条二次序列化畸形（整包 / `anchors`+`shots` / `select`+`patch`）经 `prepareArguments` → ajv → 契约 parse 全过、落到正确 operation；摘掉容忍钩子的对照臂全红 |
+| **P5 ③** 真实首调 | ✅ **3/3** | DeepSeek V4 Flash × 3 任务（建表 / 改行 / 排时间轴）：每次先 `nomi_canvas_read`，第二调 `nomi_storyboard_write` 且 `operation` 全对。**「根级扁平化后模型选错分支」这条返工风险今天没有出现** |
+| **P6** 实验室夹具 | 🟡 2 格接上、1 格接不上 | `input-streaming` 接上真投影**逐像素相等**；`output-denied` 接上后红 → 投影错（行尾印了理由 + 多了展开体），**修投影不动基线**后逐像素相等；`output-available` 的「3 段 · 9.0s」摘要与「0.4s」用时今天的投影**给不出**，那一格保持手写，缺口钉进结构测试 |
+
+**对 3a / 3c 方向的最终建议**：
+- **3a 继续 A**（停在 `before_tool` 里等）。三条修正：① 状态词用 `open` 不用 `running`；② gate 必须 `Promise.race([决定, resolveOnAbort(hookContext.abortSignal)])`，被打断时 **resolve `undefined`**，不要 reject；③ 崩溃恢复不是「写失败卡」——`resume()` 会**重新问一次** `before_tool`，宿主要么让卡再弹一次（用户看到「重启前等你确认的动作，现在再确认一次」），要么在 resume 前自己 block（"重启前没确认，已取消"）。方案 §1.5 那一行「`interruptedOutcome`」只对**已发布 intent、跑到一半**的调用成立，对停在预检里的不成立。
+- **3c 只做「挂上」这一件事**：把 `observeNativeStream` 挂进 `createNomiProvider()`，超时自然落成可重试的 `error`；不要再写归一层（写了就是 R28 说的第二份）。
+- **阶段 2 扁平 schema 不回炉**：P5 ③ 三次真实首调全中，返工的触发条件（选错分支）没出现；token 超预算是真的（2 170 vs 1 200），但它是**上下文成本**问题不是**正确率**问题，放进阶段 3 的三行（上下文那一行会把它显形）再决定要不要瘦身。
+- **阶段 4 迁移的第一档可行**：逐条回填顺序可靠；迁移脚本自己负责成对与压缩条目改写（pi 不替你查）。
+
+## 1. 复跑方法
+
+```
+pnpm run test:agent-runtime          # P1 / P2 / P3 / P5①② 全在里面（216/216）
+pnpm exec tsc -p tests/agent-runtime/tsconfig.json
+pnpm exec electron .tmp/agent-runtime-tests/tests/agent-runtime/stage3-probe-p5-real.electron.mjs   # P5③，走 app 设置读 key
+npx vitest run src/devlab/designLab/v4/laneDrivenFixtures.test.ts src/workbench/ai/lane         # P6 结构半
+NOMI_DESIGN_LAB_UPDATE=1 npx playwright test -c tests/ux/design-lab/playwright.config.mjs --update-snapshots=none \
+  --grep "v4-tool-(input-streaming|output-available|output-denied)"                              # P6 像素半（不写基线）
+```
+
+| 文件 | 探针 |
+|---|---|
+| `tests/agent-runtime/stage3ProbeHarness.mts` | 裸 lane 夹具（同 `laneHost.mts` 的装配，只把 `lane`/`harness` 交出来；不是第二个宿主） |
+| `tests/agent-runtime/stage3-probe-p1-approval-wait.test.mts` + `stage3-probe-crash-child.mts` | P1 ①②③⊕（③ 用子进程 SIGKILL 做真崩溃） |
+| `tests/agent-runtime/stage3-probe-p2-legacy-import.test.mts` | P2 ①② |
+| `tests/agent-runtime/stage3-probe-p3-watchdog.test.mts` | P3 ①② |
+| `tests/agent-runtime/stage3-probe-p5-storyboard-schema.test.mts` | P5 ①② |
+| `tests/agent-runtime/stage3-probe-p5-real.electron.mts` | P5 ③（Electron 进程；key 不打印不落盘） |
+| `src/devlab/designLab/v4/laneDrivenFixtures.ts` + `.test.ts`、`states/01-vocabulary.tsx` | P6 |
+
+## 2. P1 · 审批停在 `before_tool` 里等
+
+### 2.1 ① 等待期（`stage3-probe-p1-approval-wait.test.mts:71-89`）
+
+| 方案 §4.3 写的 | 实跑 |
+|---|---|
+| `operation.status === "running"` | **`"open"`**。0.85.1 的快照与 `inspectExecution` 只在 `open` / `aborting` 之间取值（`harness/runtime/lane.js:1444`、`:864`；归约器 `reducer.js:22` 起手就是 `open`）。`OperationStatus` 类型里的 `"running"` 在快照上从未出现 |
+| `runningTools` 为空 | ✅ 空——停在预检里的调用 `execute` 还没开始，pi 眼里它不存在 |
+| `queues` 里 `kind:"write"` 可见 | ✅ 等待期 `appendCustomEntry` 被排进 inbox 成 `write`，**不会**写在 toolCall 与 toolResult 之间（`lane.js:1490-1545`）；`steer` 同样可见 |
+| 无模型请求在飞 | ✅ loopback 计数恒 1 |
+
+**顺带实核的一条坑**：等待期排进 inbox 的宿主记录在 **abort 之后仍不落盘**（abort 不是一个边界），要等下一次 idle 时的 append 或下一轮才被一起冲出去、且排在前面。宿主若在钩子里写「你取消了」的记录再 abort，那条记录会悬在 `queues` 里——写记录要放在 abort **之后**的 idle 路径上。
+
+### 2.2 ② abort 穿透（`:91-114`）
+
+两臂只差被打断时是 resolve 还是 reject：
+
+| 臂 | 模型看到的 tool result |
+|---|---|
+| resolve-on-abort | `"Tool execution was cancelled before completion."`（pi 自己的 `abortedOutcome`，`drive/tools.js:96-101`）|
+| reject-on-abort | `"Abort requested"`——`hooks.js:121-125` 把异常洗成 `block.reason`，那是 `signal.reason.message`，一个用户从没说过的内部串 |
+
+`AbortResult.steer` 带回 `[{role:'user', content:[{type:'text', text:'不对，横屏'}]}]`——输入框能拿回没送出去的话。run 结果 `ok`，不 fault，不多花请求。
+
+### 2.3 ③ 真崩溃后的 `resume()`（`:148-197`）
+
+方法：子进程用生产路径 `openLane` 打开会话、gate 永不回答、把 sessionId 打到 stdout；父进程 `SIGKILL` 它，再用正常重开路径打开同一条会话（同进程里假崩溃会撞 `laneSession.mts` 的单持有者名单，等于测一条生产走不到的路）。
+
+| 方案 §1.5 预测 | 实跑 |
+|---|---|
+| 「工具只有 `replay:"safe"` 才重跑，我们全部 `never` → `interruptedOutcome`」 | 那条规则只管**已发布 intent** 的调用（`recoverToolInvocation`）。停在预检里的调用状态还是 `planned`，`runSequential` 对它走 `startToolInvocation`（`drive/tools.js:376-386`）——**`before_tool` 再被问一次**，放行就真跑（文稿真的被写入），不写任何 interrupted/cancelled 结果，回合继续、只多一次模型请求 |
+
+裁决：**恢复文案改**（见 §0）。并且这是件好事——它让「重启后再确认一次」成为免费的默认行为，比合成一张失败卡更接近用户想要的。
+
+### 2.4 ⊕ 阳性对照
+
+钩子 `throw new Error(reason)` → 工具没到领域端口、tool result `{text: reason, isError: true}`、下一次请求正文含 reason。G-13 在结构上已满足。
+
+## 3. P3 · 看门狗与超时归一
+
+- **①**（`stage3-probe-p3-watchdog.test.mts:39-51`）：首字节永不返回的 loopback 下，生产 `openLane` 的回合 5 000 ms 后仍 pending，`requests.length === 1`，`projection().running === true`；`execute({kind:'abort'})` 是唯一出口。这条断言**只可能因为看门狗存在而翻红**——3c 落地时它就是 R17 要的先红后绿。
+- **②**（`:53-85`）：把 `createNomiProvider` 的产物包进 `observeNativeStream`（`firstResponseMs = idleMs = 300`）后：回合 1.3 s 结束；事件序列 `retry_scheduled` → `retry_end`，无 `fault`；`retry_scheduled.errorMessage` 匹配 `/timeout/i`；两条助手消息的 `stopReason` 里**没有** `aborted`；第二次请求拿到排队的回复，最终文本 "Recovered."。
+  方案 §1.6「`fail()` 走 `controller.abort(error)` → 极可能落成 `aborted`」的推断错在：`controller.abort` 关的是**上游**流，harness 拿到的是 `observeNativeStream` 自己 `rejectFault(NativeStreamTimeout)` 那条拒绝，走的是 error 分支。
+
+## 4. P5 · 扁平版 `nomi_storyboard_write`
+
+### 4.1 ① 大小
+
+| 量法 | 数 |
+|---|---|
+| 字符 | schema 6 415 + description 1 149 |
+| pi `estimateTokens`（字符启发式） | schema 1 604 + description 288 = **1 892** |
+| DeepSeek V4 Flash 真实 tokenizer（prompt_tokens 带该工具 5 894 − 不带 3 724） | **2 170** |
+| 四个画布工具合计（pi 估计） | read 154 · canvas_write 1 439 · storyboard_write 1 892 · shot_reference_write 1 164 |
+
+方案预算 ≤ 1 200 **红**。测试把「今天 > 1 200 且 < 2 200」钉住：它长大或有人把预算当成已达成时红。
+
+### 4.2 ② 畸形参数
+
+| 畸形 | 容忍臂 | 对照臂（无 `prepareArguments`） |
+|---|---|---|
+| A · 整包参数是 JSON 字符串 | ✅ 首调非错、领域端口收到数组 | ❌ 拒收、端口零到达 |
+| B · `anchors` / `shots` 是 JSON 字符串 | ✅ | ❌ |
+| B′ · `select` / `patch` 是 JSON 字符串 | ✅ 落到 `patch_shots`，`select`/`patch` 为对象 | ❌ |
+
+### 4.3 ③ 真实模型（key 走 app 设置的读取路径）
+
+环境：Electron 进程 `app.setName('nomi')` + `userData=~/Library/Application Support/nomi`，`decryptApiKeyRecord`（safeStorage）解出 `apimart` 凭据；`apimart/deepseek-v4-flash`，`temperature 0`，系统提示词经 `composeLaneSystemPrompt`（与生产同一份两段）。每任务在第一次 `nomi_storyboard_write` 处 `block + terminate`，不花第二轮。
+
+| 任务 | 调用序列 | 首次分镜写入的 `operation` | 命中 | 首请求 prompt_tokens |
+|---|---|---|---|---|
+| 把故事拆成 3 镜图片分镜 | `nomi_canvas_read` → `nomi_storyboard_write` | `propose_storyboard_plan`（1 锚点 3 镜，字段全对） | ✅ | 5 945 |
+| 第 2、3 镜改成 4 s 视频 | `nomi_canvas_read` → `nomi_storyboard_write` | `patch_shots`，`select:{kind:'indexes',indexes:[2,3]}`，`patch:{shotKind:'video',durationSec:4}` | ✅ | 6 004 |
+| 分镜按顺序排到时间轴 | `nomi_canvas_read` → `nomi_storyboard_write` | `arrange_storyboard_to_timeline`，`nodeIds` 三个真实 id | ✅ | 5 906 |
+
+**3/3**。花费：8 次请求（2 次量 token + 3 × 2），合计 prompt ≈ 4.8 万 token、completion 几百 token，DeepSeek V4 Flash 档 ≈ ¥0.05。每次「先读画布」是 guideline 第一条要求的行为，不是选错工具。
+
+**坑一条（写进复跑方法）**：Electron 的 ESM 入口里 `ready` 要等入口模块求值完才发，顶层 `await app.whenReady()` 会互相等——第一版探针挂了 240 s 一字不出。用 `app.whenReady().then(main)`。
+
+## 5. P2 · 旧对话回填
+
+- 源：`createAgentContextService.run` 真跑一轮（loopback `read_shot` + 收尾文本）落的 `agent-thread-context-v1.json`；`importSnapshot` 读回 6 条 pi-coding-agent 条目。
+- 回填：`message` → `lane.appendMessage`；其余（`model_change` / `thinking_level_change`）→ `appendCustomEntry('nomi.legacy.<type>')`。close → 重开 → `watch.snapshot.transcript` 与源逐条同形同序（6/6）。
+- 再跑一轮：供应商请求里 `assistant(tool_calls:[legacy-read])` 的下一条是 `tool(tool_call_id:legacy-read)`，正文含旧结果。
+- 阳性对照：把 toolResult 排在 toolCall 前面 `appendMessage`，pi **照单全收**（`lane.js:1487-1512` 只拒 `stopReason:"pending"` 的助手消息）。
+- 没测的：压缩条目改写成用户消息后模型上下文是否连贯（§2.1 第二档）、[#8939](https://github.com/earendil-works/pi/issues/8939) 无 header 行的错误路径。留给迁移脚本本身的测试。
+
+## 6. P6 · 设计实验室夹具接真投影
+
+方法：手写的不再是 `ToolReceipt`，而是 pi 转录里的 entry（`LaneSnapshot`），经 `projectLaneSnapshot`（主进程）→ `laneViewModel`（渲染层）两层真投影得到收据，渲进同一格；用 `NOMI_DESIGN_LAB_UPDATE=1` 解开 v4 屏的「待拍板」跳过、`--update-snapshots=none` 禁写基线，与已拍板的 PNG 逐像素比。
+
+| 格 | 第一次 | 处置 | 第二次 |
+|---|---|---|---|
+| `v4-tool-input-streaming` | ✅ 逐像素相等 | 保持接线 | ✅ |
+| `v4-tool-output-denied` | 🔴 478 px：行尾印了拒绝理由、多了 `›` 展开体 | **投影错**：`laneViewModel.ts` 对被拒的调用只标 `output-denied`，不再把理由写进 `trailing`/`output`（拍板的格子行尾是「已拒绝」，理由住在用户填它的介入槽里）。单独 commit | ✅ 逐像素相等 |
+| `v4-tool-output-available` | 🔴 摘要「3 段 · 9.0s」与用时「0.4s」缺失，行尾退成状态词 | **不是投影错，是投影缺两个数据源**：摘要要按能力渲染，用时要 `LanePart` 带调用/结果时间戳过桥。今天做不出来 → 恢复手写夹具，缺口钉进 `laneDrivenFixtures.test.ts` | ✅（手写） |
+| 空态 | — | 空快照 → `items=[]`、`running=false`、`max`/`cost` 缺席（结构测试）；像素半要等 lane 驱动的 shell（阶段 4），`v4-empty-*` 三格今天走的是旧宿主 store | ✅（结构） |
+| 审批等待中（approval-requested / 介入槽） | — | **无法由 `LaneSnapshot` 驱动**（P1 ①：停在预检里的调用在快照里不可见）。数据源 = 阶段 3 的 `LaneProjection.pending` | — |
+
+基线 PNG 一张未动（`git status tests/ux/design-lab/__baselines__` 为空）。
+
+阶段 3 三行落地前要补的两个投影数据源（从 P6 的红里读出来）：① `tool-result` 段带 `elapsedMs`（转录时间戳差）；② 每能力一个「一句话摘要」渲染点（喂 `details`），否则收据行永远只能画状态词。
+
+## 7. 遗留（明标）
+
+- P4（花费行 / `Model.tokenPricing`）本轮未做。
+- P2 只验了消息 + 两条设置类条目；`compaction` / `custom_message`（PDF）改写后的模型连贯性未验。
+- P5 ③ 只跑了一个模型（DeepSeek V4 Flash）× 3 任务 × 1 次；不是统计，是「返工触发条件今天没出现」。
+- P6 的 `v4-tool-output-available` 与空态、审批等待三格仍是手写/旧 store 驱动，原因如 §6 表。
+- `pnpm run delivery:preflight` 在脏工作区上跳过（前两位工人留下 4 个未提交改动）；分支已与 `origin/main` 对齐（0 behind）。

--- a/src/devlab/designLab/v4/laneDrivenFixtures.test.ts
+++ b/src/devlab/designLab/v4/laneDrivenFixtures.test.ts
@@ -1,0 +1,56 @@
+// 探针 P6 的结构那一半：把三份 `LaneSnapshot`（空态 / 单工具 / 审批被拒）过两层真投影，
+// 钉住「今天的投影离拍板过的收据差什么」。像素那一半在设计实验室（`01-vocabulary.tsx` 的
+// `LaneReceiptCell`）；这里钉的是接不上去的那一格**为什么**接不上——缺口清单一变就红。
+import { describe, expect, it } from 'vitest'
+
+import { projectLaneSnapshot } from '../../../../electron/agentLane/laneProjection.mjs'
+import { laneViewModel, type LaneViewModelLabels } from '../../../workbench/ai/lane/laneViewModel'
+import {
+  laneDrivenReceipt,
+  laneSnapshotToolDenied,
+  laneSnapshotToolDone,
+  laneSnapshotToolRunning,
+} from './laneDrivenFixtures'
+
+const labels: LaneViewModelLabels = {
+  toolLabel: () => '读取时间轴',
+  thinkingLabel: '正在想…',
+  formatTokens: (value) => String(value),
+  formatCost: (usd) => `$${usd.toFixed(2)}`,
+}
+
+describe('design-lab fixtures driven by a LaneSnapshot (probe P6)', () => {
+  it('empty: an empty transcript projects to no items, not running, and no invented ceiling/cost', () => {
+    const empty = { ...laneSnapshotToolRunning(), transcript: [], tipId: null, operation: null }
+    const model = laneViewModel(projectLaneSnapshot(empty), labels)
+    expect(model.items).toEqual([])
+    expect(model.running).toBe(false)
+    expect(model.usage.max).toBeUndefined()
+    expect(model.usage.cost).toBeUndefined()
+    // `AgentPanelV4Panel` renders `V4EmptyState` on `flow.length === 0`; the surface-derived
+    // starter chips are the shell's, so the pixel half of this cell waits for a lane-driven shell (stage 4).
+  })
+
+  it('single tool, in flight: matches the approved input-streaming cell field for field', () => {
+    const receipt = laneDrivenReceipt(laneSnapshotToolRunning(), labels)
+    expect(receipt).toEqual({ label: '读取时间轴', action: 'timeline', status: 'input-available', input: undefined })
+  })
+
+  it('approval denied: only the status word, no trailing reason, no expandable body', () => {
+    const receipt = laneDrivenReceipt(laneSnapshotToolDenied('这次先不删'), labels)
+    expect(receipt.status).toBe('output-denied')
+    expect(receipt.trailing).toBeUndefined()
+    expect(receipt.output).toBeUndefined()
+    expect(receipt.summary).toBeUndefined()
+  })
+
+  it('single tool, done: pins the two fields the projection cannot derive yet (why that cell stays hand-written)', () => {
+    const receipt = laneDrivenReceipt(laneSnapshotToolDone(), labels)
+    expect(receipt.status).toBe('output-available')
+    expect(receipt.output).toBe('clips: 3 · duration: 9.0s · selected: clip-2 (0:03–0:06)')
+    // 拍板的格子有「3 段 · 9.0s」（按能力渲染的摘要）与「0.4s」（调用→结果的时间戳差）。
+    // 前者要一个按能力的摘要渲染点，后者要 `LanePart` 带时间戳过桥——两者都还没有。
+    expect(receipt.summary).toBeUndefined()
+    expect(receipt.trailing).toBeUndefined()
+  })
+})

--- a/src/devlab/designLab/v4/laneDrivenFixtures.ts
+++ b/src/devlab/designLab/v4/laneDrivenFixtures.ts
@@ -1,0 +1,91 @@
+// 设计实验室 · Agent 面板 v4 · **由 `LaneSnapshot` 驱动**的收据夹具（阶段 3 前置探针 P6）。
+//
+// 这一屏其余格子的收据都是手写的 `ToolReceipt`（「给积木喂 view model，看它长什么样」）。
+// 那证明的是组件契约，证明不了投影：宿主快照怎么变成这些 props 那一层完全没被跑到。
+// 阶段 4 切换后，快照的形状是 pi 的 `LaneSnapshot`，中间两层是
+//   `projectLaneSnapshot`（主进程，纯函数）→ `laneViewModel`（渲染层，纯函数）。
+// 这里把这两层**真的跑一遍**：手写的是 pi 转录里的 entry，而不是收据。
+// 于是同一格的基线一旦红，红的就是「投影产出的收据 ≠ 拍板过的收据」——那是投影的错，
+// 修投影，不动基线（方案 §4.3 P6）。
+//
+// 三个可从快照推出的态各一格：单工具进行中 / 单工具完成 / 审批被拒。
+// **审批等待中（approval-requested）刻意不在这里**：停在 `before_tool` 里的调用在 pi 快照里
+// 不可见（`runningTools` 为空，探针 P1 ① 实核），那一态只能由宿主内存投影，等阶段 3 的
+// `LaneProjection.pending` 落地才有数据源可驱动。
+import type { LaneSnapshot } from '@earendil-works/pi-agent-core'
+import type { AssistantMessage } from '@earendil-works/pi-ai'
+import { LANE_APPROVAL_NOTE_TYPE } from '../../../../electron/shared/agentLane/laneContracts'
+import { projectLaneSnapshot } from '../../../../electron/agentLane/laneProjection.mjs'
+import { laneViewModel, type LaneViewModelLabels } from '../../../workbench/ai/lane/laneViewModel'
+import type { ToolReceipt } from '../../../workbench/ai/v4/agentPanelV4Types'
+
+/** 冻结时间戳（基线不能随钟走）。 */
+const AT = 1_757_154_000_000
+const TOOL = 'nomi_timeline_read'
+const CALL = 'call-timeline-1'
+
+const usage = { input: 62_400, output: 9_800, cacheRead: 2_400, cacheWrite: 0, totalTokens: 74_600, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } }
+
+function assistantCall(): AssistantMessage {
+  return {
+    role: 'assistant',
+    content: [{ type: 'toolCall', id: CALL, name: TOOL, arguments: {} }],
+    api: 'openai-completions', provider: 'nomi-lane', model: 'chosen-model',
+    usage, stopReason: 'toolUse', timestamp: AT,
+  }
+}
+
+type Transcript = LaneSnapshot['transcript']
+
+function snapshot(transcript: Transcript, operation: LaneSnapshot['operation'] = null): LaneSnapshot {
+  return {
+    lane: 'main',
+    transcript,
+    tipId: transcript.at(-1)?.id ?? null,
+    configuration: { model: { provider: 'nomi-lane', modelId: 'chosen-model' }, thinkingLevel: 'off', activeToolNames: [TOOL] },
+    stats: { messageCount: transcript.length, usage },
+    operation,
+    queues: [],
+    faulted: false,
+  }
+}
+
+const userEntry = { id: 'e1', parentId: null, seq: 1, timestamp: AT, type: 'message' as const, message: { role: 'user' as const, content: [{ type: 'text' as const, text: '看看时间轴上现在有什么。' }], timestamp: AT } }
+const callEntry = { id: 'e2', parentId: 'e1', seq: 2, timestamp: AT, type: 'message' as const, message: assistantCall() }
+
+/** 单工具 · 进行中：调用已发布、结果未落。pi 眼里它在 `runningTools`。 */
+export function laneSnapshotToolRunning(): LaneSnapshot {
+  return snapshot([userEntry, callEntry], {
+    id: 'op-1', kind: 'run', startedAt: AT, fromTipId: 'e1', status: 'running',
+    runningTools: [{ status: 'running', toolCallId: CALL, toolName: TOOL, args: {} }],
+  })
+}
+
+/** 单工具 · 完成：toolResult 落盘。 */
+export function laneSnapshotToolDone(): LaneSnapshot {
+  return snapshot([userEntry, callEntry, {
+    id: 'e3', parentId: 'e2', seq: 3, timestamp: AT + 400, type: 'message',
+    message: { role: 'toolResult', toolCallId: CALL, toolName: TOOL, content: [{ type: 'text', text: 'clips: 3 · duration: 9.0s · selected: clip-2 (0:03–0:06)' }], isError: false, timestamp: AT + 400 },
+  }])
+}
+
+/** 审批被拒：宿主的审批记录骑在同一条转录上、排在被拒的调用之前（`lane-slice.test.mts` 实核的顺序）。 */
+export function laneSnapshotToolDenied(reason: string): LaneSnapshot {
+  return snapshot([
+    userEntry,
+    { id: 'n1', parentId: 'e1', seq: 2, timestamp: AT, type: 'custom', customType: LANE_APPROVAL_NOTE_TYPE, data: { toolCallId: CALL, toolName: TOOL, decision: 'denied', reason } },
+    { ...callEntry, parentId: 'n1', seq: 3 },
+    {
+      id: 'e3', parentId: 'e2', seq: 4, timestamp: AT, type: 'message',
+      message: { role: 'toolResult', toolCallId: CALL, toolName: TOOL, content: [{ type: 'text', text: reason }], isError: true, timestamp: AT },
+    },
+  ])
+}
+
+/** 两层投影真的跑一遍，取出那一行收据。 */
+export function laneDrivenReceipt(lane: LaneSnapshot, labels: LaneViewModelLabels): ToolReceipt {
+  const model = laneViewModel(projectLaneSnapshot(lane), labels)
+  const tool = model.items.find((item) => item.kind === 'tool')
+  if (!tool || tool.kind !== 'tool') throw new Error('the lane snapshot projected no tool receipt')
+  return tool.receipt
+}

--- a/src/devlab/designLab/v4/states/01-vocabulary.tsx
+++ b/src/devlab/designLab/v4/states/01-vocabulary.tsx
@@ -6,6 +6,7 @@
 // 顺序有意义：`labStates.mjs` 按本屏目录里 `NN-*.tsx` 的文件名排序解析，汇总口按同样顺序拼接，
 // 走查再拿活页面的 `window.__designLabStates` 与解析结果逐项比对——三者对不上当场红。
 import React from 'react'
+import type { LaneSnapshot } from '@earendil-works/pi-agent-core'
 import { IconBrowser, IconSettings } from '../../../../vendor/tablerIcons'
 import { V4Intervention, V4Queue, V4TaskCard } from '../../../../workbench/ai/v4/AgentPanelV4Cards'
 import { V4ContextRing } from '../../../../workbench/ai/v4/AgentPanelV4Context'
@@ -19,6 +20,7 @@ import { V4FlowRow } from '../../../../workbench/ai/v4/AgentPanelV4Panel'
 import { useV4Labels } from '../../../../workbench/ai/v4/agentPanelV4Labels'
 import type { ToolReceipt, V4AssistantStatus } from '../../../../workbench/ai/v4/agentPanelV4Types'
 import { Piece, useV4Fixtures } from '../agentPanelV4LabKit'
+import { laneDrivenReceipt, laneSnapshotToolDenied, laneSnapshotToolRunning } from '../laneDrivenFixtures'
 import type { LabState } from '../../labScreen'
 
 
@@ -83,6 +85,29 @@ function ReceiptCell({ pick, errorBar }: { pick: keyof ReturnType<typeof useV4Fi
       {errorBar ? (
         <V4ErrorBar reason={fx.t('agentPanelV4.fixtureVendorFailure')} action={fx.t('agentPanelV4.fixtureRetryOtherModel')} />
       ) : null}
+    </Piece>
+  )
+}
+
+/**
+ * 由 `LaneSnapshot` 驱动的两格（探针 P6）：收据不是手写的，是 pi 转录 → `projectLaneSnapshot`
+ * → `laneViewModel` 真跑出来的。可见文字仍由实验室给（`toolLabel` 等，R15），和其它格同一份词条。
+ * 「完成」那一格没接：它的摘要（「3 段 · 9.0s」）与用时（「0.4s」）今天的投影给不出来
+ * （摘要要按能力渲染、用时要转录时间戳过桥），接上去就是一张不该被录进基线的红——
+ * 见 `laneDrivenFixtures.test.ts` 钉住的缺口清单。
+ */
+function LaneReceiptCell({ lane }: { lane: (rejectReason: string) => LaneSnapshot }): JSX.Element {
+  const fx = useV4Fixtures()
+  const labels = useV4Labels()
+  const receipt = laneDrivenReceipt(lane(fx.t('agentPanelV4.slotRejectSample')), {
+    toolLabel: () => fx.t('agentPanelV4.fixtureReadTimeline'),
+    thinkingLabel: fx.t('agentPanelV4.thinkingLabel'),
+    formatTokens: (value) => String(value),
+    formatCost: (usd) => `$${usd.toFixed(2)}`,
+  })
+  return (
+    <Piece>
+      <V4ToolReceipt receipt={receipt} statusLabel={labels.toolStatus[receipt.status]} undoLabel={labels.task.undo} />
     </Piece>
   )
 }
@@ -236,7 +261,7 @@ export const V4_VOCABULARY_STATES: readonly LabState[] = [
     name: '③ 收据 · input-streaming（进行中）',
     source: '2026-09-06-agent-panel-v4.md · Vocabulary 板',
     coverage: 'component-only',
-    render: () => <ReceiptCell pick="running" />,
+    render: () => <LaneReceiptCell lane={laneSnapshotToolRunning} />,
   },
   {
     id: 'v4-tool-input-available',
@@ -292,7 +317,7 @@ export const V4_VOCABULARY_STATES: readonly LabState[] = [
     name: '③ 收据 · output-denied（你点了不要）',
     source: '2026-09-06-agent-panel-v4.md · Vocabulary 板',
     coverage: 'component-only',
-    render: () => <ReceiptCell pick="denied" />,
+    render: () => <LaneReceiptCell lane={laneSnapshotToolDenied} />,
   },
   {
     id: 'v4-tool-output-error',

--- a/src/workbench/ai/lane/laneViewModel.test.ts
+++ b/src/workbench/ai/lane/laneViewModel.test.ts
@@ -96,7 +96,14 @@ describe('laneViewModel', () => {
       part({ kind: 'tool-result', toolCallId: 'c1', toolName: 'append_to_end', text: 'Locked.', isError: true }),
     ]), labels)
     expect(model.items).toHaveLength(1)
-    expect(JSON.stringify(model.items).split('Locked.').length - 1).toBe(2) // trailing + output，不是三处
+    // 拍板过的那一格（`v4-tool-output-denied`）行尾只有「已拒绝」：理由既不进行尾也不进展开体，
+    // 它住在用户填它的介入槽里。设计实验室 P6 把这一格接上真投影时，"trailing = 理由 + 展开体 = 理由"
+    // 那版当场和基线红了——修投影，不动基线。
+    expect(JSON.stringify(model.items).split('Locked.').length - 1).toBe(0)
+    const denied = model.items[0]
+    expect(denied.kind === 'tool' && denied.receipt.status).toBe('output-denied')
+    expect(denied.kind === 'tool' && denied.receipt.trailing).toBeUndefined()
+    expect(denied.kind === 'tool' && denied.receipt.output).toBeUndefined()
   })
 
   it('never invents a bubble for a result whose call it cannot see', () => {

--- a/src/workbench/ai/lane/laneViewModel.ts
+++ b/src/workbench/ai/lane/laneViewModel.ts
@@ -149,14 +149,14 @@ export function laneViewModel(projection: LaneProjection, labels: LaneViewModelL
     const denial = denials.get(part.toolCallId)
     const existing = items[slot.index]
     if (existing.kind !== 'tool') continue
+    // 被拒的那一行只说「已拒绝」（拍板过的 Vocabulary 板 `v4-tool-output-denied`：行尾是状态词，
+    // 没有摘要、没有展开体）。理由住在用户自己填它的那张介入槽里；再把它印到行尾、又塞进
+    // 展开体，同一句话就在面板上出现三次——设计实验室 P6 探针把这一格接上真投影时当场红了。
     items[slot.index] = {
       kind: 'tool',
-      receipt: {
-        ...existing.receipt,
-        status: settledStatus(part.isError, denial !== undefined),
-        output: part.text || undefined,
-        ...(denial?.reason ? { trailing: denial.reason } : {}),
-      },
+      receipt: denial !== undefined
+        ? { ...existing.receipt, status: 'output-denied' }
+        : { ...existing.receipt, status: settledStatus(part.isError, false), output: part.text || undefined },
     }
   }
 

--- a/tests/agent-runtime/stage3-probe-crash-child.mts
+++ b/tests/agent-runtime/stage3-probe-crash-child.mts
@@ -1,0 +1,26 @@
+// P1 ③ 的**被杀掉的那半**：用生产路径 `openLane` 打开一条 lane，闸永远不回答，
+// 把会话 id 打到 stdout，然后等着被父进程 `SIGKILL`。
+//
+// 不是测试文件（没有 `.test.`），只被 `stage3-probe-p1-approval-wait.test.mts` spawn。
+// 为什么必须是子进程：同一进程里第二次打开同一条会话会被 `laneSession.mts` 的单持有者
+// 名单拦下；绕过它就等于测了一条生产走不到的路。真崩溃 = 进程没了、盘上有一个 open 的操作。
+import { openLane } from '../../electron/agentLane/laneHost.mjs';
+import { createDocumentLaneTools } from '../../electron/agentLane/laneDocumentTools.js';
+import { createDocumentPort, LANE_SYSTEM_PROMPT } from './laneFixture.mjs';
+
+const [projectDir, baseURL] = process.argv.slice(2);
+if (!projectDir || !baseURL) throw new Error('usage: stage3-probe-crash-child <projectDir> <baseURL>');
+
+const lane = await openLane({
+  projectDir,
+  systemPrompt: LANE_SYSTEM_PROMPT,
+  model: { kind: 'openai-compatible', providerId: 'nomi-lane', modelId: 'chosen-model', baseURL, authType: 'api-key', apiKey: 'fixture-key' },
+  tools: createDocumentLaneTools(createDocumentPort()),
+  gate: () => {
+    process.stdout.write(`PARKED session=${lane.sessionId}\n`);
+    return new Promise(() => {});
+  },
+});
+// 不 await：这一轮永远不会结束。进程活着，直到父进程杀掉它。
+void lane.execute({ kind: 'prompt', text: 'Append something.' });
+setInterval(() => {}, 60_000);

--- a/tests/agent-runtime/stage3-probe-p1-approval-wait.test.mts
+++ b/tests/agent-runtime/stage3-probe-p1-approval-wait.test.mts
@@ -1,0 +1,197 @@
+// 阶段 3 前置探针 **P1**（方案 §4.3）：审批停在 `before_tool` 里等——abort 穿不穿得透、
+// 崩溃恢复对「停在预检里的调用」给什么形状。
+//
+// 它裁决的是 §1.2 岔路 1 的 A 案（在钩子里 `await` 用户）能不能站住：
+//   ① 等待期 `operation.status === "running"`、`runningTools` 为空、`queues` 里能看到 `kind:"write"`，
+//      且**没有模型请求在飞**（loopback 计数不涨）——① 红 = 翻到 §1.2 方案 B。
+//   ② `lane.abort()` 打断钩子里的 race，得到 `abortedOutcome`，`AbortResult` 带回未消费的 steer。
+//   ③ 不 close 直接把进程杀掉 → 重开 `resume()`：是重跑，还是合成 `interruptedOutcome`——③ 红 = 恢复文案改。
+//   ⊕ 阳性对照：钩子抛异常 = block（`hooks.js:113-118`），工具没跑、reason 逐字到模型。
+//
+// 结果与裁决写在 `docs/research/2026-09-07-agent-lane-stage3-probes.md`。这里只钉「今天是什么」。
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { once } from 'node:events';
+import { fileURLToPath } from 'node:url';
+import { test } from 'node:test';
+import type { Entry } from '@earendil-works/pi-agent-core';
+
+import { createDocumentLaneTools } from '../../electron/agentLane/laneDocumentTools.js';
+import { createDocumentPort, createLaneFixture } from './laneFixture.mjs';
+import {
+  PROBE_CONTEXT, deferred, openProbeLane, rejectOnAbort, resolveOnAbort,
+} from './stage3ProbeHarness.mjs';
+
+const APPEND = { type: 'tool' as const, calls: [{ id: 'call-append', name: 'append_to_end', arguments: { content: 'unapproved' } }] };
+const CLOSING = { type: 'text' as const, text: 'Understood.' };
+
+/** 转录里那次调用的结果。**从 pi 的转录读**，不从我们的投影读——探针问的是 pi。 */
+function toolResultOf(entries: readonly Entry[], toolCallId: string) {
+  for (const entry of entries) {
+    if (entry.type !== 'message' || entry.message.role !== 'toolResult') continue;
+    if (entry.message.toolCallId !== toolCallId) continue;
+    const content = entry.message.content;
+    const text = content.filter((part): part is { type: 'text'; text: string } => part.type === 'text').map((part) => part.text).join('');
+    return { text, isError: entry.message.isError };
+  }
+  return undefined;
+}
+
+for (const arm of ['resolve-on-abort', 'reject-on-abort'] as const) {
+  test(`P1 ①② · a gate that awaits inside before_tool: status while waiting, and what abort() hands back (${arm})`, async (t) => {
+    const fixture = await createLaneFixture(t, [APPEND, CLOSING]);
+    const entered = deferred<{ hasSignal: boolean }>();
+    let hookSettledBy: 'abort' | 'never' = 'never';
+    const probe = await openProbeLane(t, fixture.options, {
+      beforeTool: async (_event, hookContext) => {
+        const signal = hookContext.abortSignal;
+        entered.resolve({ hasSignal: signal !== undefined });
+        // §1.2 实核：pi 只在**进入前** throwIfAborted，等待中的 promise 它不替我们打断。
+        // 宿主的 gate 必须自己 race 这个 signal。两臂只差「被打断时是 resolve 还是 reject」。
+        const never = new Promise<undefined>(() => {});
+        if (arm === 'resolve-on-abort') {
+          await Promise.race([never, resolveOnAbort(signal)]);
+          hookSettledBy = 'abort';
+          return undefined;
+        }
+        try {
+          return await Promise.race([never, rejectOnAbort(signal)]);
+        } finally { hookSettledBy = 'abort'; }
+      },
+    });
+    const { lane } = probe;
+    const watch = await lane.watch(PROBE_CONTEXT);
+    t.after(() => watch.unsubscribe());
+    watch.start(() => {});
+
+    const run = lane.prompt('Append something.', undefined, PROBE_CONTEXT);
+    const { hasSignal } = await entered.promise;
+    assert.equal(hasSignal, true, 'the hook context carries the operation abort signal (hooks.js:40-47)');
+
+    // ① 等待期：pi 眼里这条 lane 是什么状态。
+    const note = await lane.appendCustomEntry('nomi.probe.note', { while: 'waiting' }, PROBE_CONTEXT);
+    const steer = await lane.steer('不对，横屏', undefined, PROBE_CONTEXT);
+    assert.ok(steer.ok, 'steer is accepted while the gate waits');
+    const waiting = await watch.resnapshot(PROBE_CONTEXT);
+    assert.ok(waiting.operation, 'there is an operation while the gate waits');
+    // 方案 §4.3 P1 写的是 `status === "running"`。实跑：0.85.1 的快照**从不产出 "running"**——
+    // 快照与 `inspectExecution` 只在 `open` / `aborting` 之间取值（`lane.js:1444`、`:864`；
+    // 归约器 `reducer.js:22` 起手就是 `open`）。「在等人」还是「在跑请求」pi 一律写 `open`，
+    // 所以这条断言按 pi 的词表钉：有操作、且不在 aborting。
+    assert.equal(waiting.operation.status, 'open', 'pi 0.85.1 never reports "running" on a snapshot — the waiting lane is "open"');
+    assert.deepEqual(waiting.operation.runningTools, [], 'a call stuck in preflight is NOT in runningTools — the host must project "waiting for you" itself');
+    assert.ok(waiting.queues.some((item) => item.kind === 'write' && item.type === 'custom' && item.customType === 'nomi.probe.note'),
+      'appendCustomEntry during an operation is queued as kind:"write", not written between toolCall and toolResult (lane.js:1490-1545)');
+    assert.ok(waiting.queues.some((item) => item.kind === 'steer'), 'the steer is visible in queues while waiting');
+    const inspected = await lane.inspectExecution(PROBE_CONTEXT);
+    assert.equal(inspected.current?.status, 'open', 'inspectExecution says the same word as the snapshot');
+    assert.equal(fixture.http.requests.length, 1, 'no model request is in flight while the gate waits (G3b ①)');
+    assert.equal(fixture.document.text(), 'The opening scene.', 'the tool has not run');
+
+    // ② abort 穿透钩子里的 race。
+    const aborted = await lane.abort(PROBE_CONTEXT);
+    assert.ok(aborted.ok, 'abort() succeeds against an operation parked in before_tool');
+    assert.equal(hookSettledBy, 'abort', 'the race inside the hook was broken by the operation signal');
+    assert.deepEqual(aborted.value.steer.map((message) => message.role === 'user' ? JSON.stringify(message.content) : message.role), [JSON.stringify([{ type: 'text', text: '不对，横屏' }])],
+      'AbortResult hands back the unconsumed steer so the host can put it back in the input box (lane.js:1082)');
+    const result = await run;
+    assert.ok(result.ok, `the run settles instead of faulting: ${result.ok ? '' : JSON.stringify(result.error)}`);
+    const entries = await lane.findEntries(undefined, PROBE_CONTEXT);
+    const settled = toolResultOf(entries, 'call-append');
+    assert.ok(settled, 'the parked call settles as a toolResult entry');
+    assert.equal(settled.isError, true);
+    assert.equal(fixture.document.text(), 'The opening scene.', 'the tool never ran');
+    assert.equal(fixture.http.requests.length, 1, 'abort does not spend another model request');
+    if (arm === 'resolve-on-abort') {
+      assert.equal(settled.text, 'Tool execution was cancelled before completion.',
+        'resolving the hook on abort yields pi\'s own abortedOutcome (drive/tools.js:96-101)');
+    } else {
+      // 拒绝那一臂：`hooks.js:121-125` 把任何异常变成 `block = { reason: error.message }`——
+      // 所以模型看到的不是 abortedOutcome，而是 signal.reason 的 message。钉住它，宿主别走这一臂。
+      assert.notEqual(settled.text, 'Tool execution was cancelled before completion.',
+        'rejecting the hook on abort is laundered into a block reason by hooks.js:121-125 — not the cancelled outcome');
+      assert.equal(settled.text, 'Abort requested', 'the block reason is AbortRequested.message, an internal string the user never asked for');
+    }
+    // 等待期排进 inbox 的宿主记录：abort 之后它**没有**落盘——还在 `queues` 里（§1.4 说的
+    // 「落盘延迟到边界」，而 abort 不是一个边界）。它要等下一次 idle 时的 append 或下一轮
+    // 才被一起冲出去。宿主若在钩子里写「你取消了」的记录，再 abort，那条记录就悬在这里。
+    const landedNow = entries.some((entry) => entry.type === 'custom' && entry.customType === 'nomi.probe.note');
+    assert.equal(landedNow, false, `custom entry ${note} appended during the wait is NOT flushed by abort`);
+    const afterAbort = await watch.resnapshot(PROBE_CONTEXT);
+    assert.equal(afterAbort.operation, null);
+    assert.ok(afterAbort.queues.some((item) => item.kind === 'write' && item.type === 'custom' && item.customType === 'nomi.probe.note'),
+      'it is still parked in queues after the operation settled');
+    await lane.appendCustomEntry('nomi.probe.after', undefined, PROBE_CONTEXT);
+    // 顺序从快照的 transcript 读（那是投影用的那条有序流）；`findEntries` 是按 tip 往回扫的。
+    const flushed = (await watch.resnapshot(PROBE_CONTEXT)).transcript;
+    const customTypes = flushed.filter((entry) => entry.type === 'custom').map((entry) => entry.customType);
+    assert.deepEqual(customTypes, ['nomi.probe.note', 'nomi.probe.after'],
+      'an idle-time append flushes the stranded write first, in order (lane.js:1502-1512)');
+  });
+}
+
+test('P1 ⊕ positive control · a hook that throws is a block: the tool never runs and the message reaches the model verbatim', async (t) => {
+  const fixture = await createLaneFixture(t, [APPEND, CLOSING]);
+  const reason = 'Approval service crashed: ask the user to reopen the panel before appending.';
+  const probe = await openProbeLane(t, fixture.options, {
+    beforeTool: async () => { throw new Error(reason); },
+  });
+  const result = await probe.lane.prompt('Append something.', undefined, PROBE_CONTEXT);
+  assert.ok(result.ok);
+  const settled = toolResultOf(await probe.lane.findEntries(undefined, PROBE_CONTEXT), 'call-append');
+  assert.deepEqual(settled, { text: reason, isError: true }, 'hooks.js:113-118 — a throwing before_tool is fail-closed into a block whose reason is the error message');
+  assert.equal(fixture.document.text(), 'The opening scene.', 'the tool never reached the domain port');
+  const nextRequest = JSON.stringify(fixture.http.requests[1]?.body ?? {});
+  assert.ok(nextRequest.includes(reason), 'the model reads the reason in the next request');
+});
+
+/**
+ * ③ 真崩溃：子进程打开同一条会话、停在 gate 里，父进程 `SIGKILL` 它，再用**正常重开路径**打开。
+ * 不在同一进程里假装崩溃：同一进程里第二次打开会撞 `laneSession.mts` 的单持有者名单，
+ * 绕过它就等于测了一条生产走不到的路。
+ */
+test('P1 ③ · after a hard crash while parked in before_tool, resume() re-plans the call (before_tool runs again) instead of synthesizing an interrupted result', async (t) => {
+  const fixture = await createLaneFixture(t, [APPEND, CLOSING]);
+  const child = spawn(process.execPath, [
+    fileURLToPath(new URL('./stage3-probe-crash-child.mjs', import.meta.url)),
+    fixture.projectDir, fixture.http.baseURL,
+  ], { stdio: ['ignore', 'pipe', 'inherit'] });
+  let stdout = '';
+  const parked = deferred<string>();
+  child.stdout.setEncoding('utf8');
+  child.stdout.on('data', (chunk: string) => {
+    stdout += chunk;
+    const match = /PARKED session=(\S+)/.exec(stdout);
+    if (match) parked.resolve(match[1]);
+  });
+  const exited = once(child, 'exit');
+  const sessionId = await Promise.race([parked.promise, exited.then(() => { throw new Error(`child exited early:\n${stdout}`); })]);
+  assert.equal(fixture.http.requests.length, 1, 'the child got exactly one model reply (the tool call) before parking');
+  child.kill('SIGKILL');
+  await exited;
+
+  // 父进程：一个**新的**端口 + 新的 harness，钩子这次记录它有没有被再次问到。
+  const document = createDocumentPort();
+  const hookCalls: string[] = [];
+  const reopened = await openProbeLane(t, { ...fixture.options, tools: createDocumentLaneTools(document) }, {
+    sessionId,
+    beforeTool: async (event) => { hookCalls.push(event.toolCallId); return undefined; },
+  });
+  const before = await reopened.lane.inspectExecution(PROBE_CONTEXT);
+  assert.ok(before.current, 'the crashed operation is still open on disk — "crash" is an open operation, not a reason code (§1.5)');
+  assert.equal(before.current.status, 'open');
+
+  const resumed = await reopened.lane.resume(PROBE_CONTEXT);
+  assert.ok(resumed.ok, `resume settles: ${resumed.ok ? '' : JSON.stringify(resumed.error)}`);
+  const settled = toolResultOf(await reopened.lane.findEntries(undefined, PROBE_CONTEXT), 'call-append');
+  assert.ok(settled, 'the parked call has a result after resume');
+
+  // 今天的形状（钉住，不是期望）：调用还在 `planned`（intent 没发布），`runSequential` 走
+  // `startToolInvocation` 而不是 `recoverToolInvocation`（drive/tools.js:376-386）——
+  // 于是 before_tool **再问一次**，钩子放行就真的跑了。不是 interruptedOutcome。
+  assert.deepEqual(hookCalls, ['call-append'], 'before_tool is asked again for the call that was parked when the process died');
+  assert.equal(settled.isError, false, 'with the gate answering "allow" on resume, the tool executes for real');
+  assert.doesNotMatch(settled.text, /interrupted|cancelled/i, 'no synthetic interrupted/cancelled outcome is written');
+  assert.equal(document.text(), 'The opening scene.unapproved', 'the domain port in the resumed process received the write');
+  assert.equal(fixture.http.requests.length, 2, 'resume continues the turn with one more model request, not a replay from the start');
+});

--- a/tests/agent-runtime/stage3-probe-p2-legacy-import.test.mts
+++ b/tests/agent-runtime/stage3-probe-p2-legacy-import.test.mts
@@ -1,0 +1,139 @@
+// 阶段 3 前置探针 **P2（轻量）**（方案 §4.3）：旧对话（`agent-thread-context-v1.json`）能不能
+// 逐条回填进 pi 的 lane 转录——§2.1 第一档「`appendMessage` + `appendCustomEntry` 逐条回填」
+// 押的就是这件事。只出结论，不做迁移。
+//
+// 两个问题，各一条断言：
+//   ① 逐条 `appendMessage` / `appendCustomEntry` → close → 重开 + watch：段数与顺序 = 源文件。
+//   ② toolCall / toolResult **成对追加**会不会被 pi 的顺序校验拒收；回填之后再跑一轮，
+//      供应商收到的历史里 toolResult 是否紧跟 toolCall（这才是模型侧「上下文连贯」的判据）。
+//
+// 源文件**不是手写的**：先用今天的生产写入路径（`createAgentContextService.run`）真跑一轮
+// 落一份 v1 文件，再从那份文件读回来。手写一份「像 v1 的 JSON」只能证明我写的假数据和我写的
+// 断言一致。
+import assert from 'node:assert/strict';
+import { join } from 'node:path';
+import { test } from 'node:test';
+import { z } from 'zod';
+import type { AgentMessage, Entry } from '@earendil-works/pi-agent-core';
+
+import type { AgentContextBinding, AgentContextScope } from '../../electron/harness/context/contextBinding.js';
+import { createAgentContextService } from '../../electron/harness/context/contextService.js';
+import { createAgentContextStore } from '../../electron/harness/context/contextStore.js';
+import { runAgentTurn, snapshotCodec } from '../../electron/harness/runtime/pi/nativeLoader.cjs';
+import { importSnapshot } from '../../electron/harness/runtime/pi/snapshot.mjs';
+import { createProjectAgentContextBinding } from '../../electron/shared/contracts/projectAgentContextBinding.js';
+import { createRuntimeFixture } from './httpFixture.mjs';
+import { createLaneFixture } from './laneFixture.mjs';
+import { PROBE_CONTEXT, openProbeLane } from './stage3ProbeHarness.mjs';
+
+const LEGACY_TOOL_RESULT = 'LEGACY_SHOT_RESULT_FROM_THE_OLD_RUNTIME';
+const binding: AgentContextBinding = createProjectAgentContextBinding(
+  { projectId: 'project-1', immutableProjectUuid: '4d80f2e0-4a45-4a8f-8fe1-78ac659177c8', projectGeneration: 3 },
+  'thread-creation',
+);
+const persistent: AgentContextScope = { kind: 'persistent', binding };
+
+/** 一条转录段的身份：类型 + 角色/自定义类型 + 它自己的一句话。刻意不含 id/seq——否则断言在自证。 */
+function shapeOfLegacy(entry: { type: string; message?: { role: string; content: unknown; toolCallId?: string }; customType?: string; summary?: string }): string {
+  if (entry.type === 'message' && entry.message) {
+    const message = entry.message;
+    return `message:${message.role}:${message.toolCallId ?? ''}:${textOf(message.content)}`;
+  }
+  return `custom:nomi.legacy.${entry.type}:${entry.customType ?? ''}`;
+}
+
+function shapeOfLane(entry: Entry): string {
+  if (entry.type === 'message') {
+    const message = entry.message as { role: string; content: unknown; toolCallId?: string };
+    return `message:${message.role}:${message.toolCallId ?? ''}:${textOf(message.content)}`;
+  }
+  if (entry.type === 'custom') return `custom:${entry.customType}:${(entry.data as { customType?: string } | undefined)?.customType ?? ''}`;
+  return `${entry.type}`;
+}
+
+function textOf(content: unknown): string {
+  if (typeof content === 'string') return content;
+  if (!Array.isArray(content)) return '';
+  return content.map((part) => {
+    if (part?.type === 'text') return part.text;
+    if (part?.type === 'toolCall') return `toolCall(${part.name}#${part.id})`;
+    return `[${part?.type}]`;
+  }).join('|');
+}
+
+/** 用**今天的生产写入路径**落一份真实的 v1 文件，再把它的 pi 条目读回来。 */
+async function writeLegacyContext(t: Parameters<typeof createRuntimeFixture>[0]) {
+  const { request, http } = await createRuntimeFixture(t, [
+    { type: 'tool', calls: [{ id: 'legacy-read', name: 'read_shot', arguments: {} }] },
+    { type: 'text', text: 'The shot is recorded.' },
+  ]);
+  request.tools = [{ name: 'read_shot', description: 'Read the current shot once.', schema: z.object({}) }];
+  const file = join(request.cwd, '.nomi', 'agent-thread-context-v1.json');
+  const store = createAgentContextStore({ resolveFile: () => file });
+  const service = createAgentContextService({ store, codec: snapshotCodec, runAgentTurn });
+  const hooks = { emit: () => {}, awaitToolConfirmation: async () => ({ ok: true as const, result: LEGACY_TOOL_RESULT }) };
+  const finished = await service.run(persistent, () => ({ ...request, user: { durableText: 'Read the shot for me.' } }), hooks);
+  assert.equal(finished.status, 'finished');
+  assert.equal(http.requests.length, 2, 'the legacy runtime spent two requests: tool call + closing text');
+  const stored = store.read(binding);
+  assert.ok(stored?.snapshot, 'the v1 file holds a native snapshot');
+  const manager = await importSnapshot(stored.snapshot, request);
+  return { entries: manager.getEntries() as Array<{ type: string; message?: { role: string; content: unknown; toolCallId?: string }; customType?: string; summary?: string }>, request };
+}
+
+test('P2 ① · a real v1 file replays entry by entry into a lane and survives close → reopen in the same order', async (t) => {
+  const legacy = await writeLegacyContext(t);
+  const source = legacy.entries.map(shapeOfLegacy);
+  assert.ok(source.some((line) => line.startsWith('message:toolResult:legacy-read')), 'the source really contains a tool pair');
+
+  const laneFixture = await createLaneFixture(t, [{ type: 'text', text: 'Continuing from the old conversation.' }]);
+  const first = await openProbeLane(t, laneFixture.options);
+  for (const entry of legacy.entries) {
+    if (entry.type === 'message' && entry.message) {
+      await first.lane.appendMessage(entry.message as AgentMessage, PROBE_CONTEXT);
+      continue;
+    }
+    // 非消息条目（model_change / compaction / custom_message …）：P2 轻量只验「能落、顺序在」，
+    // 迁移时各自怎么改写（§2.1 三档）不在这里裁。
+    await first.lane.appendCustomEntry(`nomi.legacy.${entry.type}`, entry.customType ? { customType: entry.customType } : undefined, PROBE_CONTEXT);
+  }
+  const { sessionId } = first;
+  await first.close();
+
+  const reopened = await openProbeLane(t, laneFixture.options, { sessionId });
+  const watch = await reopened.lane.watch(PROBE_CONTEXT);
+  t.after(() => watch.unsubscribe());
+  const replayed = watch.snapshot.transcript.map(shapeOfLane);
+  assert.deepEqual(replayed, source, 'segment count and order after reopen equal the v1 source');
+  console.log(`[P2] replayed ${replayed.length} entries: ${replayed.map((line) => line.split(':').slice(0, 2).join(':')).join(' → ')}`);
+
+  // ② 回填之后再跑一轮：供应商收到的历史里 toolResult 紧跟它的 toolCall。
+  const run = await reopened.lane.prompt('Continue.', undefined, PROBE_CONTEXT);
+  assert.ok(run.ok, `the continued turn settles: ${run.ok ? '' : JSON.stringify(run.error)}`);
+  const wire = laneFixture.http.requests[0]?.body as { messages: Array<{ role: string; content?: unknown; tool_calls?: Array<{ id: string }>; tool_call_id?: string }> };
+  const callIndex = wire.messages.findIndex((message) => message.role === 'assistant' && message.tool_calls?.some((call) => call.id === 'legacy-read'));
+  assert.ok(callIndex >= 0, 'the legacy tool call reached the provider');
+  const next = wire.messages[callIndex + 1];
+  assert.equal(next?.role, 'tool', 'the tool result follows its call immediately on the wire');
+  assert.equal(next?.tool_call_id, 'legacy-read');
+  assert.match(JSON.stringify(next?.content), new RegExp(LEGACY_TOOL_RESULT), 'the old result text is what the model reads');
+});
+
+test('P2 ② positive control · pi does NOT validate tool pairing on append: a result appended before its call is stored in that order', async (t) => {
+  // 如果这条也「按顺序」通过，上面那条断言就什么都没证明。这里故意把 toolResult 排在
+  // toolCall 前面：pi 若拒收，`appendMessage` 会抛/返错；实跑它**照单全收**——顺序校验
+  // 不存在，成对与否是迁移脚本自己的责任。
+  const laneFixture = await createLaneFixture(t, [{ type: 'text', text: 'Unreachable.' }]);
+  const probe = await openProbeLane(t, laneFixture.options);
+  const timestamp = 1_700_000_000_000;
+  const result: AgentMessage = { role: 'toolResult', toolCallId: 'orphan', toolName: 'read_shot', content: [{ type: 'text', text: 'early' }], isError: false, timestamp };
+  const call: AgentMessage = {
+    role: 'assistant', content: [{ type: 'toolCall', id: 'orphan', name: 'read_shot', arguments: {} }],
+    api: 'openai-completions', provider: 'nomi-lane', model: 'chosen-model', stopReason: 'toolUse', timestamp,
+    usage: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0, totalTokens: 2, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } },
+  };
+  await assert.doesNotReject(() => probe.lane.appendMessage(result, PROBE_CONTEXT), 'a toolResult with no preceding call is accepted');
+  await assert.doesNotReject(() => probe.lane.appendMessage(call, PROBE_CONTEXT));
+  const entries = (await probe.lane.watch(PROBE_CONTEXT)).snapshot.transcript.map(shapeOfLane);
+  assert.deepEqual(entries.map((line) => line.split(':')[1]), ['toolResult', 'assistant'], 'stored exactly as appended, wrong order and all');
+});

--- a/tests/agent-runtime/stage3-probe-p3-watchdog.test.mts
+++ b/tests/agent-runtime/stage3-probe-p3-watchdog.test.mts
@@ -1,0 +1,85 @@
+// 阶段 3 前置探针 **P3**（方案 §4.3）：lane 无看门狗，以及超时挂上看门狗后会被归成什么。
+//
+// 两个问题，各一条**只写探针不修**的断言（修在 3c，另一位工人并行在做）：
+//   ① 首字节永不返回时，lane 今天**挂死**——用有界等待证明它超过 N 秒仍无结果（阳性对照：
+//      同一条 loopback 挂上 `observeNativeStream` 就会结束）。这是 G3c 「今天会红」的那半。
+//   ② `observeStream.mts:66` 的 `fail()` 走 `controller.abort(error)`。方案 §1.6 预测它「极可能
+//      落成 `aborted` → 永不重试」。实跑记录：stopReason 是什么、`retry_scheduled` 有没有触发、
+//      harness 有没有 fault。这决定 3c 的归一策略。
+//
+// 等待纪律（`check:test-waits`）：这里没有私有 waitFor、没有 Date.now() 截止轮询。
+// ① 的「N 秒仍无结果」是一条**只可能因为看门狗存在而翻红**的断言——机器越慢它越真。
+import assert from 'node:assert/strict';
+import { setTimeout as sleep } from 'node:timers/promises';
+import { test } from 'node:test';
+import type { Provider } from '@earendil-works/pi-ai';
+import type { HarnessEvent } from '@earendil-works/pi-agent-core';
+
+import { openLane } from '../../electron/agentLane/laneHost.mjs';
+import { observeNativeStream } from '../../electron/harness/runtime/pi/observeStream.mjs';
+import { createLaneFixture } from './laneFixture.mjs';
+import { PROBE_CONTEXT, openProbeLane } from './stage3ProbeHarness.mjs';
+
+/** 首字节永不返回：服务器收到请求后**什么都不写**。 */
+const NEVER_FIRST_BYTE = { type: 'deferred' as const, beforeReply: () => new Promise<never>(() => {}) };
+const HANG_PROOF_MS = 5_000;
+
+/** 把 `createNomiProvider` 的产物包进 `observeNativeStream`——3c 要做的那件事，先在测试里做一遍。 */
+function withWatchdog(provider: Provider, firstResponseMs: number): Provider {
+  const watched: Provider = Object.create(provider) as Provider;
+  Object.defineProperty(watched, 'streamSimple', {
+    value: (model: Parameters<Provider['streamSimple']>[0], context: Parameters<Provider['streamSimple']>[1], options?: Parameters<Provider['streamSimple']>[2]) =>
+      observeNativeStream((signal) => provider.streamSimple(model, context, { ...options, signal }), {
+        ...(options?.signal ? { signal: options.signal } : {}), firstResponseMs, idleMs: firstResponseMs,
+      }),
+  });
+  return watched;
+}
+
+test('P3 ① · today the lane has no watchdog: a stream that never sends its first byte hangs the turn', async (t) => {
+  const fixture = await createLaneFixture(t, [NEVER_FIRST_BYTE]);
+  const lane = await openLane(fixture.options);
+  t.after(() => lane.close());
+  const turn = lane.execute({ kind: 'prompt', text: 'Hello?' }).then(() => 'settled' as const);
+  const verdict = await Promise.race([turn, sleep(HANG_PROOF_MS).then(() => 'still-hanging' as const)]);
+  assert.equal(verdict, 'still-hanging', `no watchdog: the turn is still pending after ${HANG_PROOF_MS}ms with the request in flight`);
+  assert.equal(fixture.http.requests.length, 1, 'exactly one request is in flight — nothing retried, nothing timed out');
+  assert.equal(lane.projection().running, true);
+  // 解锁：用户按停止是今天唯一能结束这一轮的东西。
+  await lane.execute({ kind: 'abort' });
+  assert.equal(await turn, 'settled');
+});
+
+test('P3 ① positive control · the same stalled stream ends within the budget once observeNativeStream is on the provider', async (t) => {
+  const fixture = await createLaneFixture(t, [NEVER_FIRST_BYTE, { type: 'text', text: 'Recovered.' }]);
+  const events: HarnessEvent[] = [];
+  const probe = await openProbeLane(t, fixture.options, { wrapProvider: (provider) => withWatchdog(provider, 300) });
+  probe.harness.events.on('retry_scheduled', (event) => { events.push(event); });
+  probe.harness.events.on('retry_end', (event) => { events.push(event); });
+  probe.harness.events.on('fault', (event) => { events.push(event); });
+  const result = await Promise.race([
+    probe.lane.prompt('Hello?', undefined, PROBE_CONTEXT).then((value) => ({ kind: 'settled' as const, value })),
+    sleep(HANG_PROOF_MS).then(() => ({ kind: 'still-hanging' as const })),
+  ]);
+  assert.equal(result.kind, 'settled', 'with the watchdog the turn ends instead of hanging');
+  if (result.kind !== 'settled') return;
+
+  // ② 归一：超时被 pi 记成了什么。
+  const transcript = (await probe.lane.watch(PROBE_CONTEXT)).snapshot.transcript;
+  const assistants = transcript.flatMap((entry) => entry.type === 'message' && entry.message.role === 'assistant' ? [entry.message] : []);
+  const stopReasons = assistants.map((message) => message.stopReason);
+  const scheduled = events.filter((event) => event.type === 'retry_scheduled');
+  const faults = events.filter((event) => event.type === 'fault');
+  assert.deepEqual(faults, [], 'the harness does not fault on a watchdog timeout');
+  // 方案 §1.6 预测「极可能落成 aborted → 永不重试」。实跑推翻了它：`observeNativeStream` 把
+  // 上游流关掉之后**自己**以 `NativeStreamTimeout` 拒绝 `result()`，harness 拿到的是
+  // `stopReason:"error"` + 含 "timeout" 的文本——`isRetryableAssistantError` 认它，于是重试。
+  assert.ok(scheduled.length >= 1, `a retry is scheduled after the timeout; events=${JSON.stringify(events.map((event) => event.type))}`);
+  assert.match(scheduled[0].type === 'retry_scheduled' ? scheduled[0].errorMessage : '', /timeout/i,
+    'the retry reason is the watchdog\'s own sentence, which is what the English regex keys on');
+  assert.equal(stopReasons.includes('aborted'), false, `no assistant message was recorded as aborted: ${JSON.stringify(stopReasons)}`);
+  assert.ok(result.value.ok, `the retried turn finishes: ${result.value.ok ? '' : JSON.stringify(result.value.error)}`);
+  assert.equal(fixture.http.requests.length, 2, 'the second request is the retry that got the queued reply');
+  const finalText = assistants.at(-1)?.content.map((part) => part.type === 'text' ? part.text : '').join('');
+  assert.equal(finalText, 'Recovered.');
+});

--- a/tests/agent-runtime/stage3-probe-p5-real.electron.mts
+++ b/tests/agent-runtime/stage3-probe-p5-real.electron.mts
@@ -1,0 +1,210 @@
+// 阶段 3 前置探针 **P5 ③**：真实模型三次调用，看扁平版 `nomi_storyboard_write` 的**首调**
+// 有没有命中正确的 operation；顺带用「带 / 不带这个工具」两次请求的 prompt_tokens 之差，
+// 量出它在真实 tokenizer 下的 token 成本（① 的估计值只是字符启发式）。
+//
+// **不是测试文件**（没有 `.test.`），要用 Electron 跑：
+//   pnpm exec tsc -p tests/agent-runtime/tsconfig.json
+//   pnpm exec electron .tmp/agent-runtime-tests/tests/agent-runtime/stage3-probe-p5-real.electron.mjs
+// 为什么必须是 Electron 进程：key 走 app 设置的读取路径（`chooseTextModel` →
+// `decryptApiKeyRecord` → `safeStorage`），而 safeStorage 只在 Electron 主进程里活着。
+// 身份要与写入密文的那个 app 一致（`app.setName`，同 `main.ts:116-119` 的理由）。
+//
+// key **不打印、不落盘、不进报告**；输出只有工具名 / operation / token 数。
+// 单次预算：每个任务 ≤ 3 次请求（读画布 + 写分镜 + 兜底），外加 2 次量 token；DeepSeek V4 Flash 级别 ≈ 分毫。
+import { app } from 'electron';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import type { HookHandler, LaneSnapshot } from '@earendil-works/pi-agent-core';
+
+import { canvasLaneToolSpecs, createCanvasLaneTools, type CanvasLanePort } from '../../electron/agentLane/laneCanvasTools.js';
+import { composeLaneSystemPrompt } from '../../electron/agentLane/lanePromptSections.js';
+import type { LaneToolDescriptor } from '../../electron/agentLane/laneRuntimePort.js';
+import type { ApiKeyRecord } from '../../electron/catalog/secrets.js';
+import type { NomiModelConfig } from '../../electron/harness/runtime/runtimePort.js';
+import { PROBE_CONTEXT, openProbeLane, type ProbeCleanup } from './stage3ProbeHarness.mjs';
+
+const VENDOR = process.env.NOMI_PROBE_VENDOR || 'apimart';
+const MODEL = process.env.NOMI_PROBE_MODEL || 'deepseek-v4-flash';
+const STORYBOARD_TOOL = 'nomi_storyboard_write';
+const IDENTITY_PROMPT = [
+  'You are Nomi, the assistant inside a local-first AI video workbench.',
+  'The user is writing a short film. Use the tools to act on the storyboard and canvas; reply in the user\'s language.',
+].join(' ');
+
+const SCRIPT = '林夏站在黄昏的天台上，风把她的校服吹得鼓起来。她走到栏杆边，低头看了很久，然后深吸一口气，转身笑了。';
+
+interface TaskSpec {
+  id: string
+  prompt: string
+  expectedOperation: string
+  /** 画布上已有的分镜节点：patch / arrange 两个任务需要它，模型会先读画布。 */
+  canvasShots: number
+}
+
+const TASKS: readonly TaskSpec[] = [
+  { id: 'propose', prompt: `把下面这段故事拆成 3 个镜头的图片分镜表，一个角色锚点。\n\n${SCRIPT}`, expectedOperation: 'propose_storyboard_plan', canvasShots: 0 },
+  { id: 'patch', prompt: '画布上已经有一张 3 镜的分镜表。把第 2 镜和第 3 镜改成 4 秒的视频镜头，其它不动。', expectedOperation: 'patch_shots', canvasShots: 3 },
+  { id: 'arrange', prompt: '把画布上现有的分镜镜头按故事顺序排到时间轴上。', expectedOperation: 'arrange_storyboard_to_timeline', canvasShots: 3 },
+];
+
+interface FirstCall { toolName: string; operation?: string; args: unknown }
+interface TaskResult {
+  id: string
+  expectedOperation: string
+  calls: FirstCall[]
+  firstStoryboardCall?: FirstCall
+  hit: boolean
+  requests: number
+  promptTokensFirstRequest?: number
+  stopReasons: string[]
+  error?: string
+}
+
+function canvasPort(shots: number): CanvasLanePort {
+  const nodes = Array.from({ length: shots }, (_, index) => ({
+    id: `node-shot-${index + 1}`, kind: 'keyframe', title: `镜 ${index + 1}`, prompt: `Shot ${index + 1} of the rooftop scene.`,
+    status: 'idle', position: { x: index * 320, y: 0 }, locked: false, shotIndex: index + 1, hasResult: false,
+  }));
+  return {
+    read: async () => ({ nodes, edges: [], groups: [], selectedNodeIds: [] }),
+    write: async (input) => ({ applied: true, proposalId: 'probe-proposal', operation: input.operation, result: {}, reconciliation: { ok: true, deviationCount: 0 } } as never),
+  };
+}
+
+/** 今天的 lane 没有看门狗（P3 ①），一次挂死的请求会让探针永远不结束：90s 没回就按停。 */
+async function bounded<T>(promise: Promise<T>, stop: () => Promise<unknown>): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const deadline = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(() => { void stop().catch(() => undefined); reject(new Error('probe request exceeded 90s')); }, 90_000);
+  });
+  try { return await Promise.race([promise, deadline]); } finally { if (timer) clearTimeout(timer); }
+}
+
+function cleanup(): ProbeCleanup & { run(): Promise<void> } {
+  const fns: Array<() => void | Promise<void>> = [];
+  return { after: (fn) => { fns.push(fn); }, run: async () => { for (const fn of fns.reverse()) await fn(); } };
+}
+
+interface CatalogFile {
+  vendors: Array<{ key: string; baseUrlHint?: string; authType: string; providerKind?: string }>
+  models: Array<{ vendorKey: string; modelKey: string; modelAlias?: string | null; kind: string; enabled: boolean }>
+  apiKeysByVendor: Record<string, ApiKeyRecord>
+}
+
+/**
+ * 同一条读取路径：`<userData>/model-catalog.json` → `apiKeysByVendor[vendor]` → `decryptApiKeyRecord`
+ * （safeStorage）。不经 `chooseTextModel`：它的 import 图拖进一串不走 NodeNext 的目录文件，
+ * 这个 tsconfig 编不过；这里只复述它选模型的那三行（同 vendor + 同 modelKey + kind text）。
+ * baseURL 规则照 `vendorModelConnection.ts:resolveSdkBaseUrl`：裸 origin 补 `/v1`。
+ */
+async function resolveModel(): Promise<{ config: NomiModelConfig; label: string }> {
+  const { decryptApiKeyRecord } = await import('../../electron/catalog/secrets.js');
+  const catalog = JSON.parse(await readFile(join(app.getPath('userData'), 'model-catalog.json'), 'utf8')) as CatalogFile;
+  const vendor = catalog.vendors.find((candidate) => candidate.key === VENDOR);
+  const model = catalog.models.find((candidate) => candidate.vendorKey === VENDOR && candidate.modelKey === MODEL && candidate.kind === 'text' && candidate.enabled);
+  if (!vendor || !model) throw new Error(`No enabled text model ${VENDOR}/${MODEL} in the app catalog`);
+  const apiKey = decryptApiKeyRecord(catalog.apiKeysByVendor[VENDOR]);
+  if (!apiKey) throw new Error(`The ${VENDOR} credential is present but this process cannot decrypt it (safeStorage identity mismatch?)`);
+  const base = (vendor.baseUrlHint || '').trim().replace(/\/+$/, '');
+  const url = new URL(base);
+  if (!url.pathname || url.pathname === '/') url.pathname = '/v1';
+  const kind = vendor.providerKind === 'anthropic' ? 'anthropic' : vendor.providerKind === 'openai-responses' ? 'openai-responses' : 'openai-compatible';
+  const config: NomiModelConfig = { kind, providerId: vendor.key, modelId: (model.modelAlias || model.modelKey).trim(), baseURL: url.toString(), authType: 'api-key', apiKey, temperature: 0 };
+  return { config, label: `${vendor.key}/${config.modelId} (${kind} @ ${config.baseURL})` };
+}
+
+async function runTask(config: NomiModelConfig, task: TaskSpec, tools: LaneToolDescriptor[]): Promise<TaskResult> {
+  const scope = cleanup();
+  const calls: FirstCall[] = [];
+  let requests = 0;
+  const beforeTool: HookHandler<'before_tool'> = async (event) => {
+    const args = event.args as { operation?: string } | undefined;
+    const call: FirstCall = { toolName: event.toolName, args: event.args, ...(args?.operation ? { operation: args.operation } : {}) };
+    calls.push(call);
+    // 读画布放行（模型按 guideline 先读是对的）；第一次碰到分镜写入就停——问题已经答了，
+    // 不花第二轮的钱。任何第三次调用也停：本探针每任务最多 3 次请求。
+    if (event.toolName === STORYBOARD_TOOL || calls.length >= 3) {
+      return { block: { reason: 'Probe stop: the first storyboard call has been recorded.', terminate: true } };
+    }
+    return undefined;
+  };
+  try {
+    const probe = await openProbeLane(scope, {
+      projectDir: join(app.getPath('temp'), `nomi-p5-${task.id}-${Date.now()}`),
+      systemPrompt: composeLaneSystemPrompt(IDENTITY_PROMPT, canvasLaneToolSpecs()),
+      model: config, tools,
+    }, { beforeTool });
+    probe.harness.hooks.on('before_request', async () => { requests += 1; return undefined; });
+    mark(`task ${task.id} prompt`);
+    const result = await bounded(probe.lane.prompt(task.prompt, undefined, PROBE_CONTEXT), () => probe.lane.abort(PROBE_CONTEXT));
+    const snapshot: LaneSnapshot = (await probe.lane.watch(PROBE_CONTEXT)).snapshot;
+    const assistants = snapshot.transcript.flatMap((entry) => entry.type === 'message' && entry.message.role === 'assistant' ? [entry.message] : []);
+    const firstStoryboardCall = calls.find((call) => call.toolName === STORYBOARD_TOOL);
+    return {
+      id: task.id, expectedOperation: task.expectedOperation, calls, requests,
+      ...(firstStoryboardCall ? { firstStoryboardCall } : {}),
+      hit: firstStoryboardCall?.operation === task.expectedOperation,
+      ...(assistants[0] ? { promptTokensFirstRequest: assistants[0].usage.input + assistants[0].usage.cacheRead } : {}),
+      stopReasons: assistants.map((message) => message.stopReason),
+      ...(result.ok ? {} : { error: JSON.stringify(result.error) }),
+    };
+  } catch (error) {
+    return { id: task.id, expectedOperation: task.expectedOperation, calls, requests, hit: false, stopReasons: [], error: error instanceof Error ? error.message : String(error) };
+  } finally {
+    await scope.run();
+  }
+}
+
+/** 「回复 ok」一次，只取第一条助手消息的输入 token。带与不带分镜工具各跑一次，差 = 该工具的真实 token 成本。 */
+async function measurePromptTokens(config: NomiModelConfig, tools: LaneToolDescriptor[]): Promise<number> {
+  const scope = cleanup();
+  try {
+    const probe = await openProbeLane(scope, {
+      projectDir: join(app.getPath('temp'), `nomi-p5-measure-${tools.length}-${Date.now()}`),
+      systemPrompt: composeLaneSystemPrompt(IDENTITY_PROMPT, tools), model: config, tools,
+    });
+    await bounded(probe.lane.prompt('只回复 ok。', undefined, PROBE_CONTEXT), () => probe.lane.abort(PROBE_CONTEXT));
+    const snapshot = (await probe.lane.watch(PROBE_CONTEXT)).snapshot;
+    const first = snapshot.transcript.find((entry) => entry.type === 'message' && entry.message.role === 'assistant');
+    if (!first || first.type !== 'message' || first.message.role !== 'assistant') throw new Error('no assistant message');
+    return first.message.usage.input + first.message.usage.cacheRead;
+  } finally {
+    await scope.run();
+  }
+}
+
+const mark = (stage: string) => process.stderr.write(`[p5-real] ${new Date().toISOString()} ${stage}\n`);
+app.setName('nomi');
+app.setPath('userData', join(app.getPath('appData'), 'nomi'));
+// ⚠️ Electron 的 ESM 入口：`ready` 要等入口模块**求值完**才会发（官方 ESM 限制），
+// 所以在顶层 `await app.whenReady()` 会与它互相等——第一版探针就这样挂了 240s 一字不出。
+void app.whenReady().then(main);
+
+async function main(): Promise<void> {
+  mark('ready');
+  const report: Record<string, unknown> = { vendor: VENDOR, model: MODEL, startedAt: new Date().toISOString() };
+  try {
+    const { config, label } = await resolveModel();
+    report.resolved = label;
+    mark(`resolved ${label}`);
+    const withStoryboard = createCanvasLaneTools(canvasPort(3));
+    const withoutStoryboard = withStoryboard.filter((tool) => tool.name !== STORYBOARD_TOOL);
+    const promptWith = await measurePromptTokens(config, withStoryboard);
+    mark(`measured with=${promptWith}`);
+    const promptWithout = await measurePromptTokens(config, withoutStoryboard);
+    mark(`measured without=${promptWithout}`);
+    report.tokenCost = { promptTokensWithStoryboardTool: promptWith, promptTokensWithoutStoryboardTool: promptWithout, storyboardToolTokens: promptWith - promptWithout };
+    const tasks: TaskResult[] = [];
+    for (const task of TASKS) {
+      tasks.push(await runTask(config, task, createCanvasLaneTools(canvasPort(task.canvasShots))));
+      mark(`task ${task.id} done: ${JSON.stringify(tasks.at(-1))}`);
+    }
+    report.tasks = tasks;
+    report.hits = `${tasks.filter((task) => task.hit).length}/${tasks.length}`;
+  } catch (error) {
+    report.fatal = error instanceof Error ? `${error.name}: ${error.message}` : String(error);
+  }
+  report.finishedAt = new Date().toISOString();
+  process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+  app.exit(report.fatal ? 1 : 0);
+}

--- a/tests/agent-runtime/stage3-probe-p5-storyboard-schema.test.mts
+++ b/tests/agent-runtime/stage3-probe-p5-storyboard-schema.test.mts
@@ -1,0 +1,110 @@
+// 阶段 3 前置探针 **P5**（方案 §4.3）的零额度那两半：扁平版 `nomi_storyboard_write`
+// ① 有多大（token）② 三条真机见过的畸形参数经 `prepareArguments` 能不能过。
+// ③（真实模型三次调用、首调 operation 命中率）在 `stage3-probe-p5-real.electron.mts`，
+// 它要 Electron 的 safeStorage 才读得到 app 设置里的 key，不在这个 runner 里跑。
+//
+// ① 的数字是**估计**：pi 自己的 `estimateTokens`（保守的字符启发式）。真实 tokenizer 的数
+// 由 ③ 用「带 / 不带这个工具」两次请求的 prompt_tokens 之差量出来，写进研究文档；这里只钉
+// 「今天的估计值」，让它长大时有人看见。
+// ② 带阳性对照：同一批畸形喂给摘掉 `prepareArguments` 的对照臂，必须红。
+import assert from 'node:assert/strict';
+import { test, type TestContext } from 'node:test';
+import { estimateTokens } from '@earendil-works/pi-agent-core';
+
+import { createCanvasLaneTools, type CanvasLanePort } from '../../electron/agentLane/laneCanvasTools.js';
+import type { LaneToolDescriptor } from '../../electron/agentLane/laneRuntimePort.js';
+import { createLaneTools } from '../../electron/agentLane/laneTools.mjs';
+import { openLane } from '../../electron/agentLane/laneHost.mjs';
+import { createLaneFixture } from './laneFixture.mjs';
+
+const TOOL = 'nomi_storyboard_write';
+/** 方案 §4.3 P5 写的预算。 */
+const TOKEN_BUDGET = 1_200;
+
+const ANCHOR = { id: 'anchor-1', kind: 'character', name: '林夏', description: '17-year-old girl, short black hair, school uniform.', carrier: 'visual' };
+const SHOTS = [
+  { index: 1, shotKind: 'image', durationSec: 0, anchorIds: ['anchor-1'], prompt: 'Wide: she steps onto the rooftop, dusk light behind her.' },
+  { index: 2, shotKind: 'video', durationSec: 4, anchorIds: ['anchor-1'], prompt: 'Slow push-in as she leans on the railing and exhales.' },
+];
+const PLAN = { operation: 'propose_storyboard_plan', title: '天台的三分钟', anchors: [ANCHOR], shots: SHOTS };
+
+/** 三条畸形，都是 #547 §3.2 那一族（结构化值被二次序列化），各打在扁平 schema 的不同层。 */
+const MALFORMED: ReadonlyArray<{ label: string; args: unknown; operation: string }> = [
+  { label: 'A · whole argument object serialized as a JSON string', args: JSON.stringify(PLAN), operation: 'propose_storyboard_plan' },
+  { label: 'B · `anchors` and `shots` arrays serialized as JSON strings', args: { ...PLAN, anchors: JSON.stringify([ANCHOR]), shots: JSON.stringify(SHOTS) }, operation: 'propose_storyboard_plan' },
+  { label: 'B\' · `select` / `patch` objects serialized as JSON strings', args: { operation: 'patch_shots', select: JSON.stringify({ kind: 'indexes', indexes: [2, 3] }), patch: JSON.stringify({ shotKind: 'video', durationSec: 4 }) }, operation: 'patch_shots' },
+];
+
+function port(writes: unknown[]): CanvasLanePort {
+  return {
+    read: async () => ({ nodes: [], edges: [], groups: [], selectedNodeIds: [] }),
+    write: async (input) => {
+      writes.push(input);
+      const base = { applied: true as const, proposalId: 'proposal-1', result: {}, reconciliation: { ok: true, deviationCount: 0 } };
+      if (input.operation === 'patch_shots') return { ...base, operation: 'patch_shots', changedShotIndexes: [2, 3], changedFields: ['shotKind', 'durationSec'] } as never;
+      return { ...base, operation: input.operation } as never;
+    },
+  };
+}
+
+function withoutTolerance(descriptors: readonly LaneToolDescriptor[]): LaneToolDescriptor[] {
+  return descriptors.map(({ prepareArguments: _dropped, ...rest }) => ({ ...rest }));
+}
+
+test('P5 ① · size of the flat nomi_storyboard_write schema, by pi\'s own estimator', () => {
+  const tools = createLaneTools(createCanvasLaneTools(port([])));
+  const storyboard = tools.find((tool) => tool.name === TOOL);
+  assert.ok(storyboard, `${TOOL} is on the lane`);
+  const estimate = (text: string) => estimateTokens({ role: 'user', content: [{ type: 'text', text }], timestamp: 0 });
+  const schema = JSON.stringify(storyboard.parameters);
+  const schemaTokens = estimate(schema);
+  const descriptionTokens = estimate(storyboard.description);
+  console.log(`[P5①] ${TOOL}: schema ${schema.length} chars ≈ ${schemaTokens} tokens · description ${storyboard.description.length} chars ≈ ${descriptionTokens} tokens · total ≈ ${schemaTokens + descriptionTokens} (budget ${TOKEN_BUDGET})`);
+  for (const tool of tools) {
+    const size = estimate(JSON.stringify(tool.parameters)) + estimate(tool.description);
+    console.log(`[P5①]   ${tool.name}: ≈ ${size} tokens`);
+  }
+  const properties = Object.keys((storyboard.parameters as { properties: Record<string, unknown> }).properties);
+  assert.deepEqual(properties, ['operation', 'title', 'anchors', 'shots', 'select', 'patch', 'nodeIds'], 'flat root: one enum + every branch field as optional');
+  // 钉住今天的数：估计值已经**超过**方案写的 1 200。这不是让测试红，是让它在长得更大、
+  // 或有人把预算当成已达成时红。真实 tokenizer 的数见 ③ 与研究文档。
+  assert.ok(schemaTokens + descriptionTokens > TOKEN_BUDGET, `pi's estimate (${schemaTokens + descriptionTokens}) is over the §4.3 budget of ${TOKEN_BUDGET} — recorded as red in the probe report`);
+  assert.ok(schemaTokens + descriptionTokens < 2_200, 'and it has not grown past the value the probe report was written against');
+});
+
+async function firstCallSucceeds(t: TestContext, arm: 'with-tolerance' | 'without-tolerance', args: unknown) {
+  const writes: unknown[] = [];
+  const tools = createCanvasLaneTools(port(writes));
+  const fixture = await createLaneFixture(t, [
+    { type: 'tool', calls: [{ id: 'first', name: TOOL, arguments: args }] },
+    { type: 'text', text: 'Done.' },
+  ]);
+  const lane = await openLane({ ...fixture.options, tools: arm === 'with-tolerance' ? tools : withoutTolerance(tools) });
+  t.after(() => lane.close());
+  await lane.execute({ kind: 'prompt', text: 'Save the storyboard.' });
+  const result = lane.projection().parts.find((part) => part.kind === 'tool-result' && part.toolCallId === 'first');
+  assert.ok(result?.kind === 'tool-result');
+  return { ok: !result.isError, text: result.text, writes };
+}
+
+for (const shape of MALFORMED) {
+  test(`P5 ② · ${shape.label} passes prepareArguments → ajv → contract parse, and lands on the right operation`, async (t) => {
+    const treated = await firstCallSucceeds(t, 'with-tolerance', shape.args);
+    assert.equal(treated.ok, true, `first call is not an error: ${treated.text}`);
+    assert.equal(treated.writes.length, 1, 'exactly one write reached the domain port');
+    const written = treated.writes[0] as { operation: string; anchors?: unknown; shots?: unknown; select?: unknown; patch?: unknown };
+    assert.equal(written.operation, shape.operation);
+    if (written.operation === 'propose_storyboard_plan') {
+      assert.ok(Array.isArray(written.anchors) && Array.isArray(written.shots), 'the arrays arrive as arrays, not JSON text');
+      assert.deepEqual(written.shots, SHOTS);
+    } else {
+      assert.deepEqual(written.select, { kind: 'indexes', indexes: [2, 3] });
+      assert.deepEqual(written.patch, { shotKind: 'video', durationSec: 4 });
+    }
+
+    // 阳性对照：没有容忍钩子，同一条调用必须被拒——否则上面那个绿证明不了容忍在起作用。
+    const control = await firstCallSucceeds(t, 'without-tolerance', shape.args);
+    assert.equal(control.ok, false, 'the control arm (no prepareArguments) rejects the same call');
+    assert.equal(control.writes.length, 0, 'and nothing reached the domain port');
+  });
+}

--- a/tests/agent-runtime/stage3ProbeHarness.mts
+++ b/tests/agent-runtime/stage3ProbeHarness.mts
@@ -1,0 +1,97 @@
+// 阶段 3 前置探针（方案 §4.3）的**裸 lane 夹具**。
+//
+// `openLane`（`laneHost.mts`）故意只露 `prompt` / `abort` 两条命令——那是产品面。探针要问的
+// 是 pi 自己的行为：`steer` / `abort` 带回什么、`resume` 对停在预检里的调用做什么、
+// `appendMessage` 会不会拒收乱序的 toolResult。这些都在 `AgentLane` 上，产品面**不该**露它们。
+//
+// 所以这里把 `laneHost.mts` 的装配步骤原样复述一遍（同一个 session repo、同一个 provider、
+// 同一个 `createLaneTools`），只是把 `lane` 与 `harness` 本体交出来。它**不是**第二个宿主：
+// 不投影、不存转录、不做闸——探针自己在 `before_tool` 上挂它要问的东西。
+import { AgentHarness, type AgentLane, type HookHandler } from '@earendil-works/pi-agent-core';
+import { BACKGROUND_CONTEXT, type Context } from '@earendil-works/pi-agent-core/harness/context';
+import { createModels, type Provider } from '@earendil-works/pi-ai';
+
+import { createNomiProvider } from '../../electron/harness/runtime/pi/model.mjs';
+import { createLaneTools } from '../../electron/agentLane/laneTools.mjs';
+import { openLaneSession } from '../../electron/agentLane/laneSession.mjs';
+import type { OpenLaneOptions } from '../../electron/agentLane/laneRuntimePort.js';
+import { LANE_SYSTEM_PROMPT } from './laneFixture.mjs';
+
+export const PROBE_CONTEXT: Context = BACKGROUND_CONTEXT;
+
+/**
+ * `node:test` 的 `t.after` 就够了；把参数收窄到这一个方法，是为了 P5③ 那个**不在测试
+ * runner 里跑**的真实模型探针（Electron 进程，要 safeStorage 才解得开 app 设置里的 key）
+ * 也能复用同一套装配，而不是再抄一份 `AgentHarness.create`。
+ */
+export interface ProbeCleanup {
+  after(fn: () => void | Promise<void>): void
+}
+
+export interface ProbeLane {
+  harness: AgentHarness<undefined>
+  lane: AgentLane
+  sessionId: string
+  /** 正常关闭：关 harness、交还 repo 持有权。P1③ 的「崩溃」臂**故意不调它**。 */
+  close(): Promise<void>
+}
+
+export interface ProbeLaneOptions {
+  /** 复用一条落盘会话（P1③ 重开、P2 迁移后重开走这里）。 */
+  sessionId?: string
+  /** 在 `createNomiProvider` 的产物外面再包一层（P3② 用它挂看门狗）。 */
+  wrapProvider?(provider: Provider): Provider
+  beforeTool?: HookHandler<'before_tool'>
+}
+
+export async function openProbeLane(
+  t: ProbeCleanup, options: Omit<OpenLaneOptions, 'gate'>, probe: ProbeLaneOptions = {},
+): Promise<ProbeLane> {
+  const { session, sessionId, release } = await openLaneSession(
+    { projectDir: options.projectDir, ...(probe.sessionId ? { sessionId: probe.sessionId } : {}) }, PROBE_CONTEXT,
+  );
+  const { provider, model, credentials } = await createNomiProvider(options.model);
+  const models = createModels({ credentials });
+  models.setProvider(probe.wrapProvider ? probe.wrapProvider(provider) : provider);
+  const tools = createLaneTools(options.tools);
+  const { harness } = await AgentHarness.create<undefined>({
+    session, models, model, systemPrompt: options.systemPrompt || LANE_SYSTEM_PROMPT, tools,
+    activeToolNames: tools.map((tool) => tool.name),
+    toolExecution: 'sequential',
+  }, PROBE_CONTEXT);
+  const lane = await harness.lane(options.laneName ?? 'main', PROBE_CONTEXT);
+  if (probe.beforeTool) harness.hooks.on('before_tool', probe.beforeTool);
+  let closing: Promise<void> | undefined;
+  const close = () => closing ??= (async () => {
+    await harness.close(PROBE_CONTEXT);
+    await release(PROBE_CONTEXT);
+  })();
+  t.after(() => close());
+  return { harness, lane, sessionId, close };
+}
+
+/** 一个外部可 resolve 的 promise：探针用它把「钩子进来了」这件事交给测试主体，不用墙钟等。 */
+export function deferred<T = void>(): { promise: Promise<T>; resolve: (value: T) => void; reject: (error: unknown) => void } {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((yes, no) => { resolve = yes; reject = no; });
+  return { promise, resolve, reject };
+}
+
+/** `AbortSignal` → 一个在 abort 时**拒绝**的 promise（拒绝理由 = `signal.reason`）。 */
+export function rejectOnAbort(signal: AbortSignal | undefined): Promise<never> {
+  return new Promise<never>((_resolve, reject) => {
+    if (!signal) return;
+    if (signal.aborted) { reject(signal.reason); return; }
+    signal.addEventListener('abort', () => reject(signal.reason), { once: true });
+  });
+}
+
+/** `AbortSignal` → 一个在 abort 时**兑现**的 promise。 */
+export function resolveOnAbort(signal: AbortSignal | undefined): Promise<void> {
+  return new Promise<void>((resolve) => {
+    if (!signal) return;
+    if (signal.aborted) { resolve(); return; }
+    signal.addEventListener('abort', () => resolve(), { once: true });
+  });
+}


### PR DESCRIPTION
## 方案

`docs/plan/2026-09-07-agent-rebuild-stage3-5-deep-plan.md` **§4.3「最可能逼我们再返工的五处 + 便宜探针」**（P1 / P2 轻量 / P3 / P5 / P6；P4 不在本轮）。母方案 `docs/plan/2026-09-07-agent-runtime-rebuild.md`。阶段 1/2 已合（#567、#591）。

**只含探针（进仓库当阳性对照）+ 一份实跑记录**：[`docs/research/2026-09-07-agent-lane-stage3-probes.md`](docs/research/2026-09-07-agent-lane-stage3-probes.md)。唯一的产品代码改动是 P6 逼出来的一处投影修正（单独 commit `a983e3f19`）。

## 验收门逐条（方案 §4.3 那一列）

| 探针 | 结果 | 裁决 |
|---|---|---|
| P1 ① 等待期 `status==="running"` / `runningTools` 空 / `queues` 见 `write` | 🟡 绿但词表不同：pi 0.85.1 快照**从不**产出 `running`，等待期是 `open`；其余全对，零请求在飞 | **不翻方案 B**；§1.2/§4.3 把 `running` 改成 `open`，「在等你」由宿主 `LaneProjection.pending` 投影 |
| P1 ② `abort()` 打断 race → `abortedOutcome` + `AbortResult` 带回 steer | ✅ | gate 必须 **resolve**-on-abort；reject 会被 `hooks.js:121-125` 洗成 `block.reason`（"Abort requested"） |
| P1 ③ 不 close 直接丢 → `resume()` 得 `interruptedOutcome` | 🔴 真崩溃（子进程 SIGKILL）后 `resume()` **再问一次 `before_tool`**，放行就真跑；不合成 interrupted | **恢复文案改**：不是「重启前等你确认的动作没有执行」，而是这张确认卡重启后再弹一次（或宿主在 resume 前 block） |
| P1 ⊕ 钩子抛异常 = block | ✅ 阳性对照 | — |
| P3 ① 首字节永不返回 → lane 今天挂死 | 🔴（预期中的红，G3c 先红） | 3c 落地时这条自然翻绿 |
| P3 ② `observeStream.mts:66` 的 `fail()` 后 stopReason | 🟢 **推翻 §1.6 预测**：不是 `aborted`，是 `error` + "timeout" → `retry_scheduled` 触发、重试成功、无 fault | 3c **只做「挂上」**，不要另写归一层 |
| P5 ① 扁平 schema ≤ 1 200 token | 🔴 pi 估计 1 892；DeepSeek V4 Flash 真实 tokenizer **2 170** | 是上下文成本不是正确率问题；放进阶段 3 三行显形后再决定瘦身 |
| P5 ② 3 条畸形经 `prepareArguments` | ✅（对照臂全红） | — |
| P5 ③ 3 次真实调用首调 operation | ✅ **3/3**（建表 / 改行 / 排时间轴，每次先 `nomi_canvas_read` 再 `nomi_storyboard_write`，operation 全对） | **阶段 2 不回炉** |
| P6 3 个夹具改 `LaneSnapshot` 驱动 + `check:design-lab` | 🟡 `input-streaming` 逐像素相等；`output-denied` 红 → **投影错**（行尾印理由 + 多展开体）→ 修投影后逐像素相等；`output-available` 缺摘要与用时两个数据源 → 保持手写、缺口钉进结构测试；审批等待中无法由快照驱动（P1 ①） | 基线 PNG 一张未动 |
| P2 轻量 · 逐条回填 → close → 重开顺序 = 源 | ✅ 6/6；再跑一轮供应商收到的 `tool` 紧跟 `tool_calls` | pi **不校验成对**（阳性对照）——迁移脚本自己负责 |

**对 3a / 3c 的建议**：3a 继续 A，三条修正（词 `open`、resolve-on-abort、崩溃恢复=再问一次）；3c 只挂 `observeNativeStream` 进 `createNomiProvider()`。详见研究文档 §0。

## R30 数字

- 零额度：`test:agent-runtime` **216/216**（#591 基线 204 + 12 条探针）。
- 真实模型：`apimart/deepseek-v4-flash`，首调 operation 命中 **3/3**；8 次请求 ≈ 4.8 万 prompt token ≈ ¥0.05。key 走 app 设置读取路径（Electron 进程 + safeStorage），不打印不落盘。

## 删旧清单

无（探针 PR；投影修正是行为修正，不是替换实现）。

## 遗留（明标）

- P4 花费行未做。
- P2 未验压缩条目 / PDF custom_message 改写后的模型连贯性、#8939 无 header 错误路径。
- P5 ③ 单模型 × 3 任务 × 1 次，不是统计。
- P6 `v4-tool-output-available` / 空态 / 审批等待三格仍手写或旧 store 驱动；阶段 3 要补 `tool-result` 的 `elapsedMs` 与每能力摘要渲染点。
- `delivery:preflight` 在脏工作区跳过；分支与 `origin/main` 对齐（0 behind）。

## 验证

- `pnpm run gates` 本地：全绿（72/72 contracts · unit + agent-runtime 216/216 · build），五门戳 sha=f74879390；第一轮唯一红是 `check:vocabularies`（实验室格子的 `pick` 字面量 union），改成传快照构造器后复跑全绿
- P6 像素半：`NOMI_DESIGN_LAB_UPDATE=1 npx playwright test … --update-snapshots=none --grep "v4-tool-(input-streaming|output-available|output-denied)"` 3/3 ✅（第一轮 denied 红 → 修投影 → 第二轮全绿）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
