### PR TITLE
fix(test): preserve MCP capability directory in shared launcher

### DIFF
--- a/docs/fixes/2026-09-09-packaged-mcp-smoke-capability-dir.root-cause.json
+++ b/docs/fixes/2026-09-09-packaged-mcp-smoke-capability-dir.root-cause.json
@@ -1,0 +1,103 @@
+{
+  "schema_version": 3,
+  "id": "2026-09-09-packaged-mcp-smoke-capability-dir",
+  "problem_type": "Derived launcher defaults overwrite caller environment configuration",
+  "symptom": "Packaged MCP claude resources/list times out after 15 seconds before the lane is reached.",
+  "direct_cause": "launchNomiApp derives a separate capability directory despite env.NOMI_CAPABILITY_DIR; buildNomiLaunchEnv overwrites the supplied env, separating GUI advert/token from helper discovery.",
+  "class_root": "Explicit capability configuration and derived isolation defaults lack a single precedence boundary shared by directory creation, launch env and returned handle.",
+  "affected_population": [
+    "Packaged MCP smoke and any walkthrough coordinating GUI and helper through env.NOMI_CAPABILITY_DIR"
+  ],
+  "scope_paths": [
+    "tests/ux/_launchApp.mjs",
+    "tests/ux/packaged-mcp-smoke.e2e.mjs",
+    "scripts/check-e2e-launch.mjs"
+  ],
+  "entry_points": [
+    "launchNomiApp(options) for smoke, walkthroughs and evals"
+  ],
+  "external_sources": [],
+  "internal_only_reason": "Internal test harness precedence; no external format, SDK or production protocol changes.",
+  "invariants": [
+    "Explicit capabilityDir > caller env > inherited env > isolated derived directory; mkdir, GUI env and returned capabilityDir agree.",
+    "With no configuration and isolate:false, no capability directory is derived."
+  ],
+  "generality_proof": "All scanned launchNomiApp callers converge before mkdir and buildNomiLaunchEnv. Defaults are selected only after supplied configuration, so helper-sharing callers need no local workaround.",
+  "shared_boundaries": [
+    {
+      "path": "tests/ux/_launchApp.mjs",
+      "symbol": "launchNomiApp",
+      "responsibility": "Resolve capability directory once before creating directories and composing Electron launch options."
+    }
+  ],
+  "same_class_entry_points": [
+    {
+      "path": "tests/ux/packaged-mcp-smoke.e2e.mjs",
+      "entry_point": "launchNomiApp env plus smokeClient helper env",
+      "disposition": "enforced",
+      "evidence": "Both pass the same intended capabilityDir; red run printed different GUI/helper directories."
+    },
+    {
+      "path": "tests/ux/plan-gate.walk.mjs",
+      "entry_point": "launchNomiApp env.NOMI_CAPABILITY_DIR",
+      "disposition": "enforced",
+      "evidence": "capDir is shared by GUI and stdio MCP client; same launcher previously overwrote it."
+    },
+    {
+      "path": "tests/ux/mcp-lease-project-binding.e2e.mjs",
+      "entry_point": "launchNomiApp options.capabilityDir",
+      "disposition": "enforced",
+      "evidence": "Explicit option already bypassed the bug; precedence test preserves that supported input."
+    }
+  ],
+  "recurrence": {
+    "classification": "recurring",
+    "reason": "Every future env-based caller or inherited configuration can reproduce the override, independently of app version or client identity.",
+    "same_class_scan": [
+      "rg -n NOMI_CAPABILITY_DIR tests/ux evals: independently checked packaged smoke, plan-gate, mcp-client-activation and _mcpJourney.",
+      "Read buildNomiLaunchEnv and launchNomiApp: override occurs after extraEnv and after independent tempRoot derivation."
+    ]
+  },
+  "prevention": {
+    "kind": "centralized-boundary",
+    "enforcement_path": "tests/ux/_launchApp.mjs",
+    "invariant": "Resolve supplied capability configuration before deriving isolation defaults.",
+    "failure_mode": "Configured paths propagate unchanged; invalid filesystem paths fail at directory creation rather than silently selecting a different isolated directory.",
+    "exception_policy": "none",
+    "strategy": "Replace unconditional isolated derivation at the shared launch boundary; check:e2e-launch runs node assembly regression on every contracts run.",
+    "artifacts": [
+      "tests/ux/_launchApp.mjs",
+      "scripts/check-e2e-launch.mjs"
+    ]
+  },
+  "regression_tests": [
+    "scripts/e2e-launch-capability.node-test.mjs",
+    "tests/ux/packaged-mcp-smoke.e2e.mjs"
+  ],
+  "class_regression_tests": [
+    "scripts/e2e-launch-capability.node-test.mjs"
+  ],
+  "legacy_paths": {
+    "status": "removed",
+    "removed_paths": [
+      "tests/ux/_launchApp.mjs"
+    ],
+    "rationale": "Removed the env-blind capability directory derivation; no parallel launch path or caller workaround added."
+  },
+  "dependency_lifecycle": {
+    "decision": "not-applicable",
+    "rationale": "This is repository-owned test assembly, not Electron or Playwright behavior; same existing app used before and after.",
+    "exit_criteria": []
+  },
+  "migration": "No user data or package migration. Existing env and explicit-option callers use the shared resolution automatically.",
+  "residual_risks": [
+    "No production helper defect was observed after correcting assembly. This test does not certify paid provider generation or lane performance."
+  ],
+  "invariant_owner_layer": {
+    "layer": "tests/ux/_launchApp.mjs",
+    "tests": [
+      "scripts/e2e-launch-capability.node-test.mjs"
+    ],
+    "why": "The launcher assembles configuration for all callers and owns precedence before mkdir/spawn. The regression mocks only Electron launch and checks the actual composed env and returned directory."
+  }
+}

--- a/docs/lessons/INDEX.md
+++ b/docs/lessons/INDEX.md
@@ -61,6 +61,7 @@
 
 ## B. 测试与 CI 的红绿判读
 
+- [启动器默认值不能覆盖调用配置](launcher-defaults-must-not-override-env.md) — GUI 已起但 MCP resources/list 超时：先打印双方 capabilityDir；默认派生只能在显式参数与 env 都未配置时发生。
 - [测试目录必须等资源真正关闭后再删](fixture-teardown-must-await-resource-owners.md) — node:test 红后挂死、临时目录 ENOTEMPTY、kill-only 清理。
 - [停掉一个 agent ≠ 现场清空：子 agent 还在写、哨兵还在跑](stopping-an-agent-leaves-children-and-sentinels.md) — B · TaskStop 只停一个；先 ListAgents 停子 agent，再 pgrep 杀 until 循环，证明无写入后才派接力写手
 

--- a/docs/lessons/iso-walkthrough-key-seeding-traps.md
+++ b/docs/lessons/iso-walkthrough-key-seeding-traps.md
@@ -11,7 +11,7 @@
 
 2. **别手拷设置文件自拼隔离环境**：真实设置根下除 `model-catalog.json` 还有 `provider-adapters.json`、`generation-model-defaults.json`（文本大脑选择）、`system-prompts.json` 等，**漏一个就出「No local text model is configured」这类像 key 坏了的假象**。用 `evals/lib/isoApp.mjs` 的 `prepareIsolation`（付费验收已验证它 + dev electron 能解真 catalog 的 safeStorage key）。
 
-3. **隔离必须四路全设**：`NOMI_ELECTRON_USER_DATA_DIR` / `NOMI_SETTINGS_DIR` / `NOMI_PROJECTS_DIR` / **`NOMI_CAPABILITY_DIR`**。最后这个 `_launchApp` / `ui-driver` 都不管，**漏了会和真实 Nomi 抢 `~/.nomi/capability-core` 的 advert/token，串库**。
+3. **隔离必须四路全设**：`NOMI_ELECTRON_USER_DATA_DIR` / `NOMI_SETTINGS_DIR` / `NOMI_PROJECTS_DIR` / **`NOMI_CAPABILITY_DIR`**。共享 `_launchApp` 已为隔离实例派生 capability 目录；若另起 MCP helper，仍须给双方同一个目录，不能各自派生。2026-09-09 起启动器按显式参数 > env > 派生解析（此前 env 会被派生值覆盖，见 [启动器默认值不能覆盖调用配置](launcher-defaults-must-not-override-env.md)）。绕开共享启动器且漏设会与真实 Nomi 抢 `~/.nomi/capability-core` 的 advert/token，串库。
 
 ## 另外两条
 

--- a/docs/lessons/launcher-defaults-must-not-override-env.md
+++ b/docs/lessons/launcher-defaults-must-not-override-env.md
@@ -1,0 +1,14 @@
+# 启动器默认值不能覆盖调用配置
+
+> 教训 · 2026-09-09 · 状态：现行
+> 触发：打包 MCP initialize/tools/list 正常，resources/list 超时；或启动器与子进程共享目录。
+
+先打印 GUI 实际环境和 helper 读的目录。设置过 NOMI_CAPABILITY_DIR 不等于进程收到它：共享启动器曾另建 tempRoot，并把派生 capabilityDir 放在 extraEnv 后覆盖。GUI advert/token 与 helper 分家，首个 invoke 落在发现/冷启等待，15s 超时不能据此归咎 lane。
+
+在共享 launchNomiApp 边界统一解析：显式参数 > 调用 env > 继承 env > 隔离派生。mkdir、GUI env、返回 handle 都消费同一个值。不要要求每个调用者改传参绕过坏默认值，也不要增加 timeout。
+
+证据：2026-09-09 同一 switch-gate 现成包，修前 GUI=`packaged-mcp-smoke-m3ODIw/capability`，helper=`nomi-packaged-mcp-smoke-vTGpCm/capability`，claude resources/list 15s 超时；修后目录一致，25 tools / 34 resources，三签名身份通过，未签名写拒绝。
+
+防复发：`scripts/e2e-launch-capability.node-test.mjs` 直接调用真实启动器，仅 mock Electron spawn，验证实际 env、返回目录与 mkdir；由 `check:e2e-launch` 在 contracts 每次执行。env 与继承 env 两例先红，修后全绿。
+
+相关：[隔离实例的 key / 设置组装三坑](iso-walkthrough-key-seeding-traps.md)。

--- a/docs/plan/2026-09-09-packaged-mcp-smoke-capability-dir.md
+++ b/docs/plan/2026-09-09-packaged-mcp-smoke-capability-dir.md
@@ -1,0 +1,24 @@
+# 打包 MCP 冒烟 capability 目录装配修复
+
+状态：实施中。范围仅 tests/ux、scripts、docs；不改生产代码、不重打包、不安装 app。
+
+真实摩擦：GUI 已启动但 helper 找不到它，resources/list 在发现/冷启阶段先撞 15s 超时。
+共享启动器把调用方 env 指定的 capability 目录覆盖成新临时目录，导致 advert 与 token 分家。
+
+方案：在 launchNomiApp 单点按显式 capabilityDir > 调用 env > 继承 env > 隔离派生目录解析，返回值、mkdir、GUI env 同源。未隔离且无配置时不派生。保留必需 E2E 环境保护。
+先查别人：本仓 _launchApp.mjs 的目录装配与 packaged-mcp-smoke.e2e.mjs 的 helper env 是直接证据；plan-gate.walk.mjs、mcp-client-activation.walk.mjs、_mcpJourney.mjs 有同类 env 调用。无外部协议或框架变更，不涉及第三方升级。
+
+步骤：同一个现成 app 打印 GUI/helper 目录并复现红；node:test mock Electron spawn 捕获真实启动参数，先红后绿；共享边界修复；原包冒烟与启动/走查门岗；schema-v3 合同与教训；contracts 后提交 PR。
+验收：env 不覆盖、显式参数优先、继承 env、无配置隔离派生/非隔离不派生；三签名客户端资源读取和完整 smoke 绿，未签名写拒绝仍成立。
+回滚：整体 revert 本次 scoped commit；不迁移用户数据。包内 helper 若另有真 bug 只报告，不修改。
+
+验证证据（2026-09-09）：本 worktree 执行 build:electron 只生成 smoke 期望目录模块，未打包/安装 app；现成 switch-gate Nomi.app 修前 resources/list 15s 红且打印目录分离，修后 25 tools / 34 resources / 7885 chars，claude/codex/cursor/external 通过，未签名写拒绝。node:test 原始 5 例中 env/inherited 两例先红，修后 5/5 绿。日志保留于 .tmp/packaged-smoke-{red,green}.log、.tmp/capability-node-{red,green}.log。
+
+
+## 先查别人
+
+- 仓库已有唯一装配边界：[launchNomiApp](../../tests/ux/_launchApp.mjs) 的目录解析与 buildNomiLaunchEnv。复用此边界，不增加第二份启动器；故障由本仓默认值覆盖顺序决定，外部 SDK 不负责这条规则。
+- 仓库已有双进程调用：[packaged smoke](../../tests/ux/packaged-mcp-smoke.e2e.mjs) 与 [plan-gate](../../tests/ux/plan-gate.walk.mjs) 均给 GUI/helper 同一个 env 目录。两条独立入口证明应修共享装配，不能只改 smoke 参数。
+- 仓库已有规避例：[mcp-lease-project-binding](../../tests/ux/mcp-lease-project-binding.e2e.mjs) 用显式 capabilityDir 避开覆盖。保留优先级并删除过期的“env 不可用”说明；[隔离教训](../lessons/iso-walkthrough-key-seeding-traps.md) 同步更新。
+
+结论：用已有启动器恢复配置优先级，不引入依赖或格式。本次没有生态选型、自研通用能力或外部协议变化，外部文档和自媒体无法裁决内部路径装配；不声称做过无关联网调研。

--- a/scripts/check-e2e-launch.mjs
+++ b/scripts/check-e2e-launch.mjs
@@ -5,6 +5,7 @@
 // 干等到超时、零截图、零提示，排查时像脚本自己写错了（两条死法见 tests/ux/_launchApp.mjs 文件头）。
 // 而 eslint.config.mjs 把 tests/ux/** 整个 ignore 了，现有五门**没有任何一道**能看见这片地。
 // 没有这道门，改完照样会有人再抄一份坏的进来。
+import { spawnSync } from 'node:child_process'
 import fs from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -53,3 +54,8 @@ if (offenders.length) {
 }
 
 console.log('✅ check:e2e-launch —— 无直接 electron.launch 调用（全部走 _launchApp.mjs）')
+
+// Exercise launchNomiApp assembly as well as banning alternate launch paths.
+const regression = spawnSync(process.execPath, ['--test', path.join(repoRoot, 'scripts/e2e-launch-capability.node-test.mjs')], { stdio: 'inherit' })
+if (regression.error) throw regression.error
+if (regression.status !== 0) process.exit(regression.status ?? 1)

--- a/scripts/e2e-launch-capability.node-test.mjs
+++ b/scripts/e2e-launch-capability.node-test.mjs
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { test } from 'node:test'
+import { _electron as electron } from 'playwright'
+import { launchNomiApp } from '../tests/ux/_launchApp.mjs'
+
+// Exercise the real assembly boundary; replace only the expensive Electron spawn.
+for (const scenario of ['env', 'explicit', 'inherited', 'derived', 'non-isolated']) {
+  test(`capability directory has one source: ${scenario}`, async (t) => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'nomi-launch-capability-'))
+    t.after(() => fs.rmSync(root, { recursive: true, force: true }))
+    const inherited = process.env.NOMI_CAPABILITY_DIR
+    delete process.env.NOMI_CAPABILITY_DIR
+    t.after(() => {
+      if (inherited === undefined) delete process.env.NOMI_CAPABILITY_DIR
+      else process.env.NOMI_CAPABILITY_DIR = inherited
+    })
+    const options = {
+      tempRoot: root,
+      executablePath: '/fixture/Nomi',
+      waitForWindow: false,
+      env: {},
+    }
+    let expected
+    if (scenario === 'env' || scenario === 'explicit') {
+      options.env.NOMI_CAPABILITY_DIR = path.join(root, 'shared')
+      process.env.NOMI_CAPABILITY_DIR = path.join(root, 'inherited')
+      expected = options.env.NOMI_CAPABILITY_DIR
+    }
+    if (scenario === 'explicit') {
+      options.capabilityDir = path.join(root, 'explicit')
+      expected = options.capabilityDir
+    }
+    if (scenario === 'inherited') {
+      process.env.NOMI_CAPABILITY_DIR = path.join(root, 'inherited')
+      expected = process.env.NOMI_CAPABILITY_DIR
+    }
+    if (scenario === 'derived') expected = path.join(root, 'capability')
+    if (scenario === 'non-isolated') options.isolate = false
+    let launched
+    t.mock.method(electron, 'launch', async (launchOptions) => {
+      launched = launchOptions
+      return { process: () => ({}) }
+    })
+    const handle = await launchNomiApp(options)
+    assert.equal(launched.env.NOMI_CAPABILITY_DIR, expected)
+    assert.equal(handle.capabilityDir, expected ?? null)
+    if (expected) assert.ok(fs.statSync(expected).isDirectory())
+    if (scenario !== 'derived') assert.equal(fs.existsSync(path.join(root, 'capability')), false)
+  })
+}

--- a/tests/ux/_launchApp.mjs
+++ b/tests/ux/_launchApp.mjs
@@ -168,7 +168,7 @@ export function withPackagedPlaywrightOrigin(args, isPackaged) {
  * @param {string} [options.userDataDir]    单独指定（默认 <tempRoot>/user-data）
  * @param {string} [options.settingsDir]    单独指定（默认 <tempRoot>/settings）
  * @param {string} [options.projectsDir]    单独指定（默认 <tempRoot>/projects）
- * @param {string} [options.capabilityDir]  单独指定（默认 <tempRoot>/capability）
+ * @param {string} [options.capabilityDir]  优先于 env.NOMI_CAPABILITY_DIR；均未设时隔离实例派生 <tempRoot>/capability
  * @param {number} [options.testedCatalogVersion]  被测构建的 catalog 版本；默认读取仓库 canonical manifest
  * @param {number} [options.timeout]        等窗口上限（ms）
  * @param {number} [options.settleMs=1500]  domcontentloaded 后再等一会儿（渲染层挂载）
@@ -211,7 +211,11 @@ export async function launchNomiApp(options = {}) {
   const userDataDir = isolate ? (options.userDataDir ?? path.join(tempRoot, 'user-data')) : null
   const settingsDir = isolate ? (options.settingsDir ?? path.join(tempRoot, 'settings')) : null
   const projectsDir = isolate ? (options.projectsDir ?? path.join(tempRoot, 'projects')) : null
-  const capabilityDir = isolate ? (options.capabilityDir ?? path.join(tempRoot, 'capability')) : null
+  // GUI advert/token 与 helper 发现目录必须同源；显式配置优先，最后才派生隔离默认值。
+  const capabilityDir = options.capabilityDir
+    ?? extraEnv.NOMI_CAPABILITY_DIR
+    ?? process.env.NOMI_CAPABILITY_DIR
+    ?? (isolate ? path.join(tempRoot, 'capability') : null)
 
   // 只建目录，**绝不清空**：不少走查会在起飞前往 projectsDir/settingsDir 里预埋工程或 catalog
   //（如 toolbar-order.walk.mjs 先写好 project.json 再启动）。启动器擅自 rm 会把它们的前置条件擦掉。

--- a/tests/ux/mcp-lease-project-binding.e2e.mjs
+++ b/tests/ux/mcp-lease-project-binding.e2e.mjs
@@ -69,8 +69,7 @@ try {
     userDataDir: dirs.userDataDir,
     settingsDir: dirs.settingsDir,
     projectsDir: dirs.projectsDir,
-    // capabilityDir 必须走**选项**：buildNomiLaunchEnv 把 NOMI_CAPABILITY_DIR 放在 extraEnv 之后，
-    // 从 env 传会被启动器自己那份覆盖掉，MCP 客户端和 app 于是各读各的 token（ENOENT）。
+    // 显式 capabilityDir 与 env 均由共享启动器解析；GUI 与 MCP 客户端使用同一目录。
     capabilityDir: dirs.capabilityDir,
     args: ['--disable-gpu', '--disable-software-rasterizer'],
     settleMs: 0,

--- a/tests/ux/packaged-mcp-smoke.e2e.mjs
+++ b/tests/ux/packaged-mcp-smoke.e2e.mjs
@@ -275,6 +275,9 @@ try {
     projectsDir: path.join(tempRoot, 'projects'),
     env: { NOMI_CAPABILITY_DIR: capabilityDir },
   })
+  const guiCapabilityDir = await gui.app.evaluate(() => process.env.NOMI_CAPABILITY_DIR)
+  console.log(`PACKAGED MCP capabilityDir: GUI=${guiCapabilityDir}; helper=${capabilityDir}`)
+  assert(guiCapabilityDir === capabilityDir && gui.capabilityDir === capabilityDir, 'GUI and helper capability directories agree')
   const evidence = []
   for (const client of clients) evidence.push(await smokeClient(client))
   evidence.push(await smokeClient('generic', { signed: false }))


### PR DESCRIPTION
## 问题与修复

打包 MCP smoke 仅经 env 传 capabilityDir；共享启动器另派生目录并覆盖 env，GUI advert/token 与 helper 发现目录分离，导致 claude resources/list 在发现/冷启阶段撞 15s 超时。

launchNomiApp 现在按显式参数 > 调用 env > 继承 env > 隔离派生解析，mkdir、GUI env 与返回 handle 同源。新增 node:test 直接验证真实启动装配，并接入 check:e2e-launch；smoke 打印并断言双方实际目录一致。附 schema-v3 recurring 合同及教训，修正旧的调用者规避说明。仅修改测试、脚本和文档，无生产代码或包内容变动。

## 验证

- 同一现成 switch-gate Nomi.app：修前目录不一致、claude resources/list 15s 超时；修后 25 tools / 34 resources / director body 7885 chars，claude/codex/cursor/external 全通过，未签名写入仍拒绝。零供应商调用。
- node:test：env/inherited 两例先红，修后 5/5 通过；check:e2e-launch、check:walkthroughs、check:root-cause-contracts 通过。
- gates:contracts：75 项，72 通过 / 0 阻断失败 / 3 advisory 提醒；退出码 0。
- 全量 pnpm run test：Vitest 1289 个文件、11987 条通过（1 文件、2 条跳过）；另有 327 条 Node/Agent 测试通过。
- 方案：docs/plan/2026-09-09-packaged-mcp-smoke-capability-dir.md。既有包实跑替代重打包；只执行 build:electron 生成 smoke 期望模块，没有安装 app。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
