### PR TITLE
test: C0 视频终态等待与无参考卡修补方案

### DIFF
--- a/docs/plan/sweep-evidence/c0-video-wait-green.log
+++ b/docs/plan/sweep-evidence/c0-video-wait-green.log
@@ -1,0 +1,34 @@
+feel record: g1-c0/waitForFunction.png; findings=5; new-surfaces=1; evidence: /Users/aoqimin/Desktop/Nomi-sweep-b/artifacts/feel/g1-c0-4451d39c-34b4-4f82-a1a5-73e780b57cc8
+feel record: g1-c0/00.png; findings=5; new-surfaces=1; evidence: /Users/aoqimin/Desktop/Nomi-sweep-b/artifacts/feel/g1-c0-4451d39c-34b4-4f82-a1a5-73e780b57cc8
+feel record: g1-c0/waitForFunction.png; findings=5; new-surfaces=0; evidence: /Users/aoqimin/Desktop/Nomi-sweep-b/artifacts/feel/g1-c0-4451d39c-34b4-4f82-a1a5-73e780b57cc8
+feel record: g1-c0/01.png; findings=5; new-surfaces=1; evidence: /Users/aoqimin/Desktop/Nomi-sweep-b/artifacts/feel/g1-c0-4451d39c-34b4-4f82-a1a5-73e780b57cc8
+feel record: g1-c0/waitForFunction.png; findings=21; new-surfaces=1; evidence: /Users/aoqimin/Desktop/Nomi-sweep-b/artifacts/feel/g1-c0-4451d39c-34b4-4f82-a1a5-73e780b57cc8
+feel record: g1-c0/C0-e1f7e732-02-approval.png; findings=21; new-surfaces=2; evidence: /Users/aoqimin/Desktop/Nomi-sweep-b/artifacts/feel/g1-c0-4451d39c-34b4-4f82-a1a5-73e780b57cc8
+feel record: g1-c0/waitForFunction.png; findings=36; new-surfaces=2; evidence: /Users/aoqimin/Desktop/Nomi-sweep-b/artifacts/feel/g1-c0-4451d39c-34b4-4f82-a1a5-73e780b57cc8
+feel record: g1-c0/02.png; findings=36; new-surfaces=3; evidence: /Users/aoqimin/Desktop/Nomi-sweep-b/artifacts/feel/g1-c0-4451d39c-34b4-4f82-a1a5-73e780b57cc8
+feel record: g1-c0/waitForFunction.png; findings=97; new-surfaces=0; evidence: /Users/aoqimin/Desktop/Nomi-sweep-b/artifacts/feel/g1-c0-4451d39c-34b4-4f82-a1a5-73e780b57cc8
+feel record: g1-c0/03.png; findings=97; new-surfaces=3; evidence: /Users/aoqimin/Desktop/Nomi-sweep-b/artifacts/feel/g1-c0-4451d39c-34b4-4f82-a1a5-73e780b57cc8
+feel record: g1-c0/waitForFunction.png; findings=38; new-surfaces=0; evidence: /Users/aoqimin/Desktop/Nomi-sweep-b/artifacts/feel/g1-c0-4451d39c-34b4-4f82-a1a5-73e780b57cc8
+feel record: g1-c0/C0-e1f7e732-04-submitted.png; findings=38; new-surfaces=3; evidence: /Users/aoqimin/Desktop/Nomi-sweep-b/artifacts/feel/g1-c0-4451d39c-34b4-4f82-a1a5-73e780b57cc8
+C0_VIDEO_PROGRESS {"waitedMs":0,"ready":6,"failed":0,"total":8,"budget":600000}
+C0_VIDEO_PROGRESS {"waitedMs":30801,"ready":6,"failed":0,"total":8,"budget":600000}
+C0_VIDEO_PROGRESS {"waitedMs":61398,"ready":6,"failed":0,"total":8,"budget":600000}
+C0_VIDEO_PROGRESS {"waitedMs":91892,"ready":6,"failed":0,"total":8,"budget":600000}
+C0_VIDEO_PROGRESS {"waitedMs":122368,"ready":6,"failed":0,"total":8,"budget":600000}
+C0_VIDEO_PROGRESS {"waitedMs":152868,"ready":6,"failed":0,"total":8,"budget":600000}
+C0_VIDEO_PROGRESS {"waitedMs":183489,"ready":6,"failed":0,"total":8,"budget":600000}
+C0_VIDEO_PROGRESS {"waitedMs":189230,"ready":8,"failed":0,"total":8,"budget":600000,"final":true}
+feel record: g1-c0/waitForFunction.png; findings=91; new-surfaces=0; evidence: /Users/aoqimin/Desktop/Nomi-sweep-b/artifacts/feel/g1-c0-4451d39c-34b4-4f82-a1a5-73e780b57cc8
+feel record: g1-c0/04.png; findings=88; new-surfaces=4; evidence: /Users/aoqimin/Desktop/Nomi-sweep-b/artifacts/feel/g1-c0-4451d39c-34b4-4f82-a1a5-73e780b57cc8
+feel record: g1-c0/waitForFunction.png; findings=91; new-surfaces=0; evidence: /Users/aoqimin/Desktop/Nomi-sweep-b/artifacts/feel/g1-c0-4451d39c-34b4-4f82-a1a5-73e780b57cc8
+feel record: g1-c0/05.png; findings=91; new-surfaces=2; evidence: /Users/aoqimin/Desktop/Nomi-sweep-b/artifacts/feel/g1-c0-4451d39c-34b4-4f82-a1a5-73e780b57cc8
+feel record: g1-c0/waitForFunction.png; findings=99; new-surfaces=0; evidence: /Users/aoqimin/Desktop/Nomi-sweep-b/artifacts/feel/g1-c0-4451d39c-34b4-4f82-a1a5-73e780b57cc8
+feel record: g1-c0/06.png; findings=92; new-surfaces=3; evidence: /Users/aoqimin/Desktop/Nomi-sweep-b/artifacts/feel/g1-c0-4451d39c-34b4-4f82-a1a5-73e780b57cc8
+feel record: g1-c0/waitForFunction.png; findings=90; new-surfaces=2; evidence: /Users/aoqimin/Desktop/Nomi-sweep-b/artifacts/feel/g1-c0-11e8e844-b61c-408c-8cc7-e7f2bea8bd79
+feel record: g1-c0/07.png; findings=90; new-surfaces=2; evidence: /Users/aoqimin/Desktop/Nomi-sweep-b/artifacts/feel/g1-c0-11e8e844-b61c-408c-8cc7-e7f2bea8bd79
+C0 collected-deviations; evidence: /Users/aoqimin/Desktop/Nomi-sweep-b/artifacts/sweep/c0-video-wait-green; paid calls: 0
+
+GREEN_RECEIPT {"result": "collected-deviations", "functionalDeviations": 0, "feelDeviations": 504, "exportSeconds": "64.000000", "exportSha256": "760d8f6370e3b032f445462135bcc48c2d63d5cee93331d2c49657fa821f6e1b", "frames": {"first.png": "2c475ced49729abdf79f704ebb868c610322ac037cd40a3b028a252f09914183", "middle.png": "50e7d6b3da2401043803ff53e05a0ad973f8066f7ea73223b1a1d5dda6db9b94", "last.png": "08c04448baeab8ef0ed9f7036bda39e570445b280c2dcf3212ef4ca15afd7e46"}}
+VISUAL_REVIEW: first/middle/last PNG inspected: distinct expected loopback test patterns, final frame timecode 00:00:07.000 of eighth clip. These prove export continuity and decoding only, not real story/identity quality.
+FULL_SWEEP_RECEIPT {"ledger": "artifacts/sweep/2026-09-09T01-00-44.689Z/report.md", "completedCases": 33, "functionalDeviations": [], "feelFindings": 5912, "exitCode": 0}
+GATES_RECEIPT {"command": "python3 scripts/with-gates-lock.py -- pnpm run gates", "exitCode": 0, "log": "artifacts/sweep/c0-video-wait-gates.log", "sha256": "9d79d3778970a6d26bc76d437c185a6617462c996aca0a869ffd0517c32a7877", "contracts": "76 total; 73 passed; 0 blocking; 3 advisory", "vitest": "12083 passed; 2 skipped"}

--- a/docs/plan/sweep-evidence/c0-video-wait-plan.md
+++ b/docs/plan/sweep-evidence/c0-video-wait-plan.md
@@ -1,0 +1,22 @@
+# C0 视频等待测试装配
+
+状态：已实现并通过本地验证，待 PR 评审。
+
+范围：仅 tests/ux/g1 与测试装配；不改生产。按任务书第四轮总账簇 B 执行。
+证据：~/Desktop/Nomi-switch-gate/artifacts/sweep/gate4b-20260909/nano/deviations.json。
+症状：180 秒只齐 6/8，继续读取缺失 result.url 异常，05/06 级联不可达。
+根因（recurring）：装配以固定完成数等待，collect 软断言失败后消费方仍假设所有产物存在。
+同类入口：04 的 ready 计数与结果读取；05 的八镜入轴消费；02 修补跨真实/loopback 模型的档案。
+共享边界：测试侧视频终态等待与结果筛选；记录缺失/失败而不把它当成功，保留完整八镜断言。
+依赖：not-applicable，不升级库或新增框架。现有 Playwright poll 与生产节点/任务持久化状态为事实源。
+红证：loopback 第 7/8 镜响应延迟 190 秒，原等待和消费代码不动。绿证：相同延迟重跑，必须导出三帧，再全量 sweep。
+验收：类级回归、全量 sweep 零功能偏差、完整 gates exit 0、hooks 正常 commit/push、PR。
+回滚：撤回本任务测试装配提交。
+
+补充事实：直接把 HTTP 响应挂起会先撞到生产 120s transport timeout，因此红绿夹具使用已有 APIMart create→query 形状（electron/catalog/apimartVendor.ts:45–80），并同时设置 provider_meta_mapping（electron/runtime.ts:302–310/414）。前两次夹具装配失败保留在 artifacts/sweep，不能当目标红证。
+原结果表达式的崩溃以真实 pending-result-snapshot.json 重放证明；纯 loopback 调度器还会等待审片，可能在读 URL 前等到视频，所以与真实供应商即时账本快照的后置行为必须区分。
+
+重跑绿证（同一工作目录）：
+`NOMI_WALK_MODE=collect NOMI_SWEEP_CASE_DIR=$PWD/artifacts/sweep/c0-video-wait-green-recheck NOMI_C0_VIDEO_DELAYS='{"7":190000,"8":190000}' node tests/ux/g1/c0-short-film.walk.mjs --dry-run`
+红证原版源码固定为 `e1f7e7329f14ceded007082dd348449da4d08aaf:tests/ux/g1/c0-short-film.walk.mjs`，复制到同目录临时 `.walk.mjs` 后以相同参数运行。临时文件在验证后删除，不留旧实现。
+绿证必须读 deviations.json 的功能断言，不能把 collect 进程 exit 0 当验收通过；feel:* 原样保留，不归本测试装配修改。

--- a/docs/plan/sweep-evidence/c0-video-wait-red.log
+++ b/docs/plan/sweep-evidence/c0-video-wait-red.log
@@ -1,0 +1,38 @@
+feel record: g1-c0/waitForFunction.png; findings=5; new-surfaces=1; evidence: /Users/aoqimin/Desktop/Nomi-sweep-b/artifacts/feel/g1-c0-ca522f83-a475-4a05-8190-ccad0677c8ed
+feel record: g1-c0/00.png; findings=5; new-surfaces=1; evidence: /Users/aoqimin/Desktop/Nomi-sweep-b/artifacts/feel/g1-c0-ca522f83-a475-4a05-8190-ccad0677c8ed
+feel record: g1-c0/waitForFunction.png; findings=5; new-surfaces=0; evidence: /Users/aoqimin/Desktop/Nomi-sweep-b/artifacts/feel/g1-c0-ca522f83-a475-4a05-8190-ccad0677c8ed
+feel record: g1-c0/01.png; findings=5; new-surfaces=1; evidence: /Users/aoqimin/Desktop/Nomi-sweep-b/artifacts/feel/g1-c0-ca522f83-a475-4a05-8190-ccad0677c8ed
+feel record: g1-c0/waitForFunction.png; findings=21; new-surfaces=1; evidence: /Users/aoqimin/Desktop/Nomi-sweep-b/artifacts/feel/g1-c0-ca522f83-a475-4a05-8190-ccad0677c8ed
+feel record: g1-c0/C0-e1f7e732-02-approval.png; findings=21; new-surfaces=2; evidence: /Users/aoqimin/Desktop/Nomi-sweep-b/artifacts/feel/g1-c0-ca522f83-a475-4a05-8190-ccad0677c8ed
+feel record: g1-c0/waitForFunction.png; findings=36; new-surfaces=2; evidence: /Users/aoqimin/Desktop/Nomi-sweep-b/artifacts/feel/g1-c0-ca522f83-a475-4a05-8190-ccad0677c8ed
+feel record: g1-c0/02.png; findings=36; new-surfaces=3; evidence: /Users/aoqimin/Desktop/Nomi-sweep-b/artifacts/feel/g1-c0-ca522f83-a475-4a05-8190-ccad0677c8ed
+feel record: g1-c0/waitForFunction.png; findings=97; new-surfaces=0; evidence: /Users/aoqimin/Desktop/Nomi-sweep-b/artifacts/feel/g1-c0-ca522f83-a475-4a05-8190-ccad0677c8ed
+feel record: g1-c0/03.png; findings=97; new-surfaces=3; evidence: /Users/aoqimin/Desktop/Nomi-sweep-b/artifacts/feel/g1-c0-ca522f83-a475-4a05-8190-ccad0677c8ed
+feel record: g1-c0/waitForFunction.png; findings=38; new-surfaces=0; evidence: /Users/aoqimin/Desktop/Nomi-sweep-b/artifacts/feel/g1-c0-ca522f83-a475-4a05-8190-ccad0677c8ed
+feel record: g1-c0/C0-e1f7e732-04-submitted.png; findings=38; new-surfaces=3; evidence: /Users/aoqimin/Desktop/Nomi-sweep-b/artifacts/feel/g1-c0-ca522f83-a475-4a05-8190-ccad0677c8ed
+feel record: g1-c0/waitForFunction.png; findings=92; new-surfaces=0; evidence: /Users/aoqimin/Desktop/Nomi-sweep-b/artifacts/feel/g1-c0-ca522f83-a475-4a05-8190-ccad0677c8ed
+feel record: g1-c0/04.png; findings=88; new-surfaces=4; evidence: /Users/aoqimin/Desktop/Nomi-sweep-b/artifacts/feel/g1-c0-ca522f83-a475-4a05-8190-ccad0677c8ed
+feel record: g1-c0/waitForFunction.png; findings=91; new-surfaces=0; evidence: /Users/aoqimin/Desktop/Nomi-sweep-b/artifacts/feel/g1-c0-ca522f83-a475-4a05-8190-ccad0677c8ed
+feel record: g1-c0/05.png; findings=91; new-surfaces=2; evidence: /Users/aoqimin/Desktop/Nomi-sweep-b/artifacts/feel/g1-c0-ca522f83-a475-4a05-8190-ccad0677c8ed
+feel record: g1-c0/waitForFunction.png; findings=98; new-surfaces=0; evidence: /Users/aoqimin/Desktop/Nomi-sweep-b/artifacts/feel/g1-c0-ca522f83-a475-4a05-8190-ccad0677c8ed
+feel record: g1-c0/06.png; findings=91; new-surfaces=2; evidence: /Users/aoqimin/Desktop/Nomi-sweep-b/artifacts/feel/g1-c0-ca522f83-a475-4a05-8190-ccad0677c8ed
+feel record: g1-c0/waitForFunction.png; findings=90; new-surfaces=2; evidence: /Users/aoqimin/Desktop/Nomi-sweep-b/artifacts/feel/g1-c0-960e8d41-9379-4614-90fa-bbf803911ca5
+feel record: g1-c0/07.png; findings=90; new-surfaces=2; evidence: /Users/aoqimin/Desktop/Nomi-sweep-b/artifacts/feel/g1-c0-960e8d41-9379-4614-90fa-bbf803911ca5
+C0 collected-deviations; evidence: /Users/aoqimin/Desktop/Nomi-sweep-b/artifacts/sweep/c0-video-wait-red-poll; paid calls: 0
+inal result expression replay on real loopback pending snapshot: TypeError: Cannot read properties of undefined (reading 'url')
+    at eval (eval at <anonymous> (file:///Users/aoqimin/Desktop/Nomi-sweep-b/[eval1]:14:7), <anonymous>:3:44)
+    at Array.every (<anonymous>)
+    at eval (eval at <anonymous> (file:///Users/aoqimin/Desktop/Nomi-sweep-b/[eval1]:14:7), <anonymous>:3:14)
+    at file:///Users/aoqimin/Desktop/Nomi-sweep-b/[eval1]:14:56
+    at ModuleJob.run (node:internal/modules/esm/module_job:430:25)
+    at process.processTicksAndRejections (node:internal/process/task_queues:103:5)
+    at async onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:268:26)
+    at async ModuleLoader.executeModuleJob (node:internal/modules/esm/loader:265:20)
+    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:101:5)
+
+TARGET RED: original station 04: Expected 8, Received 6; Timeout 180000ms exceeded. Source: artifacts/sweep/c0-video-wait-red-poll/deviations.json
+RESULT READ RED: original n.result.url expression on actual 6/8 pending snapshot throws Cannot read properties of undefined (reading 'url'). Source: artifacts/sweep/c0-video-wait-red-poll/pending-result-snapshot.json
+
+RED RECEIPT: original source e1f7e7329f14ceded007082dd348449da4d08aaf:tests/ux/g1/c0-short-film.walk.mjs; loopback videoDelayMs={7:190000,8:190000}.
+Original full walk returned collect exit 0 with station 04 Expected 8 / Received 6 / Timeout 180000ms. A collect exit 0 is not a passing assertion.
+Original n.result.url replay against pending-result-snapshot.json: TypeError: Cannot read properties of undefined (reading 'url'). The loopback scheduler waits for review completion after timeout; the real scheduler only snapshots billing, so this consumer failure is independently demonstrated on the pending snapshot.

--- a/tests/ux/g1/c0-fixture.mjs
+++ b/tests/ux/g1/c0-fixture.mjs
@@ -23,10 +23,10 @@ export const shots = [
 
 // These are deliberately synthetic motion/audio test signals, NOT a pre-made film.
 // Each request selects its own shot; results enter the project only through generation.
-export async function createC0Fixture(rootDir, settingsDir, mediaDir) {
+export async function createC0Fixture(rootDir, settingsDir, mediaDir, { videoDelayMs = {} } = {}) {
   const text = await createAgentRuntimeFixture({ rootDir, settingsDir })
   const calls = []
-  const sockets = new Set()
+  const sockets = new Set(), tasks = new Map()
   let server
   try {
     fs.mkdirSync(mediaDir, { recursive: true })
@@ -41,6 +41,15 @@ export async function createC0Fixture(rootDir, settingsDir, mediaDir) {
     })
     server = http.createServer(async (req, res) => {
       try {
+        if (req.method === 'GET' && req.url.startsWith('/v1/tasks/')) {
+          const id = req.url.split('/').at(-1), task = tasks.get(id)
+          if (!task) { res.writeHead(404).end(); return }
+          const ready = performance.now() >= task.readyAt
+          res.writeHead(200, { 'Content-Type': 'application/json' })
+          res.end(JSON.stringify({ data: { id, status: ready ? 'completed' : 'processing',
+            ...(ready ? { result: { videos: [{ url: [results[task.index]] }] } } : {}) } }))
+          return
+        }
         const chunks = []
         for await (const chunk of req) chunks.push(chunk)
         const body = JSON.parse(Buffer.concat(chunks).toString('utf8'))
@@ -52,6 +61,13 @@ export async function createC0Fixture(rootDir, settingsDir, mediaDir) {
           return
         }
         calls.push(index + 1)
+        if (videoDelayMs[index + 1]) {
+          const taskId = `c0-delayed-${index + 1}`
+          tasks.set(taskId, { index, readyAt: performance.now() + videoDelayMs[index + 1] })
+          res.writeHead(200, { 'Content-Type': 'application/json' })
+          res.end(JSON.stringify({ data: [{ status: 'submitted', task_id: taskId }] }))
+          return
+        }
         res.writeHead(200, { 'Content-Type': 'application/json' })
         res.end(JSON.stringify({ data: [{ url: results[index] }] }))
       } catch {
@@ -80,7 +96,11 @@ export async function createC0Fixture(rootDir, settingsDir, mediaDir) {
       create: { method: 'POST', path: '/v1/videos/generations',
         headers: { 'Content-Type': 'application/json' },
         body: { model: '{{model.modelKey}}', prompt: '{{request.prompt}}' },
-        response_mapping: { video_url: 'data.0.url' } } })
+        response_mapping: { video_url: 'data.0.url', task_id: 'data.0.task_id' },
+        provider_meta_mapping: { task_id: 'data.0.task_id' } },
+      query: { method: 'GET', path: '/v1/tasks/{{providerMeta.task_id}}',
+        response_mapping: { task_id: 'data.id', status: 'data.status', video_url: 'data.result.videos.0.url.0' } },
+      statusMapping: { queued: ['submitted'], running: ['processing'], succeeded: ['completed'], failed: ['failed'] } })
     fs.writeFileSync(catalogFile, JSON.stringify(catalog))
     return { text, calls, async close() {
       await text.close()
@@ -99,11 +119,15 @@ export async function createC0Fixture(rootDir, settingsDir, mediaDir) {
 
 // Provider behavior only; the walk owns every UI action and domain assertion.
 export async function createDryScheduler(root, settingsDir, mediaDir, report) {
-  const fixture = await createC0Fixture(root, settingsDir, mediaDir)
+  const videoDelayMs = JSON.parse(process.env.NOMI_C0_VIDEO_DELAYS ?? '{}')
+  report.videoFixtureDelays = videoDelayMs
+  const fixture = await createC0Fixture(root, settingsDir, mediaDir, { videoDelayMs })
   let plan, done
   const planId = 'c0-plan-1', reviews = []
   return {
     model: MODEL,
+    async videoWaitQuote() { return { requests: shots.map(s => ({ model: MODEL, duration: s.durationSec })),
+      concurrency: 6, measuredMultiplier: 30, source: 'gate4b task brief: 8s clips take 120–240s; loopback uses same wait contract' } },
     get requests() { return fixture.text.requests },
     async attach() {},
     async assertNoGeneration(expect) { expect(fixture.calls).toEqual([]) },
@@ -133,9 +157,9 @@ export async function createDryScheduler(root, settingsDir, mediaDir, report) {
       reply: { type: 'text', text: JSON.stringify({ reason: '零额度测试信号，不能评故事质量；待真实模型验收。', scores: { identity: 0, composition: 0, continuity: 0, action: 0 } }) },
     }))
     },
-    async generationCompleted({ expect }) {
+    async generationCompleted({ expect, complete = true }) {
       expect([...fixture.calls].sort((a, b) => a - b)).toEqual(shots.map((s) => s.index))
-      await Promise.all(reviews.map((r) => recorded(r.received, 'C0 synthetic review')))
+      if (complete) await Promise.all(reviews.map((r) => recorded(r.received, 'C0 synthetic review')))
     },
     async finish() {
       fixture.text.assertClean()

--- a/tests/ux/g1/c0-fixture.node-test.mjs
+++ b/tests/ux/g1/c0-fixture.node-test.mjs
@@ -50,3 +50,25 @@ test('C0 loopback works without system media tools, returns eight decodable clip
     fs.rmSync(temp, { recursive: true, force: true })
   }
 })
+
+test('delayed loopback submits immediately and exposes pending then completed through task polling', async () => {
+  const temp = fs.mkdtempSync(path.join(os.tmpdir(), 'c0-delayed-test-'))
+  const fixture = await createC0Fixture(rootDir, path.join(temp, 'settings'), path.join(temp, 'media'), { videoDelayMs: { 7: 190_000, 8: 1 } })
+  try {
+    const catalog = JSON.parse(fs.readFileSync(path.join(temp, 'settings/model-catalog.json'), 'utf8'))
+    const base = catalog.vendors.find(v => v.key === 'c0-video-loopback').baseUrlHint
+    for (const index of [7, 8]) {
+      const response = await fetch(`${base}/v1/videos/generations`, { method: 'POST',
+        body: JSON.stringify({ model: MODEL, prompt: shots[index - 1].prompt }) })
+      const created = await response.json()
+      assert.equal(created.data[0].task_id, `c0-delayed-${index}`)
+    }
+    const pending = await (await fetch(`${base}/v1/tasks/c0-delayed-7`)).json()
+    assert.equal(pending.data.status, 'processing')
+    assert.equal(pending.data.result, undefined)
+    const { expect } = await import('@playwright/test')
+    await expect.poll(async () => (await (await fetch(`${base}/v1/tasks/c0-delayed-8`)).json()).data.status).toBe('completed')
+    const completed = await (await fetch(`${base}/v1/tasks/c0-delayed-8`)).json()
+    assert.match(completed.data.result.videos[0].url[0], /^data:video\/mp4;base64,/)
+  } finally { await fixture.close(); fs.rmSync(temp, { recursive: true, force: true }) }
+})

--- a/tests/ux/g1/c0-real-scheduler.mjs
+++ b/tests/ux/g1/c0-real-scheduler.mjs
@@ -1,8 +1,9 @@
 import fs from 'node:fs'
+import { shots } from './c0-fixture.mjs'
 import { scorePlanner, scoreLanePlanner } from './c0-r30.mjs'
 import path from 'node:path'
 import { prepareIsolation, readEventsLog } from '../../../evals/lib/isoApp.mjs'
-import { publicPrices, quoteC0, assertAffordable, REAL_MODELS } from './c0-real-budget.mjs'
+import { publicPrices, quoteC0, assertAffordable, REAL_MODELS, requestQuote } from './c0-real-budget.mjs'
 
 export async function createRealScheduler({ tempRoot, attemptDir, outputDir, report }) {
   const response = await fetch('https://apimart.ai/pricing', { signal: AbortSignal.timeout(30_000), redirect: 'error' })
@@ -66,6 +67,14 @@ export async function createRealScheduler({ tempRoot, attemptDir, outputDir, rep
   }
   return {
     iso, model: REAL_MODELS.video,
+    async videoWaitQuote() {
+      const reserved = JSON.parse(fs.readFileSync(ledgerPath, 'utf8')).requests.filter(r => r.model === REAL_MODELS.video)
+      // Queued shots may not have reached dispatch: use the same reservation quote function.
+      const planned = shots.map(s => requestQuote('https://api.apimart.ai/v1/videos/generations', 'POST',
+        { model: REAL_MODELS.video, resolution: '768P', duration: s.durationSec, aspect_ratio: '16:9' }, quote))
+      return { requests: reserved.length === planned.length ? reserved : planned,
+        concurrency: 6, measuredMultiplier: 30, source: 'gate4b measured 120–240s per 8s video', ledgerPath }
+    },
     async attach(launched) {
       app = launched.app
       await app.evaluate(async (_electron, options) => {

--- a/tests/ux/g1/c0-short-film.walk.mjs
+++ b/tests/ux/g1/c0-short-film.walk.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 // C0: one UI journey, with either synthetic or budgeted real provider dispatch.
 import fs from 'node:fs'
+import { videoWaitBudget, waitForVideos } from './c0-video-wait.mjs'
 import { BUDGET_CNY } from './c0-real-budget.mjs'
 import ffmpeg from '@ffmpeg-installer/ffmpeg'
 import ffprobe from '@ffprobe-installer/ffprobe'
@@ -179,7 +180,7 @@ try {
     await clickOrFail(win.locator('[data-storyboard-id]').first(), '进入可编辑分镜表')
     await expect(win.getByRole('textbox', { name: '方案标题', exact: true })).toHaveValue('日落前的一分钟')
   }, '分镜审批 1 次')
-  let spendDialog, spendProof
+  let spendDialog, spendProof, readyNodeIds = []
   await step('03', '分镜物化到画布', '八个节点顺序、参数对应；生成前仍零媒体请求', async () => {
     await clickOrFail(win.locator('[data-storyboard-batch="true"]'), '生成未生成的八镜')
     await expect.poll(async () => (await payload()).generationCanvas.nodes.length).toBe(8)
@@ -199,20 +200,32 @@ try {
     await clickOrFail(spendDialog.getByRole('button', { name: '生成', exact: true }), values.real ? '批准预算内生成' : '批准零额度生成')
     await expectAbsent(spendDialog, { provenBy: spendProof, message: '生成确认已消费' })
     await screenshotSettled(win, { path: path.join(attemptDir, `C0-${sha.slice(0, 8)}-04-submitted.png`) })
-    await expect.poll(async () => {
-      const nodes = (await payload()).generationCanvas.nodes
-      const failed = nodes.find((n) => n.status === 'error')
-      if (failed) throw new Error(`Generation failed: ${failed.error}`)
-      return nodes.filter((n) => n.result?.type === 'video' && n.result.url.startsWith('nomi-local://')).length
-    }, { timeout: 180_000 }).toBe(8)
+    const waitQuote = await scheduler.videoWaitQuote()
+    const budget = videoWaitBudget(waitQuote)
+    report.videoWaitQuote = waitQuote
+    const observations = await waitForVideos({ nodeIds, budget,
+      readNodes: async () => (await payload()).generationCanvas.nodes,
+      progress: row => {
+        fs.appendFileSync(path.join(attemptDir, 'video-progress.jsonl'), JSON.stringify(row) + '\n')
+        console.log('C0_VIDEO_PROGRESS', JSON.stringify(row))
+      },
+      deviation: row => {
+        const error = Error(`视频未就绪：${JSON.stringify(row)}`)
+        if (collection) collection.walk.record(error, collection.walk.stations.at(-1),
+          { assertion: 'video-terminal-result', ...row })
+        else { report.videoDeviations ??= []; report.videoDeviations.push(row) }
+      },
+    })
+    readyNodeIds = observations.filter(row => row.ready).map(row => row.nodeId)
+    expect(readyNodeIds).toHaveLength(8)
     expect((await payload()).generationCanvas.nodes.every((n) => n.meta.modelKey === MODEL)).toBe(true)
-    await scheduler.generationCompleted({ expect })
+    await scheduler.generationCompleted({ expect, readyNodeIds, complete: readyNodeIds.length === nodeIds.length })
     await openCanvas(win)
     await clickOrFail(win.getByLabel('适应视图').first(), '检查画布全貌')
-    expect((await payload()).generationCanvas.nodes.every((n) => Boolean(n.result.url))).toBe(true)
+    expect(observations.every(row => row.ready)).toBe(true)
   }, values.real ? '预算内生成确认 1 次' : '零额度生成确认 1 次')
   await step('05', '按叙事加入时间轴并预览', '八段引用对应节点、无空隙、64秒；预览真实推进', async () => {
-    for (const [i, id] of nodeIds.entries()) {
+    for (const [i, id] of readyNodeIds.entries()) {
       const node = win.locator(`[data-node-id="${id}"]`)
       // The minimum zoom can leave the last row below the viewport after the timeline opens.
       if (await node.count() === 0) {
@@ -230,7 +243,7 @@ try {
     const clips = videoClips(p)
     expect(clips.map((c) => c.sourceNodeId)).toEqual(nodeIds)
     for (const [i, clip] of clips.entries()) expect(clip.startFrame).toBe(i ? clips[i - 1].endFrame : 0)
-    expect(clips.at(-1).endFrame / p.timeline.fps).toBeCloseTo(64, 1)
+    expect((clips.at(-1)?.endFrame ?? 0) / p.timeline.fps).toBeCloseTo(64, 1)
     await clickOrFail(win.locator('[aria-label="工作区切换"]').getByText('预览', { exact: true }), '预览成片')
     const video = win.locator('.workbench-preview-player__video').first()
     await expect(video).toBeVisible()

--- a/tests/ux/g1/c0-video-wait.mjs
+++ b/tests/ux/g1/c0-video-wait.mjs
@@ -1,0 +1,52 @@
+import { expect } from '@playwright/test'
+
+// Timing calibration from gate4b: 8s H3 clips take 120–240s (upper ratio 30).
+// Quotes own duration; this is a wait estimate, never a spend authorization.
+export function videoWaitBudget({ requests, concurrency, measuredMultiplier }) {
+  if (!requests.length || !Number.isInteger(concurrency) || concurrency < 1
+    || !Number.isFinite(measuredMultiplier) || measuredMultiplier <= 0
+    || requests.some(r => !Number.isFinite(r.duration) || r.duration <= 0)) throw Error('C0_INVALID_WAIT_QUOTE')
+  const rounds = Math.ceil(requests.length / concurrency)
+  return Math.max(600_000, Math.max(...requests.map(r => r.duration)) * rounds * measuredMultiplier * 1000)
+}
+
+export function videoObservation(nodeId, nodes, waitedMs) {
+  const node = nodes.find(n => n.id === nodeId), run = node?.runs?.at(-1)
+  const status = run?.status === 'cancelled' ? 'cancelled' : node?.status ?? 'missing'
+  const terminal = ['success', 'error', 'cancelled'].includes(status)
+  const ready = status === 'success' && node?.result?.type === 'video'
+    && typeof node.result.url === 'string' && node.result.url.startsWith('nomi-local://')
+  return { nodeId, jobId: node?.progress?.taskId ?? run?.taskId ?? node?.progress?.runId ?? run?.id ?? null,
+    status, terminal, ready, waitedMs }
+}
+
+export async function waitForVideos({ nodeIds, readNodes, budget, progress, deviation }) {
+  const began = performance.now(), reported = new Set()
+  let lastProgress = -30_000, observations = []
+  const sample = async () => {
+    const waitedMs = Math.round(performance.now() - began)
+    const nodes = await readNodes()
+    observations = nodeIds.map(id => videoObservation(id, nodes, waitedMs))
+    for (const row of observations) if (row.terminal && !row.ready && !reported.has(row.nodeId)) {
+      reported.add(row.nodeId)
+      await deviation(row)
+    }
+    if (waitedMs - lastProgress >= 30_000) {
+      lastProgress = waitedMs
+      await progress({ waitedMs, ready: observations.filter(r => r.ready).length,
+        failed: observations.filter(r => r.terminal && !r.ready).length, total: nodeIds.length, budget })
+    }
+    return observations.every(r => r.terminal)
+  }
+  try {
+    // Use native poll here: the boundary below emits per-job evidence in either walk mode.
+    await expect.poll(sample, { timeout: budget, intervals: [1000] }).toBe(true)
+  } catch (error) {
+    if (!error.matcherResult) throw error
+    await sample()
+  }
+  for (const row of observations) if (!row.ready && !reported.has(row.nodeId)) await deviation(row)
+  await progress({ waitedMs: Math.round(performance.now() - began), ready: observations.filter(r => r.ready).length,
+    failed: observations.filter(r => r.terminal && !r.ready).length, total: nodeIds.length, budget, final: true })
+  return observations
+}

--- a/tests/ux/g1/c0-video-wait.node-test.mjs
+++ b/tests/ux/g1/c0-video-wait.node-test.mjs
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { videoWaitBudget, videoObservation, waitForVideos } from './c0-video-wait.mjs'
+
+test('quote duration, concurrency rounds and measured ratio determine budget with ten minute floor', () => {
+  const requests = Array.from({ length: 8 }, () => ({ duration: 8 }))
+  assert.equal(videoWaitBudget({ requests, concurrency: 6, measuredMultiplier: 30 }), 600_000)
+  assert.equal(videoWaitBudget({ requests, concurrency: 2, measuredMultiplier: 30 }), 960_000)
+  assert.throws(() => videoWaitBudget({ requests: [{ duration: NaN }], concurrency: 6, measuredMultiplier: 30 }))
+})
+test('only terminal local videos are consumable; stale results, missing nodes and cancellation stay visible', () => {
+  for (const status of ['queued', 'running', 'recoverable', 'error']) {
+    assert.equal(videoObservation('a', [{ id: 'a', status, result: { type: 'video', url: 'nomi-local://old' } }], 12).ready, false)
+  }
+  assert.deepEqual(videoObservation('a', [], 12), { nodeId: 'a', jobId: null, status: 'missing', terminal: false, ready: false, waitedMs: 12 })
+  assert.equal(videoObservation('a', [{ id: 'a', status: 'idle', runs: [{ id: 'run', taskId: 'job', status: 'cancelled' }] }], 12).status, 'cancelled')
+})
+test('failed job does not prevent waiting for sibling or continuing; deadline records unfinished job identity', async () => {
+  const deviations = [], progress = []
+  const rows = await waitForVideos({ nodeIds: ['a', 'b', 'c'], budget: 20,
+    readNodes: async () => [{ id: 'a', status: 'error', runs: [{ id: 'failed' }] },
+      { id: 'b', status: 'running', progress: { taskId: 'unfinished' } },
+      { id: 'c', status: 'success', result: { type: 'video', url: 'nomi-local://clip' } }],
+    deviation: row => deviations.push(row), progress: row => progress.push(row) })
+  assert.deepEqual(deviations.map(r => r.jobId), ['failed', 'unfinished'])
+  assert.equal(rows.filter(r => r.ready).length, 1)
+  assert.equal(progress.at(-1).final, true)
+})
+
+test('C0 repair remains eight pure text videos with script model parameters in both modes', async () => {
+  const { c0RepairPlan } = await import('./sweep-repair.mjs')
+  for (const mode of ['real', 'dry-run']) {
+    const plan = c0RepairPlan(mode)
+    assert.deepEqual(plan.anchors, [])
+    assert.equal(plan.shots.length, 8)
+    for (const shot of plan.shots) {
+      assert.deepEqual(shot.anchorIds, [])
+      assert.equal(shot.modelKey, mode === 'real' ? 'MiniMax-H3' : 'c0-loopback-video')
+      assert.equal(shot.modeId, 't2v')
+      assert.deepEqual(shot.params, { duration: 8, size: '16:9', resolution: '768P' })
+    }
+  }
+})

--- a/tests/ux/g1/sweep-c0.mjs
+++ b/tests/ux/g1/sweep-c0.mjs
@@ -2,8 +2,7 @@ import fs from 'node:fs'
 import path from 'node:path'
 import { createWalkSession } from '../_assert.mjs'
 import { startEvidence, saveCase, copyTranscripts, writeJson, scoreCollectedAgent } from './sweep-evidence.mjs'
-import { repairStoryboard } from './sweep-repair.mjs'
-import { shots } from './c0-fixture.mjs'
+import { repairStoryboard, c0RepairPlan } from './sweep-repair.mjs'
 
 export function createC0Collection(directory, report) {
   let evidence, read, win, projectId, evidencePrefix = '', restart = 0
@@ -27,8 +26,8 @@ export function createC0Collection(directory, report) {
       if (evidence) { const current = evidence; evidence = null; await current.stop() }
     },
     async step(id, action, expected, run, interruption) {
-      const repair = id === '02' ? { name: 'c0-fixture storyboard seed (test-side only)',
-        run: () => repairStoryboard(win, projectId(), { title: '日落前的一分钟', shots }) } : undefined
+      const repair = id === '02' ? { name: `c0-script t2v eight-shot repair (${report.mode}; no reference cards; test-side only)`,
+        run: () => repairStoryboard(win, projectId(), c0RepairPlan(report.mode)) } : undefined
       const row = await walk.station({ id, action, interruption, expected: `${action}：${expected}`, surface: Number(id) < 3 ? 'storyboard' : Number(id) < 5 ? 'canvas-node' : id === '06' ? 'export' : 'timeline', repair }, run)
       return row
     },

--- a/tests/ux/g1/sweep-repair.mjs
+++ b/tests/ux/g1/sweep-repair.mjs
@@ -1,3 +1,13 @@
+import { shots, MODEL } from './c0-fixture.mjs'
+import { REAL_MODELS } from './c0-real-budget.mjs'
+
+export function c0RepairPlan(mode) {
+  return { title: '日落前的一分钟', anchors: [], shots: shots.map(shot => ({ ...shot,
+    anchorIds: [], modelKey: mode === 'real' ? REAL_MODELS.video : MODEL, modeId: 't2v',
+    params: { duration: 8, size: '16:9', resolution: '768P' },
+  })) }
+}
+
 // Explicit test-side intervention. Caller must record failure + repair before using later stations.
 export async function repairStoryboard(win, projectId, { title, shots }) {
   const saved = await win.evaluate(async ({ projectId, title, shots }) => {


### PR DESCRIPTION
C0 的视频生成超过 180 秒时，测试会在 6/8 完成处超时，collect 模式继续读取未完成结果又产生 URL 异常，导致后续入轴／导出级联失败。本 PR 只改测试装配：按每镜终态等待，用账本同源报价时长、并发轮次与实测倍率派生总上限（至少 10 分钟），每 30 秒记录进度；未就绪任务记录身份和状态，后续只消费就绪视频，八镜／64 秒断言保留。站 02 修补明确为无参考卡的八镜 t2v，真实模式使用 H3 / 768P / 16:9 / 8s，并保留 repairedBy。

依据任务书「第四轮总账簇 B（测试装配）」；原始总账：`~/Desktop/Nomi-switch-gate/artifacts/sweep/gate4b-20260909/nano/deviations.json`。

验证与证据：

- [红证](docs/plan/sweep-evidence/c0-video-wait-red.log)：原版源码 `e1f7e7329f14ceded007082dd348449da4d08aaf`，loopback 第 7/8 镜各延迟 190 秒，原站 04 报 Expected 8 / Received 6 / Timeout 180000ms。原 URL 表达式对真实待完成快照的独立重放复现 reading 'url'。纯 loopback 的审片等待可能先等齐，故没有把这项独立重放冒称同一次完整走查的第二个异常。
- [绿证](docs/plan/sweep-evidence/c0-video-wait-green.log)：相同延迟下约 189 秒等到 8/8，0 功能 deviation；真正到达 06，导出 64 秒 MP4 并完整解码，首／中／末三帧已人眼查看、哈希在日志中。本地证据：`artifacts/sweep/c0-video-wait-green/{first,middle,last}.png`。
- 全量 `pnpm run sweep`：33 个输入，0 功能 deviation。总账：`artifacts/sweep/2026-09-09T01-00-44.689Z/report.md`。5912 条 feel findings 原样保留，未改断言或生产代码消除它们。
- G1 Node 测试 34/34 通过，包含等待上限、失败／取消／缺失结果、异步 loopback 与修补参数回归。
- `python3 scripts/with-gates-lock.py -- pnpm run gates` 完整 exit 0：contracts 76 项、0 阻断失败、3 advisory；Vitest 12083 通过、2 跳过；后续 runtime、统计、构建和盖戳均完成。完整本地日志 `artifacts/sweep/c0-video-wait-gates.log`，哈希见绿证。

费用 ¥0。loopback 三帧只证明导出链路与测试信号连续，不宣称真实模型画面质量验收。实施说明与重跑命令见 [测试装配记录](docs/plan/sweep-evidence/c0-video-wait-plan.md)。

钩子收据：pre-commit 敏感扫描与 Ponytail PASS；pre-push Ponytail 为 `completed with findings`，版本化 hook exit 0 后推送成功（未绕过）。该适配器删除临时评审正文，所以不能宣称 pre-push 无发现；此状态留给 PR 审阅。
