### PR TITLE
fix(devlab): 实验室夹具跟上三行投影签名（修 main 的类型红）

### DIFF
--- a/src/devlab/designLab/v4/laneDrivenFixtures.test.ts
+++ b/src/devlab/designLab/v4/laneDrivenFixtures.test.ts
@@ -10,6 +10,7 @@ import {
   laneSnapshotToolDenied,
   laneSnapshotToolDone,
   laneSnapshotToolRunning,
+  LAB_MODEL_FACTS,
 } from './laneDrivenFixtures'
 
 const labels: LaneViewModelLabels = {
@@ -17,16 +18,19 @@ const labels: LaneViewModelLabels = {
   thinkingLabel: '正在想…',
   formatTokens: (value) => String(value),
   formatCost: (usd) => `$${usd.toFixed(2)}`,
+  unknown: '—',
+  free: '免费',
 }
 
 describe('design-lab fixtures driven by a LaneSnapshot (probe P6)', () => {
   it('empty: an empty transcript projects to no items, not running, and no invented ceiling/cost', () => {
     const empty = { ...laneSnapshotToolRunning(), transcript: [], tipId: null, operation: null }
-    const model = laneViewModel(projectLaneSnapshot(empty), labels)
+    const model = laneViewModel(projectLaneSnapshot(empty, LAB_MODEL_FACTS), labels)
     expect(model.items).toEqual([])
     expect(model.running).toBe(false)
     expect(model.usage.max).toBeUndefined()
-    expect(model.usage.cost).toBeUndefined()
+    // 3b 三态：没登记价目的模型 → 花费「不可知」→ 渲染占位符，不是 0、也不是整行消失（那会像「这项不存在」）。
+    expect(model.usage.cost).toBe(labels.unknown)
     // `AgentPanelV4Panel` renders `V4EmptyState` on `flow.length === 0`; the surface-derived
     // starter chips are the shell's, so the pixel half of this cell waits for a lane-driven shell (stage 4).
   })

--- a/src/devlab/designLab/v4/laneDrivenFixtures.ts
+++ b/src/devlab/designLab/v4/laneDrivenFixtures.ts
@@ -87,7 +87,7 @@ export function laneSnapshotToolDenied(reason: string): LaneSnapshot {
  * 三行（阶段 3b）要的模型侧事实。收据格只看工具那一行，花费/上下文/推理都不进画面，
  * 所以价目给 `'unpriced'`（花费=「不可知」）、不给 contextWindow——和真实「没登记价目的模型」一个形状。
  */
-const LAB_MODEL_FACTS: LaneModelFacts = {
+export const LAB_MODEL_FACTS: LaneModelFacts = {
   model: {
     provider: 'nomi-lane', id: 'lab-model', name: 'lab-model', api: 'openai-completions', baseUrl: 'http://127.0.0.1/v1',
     reasoning: false, input: ['text'], cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }, contextWindow: 0, maxTokens: 0,

--- a/src/devlab/designLab/v4/laneDrivenFixtures.ts
+++ b/src/devlab/designLab/v4/laneDrivenFixtures.ts
@@ -15,7 +15,7 @@
 import type { LaneSnapshot } from '@earendil-works/pi-agent-core'
 import type { AssistantMessage } from '@earendil-works/pi-ai'
 import { LANE_APPROVAL_NOTE_TYPE } from '../../../../electron/shared/agentLane/laneContracts'
-import { projectLaneSnapshot } from '../../../../electron/agentLane/laneProjection.mjs'
+import { projectLaneSnapshot, type LaneModelFacts } from '../../../../electron/agentLane/laneProjection.mjs'
 import { laneViewModel, type LaneViewModelLabels } from '../../../workbench/ai/lane/laneViewModel'
 import type { ToolReceipt } from '../../../workbench/ai/v4/agentPanelV4Types'
 
@@ -83,8 +83,20 @@ export function laneSnapshotToolDenied(reason: string): LaneSnapshot {
 }
 
 /** 两层投影真的跑一遍，取出那一行收据。 */
+/**
+ * 三行（阶段 3b）要的模型侧事实。收据格只看工具那一行，花费/上下文/推理都不进画面，
+ * 所以价目给 `'unpriced'`（花费=「不可知」）、不给 contextWindow——和真实「没登记价目的模型」一个形状。
+ */
+const LAB_MODEL_FACTS: LaneModelFacts = {
+  model: {
+    provider: 'nomi-lane', id: 'lab-model', name: 'lab-model', api: 'openai-completions', baseUrl: 'http://127.0.0.1/v1',
+    reasoning: false, input: ['text'], cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }, contextWindow: 0, maxTokens: 0,
+  },
+  pricing: 'unpriced',
+}
+
 export function laneDrivenReceipt(lane: LaneSnapshot, labels: LaneViewModelLabels): ToolReceipt {
-  const model = laneViewModel(projectLaneSnapshot(lane), labels)
+  const model = laneViewModel(projectLaneSnapshot(lane, LAB_MODEL_FACTS), labels)
   const tool = model.items.find((item) => item.kind === 'tool')
   if (!tool || tool.kind !== 'tool') throw new Error('the lane snapshot projected no tool receipt')
   return tool.receipt

--- a/src/devlab/designLab/v4/states/01-vocabulary.tsx
+++ b/src/devlab/designLab/v4/states/01-vocabulary.tsx
@@ -104,6 +104,10 @@ function LaneReceiptCell({ lane }: { lane: (rejectReason: string) => LaneSnapsho
     thinkingLabel: fx.t('agentPanelV4.thinkingLabel'),
     formatTokens: (value) => String(value),
     formatCost: (usd) => `$${usd.toFixed(2)}`,
+    // 三行的两个占位词。这一格只画工具收据，花费/上下文行不进画面；占位词走已有的 contextUnknown，
+    // 「免费」那句不预放死键（3b 的裁决），这里同样借占位符——它在这一格永远不会被渲染。
+    unknown: fx.t('agentPanelV4.contextUnknown'),
+    free: fx.t('agentPanelV4.contextUnknown'),
   })
   return (
     <Piece>


### PR DESCRIPTION
## 为什么
#605（三行三态）改了 `projectLaneSnapshot` 的签名并给 labels 加了 `unknown/free`；#608（探针 P6）的实验室夹具基于更早的 main 写成。两个 PR 各自 CI 绿，合在一起 main 的 `tsc -p tsconfig.devlab.json` 红（`laneDrivenFixtures.ts:87`、`states/01-vocabulary.tsx:102`），后续每个 PR 的 Contracts 都跟着红。

## 改动
夹具补一份「没登记价目的模型」形状的 `LaneModelFacts`；收据格的 labels 补两个占位词（该格永远不渲染花费行）。零行为变化，基线不动。

## 根因
主线合并快于单个 PR 的 CI；同一批文件的两个 PR 分别绿不等于合起来绿。合并队列在合前该对 `origin/main` 重跑一次 Contracts（`update-branch` 只在 DIRTY/BEHIND 时触发）——记入 lessons。

🤖 Generated with [Claude Code](https://claude.com/claude-code)