### PR TITLE
test(sweep): add real-text planner with dry-run media mode

### DIFF
--- a/docs/plan/2026-09-09-sweep-collect.md
+++ b/docs/plan/2026-09-09-sweep-collect.md
@@ -78,3 +78,11 @@ Ponytail 独立明细发现四项机制问题，推送前一并修正：timeline
 总账问题分类 recurring（测试报告，非生产修复）：症状是同一批小字逐站重复使总账不可读；直接原因 saveReport 把 captureIssues 全量逐条输出；类根因是原始证据粒度与阅读粒度没有区分。实扫 startEvidence.capture → _collect.record 和 C0 createC0Collection.capture → 同一 saveReport，两类入口共用报告边界。按原始 rule/text/target/surface 元组聚合，不用坐标或站点作身份；每组保留首次站、次数、证据链接。功能 deviation 仍逐条；原始 deviations/stations/feel JSON 保持完整。依赖生命周期 not-applicable，无旧实现并行保留。
 
 验收：三站同命中先红后绿；不同规则/文字/目标/面不误合、跨 case 可合、功能断言不合并。相关 Node 测试、完整 loopback sweep、完整带锁 gates（排锁上限 40 分钟），正常 hooks commit/push 到现有 PR #666，确认无冲突。SWEEP-LAST 顶部 ≤8 行记录本轮数字与 push 后 HEAD。回滚撤销本轮测试/报告改动，保留 main 合并。
+
+## 混合模式（2026-09-09）
+
+用途：簇 A 这类模型契约验收只花文本钱；显式 `sweep --case C0 --real-text --planner-model <档> --budget <元>` 让规划请求走真实文本模型，媒体生成和审片使用有标识的本地测试信号，不能称为真实成片验收。默认 loopback 不变，不改生产代码。
+
+根因分类 recurring（测试机制）：C0 子进程始终 dry-run，CLI 的 real-text 意图未传到调度器；付费开关把文本与媒体绑在一起。实扫 scripts/sweep.mjs 的 C0/非 C0 两个入口、c0-real-main.mjs 的 appFetch/global fetch 两个出口、c0-real-budget.mjs 与 sweep-real-main.mjs 的预留边界。修在测试调度/发送边界，所有混合媒体请求只能本地响应或拒绝，文本按所选公开报价、请求字节上界和强制输出上限预留后才能发送；缺凭据明确失败，不回退。依赖版本不变，无生产修复合同；迁入补丁缺少的测试侧预算模块，不引入框架或新协议。
+
+范围：仅 scripts/tests 与本文；保留 main #668 视频等待、原生转录观察器和真实 C0 原预算。nano 输出最高 16000、deepseek 8192，报价低于上限时取小值。撤回本任务提交即可回滚，无数据迁移。验收：参数/预算传递、零媒体出站、并发及超预算拒发先红后绿；无 key 明确报错；完整 loopback 复扫及完整 gates exit 0，正常 hooks 后 push/PR。

--- a/docs/plan/2026-09-09-sweep-collect.md
+++ b/docs/plan/2026-09-09-sweep-collect.md
@@ -86,3 +86,5 @@ Ponytail 独立明细发现四项机制问题，推送前一并修正：timeline
 根因分类 recurring（测试机制）：C0 子进程始终 dry-run，CLI 的 real-text 意图未传到调度器；付费开关把文本与媒体绑在一起。实扫 scripts/sweep.mjs 的 C0/非 C0 两个入口、c0-real-main.mjs 的 appFetch/global fetch 两个出口、c0-real-budget.mjs 与 sweep-real-main.mjs 的预留边界。修在测试调度/发送边界，所有混合媒体请求只能本地响应或拒绝，文本按所选公开报价、请求字节上界和强制输出上限预留后才能发送；缺凭据明确失败，不回退。依赖版本不变，无生产修复合同；迁入补丁缺少的测试侧预算模块，不引入框架或新协议。
 
 范围：仅 scripts/tests 与本文；保留 main #668 视频等待、原生转录观察器和真实 C0 原预算。nano 输出最高 16000、deepseek 8192，报价低于上限时取小值。撤回本任务提交即可回滚，无数据迁移。验收：参数/预算传递、零媒体出站、并发及超预算拒发先红后绿；无 key 明确报错；完整 loopback 复扫及完整 gates exit 0，正常 hooks 后 push/PR。
+
+Ponytail 复核：两种模式统一复用 `c0-fixture.mjs` 的 `createSyntheticC0Media`，删除调度器内重复的 FFmpeg 编码配方；真实文本和媒体隔离发送边界不变。参数/缺 key/并发及失败预留共新增 5 项测试，和原预算测试合计 12 项通过。全量 loopback 与最终完整 gates 的收据写入 SWEEPC-LAST.md；真模型 HTTP 400 及 repair 保留，不把本任务称为生产模型契约修复。

--- a/scripts/sweep.mjs
+++ b/scripts/sweep.mjs
@@ -10,19 +10,22 @@ import { launchNomiApp } from '../tests/ux/_launchApp.mjs'
 import { createAgentRuntimeFixture } from '../tests/ux/agent-runtime-fixture.mjs'
 import { DOCUMENT } from '../tests/ux/agent-runtime-walk-support.mjs'
 import { startEvidence, copyTranscripts, writeJson, saveCase, saveReport, scoreCollectedAgent } from '../tests/ux/g1/sweep-evidence.mjs'
-import { prepareRealText, attachRealText } from '../tests/ux/g1/sweep-real.mjs'
-import { inspectMcp } from '../tests/ux/g1/sweep-mcp.mjs'
+import { prepareRealText, attachRealText, assertRealTextCredential } from '../tests/ux/g1/sweep-real.mjs'
+import { c0Invocation } from '../tests/ux/g1/sweep-c0.mjs'
 import { runSurface } from '../tests/ux/g1/sweep-surfaces.mjs'
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
 const { values } = parseArgs({ options: { packaged: { type: 'string' }, 'real-text': { type: 'boolean' },
-  budget: { type: 'string', default: '3' }, case: { type: 'string' }, help: { type: 'boolean' } } })
+  'planner-model': { type: 'string' }, budget: { type: 'string', default: '3' }, case: { type: 'string' }, help: { type: 'boolean' } } })
 if (values.help) {
-  console.log('pnpm run sweep [--packaged /absolute/Nomi.app] [--budget 3] [--case C0] [--real-text]')
+  console.log('pnpm run sweep [--packaged /absolute/Nomi.app] [--budget 3] [--case C0] [--real-text] [--planner-model gpt-5-nano|deepseek-v4-pro]')
   process.exit(0)
 }
 const budgetCny = Number(values.budget)
 if (!Number.isFinite(budgetCny) || budgetCny < 0 || budgetCny > 3) throw Error('Sweep budget must be 0–3 CNY')
+if (values['planner-model'] && (!values['real-text'] || values.case !== 'C0')) throw Error('--planner-model requires --real-text --case C0')
+if (values['real-text']) assertRealTextCredential()
+const { inspectMcp } = await import('../tests/ux/g1/sweep-mcp.mjs')
 const runId = new Date().toISOString().replaceAll(':', '-'), directory = path.join(root, 'artifacts/sweep', runId)
 fs.mkdirSync(directory, { recursive: true })
 const cases = JSON.parse(fs.readFileSync(path.join(root, 'tests/ux/g1/cases.json'), 'utf8'))
@@ -53,10 +56,16 @@ for (const entry of cases) for (const input of entry.inputs) {
   if (input.executor === 'c0') {
     let childError
     try {
-      await promisify(execFile)(process.execPath, [path.join(root, 'tests/ux/g1/c0-short-film.walk.mjs'), '--dry-run', ...(values.packaged ? ['--packaged', values.packaged] : [])],
-        { cwd: root, env: { ...process.env, NOMI_WALK_MODE: 'collect', NOMI_SWEEP_CASE_DIR: target }, maxBuffer: 1024 * 1024 })
+      const child = c0Invocation({ root, target, directory, realText: values['real-text'],
+        plannerModel: values['planner-model'], budgetCny, packaged: values.packaged })
+      await promisify(execFile)(process.execPath, child.args, { cwd: root, env: child.env, maxBuffer: 1024 * 1024 })
     } catch (error) { childError = error }
     for (const key of ['stations', 'deviations']) if (fs.existsSync(path.join(target, `${key}.json`))) record[key] = JSON.parse(fs.readFileSync(path.join(target, `${key}.json`), 'utf8'))
+    const childReport = path.join(target, 'report.json')
+    if (fs.existsSync(childReport)) {
+      const result = JSON.parse(fs.readFileSync(childReport, 'utf8'))
+      Object.assign(record, { costCny: result.costCny, reservedCny: result.reservedCny, mediaMode: result.mediaMode, plannerModel: result.plannerModel })
+    }
     Object.assign(walk, { stations: record.stations, deviations: record.deviations })
     if (childError) walk.record(Error(`C0 child failed: ${childError.code ?? 'unknown'}`), { id: 'c0-process', surface: 'storyboard' })
     if (!fs.existsSync(path.join(target, 'trace.zip'))) fs.writeFileSync(path.join(target, 'trace-unavailable.md'), 'C0 tracing did not finish; see deviations.json.\n')

--- a/tests/ux/g1/c0-fixture.mjs
+++ b/tests/ux/g1/c0-fixture.mjs
@@ -23,22 +23,26 @@ export const shots = [
 
 // These are deliberately synthetic motion/audio test signals, NOT a pre-made film.
 // Each request selects its own shot; results enter the project only through generation.
-export async function createC0Fixture(rootDir, settingsDir, mediaDir, { videoDelayMs = {} } = {}) {
-  const text = await createAgentRuntimeFixture({ rootDir, settingsDir })
-  const calls = []
-  const sockets = new Set(), tasks = new Map()
-  let server
-  try {
-    fs.mkdirSync(mediaDir, { recursive: true })
-    const results = shots.map((shot) => {
+export function createSyntheticC0Media(mediaDir) {
+  fs.mkdirSync(mediaDir, { recursive: true })
+  return shots.map((shot) => {
       const file = path.join(mediaDir, `shot-${shot.index}.mp4`)
       execFileSync(ffmpeg.path, ['-v', 'error', '-y', '-f', 'lavfi', '-i',
         `testsrc2=size=640x360:rate=24,hue=h=${shot.index * 35}`,
         '-f', 'lavfi', '-i', `sine=frequency=${220 + shot.index * 55}:sample_rate=44100`,
         '-t', String(shot.durationSec), '-c:v', 'libx264', '-preset', 'ultrafast',
         '-pix_fmt', 'yuv420p', '-c:a', 'aac', '-movflags', '+faststart', file], { stdio: 'pipe' })
-      return `data:video/mp4;base64,${fs.readFileSync(file).toString('base64')}`
+      return file
     })
+}
+
+export async function createC0Fixture(rootDir, settingsDir, mediaDir, { videoDelayMs = {} } = {}) {
+  const text = await createAgentRuntimeFixture({ rootDir, settingsDir })
+  const calls = []
+  const sockets = new Set(), tasks = new Map()
+  let server
+  try {
+    const results = createSyntheticC0Media(mediaDir).map(file => `data:video/mp4;base64,${fs.readFileSync(file).toString('base64')}`)
     server = http.createServer(async (req, res) => {
       try {
         if (req.method === 'GET' && req.url.startsWith('/v1/tasks/')) {

--- a/tests/ux/g1/c0-plan-sample-budget.mjs
+++ b/tests/ux/g1/c0-plan-sample-budget.mjs
@@ -1,0 +1,40 @@
+// Test-only text reservation boundary for mixed sweep; one ledger spans the run.
+import { REAL_MODELS, CNY_PER_USD } from './c0-real-budget.mjs'
+export function quotePlanSample(prices, model) {
+  if (!['gpt-5-nano', 'deepseek-v4-pro'].includes(model)) throw new Error('C0_SAMPLE_MODEL_REFUSED')
+  const pricing = prices.get(model)?.pricing
+  if (pricing?.unit !== 'usd_per_million_tokens' || pricing?.tier_count !== 1
+    || ![pricing.rates?.input, pricing.rates?.output, pricing.limits?.max_output_tokens].every(n => Number.isFinite(n) && n > 0)) throw new Error('C0_SAMPLE_PRICE_UNKNOWN')
+  return { models: { ...REAL_MODELS, text: model }, rates: pricing.rates,
+    maxOutputTokens: Math.min(pricing.limits.max_output_tokens, model === 'gpt-5-nano' ? 16000 : 8192), budgetCny: 3, source: 'https://apimart.ai/pricing', checkedAt: new Date().toISOString() }
+}
+export const planSampleFetch = ({ send, quote, ledger, persist }) => async (input, init) => {
+  const request = new Request(input instanceof Request ? input.clone() : input, init)
+  const url = new URL(request.url)
+  if (request.method !== 'POST' || url.origin !== 'https://api.apimart.ai'
+    || url.pathname !== '/v1/chat/completions' || url.search) throw new Error('C0_SAMPLE_OUTBOUND_REFUSED')
+  const body = await request.clone().json()
+  if (body.model !== quote.models.text || body.max_completion_tokens !== undefined) throw new Error('C0_SAMPLE_MODEL_REFUSED')
+  body.max_tokens = Math.min(body.max_tokens ?? quote.maxOutputTokens, quote.maxOutputTokens)
+  if (!Number.isInteger(body.max_tokens) || body.max_tokens < 1) throw Error('C0_OUTPUT_LIMIT_REQUIRED')
+  if (!Number.isFinite(quote.budgetCny) || quote.budgetCny <= 0 || quote.budgetCny > 3) throw Error('C0_BLOCKED_BUDGET')
+  // UTF-8 bytes upper-bound ordinary byte-token input, including schema/message wrappers.
+  const inputBytes = Buffer.byteLength(JSON.stringify(body), 'utf8')
+  const upperUsd = (inputBytes * quote.rates.input + body.max_tokens * quote.rates.output) / 1e6
+  const reservedCny = ledger.reservedCny + upperUsd * CNY_PER_USD
+  if (!Number.isFinite(upperUsd) || upperUsd <= 0 || !Number.isFinite(ledger.reservedCny) || ledger.reservedCny < 0 || !Number.isFinite(reservedCny) || reservedCny > quote.budgetCny) throw new Error('C0_BLOCKED_BUDGET')
+  const row = { model: body.model, path: url.pathname, inputBytes, maxTokens: body.max_tokens, upperUsd, started: new Date().toISOString() }
+  ledger.requests.push(row)
+  ledger.reservedCny = reservedCny
+  persist()
+  try {
+    const response = await send(request.url, { method: 'POST', headers: request.headers, signal: request.signal, body: JSON.stringify(body), redirect: 'error' })
+    row.httpStatus = response.status
+    persist()
+    return response
+  } catch {
+    row.transportFailed = true
+    persist()
+    throw new Error('C0_PROVIDER_REQUEST_FAILED')
+  }
+}

--- a/tests/ux/g1/c0-real-main.mjs
+++ b/tests/ux/g1/c0-real-main.mjs
@@ -3,8 +3,9 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import { createRequire } from 'node:module'
+import { planSampleFetch } from './c0-plan-sample-budget.mjs'
 import { budgetedFetch, CNY_PER_USD } from './c0-real-budget.mjs'
-export async function attachRealDispatch({ quote, ledgerPath }) {
+export async function attachRealDispatch({ quote, ledgerPath, mediaFiles = [], requestsPath }) {
   const require = createRequire(import.meta.url)
   const { app } = require('electron')
   const compiled = path.join(app.getAppPath(), 'dist-electron')
@@ -34,14 +35,50 @@ export async function attachRealDispatch({ quote, ledgerPath }) {
   }
   ledger.initialUsedUsd ??= await balance()
   persist()
-  transport.appFetch = budgetedFetch({ send: originalAppFetch, quote, ledger, persist })
-  globalThis.fetch = budgetedFetch({ send: originalGlobalFetch, quote, ledger, persist })
+  const wrap = createDispatchWrapper({ quote, ledger, persist, requestsPath, mediaFiles, ledgerPath })
+  transport.appFetch = wrap(originalAppFetch)
+  globalThis.fetch = wrap(originalGlobalFetch)
   return {
     async snapshot() {
       ledger.billedUsd = Math.max(ledger.billedUsd ?? 0, (await balance()) - ledger.initialUsedUsd)
       ledger.billedCnyAtBudgetRate = ledger.billedUsd * CNY_PER_USD
+      if (quote.mediaDryRun) ledger.billedCny = ledger.billedCnyAtBudgetRate
       persist()
       return ledger
     },
   }
+}
+
+export function createDispatchWrapper({ quote, ledger, persist, requestsPath, mediaFiles = [], ledgerPath }) {
+  const wrapFetch = quote.mediaDryRun ? planSampleFetch : budgetedFetch
+  const requests = requestsPath && fs.existsSync(requestsPath) ? JSON.parse(fs.readFileSync(requestsPath, 'utf8')) : []
+  let mediaIndex = 0
+  const wrap = send => {
+    const paid = wrapFetch({ send: async (input, init) => {
+      const request = new Request(input instanceof Request ? input.clone() : input, init)
+      const body = request.method === 'POST' ? await request.clone().json() : undefined
+      requests.push({ path: new URL(request.url).pathname, body })
+      if (requestsPath) fs.writeFileSync(requestsPath, JSON.stringify(requests, null, 2))
+      return send(input, init)
+    }, quote, ledger, persist })
+    return async (input, init) => {
+      if (!quote.mediaDryRun) return paid(input, init)
+      const request = new Request(input instanceof Request ? input.clone() : input, init), url = new URL(request.url)
+      if (url.origin !== 'https://api.apimart.ai' || request.method !== 'POST' || url.search) throw Error('C0_MIXED_OUTBOUND_REFUSED')
+      const body = await request.clone().json()
+      if (url.pathname === '/v1/videos/generations') {
+        if (body.model !== quote.models.video || body.resolution !== '768P' || body.duration !== 8 || mediaIndex >= mediaFiles.length) throw Error('C0_MIXED_MEDIA_REFUSED')
+        const file = mediaFiles[mediaIndex++]
+        fs.appendFileSync(ledgerPath + '.synthetic-media.jsonl', JSON.stringify({ body, file, synthetic: true }) + '\n')
+        return Response.json({ data: [{ url: 'data:video/mp4;base64,' + fs.readFileSync(file).toString('base64') }] })
+      }
+      if (url.pathname === '/v1/chat/completions' && JSON.stringify(body.messages ?? []).includes('资深影视分镜审片')) {
+        const content = JSON.stringify({ reason: '媒体 dry-run 测试信号，不评价成片', scores: { identity: 0, composition: 0, continuity: 0, action: 0 } })
+        const chunk = (delta, finish_reason) => 'data: ' + JSON.stringify({ id: 'synthetic-review', object: 'chat.completion.chunk', model: body.model, choices: [{ index: 0, delta, finish_reason }] }) + '\n\n'
+        return body.stream ? new Response(chunk({ role: 'assistant', content }, null) + chunk({}, 'stop') + 'data: [DONE]\n\n', { headers: { 'Content-Type': 'text/event-stream' } }) : Response.json({ choices: [{ message: { role: 'assistant', content }, finish_reason: 'stop' }] })
+      }
+      return paid(input, init)
+    }
+  }
+  return wrap
 }

--- a/tests/ux/g1/c0-real-scheduler.mjs
+++ b/tests/ux/g1/c0-real-scheduler.mjs
@@ -1,31 +1,46 @@
 import fs from 'node:fs'
+import ffmpeg from '@ffmpeg-installer/ffmpeg'
+import { execFileSync } from 'node:child_process'
+import { quotePlanSample } from './c0-plan-sample-budget.mjs'
 import { shots } from './c0-fixture.mjs'
 import { scorePlanner, scoreLanePlanner } from './c0-r30.mjs'
 import path from 'node:path'
 import { prepareIsolation, readEventsLog } from '../../../evals/lib/isoApp.mjs'
 import { publicPrices, quoteC0, assertAffordable, REAL_MODELS, requestQuote } from './c0-real-budget.mjs'
 
-export async function createRealScheduler({ tempRoot, attemptDir, outputDir, report }) {
+export async function createRealScheduler({ tempRoot, attemptDir, outputDir, report, plannerModel }) {
+  const mixed = process.env.NOMI_C0_MEDIA_DRY_RUN === '1'
+  if (mixed) outputDir = process.env.NOMI_C0_LEDGER_DIR ?? attemptDir
   const response = await fetch('https://apimart.ai/pricing', { signal: AbortSignal.timeout(30_000), redirect: 'error' })
   if (!response.ok) throw new Error('C0_PUBLIC_PRICE_UNAVAILABLE')
   const html = await response.text()
   fs.writeFileSync(path.join(attemptDir, 'public-pricing.html'), html)
-  const quote = quoteC0(publicPrices(html))
+  if (plannerModel && !mixed) throw new Error('C0_PLANNER_OVERRIDE_REQUIRES_MIXED_MODE')
+  const quote = mixed ? quotePlanSample(publicPrices(html), plannerModel ?? REAL_MODELS.text) : quoteC0(publicPrices(html))
+  const models = quote.models
+  if (mixed) {
+    const budget = Number(process.env.NOMI_C0_TEXT_BUDGET ?? 3)
+    if (!Number.isFinite(budget) || budget <= 0 || budget > 3) throw Error('C0_BLOCKED_BUDGET')
+    quote.budgetCny = budget
+  }
+  report.budgetCny = mixed ? quote.budgetCny : report.budgetCny
+  report.mediaMode = mixed ? 'dry-run synthetic test signals; not a film' : 'real'
+  quote.mediaDryRun = mixed
+  report.plannerModel = models.text
   report.quote = quote
   // Reject before copying settings or decrypting credentials when a complete film is unaffordable.
-  assertAffordable(quote)
+  if (!mixed) assertAffordable(quote)
   const iso = prepareIsolation(tempRoot, { requireCatalog: true })
   const catalogFile = path.join(iso.settingsDir, 'model-catalog.json')
   const catalog = JSON.parse(fs.readFileSync(catalogFile, 'utf8'))
-  // The fixture owns its fixed text model; only the encrypted vendor credential and
-  // existing media mappings come from application settings. Never edit the source catalog.
-  if (!catalog.models.some((m) => m.vendorKey === 'apimart' && m.modelKey === REAL_MODELS.text)) {
-    catalog.models.push({ vendorKey: 'apimart', modelKey: REAL_MODELS.text,
-      labelZh: REAL_MODELS.text, kind: 'text', enabled: true })
+  // Sample identity is user-selected and priced from the live official catalog; only the isolated copy changes.
+  if (!catalog.models.some((m) => m.vendorKey === 'apimart' && m.modelKey === models.text)) {
+    catalog.models.push({ vendorKey: 'apimart', modelKey: models.text, labelZh: models.text,
+      kind: 'text', enabled: true, createdAt: new Date().toISOString(), updatedAt: new Date().toISOString() })
   }
   for (const vendor of catalog.vendors) vendor.enabled = vendor.key === 'apimart'
-  for (const model of catalog.models) model.enabled = model.vendorKey === 'apimart' && Object.values(REAL_MODELS).includes(model.modelKey)
-  for (const modelKey of Object.values(REAL_MODELS)) {
+  for (const model of catalog.models) model.enabled = model.vendorKey === 'apimart' && Object.values(models).includes(model.modelKey)
+  for (const modelKey of Object.values(models)) {
     if (!catalog.models.some((m) => m.enabled && m.modelKey === modelKey)) throw new Error('C0_CONFIGURED_MODEL_UNAVAILABLE')
   }
   // Retain only encrypted APIMart credentials; never copy them into any fixture or report.
@@ -36,6 +51,16 @@ export async function createRealScheduler({ tempRoot, attemptDir, outputDir, rep
   const lock = fs.openSync(lockPath, 'wx', 0o600)
   fs.closeSync(lock)
   const ledgerPath = path.join(outputDir, 'real-budget-ledger.json')
+  const earlier = fs.existsSync(ledgerPath) ? JSON.parse(fs.readFileSync(ledgerPath, 'utf8')) : null
+  const priorCost = mixed ? (earlier?.billedCny ?? earlier?.billedCnyAtBudgetRate ?? 0) : 0
+  const priorReserved = mixed ? (earlier?.reservedCny ?? 0) : 0
+  const firstRequest = mixed ? (earlier?.requests?.length ?? 0) : 0
+  const mediaFiles = []
+  if (mixed) for (const shot of shots) {
+    const file = path.join(attemptDir, `synthetic-${shot.index}.mp4`)
+    execFileSync(ffmpeg.path, ['-v','error','-y','-f','lavfi','-i', `testsrc2=size=640x360:rate=24,hue=h=${shot.index * 35}`, '-f','lavfi','-i', `sine=frequency=${220 + shot.index * 55}:sample_rate=44100`, '-t','8','-c:v','libx264','-preset','ultrafast','-pix_fmt','yuv420p','-c:a','aac','-movflags','+faststart', file], { stdio: 'pipe' })
+    mediaFiles.push(file)
+  }
   let app, planEvents = [], nativeMessages
   const readNativeMessages = async (projectRoot) => {
     // Reuse the candidate's versioned observer rather than duplicating the pi format reader.
@@ -43,12 +68,11 @@ export async function createRealScheduler({ tempRoot, attemptDir, outputDir, rep
     return observer.readLaneTranscripts(projectRoot).flatMap(observer.laneMessages)
   }
   const bridge = path.join(tempRoot, 'c0-main.cjs')
-  fs.writeFileSync(bridge, `module.exports = import(${JSON.stringify(new URL('./c0-real-main.mjs', import.meta.url).href)});`, { mode: 0o600 })
   const snapshot = async () => {
     if (!app) return
     try {
       const ledger = await app.evaluate(() => globalThis.__c0Dispatch.snapshot())
-      report.costCny = ledger.billedCnyAtBudgetRate
+      report.costCny = ledger.billedCnyAtBudgetRate - priorCost
       report.billedUsd = ledger.billedUsd
       report.billingAttribution = 'APIMart token balance delta; concurrent use of the same token may be included'
     } catch {
@@ -59,15 +83,17 @@ export async function createRealScheduler({ tempRoot, attemptDir, outputDir, rep
       // Preserve reservations even if Electron died or the balance query failed.
       if (fs.existsSync(ledgerPath)) {
         const ledger = JSON.parse(fs.readFileSync(ledgerPath, 'utf8'))
-        report.outbound = ledger.requests
-        report.paidCalls = ledger.requests.length
-        report.reservedCny = ledger.reservedCny
+        report.outbound = ledger.requests.slice(firstRequest)
+        report.paidCalls = report.outbound.length
+        report.reservedCny = ledger.reservedCny - priorReserved
       }
     }
   }
   return {
-    iso, model: REAL_MODELS.video,
+    iso, model: models.video,
+    get requests() { const file = path.join(attemptDir, 'model-requests.json'); return fs.existsSync(file) ? JSON.parse(fs.readFileSync(file, 'utf8')) : [] },
     async videoWaitQuote() {
+      if (mixed) return { requests: shots.map(s => ({ model: models.video, duration: s.durationSec })), concurrency: 6, measuredMultiplier: 30, source: 'synthetic media, zero external dispatch' }
       const reserved = JSON.parse(fs.readFileSync(ledgerPath, 'utf8')).requests.filter(r => r.model === REAL_MODELS.video)
       // Queued shots may not have reached dispatch: use the same reservation quote function.
       const planned = shots.map(s => requestQuote('https://api.apimart.ai/v1/videos/generations', 'POST',
@@ -77,19 +103,20 @@ export async function createRealScheduler({ tempRoot, attemptDir, outputDir, rep
     },
     async attach(launched) {
       app = launched.app
-      await app.evaluate(async (_electron, options) => {
+      fs.writeFileSync(bridge, `module.exports = import(${JSON.stringify(new URL('./c0-real-main.mjs', import.meta.url).href)});`, { mode: 0o600 })
+      try { await app.evaluate(async (_electron, options) => {
         const module = await process.mainModule.require(options.bridge)
         globalThis.__c0Dispatch = await module.attachRealDispatch(options)
-      }, { bridge, quote, ledgerPath })
+      }, { bridge, quote, ledgerPath, mediaFiles, requestsPath: path.join(attemptDir, 'model-requests.json') }) } finally { fs.rmSync(bridge, { force: true }) }
       await launched.win.evaluate(({ models }) => {
         localStorage.setItem('nomi.assistantModel', JSON.stringify({ vendorKey: 'apimart', modelKey: models.text }))
         window.dispatchEvent(new CustomEvent('nomi:assistant-model-changed'))
-      }, { models: REAL_MODELS })
+      }, { models })
     },
     preparePlan() {}, async planRequested() {},
     async assertNoGeneration(expect) {
       await snapshot()
-      expect(report.outbound.filter((r) => r.model !== REAL_MODELS.text)).toEqual([])
+      expect(report.outbound.filter((r) => r.model !== models.text)).toEqual([])
     },
     async planCompleted({ projectRoot, expect }) {
       if (fs.existsSync(path.join(projectRoot, '.nomi/agent-sessions'))) {

--- a/tests/ux/g1/c0-real-scheduler.mjs
+++ b/tests/ux/g1/c0-real-scheduler.mjs
@@ -1,8 +1,6 @@
 import fs from 'node:fs'
-import ffmpeg from '@ffmpeg-installer/ffmpeg'
-import { execFileSync } from 'node:child_process'
 import { quotePlanSample } from './c0-plan-sample-budget.mjs'
-import { shots } from './c0-fixture.mjs'
+import { shots, createSyntheticC0Media } from './c0-fixture.mjs'
 import { scorePlanner, scoreLanePlanner } from './c0-r30.mjs'
 import path from 'node:path'
 import { prepareIsolation, readEventsLog } from '../../../evals/lib/isoApp.mjs'
@@ -55,12 +53,7 @@ export async function createRealScheduler({ tempRoot, attemptDir, outputDir, rep
   const priorCost = mixed ? (earlier?.billedCny ?? earlier?.billedCnyAtBudgetRate ?? 0) : 0
   const priorReserved = mixed ? (earlier?.reservedCny ?? 0) : 0
   const firstRequest = mixed ? (earlier?.requests?.length ?? 0) : 0
-  const mediaFiles = []
-  if (mixed) for (const shot of shots) {
-    const file = path.join(attemptDir, `synthetic-${shot.index}.mp4`)
-    execFileSync(ffmpeg.path, ['-v','error','-y','-f','lavfi','-i', `testsrc2=size=640x360:rate=24,hue=h=${shot.index * 35}`, '-f','lavfi','-i', `sine=frequency=${220 + shot.index * 55}:sample_rate=44100`, '-t','8','-c:v','libx264','-preset','ultrafast','-pix_fmt','yuv420p','-c:a','aac','-movflags','+faststart', file], { stdio: 'pipe' })
-    mediaFiles.push(file)
-  }
+  const mediaFiles = mixed ? createSyntheticC0Media(path.join(attemptDir, 'fixture-media')) : []
   let app, planEvents = [], nativeMessages
   const readNativeMessages = async (projectRoot) => {
     // Reuse the candidate's versioned observer rather than duplicating the pi format reader.

--- a/tests/ux/g1/c0-short-film.walk.mjs
+++ b/tests/ux/g1/c0-short-film.walk.mjs
@@ -15,7 +15,7 @@ import { parseArgs } from 'node:util'
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..')
 const { values } = parseArgs({ options: {
   'dry-run': { type: 'boolean' }, real: { type: 'boolean' },
-  packaged: { type: 'string' }, help: { type: 'boolean' },
+  'planner-model': { type: 'string' }, packaged: { type: 'string' }, help: { type: 'boolean' },
 }, allowPositionals: false })
 if (values.help) {
   console.log('node tests/ux/g1/c0-short-film.walk.mjs (--dry-run | --real) [--packaged /absolute/Nomi.app]')
@@ -104,7 +104,7 @@ try {
   }
   if (executablePath) report.executableSha256 = hash(executablePath)
   scheduler = values.real
-    ? await (await import('./c0-real-scheduler.mjs')).createRealScheduler({ tempRoot, attemptDir, outputDir, report })
+    ? await (await import('./c0-real-scheduler.mjs')).createRealScheduler({ tempRoot, attemptDir, outputDir, report, plannerModel: values['planner-model'] })
     : await createDryScheduler(root, settingsDir, path.join(attemptDir, 'fixture-media'), report)
   const MODEL = scheduler.model
   const launch = async () => {

--- a/tests/ux/g1/sweep-budget.node-test.mjs
+++ b/tests/ux/g1/sweep-budget.node-test.mjs
@@ -46,3 +46,112 @@ test('real-text bridge cleans executable scratch on both attachment success and 
     }
   } finally { fs.rmSync(profile, { recursive: true, force: true }) }
 })
+
+test('mixed dispatch caps each quoted text tier at 1.5 and never forwards media', async () => {
+  const { createDispatchWrapper } = await import('./c0-real-main.mjs')
+  const fs = await import('node:fs'), os = await import('node:os'), path = await import('node:path')
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'mixed-boundary-'))
+  try {
+    const file = path.join(dir, 'signal.mp4'); fs.writeFileSync(file, 'synthetic')
+    for (const text of ['gpt-5-nano', 'deepseek-v4-pro']) {
+      const ledger = { reservedCny: 0, requests: [] }; let sent = 0, persisted = false
+      const quote = { mediaDryRun: true, models: { text, video: 'MiniMax-H3' }, rates: { input: .1, output: 1 }, maxOutputTokens: 8192, budgetCny: 1.5 }
+      const dispatch = createDispatchWrapper({ quote, ledger, persist: () => { persisted = true }, mediaFiles: [file], ledgerPath: path.join(dir, text) })(async (_url, init) => {
+        assert.ok(persisted); sent++; assert.equal(JSON.parse(init.body).max_tokens, 8192); return new Response('native')
+      })
+      const post = body => ({ method: 'POST', body: JSON.stringify(body) })
+      assert.equal(await (await dispatch('https://api.apimart.ai/v1/chat/completions', post({ model: text, max_tokens: 16000, messages: [] }))).text(), 'native')
+      assert.equal((await (await dispatch('https://api.apimart.ai/v1/videos/generations', post({ model: 'MiniMax-H3', resolution: '768P', duration: 8 }))).json()).data[0].url, 'data:video/mp4;base64,c3ludGhldGlj')
+      ledger.reservedCny = 1.5
+      await assert.rejects(dispatch('https://api.apimart.ai/v1/chat/completions', post({ model: text })), /BLOCKED_BUDGET/)
+      await assert.rejects(dispatch('https://api.apimart.ai/v1/images/generations', post({ model: 'gpt-image-2' })), /REFUSED/)
+      assert.equal(sent, 1)
+    }
+  } finally { fs.rmSync(dir, { recursive: true, force: true }) }
+})
+
+test('C0 invocation passes the selected real text tier and budget; default stays dry', async () => {
+  const { c0Invocation } = await import('./sweep-c0.mjs')
+  const base = { root: '/repo', target: '/case', directory: '/run', budgetCny: 1.5, env: {} }
+  assert.deepEqual(c0Invocation(base).args, ['/repo/tests/ux/g1/c0-short-film.walk.mjs', '--dry-run'])
+  for (const plannerModel of ['gpt-5-nano', 'deepseek-v4-pro']) {
+    const child = c0Invocation({ ...base, realText: true, plannerModel, packaged: '/Nomi.app' })
+    assert.deepEqual(child.args.slice(1), ['--real', '--planner-model', plannerModel, '--packaged', '/Nomi.app'])
+    assert.equal(child.env.NOMI_C0_TEXT_BUDGET, '1.5')
+    assert.equal(child.env.NOMI_C0_MEDIA_DRY_RUN, '1')
+    assert.equal(child.env.NOMI_C0_LEDGER_DIR, '/run')
+  }
+})
+
+test('real-text without a configured enabled key fails explicitly before any request', async () => {
+  const { assertRealTextCredential } = await import('./sweep-real.mjs')
+  const fs = await import('node:fs'), os = await import('node:os'), path = await import('node:path')
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'mixed-key-')), file = path.join(dir, 'catalog.json')
+  try {
+    assert.throws(() => assertRealTextCredential(file), /SWEEP_REAL_TEXT_KEY_REQUIRED/)
+    const { spawnSync } = await import('node:child_process')
+    const preload = 'data:text/javascript,' + encodeURIComponent(`import os from 'node:os'; os.homedir = () => ${JSON.stringify(dir)}`)
+    const cli = spawnSync(process.execPath, ['--import', preload, new URL('../../../scripts/sweep.mjs', import.meta.url).pathname, '--case', 'C0', '--real-text'], { encoding: 'utf8' })
+    assert.equal(cli.status, 1)
+    assert.match(cli.stderr, /SWEEP_REAL_TEXT_KEY_REQUIRED/)
+    assert.doesNotMatch(cli.stdout, /SWEEP C0/)
+    for (const apimart of [undefined, { enc: 'safeStorage', enabled: false }]) {
+      fs.writeFileSync(file, JSON.stringify({ apiKeysByVendor: { apimart } }))
+      assert.throws(() => assertRealTextCredential(file), /SWEEP_REAL_TEXT_KEY_REQUIRED/)
+    }
+  } finally { fs.rmSync(dir, { recursive: true, force: true }) }
+})
+
+test('both dispatch outlets share reservations, cap output, and reject every non-text outbound route', async () => {
+  const { quotePlanSample } = await import('./c0-plan-sample-budget.mjs')
+  const { createDispatchWrapper } = await import('./c0-real-main.mjs')
+  for (const [model, cap] of [['gpt-5-nano', 16000], ['deepseek-v4-pro', 8192]]) {
+    const prices = new Map([[model, { pricing: { unit: 'usd_per_million_tokens', tier_count: 1,
+      rates: { input: .1, output: 1 }, limits: { max_output_tokens: 100000 } } }]])
+    const quote = { ...quotePlanSample(prices, model), mediaDryRun: true, budgetCny: .15 }
+    assert.equal(quote.maxOutputTokens, cap)
+    const ledger = { reservedCny: 0, requests: [] }, outgoing = []
+    const wrap = createDispatchWrapper({ quote, ledger, persist() {} })
+    const send = async (url, init) => { outgoing.push({ url, ...init }); return new Response('native') }
+    const appFetch = wrap(send), globalFetch = wrap(send)
+    const body = { model, max_tokens: 100000, messages: [{ role: 'user', content: '中文🙂' }], tools: [{ schema: 'x'.repeat(500) }] }
+    const request = () => new Request('https://api.apimart.ai/v1/chat/completions', { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify(body) })
+    const results = await Promise.allSettled(Array.from({ length: 4 }, (_, i) => (i % 2 ? appFetch : globalFetch)(request())))
+    assert.ok(results.some(r => r.status === 'rejected' && /BLOCKED_BUDGET/.test(r.reason.message)))
+    assert.ok(ledger.reservedCny <= .15)
+    assert.equal(outgoing.length, results.filter(r => r.status === 'fulfilled').length)
+    for (const row of outgoing) {
+      assert.equal(JSON.parse(row.body).max_tokens, cap)
+      assert.equal(row.headers.get('content-type'), 'application/json')
+      assert.equal(row.redirect, 'error')
+    }
+    assert.equal(ledger.requests[0].inputBytes, Buffer.byteLength(outgoing[0].body))
+    const count = outgoing.length
+    for (const url of ['https://api.apimart.ai/v1/images/generations', 'https://api.apimart.ai/v1/audio/speech', 'https://api.apimart.ai/v1/videos/generations', 'https://other.example/video.mp4', 'https://api.apimart.ai/v1/chat/completions?x=1']) {
+      await assert.rejects(appFetch(url, { method: 'POST', body: JSON.stringify({ model }) }), /REFUSED/)
+    }
+    assert.equal(outgoing.length, count)
+  }
+})
+
+test('mixed budget refuses unbounded output and keeps failed dispatch reservations', async () => {
+  const { planSampleFetch, quotePlanSample } = await import('./c0-plan-sample-budget.mjs')
+  assert.throws(() => quotePlanSample(new Map(), 'gpt-5-nano'), /PRICE_UNKNOWN/)
+  assert.throws(() => quotePlanSample(new Map(), 'unknown'), /MODEL_REFUSED/)
+  const quote = { models: { text: 'gpt-5-nano' }, rates: { input: .1, output: 1 }, maxOutputTokens: 16000, budgetCny: 1.5 }
+  let sent = 0
+  const send = async () => { sent++; throw Error('transport failed') }
+  const ledger = { requests: [], reservedCny: 0 }
+  const dispatch = planSampleFetch({ send, quote, ledger, persist() {} })
+  const call = extra => dispatch('https://api.apimart.ai/v1/chat/completions', { method: 'POST', body: JSON.stringify({ model: quote.models.text, ...extra }) })
+  for (const max_tokens of [0, -1, 1.5, 'bad']) await assert.rejects(call({ max_tokens }), /OUTPUT_LIMIT_REQUIRED/)
+  await assert.rejects(call({ max_completion_tokens: 1 }), /MODEL_REFUSED/)
+  assert.equal(sent, 0)
+  await assert.rejects(call({ messages: [] }), /PROVIDER_REQUEST_FAILED/)
+  assert.equal(sent, 1)
+  assert.ok(ledger.reservedCny > 0)
+  assert.equal(ledger.requests[0].transportFailed, true)
+  const cannotPersist = planSampleFetch({ send, quote, ledger, persist() { throw Error('disk full') } })
+  await assert.rejects(cannotPersist('https://api.apimart.ai/v1/chat/completions', { method: 'POST', body: JSON.stringify({ model: quote.models.text }) }), /disk full/)
+  assert.equal(sent, 1)
+})

--- a/tests/ux/g1/sweep-c0.mjs
+++ b/tests/ux/g1/sweep-c0.mjs
@@ -26,6 +26,8 @@ export function createC0Collection(directory, report) {
       if (evidence) { const current = evidence; evidence = null; await current.stop() }
     },
     async step(id, action, expected, run, interruption) {
+      if (id === '02' && report.mode === 'real') win.setDefaultTimeout(180_000)
+      if (id === '04' && process.env.NOMI_C0_MEDIA_DRY_RUN === '1') action = '确认并生成八段本地测试信号（媒体 dry-run，非成片）'
       const repair = id === '02' ? { name: `c0-script t2v eight-shot repair (${report.mode}; no reference cards; test-side only)`,
         run: () => repairStoryboard(win, projectId(), c0RepairPlan(report.mode)) } : undefined
       const row = await walk.station({ id, action, interruption, expected: `${action}：${expected}`, surface: Number(id) < 3 ? 'storyboard' : Number(id) < 5 ? 'canvas-node' : id === '06' ? 'export' : 'timeline', repair }, run)
@@ -42,5 +44,15 @@ export function createC0Collection(directory, report) {
       if (!files.length) walk.record(Error('当前运行时未落盘 pi 原生 JSONL；禁止用 Host 快照冒充'), { id: 'native-transcript', surface: 'agent-panel', reachedViaRepair: false })
       saveCase(directory, walk)
     },
+  }
+}
+
+export function c0Invocation({ root, target, directory, realText = false, plannerModel = 'gpt-5-nano', budgetCny, packaged, env = process.env }) {
+  return {
+    args: [path.join(root, 'tests/ux/g1/c0-short-film.walk.mjs'),
+      ...(realText ? ['--real', '--planner-model', plannerModel] : ['--dry-run']),
+      ...(packaged ? ['--packaged', packaged] : [])],
+    env: { ...env, NOMI_WALK_MODE: 'collect', NOMI_SWEEP_CASE_DIR: target,
+      NOMI_C0_MEDIA_DRY_RUN: realText ? '1' : '0', NOMI_C0_TEXT_BUDGET: String(budgetCny), NOMI_C0_LEDGER_DIR: directory },
   }
 }

--- a/tests/ux/g1/sweep-real.mjs
+++ b/tests/ux/g1/sweep-real.mjs
@@ -1,6 +1,6 @@
 import fs from 'node:fs'
 import path from 'node:path'
-import { prepareIsolation } from '../../../evals/lib/isoApp.mjs'
+import { prepareIsolation, realCatalogPath } from '../../../evals/lib/isoApp.mjs'
 import { publicPrices, REAL_MODELS } from './c0-real-budget.mjs'
 export async function prepareRealText(profile) {
   const response = await fetch('https://apimart.ai/pricing', { signal: AbortSignal.timeout(30000) })
@@ -38,4 +38,11 @@ export async function attachRealText(launched, { profile, quote, ledgerPath, bud
     localStorage.setItem('nomi.assistantModel', JSON.stringify({ vendorKey: 'apimart', modelKey }))
     window.dispatchEvent(new CustomEvent('nomi:assistant-model-changed'))
   }, REAL_MODELS.text)
+}
+
+export function assertRealTextCredential(file = realCatalogPath()) {
+  let record
+  try { record = JSON.parse(fs.readFileSync(file, 'utf8')).apiKeysByVendor?.apimart } catch { /* Report only a safe configuration error. */ }
+  if (record?.enc !== 'safeStorage' || record.enabled === false || typeof record.apiKey !== 'string' || !record.apiKey.trim())
+    throw Error('SWEEP_REAL_TEXT_KEY_REQUIRED: --real-text requires an enabled APIMart key in Nomi settings; no loopback fallback')
 }


### PR DESCRIPTION
C0 的 sweep 入口原来始终使用 loopback，无法单独验收真实模型契约。现在 `pnpm run sweep --case C0 --real-text --planner-model gpt-5-nano --budget 1.5` 使用真文本规划与本地模拟媒体；支持 deepseek-v4-pro。媒体请求只能本地响应或拒绝，缺 key 明确失败。默认 loopback 行为保持不变，保留 main #668 的视频等待与原生转录逻辑；仅改测试、脚本及计划文档。

文本按公开报价、实际请求 UTF-8 字节上界和强制输出上限预留预算后发送（nano 16000 / deepseek 8192，且不超过供应商上限）。两个发送入口、并发及重试共享账本，超预算拒绝出站。

验证：
- 相关 Node 单测 21 项通过（其中混合模式与原预算测试 12 项，新增 5 项已纳入 check:walkthroughs）；参数/凭据/预算边界有先红后绿收据。focused Node 10 项通过；related Vitest 无关联文件，exit 0；全量 Vitest 由 gates 验证。
- 完整带锁 `pnpm run gates` exit 0：76 项 contracts 无阻断失败，1302 个 Vitest 文件 / 12113 项测试通过；Agent/runtime 与构建通过。日志：`artifacts/sweep-mixed/gates-final.log`，退出码：`gates-final.exit-code`；最终 HEAD `cbd2a3bf75f1`。
- 默认全量 loopback：33 输入 / 221 站，0 功能 deviation，¥0；5938 条体感原始命中保留。报告：`artifacts/sweep/2026-09-09T02-37-05.569Z/report.md`。已查看 C0 八段素材和 64 秒时间轴预览截图，导出、冷重启走通。
- 小额真实混合 sweep：预算 ¥0.30，4 次文本请求均 HTTP 400，账单增量 ¥0，预留 ¥0.20174245；0 媒体出站，C0 8 段本地测试信号走完下游。C0 R30 工具写对率 0/0（无调用），回合成功率 0/1；失败及 repair 原样保留，不声称模型契约已修复。报告：`artifacts/sweep/2026-09-09T02-41-13.873Z/report.md`。

计划与范围：[混合模式](docs/plan/2026-09-09-sweep-collect.md#混合模式2026-09-09)。账单取共享 token 余额增量，保留并发使用的归因限制。无生产代码变更。
