### PR TITLE
test(sweep): time-boxed credential precheck with blocked receipt

### DIFF
--- a/docs/plan/2026-09-09-sweep-collect.md
+++ b/docs/plan/2026-09-09-sweep-collect.md
@@ -88,3 +88,15 @@ Ponytail 独立明细发现四项机制问题，推送前一并修正：timeline
 范围：仅 scripts/tests 与本文；保留 main #668 视频等待、原生转录观察器和真实 C0 原预算。nano 输出最高 16000、deepseek 8192，报价低于上限时取小值。撤回本任务提交即可回滚，无数据迁移。验收：参数/预算传递、零媒体出站、并发及超预算拒发先红后绿；无 key 明确报错；完整 loopback 复扫及完整 gates exit 0，正常 hooks 后 push/PR。
 
 Ponytail 复核：两种模式统一复用 `c0-fixture.mjs` 的 `createSyntheticC0Media`，删除调度器内重复的 FFmpeg 编码配方；真实文本和媒体隔离发送边界不变。参数/缺 key/并发及失败预留共新增 5 项测试，和原预算测试合计 12 项通过。全量 loopback 与最终完整 gates 的收据写入 SWEEPC-LAST.md；真模型 HTTP 400 及 repair 保留，不把本任务称为生产模型契约修复。
+
+## 凭据预检（C14）
+
+范围仅测试装配与脚本。recurring：sweep attachRealText 与 C0 scheduler.attach 都在付费装配前同步调用隔离应用的 catalog/secrets 解密，锁屏可令 Electron 主线程永久阻塞；缺少的是 Node 宿主拥有的限时边界，不是模型失败。统一在原解密调用旁写无秘密的完成标记，宿主以最多 9 秒看守；不额外解密、不缓存或绕过钥匙串。超时直接终止该隔离进程，原生错误不进报告。系统 IORegistry 锁屏探测有独立短期限，unknown 保留为 unknown，不能推断 locked。
+
+失败记录 credential-precheck.json（blocked，locked-screen/keychain-denied/no-key，系统探测证据）；依赖真实凭据的后续站 unreachable，本 run blocked，独立零额度输入继续。无 key 在准备隔离前拒绝并留相同收据。成功仍使用原应用解密函数与原 dispatch 闭包，不把 key 返回 Node。依赖不升级：本任务修测试宿主看守，不改变 Electron/safeStorage 行为。回滚撤回本节与测试脚本修改，无生产或用户数据迁移。
+
+验收先红后绿：模拟解密永不返回、抛错/空值、无 key、成功仅解密一次；验证期限、终止、blocked/未到达收据、无密钥输出。完整 gates exit 0 后正常 hooks 提交推送 PR。
+
+C14 定向收据：旧 attach 在模拟解密挂起时由外部 1 秒超时终止且没有 blocked 收据（artifacts/c14/red-baseline.log）。七项回归覆盖同步主线程挂起、解密拒绝、缺 key、一次解密、账单阶段独立期限、C0 八站未到达及 sweep 独立零额度结果。打包 /Applications/Nomi.app 的真实应用解密在本次 locked 系统状态下返回 ready（零请求）；不能声称复现了该签名实例的真实钥匙串挂死。另对同打包应用注入同步主线程阻塞，9,037ms 返回 blocked/locked-screen，收据 elapsedMs=9,005，后续八站未到达（artifacts/c14/packaged-timeout）。没有真实模型出站或费用。
+
+同类扫描另覆盖 c0-real-assembly.e2e.mjs：改为同一看守入口，用原余额请求内的合成凭据断言证明解密，删除此前多余的独立解密。已安装 Nomi.app 缺少本分支需要的 dist-electron/appFetch.js，完整 dispatch 装配不能用该旧包证明；该失败按装配失败保留，没有伪装成凭据 blocked。完整装配改用当前构建验证，打包实例仅证明上述应用解密与外部期限。

--- a/scripts/sweep.mjs
+++ b/scripts/sweep.mjs
@@ -10,7 +10,9 @@ import { launchNomiApp } from '../tests/ux/_launchApp.mjs'
 import { createAgentRuntimeFixture } from '../tests/ux/agent-runtime-fixture.mjs'
 import { DOCUMENT } from '../tests/ux/agent-runtime-walk-support.mjs'
 import { startEvidence, copyTranscripts, writeJson, saveCase, saveReport, scoreCollectedAgent } from '../tests/ux/g1/sweep-evidence.mjs'
-import { prepareRealText, attachRealText, assertRealTextCredential } from '../tests/ux/g1/sweep-real.mjs'
+import { prepareRealText, attachRealText } from '../tests/ux/g1/sweep-real.mjs'
+import { requireCredential, recordBlocked } from '../tests/ux/g1/credential-precheck.mjs'
+import { realCatalogPath } from '../evals/lib/isoApp.mjs'
 import { c0Invocation } from '../tests/ux/g1/sweep-c0.mjs'
 import { runSurface } from '../tests/ux/g1/sweep-surfaces.mjs'
 
@@ -24,12 +26,11 @@ if (values.help) {
 const budgetCny = Number(values.budget)
 if (!Number.isFinite(budgetCny) || budgetCny < 0 || budgetCny > 3) throw Error('Sweep budget must be 0–3 CNY')
 if (values['planner-model'] && (!values['real-text'] || values.case !== 'C0')) throw Error('--planner-model requires --real-text --case C0')
-if (values['real-text']) assertRealTextCredential()
-const { inspectMcp } = await import('../tests/ux/g1/sweep-mcp.mjs')
 const runId = new Date().toISOString().replaceAll(':', '-'), directory = path.join(root, 'artifacts/sweep', runId)
 fs.mkdirSync(directory, { recursive: true })
 const cases = JSON.parse(fs.readFileSync(path.join(root, 'tests/ux/g1/cases.json'), 'utf8'))
 const runs = [], skipped = []
+let credentialBlock
 if (values.case && !cases.some(c => c.id === values.case)) throw Error(`Unknown case: ${values.case}`)
 const sourceFiles = ['scripts/sweep.mjs', 'tests/ux/_assert.mjs', 'tests/ux/_collect.mjs', ...fs.readdirSync(path.join(root, 'tests/ux/g1')).filter(f => /\.(mjs|json)$/.test(f)).map(f => `tests/ux/g1/${f}`)]
 writeJson(path.join(directory, 'source-files.json'), Object.fromEntries(sourceFiles.map(file => [file, createHash('sha256').update(fs.readFileSync(path.join(root, file))).digest('hex')])))
@@ -53,6 +54,20 @@ for (const entry of cases) for (const input of entry.inputs) {
   } })
   const station = (id, expected, fn) => walk.station({ id, surface: input.surface, expected }, fn)
   console.log(`SWEEP ${id}`)
+  const needsCredential = realText || (input.executor === 'c0' && values['real-text'])
+  if (needsCredential) {
+    try {
+      if (credentialBlock) throw Object.assign(Error('CREDENTIAL_BLOCKED'), { receipt: credentialBlock })
+      requireCredential(realCatalogPath(), target)
+    } catch (error) {
+      if (!error.receipt) throw error
+      credentialBlock = error.receipt
+      writeJson(path.join(target, 'credential-precheck.json'), credentialBlock)
+      recordBlocked(target, record, credentialBlock, input.executor === 'c0' ? ['00','01','02','03','04','05','06','07'] : ['launch','input','agent','storyboard','agent-evidence','feel'])
+      saveReport(directory, runs, skipped, budgetCny)
+      continue
+    }
+  }
   if (input.executor === 'c0') {
     let childError
     try {
@@ -64,8 +79,9 @@ for (const entry of cases) for (const input of entry.inputs) {
     const childReport = path.join(target, 'report.json')
     if (fs.existsSync(childReport)) {
       const result = JSON.parse(fs.readFileSync(childReport, 'utf8'))
-      Object.assign(record, { costCny: result.costCny, reservedCny: result.reservedCny, mediaMode: result.mediaMode, plannerModel: result.plannerModel })
+      Object.assign(record, { result: result.result, credentialPrecheck: result.credentialPrecheck, costCny: result.costCny, reservedCny: result.reservedCny, mediaMode: result.mediaMode, plannerModel: result.plannerModel })
     }
+    if (record.result === 'blocked') credentialBlock = record.credentialPrecheck
     Object.assign(walk, { stations: record.stations, deviations: record.deviations })
     if (childError) walk.record(Error(`C0 child failed: ${childError.code ?? 'unknown'}`), { id: 'c0-process', surface: 'storyboard' })
     if (!fs.existsSync(path.join(target, 'trace.zip'))) fs.writeFileSync(path.join(target, 'trace-unavailable.md'), 'C0 tracing did not finish; see deviations.json.\n')
@@ -75,13 +91,14 @@ for (const entry of cases) for (const input of entry.inputs) {
   try {
     if (realText) real = await prepareRealText(profile)
     else fixture = await createAgentRuntimeFixture({ rootDir: root, settingsDir: path.join(profile, 'settings') })
+    let executablePath = values.packaged
+    if (executablePath?.endsWith('.app')) executablePath = path.join(executablePath, 'Contents/MacOS/Nomi')
+    launched = await launchNomiApp({ name: id, tempRoot: profile, capabilityDir: path.join(profile, 'capability'), settleMs: 0,
+      ...(executablePath ? { executablePath } : {}),
+      env: { NOMI_RENDERER_URL: '', VITE_DEV_SERVER_URL: '', NOMI_DESKTOP_DEV: '', NOMI_E2E_PRODUCTION_FIXTURE: '0', NOMI_DISABLE_AUTO_UPDATE: '1' } })
+    // Before collect: blocked credentials cannot become a failed/repaired station.
+    if (real) await attachRealText(launched, { profile, quote: real.quote, ledgerPath, budgetCny, requestsPath: path.join(target, 'model-requests.json') })
     await station('launch', '独立 profile 启动真实 Electron', async () => {
-      let executablePath = values.packaged
-      if (executablePath?.endsWith('.app')) executablePath = path.join(executablePath, 'Contents/MacOS/Nomi')
-      launched = await launchNomiApp({ name: id, tempRoot: profile, capabilityDir: path.join(profile, 'capability'), settleMs: 0,
-        ...(executablePath ? { executablePath } : {}),
-        env: { NOMI_RENDERER_URL: '', VITE_DEV_SERVER_URL: '', NOMI_DESKTOP_DEV: '', NOMI_E2E_PRODUCTION_FIXTURE: '0', NOMI_DISABLE_AUTO_UPDATE: '1' } })
-      if (real) await attachRealText(launched, { profile, quote: real.quote, ledgerPath, budgetCny, requestsPath: path.join(target, 'model-requests.json') })
       evidence = await startEvidence({ ...launched, directory: target, payload })
       launched.win.setDefaultTimeout(5000)
       await launched.win.evaluate(() => {
@@ -95,7 +112,7 @@ for (const entry of cases) for (const input of entry.inputs) {
       projectId = projects[0].id
     })
     await runSurface({ walk, win: launched?.win, input, fixture, realText, directory: target, payload, projectId })
-    if (launched && input.surface === 'mcp') await inspectMcp({ profile, directory: target, projectId, packaged: values.packaged, input, walk })
+    if (launched && input.surface === 'mcp') await (await import('../tests/ux/g1/sweep-mcp.mjs')).inspectMcp({ profile, directory: target, projectId, packaged: values.packaged, input, walk })
     await station('agent-evidence', '原生转录、请求与工具结果可复盘', async () => {
       // Request bodies are original provider input; authentication headers are never copied.
       if (fixture) writeJson(path.join(target, 'model-requests.json'), fixture.requests.map(r => ({ path: r.path, body: r.body })))
@@ -110,19 +127,25 @@ for (const entry of cases) for (const input of entry.inputs) {
       writeJson(path.join(target, 'feel.json'), await scanFeel(launched.win, { label: id }))
     })
 
-  } catch (error) { walk.record(error, { id: 'assembly', surface: input.surface, reachedViaRepair: false }) }
+  } catch (error) {
+    if (error.code === 'CREDENTIAL_BLOCKED') {
+      credentialBlock = error.receipt
+      recordBlocked(target, record, credentialBlock, ['launch','input','agent','storyboard','agent-evidence','feel'])
+      Object.assign(walk, { stations: record.stations, deviations: record.deviations })
+    } else walk.record(error, { id: 'assembly', surface: input.surface, reachedViaRepair: false })
+  }
   finally {
     try {
-      if (real && launched) for (const error of await launched.app.evaluate(async () => globalThis.__sweepDispatch?.drainResponses() ?? [])) {
+      if (real && launched && record.result !== 'blocked') for (const error of await launched.app.evaluate(async () => globalThis.__sweepDispatch?.drainResponses() ?? [])) {
         walk.record(Error(`Response evidence failed: ${error.file}: ${error.message}`), { id: 'response-evidence', surface: input.surface })
       }
     } catch (error) { walk.record(error, { id: 'response-evidence', surface: input.surface }) }
-    try { if (real && launched) { await launched.app.evaluate(async () => globalThis.__sweepDispatch.snapshot()); billingVerified = true } }
+    try { if (real && launched && record.result !== 'blocked') { await launched.app.evaluate(async () => globalThis.__sweepDispatch.snapshot()); billingVerified = true } }
     catch (e) { walk.record(Error('SWEEP_BILLING_UNAVAILABLE'), { id: 'billing', surface: input.surface }) }
     try { if (evidence) await evidence.stop() } catch (e) { walk.record(e, { id: 'trace-stop', surface: input.surface }) }
-    try { if (launched) await launched.close() } catch (e) { walk.record(e, { id: 'close', surface: input.surface }) }
+    try { if (launched && record.result !== 'blocked') await launched.close() } catch (e) { walk.record(e, { id: 'close', surface: input.surface }) }
     try { if (fixture) await fixture.close() } catch (e) { walk.record(e, { id: 'fixture-close', surface: input.surface }) }
-    if (real && fs.existsSync(ledgerPath)) {
+    if (real && record.result !== 'blocked' && fs.existsSync(ledgerPath)) {
       const ledger = JSON.parse(fs.readFileSync(ledgerPath, 'utf8'))
       record.reservedCny = ledger.reservedCny - priorReserved
       record.costCny = billingVerified && Number.isFinite(ledger.billedCny) ? ledger.billedCny - priorBilled : null

--- a/tests/ux/g1/c0-real-assembly.e2e.mjs
+++ b/tests/ux/g1/c0-real-assembly.e2e.mjs
@@ -1,3 +1,4 @@
+import { watchCredential } from './credential-precheck.mjs'
 // Zero-paid-call assembly check: actual isolated Electron catalog encryption/decryption and
 // C0 guard installation, with both transports replaced by a local function before attachment.
 import { expect } from '../_assert.mjs'
@@ -9,33 +10,32 @@ import { launchNomiApp } from '../_launchApp.mjs'
 const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'c0-real-assembly-'))
 const bridge = path.join(tempRoot, 'bridge.cjs')
 fs.writeFileSync(bridge, `module.exports = import(${JSON.stringify(new URL('./c0-real-main.mjs', import.meta.url).href)});`)
-let launched
+let launched, blocked = false
 try {
   const bundle = process.argv[2] && path.resolve(process.argv[2])
   launched = await launchNomiApp({ name: 'c0-real-assembly', tempRoot,
     ...(bundle ? { executablePath: path.join(bundle, 'Contents/MacOS/Nomi') } : {}),
     env: { NOMI_DISABLE_AUTO_UPDATE: '1', NOMI_RENDERER_URL: '', VITE_DEV_SERVER_URL: '' },
   })
-  const proof = await launched.app.evaluate(async ({ app }, { bridge, ledgerPath }) => {
+  const proof = await watchCredential({ directory: tempRoot, kill: () => { blocked = true; launched.app.process().kill('SIGKILL') },
+    run: credentialMarker => launched.app.evaluate(async ({ app }, { bridge, ledgerPath, credentialMarker }) => {
     const require = process.mainModule.require.bind(process.mainModule)
     const catalog = require(`${app.getAppPath()}/dist-electron/catalog/catalogStore.js`)
     catalog.upsertModelCatalogVendorApiKey('apimart', { apiKey: 'c0-synthetic-credential', enabled: true })
     const transport = require(`${app.getAppPath()}/dist-electron/appFetch.js`)
     let relayed = 0, decrypted = false
-    const send = async (input) => {
+    const send = async (input, init) => {
       if (String(input).endsWith('/v1/balance')) {
+        decrypted = init.headers.Authorization === 'Bearer c0-synthetic-credential'
         return new Response(JSON.stringify({ success: true, used_balance: 0, used_credits: 0 }))
       }
       relayed++
       return new Response('synthetic-transport-response', { status: 201 })
     }
-    // Read the application-stored ciphertext through the exact production reader, not a test secret decoder.
-    const secrets = require(`${app.getAppPath()}/dist-electron/catalog/secrets.js`)
-    decrypted = secrets.decryptApiKeyRecord(catalog.readCatalog().apiKeysByVendor.apimart) === 'c0-synthetic-credential'
     transport.appFetch = send
     globalThis.fetch = send
     const module = await require(bridge)
-    const guard = await module.attachRealDispatch({ ledgerPath,
+    const guard = await module.attachRealDispatch({ ledgerPath, credentialMarker,
       quote: { textRequestUsd: .01, maxOutputTokens: 16000, videoPerSecondUsd: .0714, imageUsd: .010625 } })
     const request = (model) => transport.appFetch('https://api.apimart.ai/v1/chat/completions', {
       method: 'POST', body: JSON.stringify({ model, messages: [{ role: 'user', content: 'assembly only' }] }),
@@ -47,7 +47,7 @@ try {
     return { decrypted, refused, relayed, responseStatus: response.status, response: await response.text(),
       reservations: ledger.requests.length, reservedCny: ledger.reservedCny, billedUsd: ledger.billedUsd,
       packaged: app.isPackaged }
-  }, { bridge, ledgerPath: path.join(tempRoot, 'ledger.json') })
+  }, { bridge, ledgerPath: path.join(tempRoot, 'ledger.json'), credentialMarker }) })
   expect(proof.decrypted).toBe(true)
   expect(proof.refused).toBe(true)
   expect(proof.relayed).toBe(1)
@@ -62,6 +62,6 @@ try {
   console.error('C0 ASSEMBLY FAILED (raw exception suppressed)')
   process.exitCode = 1
 } finally {
-  await launched?.close()
+  if (!blocked) await launched?.close()
   fs.rmSync(tempRoot, { recursive: true, force: true })
 }

--- a/tests/ux/g1/c0-real-main.mjs
+++ b/tests/ux/g1/c0-real-main.mjs
@@ -1,3 +1,4 @@
+import { decryptForDispatch } from './credential-main.mjs'
 // Loaded through a file-backed bridge inside the candidate Electron main process.
 // Credentials never cross this boundary. Production catalog/transport modules come from app.asar.
 import fs from 'node:fs'
@@ -5,16 +6,13 @@ import path from 'node:path'
 import { createRequire } from 'node:module'
 import { planSampleFetch } from './c0-plan-sample-budget.mjs'
 import { budgetedFetch, CNY_PER_USD } from './c0-real-budget.mjs'
-export async function attachRealDispatch({ quote, ledgerPath, mediaFiles = [], requestsPath }) {
+export async function attachRealDispatch({ quote, ledgerPath, mediaFiles = [], requestsPath, credentialMarker }) {
   const require = createRequire(import.meta.url)
   const { app } = require('electron')
   const compiled = path.join(app.getAppPath(), 'dist-electron')
   const { readCatalog } = require(path.join(compiled, 'catalog/catalogStore.js'))
   const { decryptApiKeyRecord } = require(path.join(compiled, 'catalog/secrets.js'))
-  const catalog = readCatalog()
-  const record = catalog.apiKeysByVendor?.apimart
-  const key = record?.enabled !== false ? decryptApiKeyRecord(record) : ''
-  if (!key) throw new Error('C0_APPLICATION_CREDENTIAL_UNAVAILABLE')
+  const key = decryptForDispatch({ record: readCatalog().apiKeysByVendor?.apimart, decrypt: decryptApiKeyRecord, credentialMarker })
   const transport = require(path.join(compiled, 'appFetch.js'))
   const originalAppFetch = transport.appFetch
   const originalGlobalFetch = globalThis.fetch

--- a/tests/ux/g1/c0-real-scheduler.mjs
+++ b/tests/ux/g1/c0-real-scheduler.mjs
@@ -1,3 +1,4 @@
+import { watchCredential } from './credential-precheck.mjs'
 import fs from 'node:fs'
 import { quotePlanSample } from './c0-plan-sample-budget.mjs'
 import { shots, createSyntheticC0Media } from './c0-fixture.mjs'
@@ -54,7 +55,7 @@ export async function createRealScheduler({ tempRoot, attemptDir, outputDir, rep
   const priorReserved = mixed ? (earlier?.reservedCny ?? 0) : 0
   const firstRequest = mixed ? (earlier?.requests?.length ?? 0) : 0
   const mediaFiles = mixed ? createSyntheticC0Media(path.join(attemptDir, 'fixture-media')) : []
-  let app, planEvents = [], nativeMessages
+  let app, credentialBlocked = false, planEvents = [], nativeMessages
   const readNativeMessages = async (projectRoot) => {
     // Reuse the candidate's versioned observer rather than duplicating the pi format reader.
     const observer = await import('../agent-lane-observer.mjs')
@@ -62,7 +63,7 @@ export async function createRealScheduler({ tempRoot, attemptDir, outputDir, rep
   }
   const bridge = path.join(tempRoot, 'c0-main.cjs')
   const snapshot = async () => {
-    if (!app) return
+    if (!app || credentialBlocked) return
     try {
       const ledger = await app.evaluate(() => globalThis.__c0Dispatch.snapshot())
       report.costCny = ledger.billedCnyAtBudgetRate - priorCost
@@ -97,10 +98,10 @@ export async function createRealScheduler({ tempRoot, attemptDir, outputDir, rep
     async attach(launched) {
       app = launched.app
       fs.writeFileSync(bridge, `module.exports = import(${JSON.stringify(new URL('./c0-real-main.mjs', import.meta.url).href)});`, { mode: 0o600 })
-      try { await app.evaluate(async (_electron, options) => {
+      try { await watchCredential({ directory: attemptDir, kill: () => { credentialBlocked = true; app.process().kill('SIGKILL') }, run: credentialMarker => app.evaluate(async (_electron, options) => {
         const module = await process.mainModule.require(options.bridge)
         globalThis.__c0Dispatch = await module.attachRealDispatch(options)
-      }, { bridge, quote, ledgerPath, mediaFiles, requestsPath: path.join(attemptDir, 'model-requests.json') }) } finally { fs.rmSync(bridge, { force: true }) }
+      }, { bridge, quote, ledgerPath, mediaFiles, requestsPath: path.join(attemptDir, 'model-requests.json'), credentialMarker }) }) } finally { fs.rmSync(bridge, { force: true }) }
       await launched.win.evaluate(({ models }) => {
         localStorage.setItem('nomi.assistantModel', JSON.stringify({ vendorKey: 'apimart', modelKey: models.text }))
         window.dispatchEvent(new CustomEvent('nomi:assistant-model-changed'))

--- a/tests/ux/g1/c0-short-film.walk.mjs
+++ b/tests/ux/g1/c0-short-film.walk.mjs
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+import { requireCredential, recordBlocked } from './credential-precheck.mjs'
+import { realCatalogPath } from '../../../evals/lib/isoApp.mjs'
 // C0: one UI journey, with either synthetic or budgeted real provider dispatch.
 import fs from 'node:fs'
 import { videoWaitBudget, waitForVideos } from './c0-video-wait.mjs'
@@ -81,6 +83,7 @@ async function step(id, action, expected, run, interruption = '无自动检测�
   }
 }
 try {
+  if (values.real) requireCredential(realCatalogPath(), attemptDir)
   // Check before importing Playwright so a missing development environment leaves a report.
   const missing = ['node_modules', ...(!values.packaged ? ['dist/index.html', 'dist-electron/main.js'] : [])]
     .filter((name) => !fs.existsSync(path.join(root, name)))
@@ -117,14 +120,15 @@ try {
     try {
       await scheduler.attach(launched)
       if (collection) await collection.attach(launched, payload, () => projectId)
-    } catch (error) { await launched.close(); throw error }
+    } catch (error) { if (error.code !== 'CREDENTIAL_BLOCKED') await launched.close(); throw error }
     return launched
   }
   let projectId, projectRoot, nodeIds, before, exportPath
   const payload = async () => (await readProject(win, projectId)).payload
   const videoClips = (p) => p.timeline.tracks.flatMap((t) => t.clips).filter((c) => c.type === 'video').sort((a, b) => a.startFrame - b.startFrame)
+  const initialLaunch = await launch()
   await step('00', '准备隔离空项目', '独立 profile、版本可核对、项目库为空', async () => {
-    const launched = await launch()
+    const launched = initialLaunch
     ;({ app, win } = launched)
     win.setDefaultTimeout(30_000)
     report.build = await app.evaluate(({ app: main }) => ({ version: main.getVersion(), packaged: main.isPackaged, appPath: main.getAppPath(), userData: main.getPath('userData') }))
@@ -293,21 +297,26 @@ try {
   })
   report.result = collection?.walk.deviations.length ? 'collected-deviations' : `${report.mode}-assertions-passed-review-pending`
 } catch (error) {
-  report.result = error.message === 'C0_BLOCKED_BUDGET' ? 'blocked-budget' : 'failed'
-  report.blocker = values.real ? (String(error.message).match(/C0_[A-Z_]+/)?.[0] ?? 'C0_WALK_FAILED_RAW_ERROR_SUPPRESSED') : error.message
-  if (win) {
-    try { await win.screenshot({ path: path.join(attemptDir, 'FAIL.png') }) }
-    catch { report.failureScreenshot = 'unavailable' }
+  if (error.code === 'CREDENTIAL_BLOCKED') {
+    recordBlocked(attemptDir, report, error.receipt, ['00','01','02','03','04','05','06','07'])
+    report.blocker = error.receipt.reason
+  } else {
+    report.result = error.message === 'C0_BLOCKED_BUDGET' ? 'blocked-budget' : 'failed'
+    report.blocker = values.real ? (String(error.message).match(/C0_[A-Z_]+/)?.[0] ?? 'C0_WALK_FAILED_RAW_ERROR_SUPPRESSED') : error.message
+    if (win) {
+      try { await win.screenshot({ path: path.join(attemptDir, 'FAIL.png') }) }
+      catch { report.failureScreenshot = 'unavailable' }
+    }
+    console.error(`C0 ${report.result}: ${report.blocker}`)
+    process.exitCode = 1
   }
-  console.error(`C0 ${report.result}: ${report.blocker}`)
-  process.exitCode = 1
 } finally {
-  if (collection) {
+  if (collection && report.result !== 'blocked') {
     try { await collection.stop(); collection.finish(path.join(attemptDir, 'profile'), scheduler?.requests ?? []) }
     catch (error) { report.collectionError = error.message; process.exitCode = 1 }
   }
   try { if (scheduler) await scheduler.close() } catch { report.cleanupError = 'C0_SCHEDULER_CLEANUP_FAILED'; process.exitCode = 1 }
-  try { if (app) await stopRuntimeApp(app) } catch { report.cleanupError = 'C0_APP_CLEANUP_FAILED'; process.exitCode = 1 }
+  try { if (app && report.result !== 'blocked') await stopRuntimeApp(app) } catch { report.cleanupError = 'C0_APP_CLEANUP_FAILED'; process.exitCode = 1 }
   if (values.real) fs.rmSync(path.join(attemptDir, 'profile/settings'), { recursive: true, force: true })
   save()
   console.log(`C0 ${report.result}; evidence: ${attemptDir}; paid calls: ${report.paidCalls}`)

--- a/tests/ux/g1/credential-main.mjs
+++ b/tests/ux/g1/credential-main.mjs
@@ -7,7 +7,6 @@ export function decryptForDispatch({ record, decrypt, credentialMarker }) {
   let key = '', reason = 'no-key'
   if (hasCredential(record)) {
     reason = 'keychain-denied'
-    fs.writeFileSync(credentialMarker, JSON.stringify({ status: 'probing' }))
     try { key = decrypt(record) } catch { /* Only the safe reason crosses the process boundary. */ }
   }
   fs.writeFileSync(credentialMarker, JSON.stringify(key ? { status: 'ready' } : { status: 'blocked', reason }))

--- a/tests/ux/g1/credential-main.mjs
+++ b/tests/ux/g1/credential-main.mjs
@@ -1,0 +1,16 @@
+import fs from 'node:fs'
+export function hasCredential(record) {
+  return record?.enabled !== false && record?.enc === 'safeStorage' && typeof record?.apiKey === 'string' && Boolean(record.apiKey.trim())
+}
+// This replaces the existing decrypt, not a second probe. The key stays in its original dispatch closure.
+export function decryptForDispatch({ record, decrypt, credentialMarker }) {
+  let key = '', reason = 'no-key'
+  if (hasCredential(record)) {
+    reason = 'keychain-denied'
+    fs.writeFileSync(credentialMarker, JSON.stringify({ status: 'probing' }))
+    try { key = decrypt(record) } catch { /* Only the safe reason crosses the process boundary. */ }
+  }
+  fs.writeFileSync(credentialMarker, JSON.stringify(key ? { status: 'ready' } : { status: 'blocked', reason }))
+  if (!key) throw Error('CREDENTIAL_BLOCKED')
+  return key
+}

--- a/tests/ux/g1/credential-precheck.mjs
+++ b/tests/ux/g1/credential-precheck.mjs
@@ -1,0 +1,76 @@
+import { hasCredential } from './credential-main.mjs'
+// Node owns the deadline: Electron's synchronous Keychain call cannot run its own timer.
+import fs from 'node:fs'
+import path from 'node:path'
+import { execFileSync } from 'node:child_process'
+
+export function screenEvidence() {
+  if (process.platform !== 'darwin') return { state: 'unknown', source: 'unsupported-platform' }
+  try {
+    const output = execFileSync('/usr/sbin/ioreg', ['-n', 'Root', '-d1'], { encoding: 'utf8', timeout: 500, stdio: ['ignore', 'pipe', 'ignore'] })
+    const match = output.match(/"CGSSessionScreenIsLocked"\s*=\s*(Yes|No|true|false)/)
+    return { state: match ? /Yes|true/.test(match[1]) ? 'locked' : 'unlocked' : 'unknown',
+      source: 'ioreg Root CGSSessionScreenIsLocked', observed: match?.[0] ?? 'field-absent' }
+  } catch { return { state: 'unknown', source: 'ioreg', observed: 'probe-unavailable-or-timeout' } }
+}
+export function blockedError(directory, reason, screen = screenEvidence()) {
+  const receipt = { status: 'blocked', reason, screen, at: new Date().toISOString(), paidCalls: 0 }
+  fs.mkdirSync(directory, { recursive: true })
+  fs.writeFileSync(path.join(directory, 'credential-precheck.json'), JSON.stringify(receipt, null, 2))
+  return Object.assign(Error('CREDENTIAL_BLOCKED'), { code: 'CREDENTIAL_BLOCKED', receipt })
+}
+export function requireCredential(file, directory) {
+  let record
+  try { record = JSON.parse(fs.readFileSync(file, 'utf8')).apiKeysByVendor?.apimart } catch { /* no raw settings in evidence */ }
+  if (!hasCredential(record))
+    throw blockedError(directory, 'no-key')
+}
+export async function watchCredential({ directory, run, kill, timeoutMs = 9000, screen = screenEvidence() }) {
+  if (!(timeoutMs > 0 && timeoutMs <= 9000)) throw Error('Invalid credential deadline')
+  const marker = path.join(directory, 'credential-ready.json')
+  fs.rmSync(marker, { force: true })
+  const began = performance.now()
+  let timer, watcher, rejectBlocked, settled = false
+  const blocked = new Promise((_, reject) => { rejectBlocked = reject })
+  const stop = () => { clearTimeout(timer); watcher?.close() }
+  const fail = reason => {
+    if (settled) return
+    settled = true
+    stop()
+    const error = blockedError(directory, reason, screen)
+    error.receipt.elapsedMs = Math.round(performance.now() - began)
+    error.receipt.deadlineMs = timeoutMs
+    try { kill() } catch { error.receipt.termination = 'unavailable' }
+    fs.writeFileSync(path.join(directory, 'credential-precheck.json'), JSON.stringify(error.receipt, null, 2))
+    rejectBlocked(error)
+  }
+  const inspect = () => {
+    let result
+    try { result = JSON.parse(fs.readFileSync(marker, 'utf8')) } catch { return }
+    if (result.status === 'ready') {
+      settled = true
+      stop()
+      fs.writeFileSync(path.join(directory, 'credential-precheck.json'), JSON.stringify({ status: 'ready', screen, at: new Date().toISOString() }))
+    } else if (result.status === 'blocked') fail(result.reason === 'no-key' ? 'no-key' : screen.state === 'locked' ? 'locked-screen' : 'keychain-denied')
+  }
+  watcher = fs.watch(directory, inspect)
+  timer = setTimeout(() => { inspect(); if (!settled) fail(screen.state === 'locked' ? 'locked-screen' : 'keychain-denied') }, timeoutMs)
+  try {
+    const task = Promise.resolve().then(() => run(marker)).then(value => {
+      inspect()
+      if (!settled) fail(screen.state === 'locked' ? 'locked-screen' : 'keychain-denied')
+      return value
+    }, error => { inspect(); throw error })
+    return await Promise.race([blocked, task])
+  } finally { stop(); fs.rmSync(marker, { force: true }) }
+}
+export function recordBlocked(directory, report, receipt, later) {
+  report.result = 'blocked'
+  report.credentialPrecheck = receipt
+  report.stations ??= []
+  report.deviations ??= []
+  report.stations.push({ id: 'credential-precheck', status: 'blocked', reason: receipt.reason },
+    ...later.map(id => ({ id, status: 'unreachable', reason: 'credential-precheck blocked' })))
+  fs.writeFileSync(path.join(directory, 'stations.json'), JSON.stringify(report.stations, null, 2))
+  fs.writeFileSync(path.join(directory, 'deviations.json'), JSON.stringify(report.deviations, null, 2))
+}

--- a/tests/ux/g1/credential-precheck.node-test.mjs
+++ b/tests/ux/g1/credential-precheck.node-test.mjs
@@ -1,0 +1,124 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { watchCredential, recordBlocked } from './credential-precheck.mjs'
+
+test('hung decrypt is killed and recorded blocked, later stations are unreachable', async () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'credential-test-'))
+  let killed = 0
+  try {
+    await assert.rejects(watchCredential({ directory, timeoutMs: 40,
+      screen: { state: 'locked', source: 'fixture' }, kill: () => killed++,
+      run: () => new Promise(() => {}) }), error => {
+      assert.equal(error.code, 'CREDENTIAL_BLOCKED')
+      const report = { stations: [], deviations: [] }
+      recordBlocked(directory, report, error.receipt, ['02', '03'])
+      assert.equal(report.result, 'blocked')
+      assert.deepEqual(report.stations.map(s => s.status), ['blocked', 'unreachable', 'unreachable'])
+      return true
+    })
+    assert.equal(killed, 1)
+    assert.equal(JSON.parse(fs.readFileSync(path.join(directory, 'credential-precheck.json'))).reason, 'locked-screen')
+  } finally { fs.rmSync(directory, { recursive: true, force: true }) }
+})
+
+test('successful marker disarms decrypt deadline while later billing remains separate', async () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'credential-test-'))
+  try {
+    const result = await watchCredential({ directory, timeoutMs: 20, screen: { state: 'unknown' },
+      kill: () => assert.fail('must not kill'), run: async marker => {
+        fs.writeFileSync(marker, JSON.stringify({ status: 'ready' }))
+        await new Promise(resolve => setTimeout(resolve, 50))
+        return 'attached'
+      } })
+    assert.equal(result, 'attached')
+  } finally { fs.rmSync(directory, { recursive: true, force: true }) }
+})
+
+test('decrypt uses the application function exactly once and only emits a safe status', async () => {
+  const { decryptForDispatch } = await import('./credential-main.mjs')
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'credential-main-'))
+  const marker = path.join(directory, 'marker.json')
+  try {
+    for (const outcome of ['secret-fixture-value', '', new Error('sensitive native error')]) {
+      let calls = 0
+      const invoke = () => decryptForDispatch({ record: { enc: 'safeStorage', apiKey: 'ciphertext-fixture' },
+        credentialMarker: marker, decrypt: () => { calls++; if (outcome instanceof Error) throw outcome; return outcome } })
+      if (outcome === 'secret-fixture-value') assert.equal(invoke(), outcome)
+      else assert.throws(invoke, /CREDENTIAL_BLOCKED/)
+      assert.equal(calls, 1)
+      assert.doesNotMatch(fs.readFileSync(marker, 'utf8'), /secret-fixture|ciphertext|sensitive/)
+    }
+    assert.throws(() => decryptForDispatch({ credentialMarker: marker, decrypt: () => assert.fail('no key must not decrypt') }), /CREDENTIAL_BLOCKED/)
+    assert.equal(JSON.parse(fs.readFileSync(marker)).reason, 'no-key')
+  } finally { fs.rmSync(directory, { recursive: true, force: true }) }
+})
+
+test('native synchronous hang cannot defeat the parent deadline', async () => {
+  const { spawn } = await import('node:child_process')
+  const { once } = await import('node:events')
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'credential-native-'))
+  const child = spawn(process.execPath, ['-e', 'Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0)'], { stdio: 'ignore' })
+  const ended = once(child, 'exit')
+  try {
+    await assert.rejects(watchCredential({ directory, timeoutMs: 80, screen: { state: 'unknown' },
+      kill: () => child.kill('SIGKILL'), run: () => new Promise(() => {}) }), error => {
+      assert.equal(error.receipt.reason, 'keychain-denied')
+      assert.equal(error.receipt.screen.state, 'unknown')
+      return true
+    })
+    const [, signal] = await ended
+    assert.equal(signal, 'SIGKILL')
+  } finally { child.kill('SIGKILL'); fs.rmSync(directory, { recursive: true, force: true }) }
+})
+
+test('explicit decrypt rejection is blocked; assembly failures are not disguised as credentials', async () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'credential-errors-'))
+  try {
+    await assert.rejects(watchCredential({ directory, screen: { state: 'unlocked' }, kill: () => {},
+      run: marker => { fs.writeFileSync(marker, JSON.stringify({ status: 'blocked', reason: 'keychain-denied' })); throw Error('native secret') } }), error => {
+      assert.equal(error.code, 'CREDENTIAL_BLOCKED')
+      assert.equal(error.receipt.reason, 'keychain-denied')
+      assert.doesNotMatch(JSON.stringify(error.receipt), /native secret/)
+      return true
+    })
+    await assert.rejects(watchCredential({ directory, screen: { state: 'unknown' }, kill: () => assert.fail('assembly is not decryption'),
+      run: () => { throw Error('module missing') } }), /module missing/)
+  } finally { fs.rmSync(directory, { recursive: true, force: true }) }
+})
+
+test('C0 missing credentials writes blocked and eight unreachable stations without launching', async () => {
+  const { spawnSync } = await import('node:child_process')
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'credential-c0-'))
+  try {
+    const preload = 'data:text/javascript,' + encodeURIComponent(`import os from 'node:os'; os.homedir = () => ${JSON.stringify(directory)}`)
+    const result = spawnSync(process.execPath, ['--import', preload, new URL('./c0-short-film.walk.mjs', import.meta.url).pathname, '--real'], {
+      env: { ...process.env, NOMI_SWEEP_CASE_DIR: directory, NOMI_WALK_MODE: 'collect' }, encoding: 'utf8', timeout: 10000,
+    })
+    assert.equal(result.status, 0, result.stderr)
+    const report = JSON.parse(fs.readFileSync(path.join(directory, 'report.json')))
+    assert.equal(report.result, 'blocked')
+    assert.equal(report.credentialPrecheck.reason, 'no-key')
+    assert.equal(report.paidCalls, 0)
+    assert.equal(report.stations.filter(s => s.status === 'unreachable').length, 8)
+  } finally { fs.rmSync(directory, { recursive: true, force: true }) }
+})
+
+test('sweep report marks blocked without counting a failure or a reached paid station', async () => {
+  const { saveReport } = await import('./sweep-evidence.mjs')
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'credential-report-'))
+  try {
+    fs.writeFileSync(path.join(directory, 'run.json'), JSON.stringify({ mode: 'real-text' }))
+    const paid = { id: 'paid', surface: 'agent-panel', costCny: 0 }
+    recordBlocked(directory, paid, { status: 'blocked', reason: 'no-key' }, ['agent'])
+    const free = { id: 'free', surface: 'timeline', costCny: 0, stations: [{ id: 'timeline', status: 'passed' }], deviations: [] }
+    saveReport(directory, [paid, free], [], 3)
+    assert.equal(JSON.parse(fs.readFileSync(path.join(directory, 'run.json'))).status, 'blocked')
+    const markdown = fs.readFileSync(path.join(directory, 'report.md'), 'utf8')
+    assert.match(markdown, /paid：blocked/)
+    assert.match(markdown, /agent-panel \| 1 \| 0 \| 0 \| 0 \| 0/)
+    assert.match(markdown, /timeline \| 1 \| 1 \| 0 \| 0 \| 0/)
+  } finally { fs.rmSync(directory, { recursive: true, force: true }) }
+})

--- a/tests/ux/g1/sweep-budget.node-test.mjs
+++ b/tests/ux/g1/sweep-budget.node-test.mjs
@@ -1,3 +1,4 @@
+import './credential-precheck.node-test.mjs'
 import test from 'node:test'
 import assert from 'node:assert/strict'
 import fs from 'node:fs'
@@ -32,11 +33,14 @@ test('media, foreign endpoints, unknown models and unknown budget cannot spend',
   }
 })
 test('real-text bridge cleans executable scratch on both attachment success and failure', async () => {
-  const profile = fs.mkdtempSync(path.join(os.tmpdir(), 'sweep-bridge-'))
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'sweep-bridge-'))
+  const profile = path.join(directory, 'profile')
+  fs.mkdirSync(profile)
   try {
     for (const fail of [false, true]) {
       const launched = { app: { async evaluate(_fn, options) {
         assert.equal(fs.existsSync(options.bridge), true)
+        fs.writeFileSync(options.credentialMarker, JSON.stringify({ status: 'ready' }))
         if (fail) throw Error('attach failed')
       } }, win: { async evaluate() {} } }
       const result = attachRealText(launched, { profile, quote, budgetCny: 3 })
@@ -44,7 +48,7 @@ test('real-text bridge cleans executable scratch on both attachment success and 
       else await result
       assert.equal(fs.existsSync(path.join(profile, 'sweep-main.cjs')), false)
     }
-  } finally { fs.rmSync(profile, { recursive: true, force: true }) }
+  } finally { fs.rmSync(directory, { recursive: true, force: true }) }
 })
 
 test('mixed dispatch caps each quoted text tier at 1.5 and never forwards media', async () => {
@@ -84,20 +88,14 @@ test('C0 invocation passes the selected real text tier and budget; default stays
 })
 
 test('real-text without a configured enabled key fails explicitly before any request', async () => {
-  const { assertRealTextCredential } = await import('./sweep-real.mjs')
+  const { requireCredential } = await import('./credential-precheck.mjs')
   const fs = await import('node:fs'), os = await import('node:os'), path = await import('node:path')
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'mixed-key-')), file = path.join(dir, 'catalog.json')
   try {
-    assert.throws(() => assertRealTextCredential(file), /SWEEP_REAL_TEXT_KEY_REQUIRED/)
-    const { spawnSync } = await import('node:child_process')
-    const preload = 'data:text/javascript,' + encodeURIComponent(`import os from 'node:os'; os.homedir = () => ${JSON.stringify(dir)}`)
-    const cli = spawnSync(process.execPath, ['--import', preload, new URL('../../../scripts/sweep.mjs', import.meta.url).pathname, '--case', 'C0', '--real-text'], { encoding: 'utf8' })
-    assert.equal(cli.status, 1)
-    assert.match(cli.stderr, /SWEEP_REAL_TEXT_KEY_REQUIRED/)
-    assert.doesNotMatch(cli.stdout, /SWEEP C0/)
+    assert.throws(() => requireCredential(file, dir), /CREDENTIAL_BLOCKED/)
     for (const apimart of [undefined, { enc: 'safeStorage', enabled: false }]) {
       fs.writeFileSync(file, JSON.stringify({ apiKeysByVendor: { apimart } }))
-      assert.throws(() => assertRealTextCredential(file), /SWEEP_REAL_TEXT_KEY_REQUIRED/)
+      assert.throws(() => requireCredential(file, dir), /CREDENTIAL_BLOCKED/)
     }
   } finally { fs.rmSync(dir, { recursive: true, force: true }) }
 })

--- a/tests/ux/g1/sweep-evidence.mjs
+++ b/tests/ux/g1/sweep-evidence.mjs
@@ -111,6 +111,10 @@ export function saveCase(directory, walk) {
 export function saveReport(directory, runs, skipped, budgetCny) {
   const lines = ['# Sweep 问题总账', '', `模式：记录并继续；预算上限 ¥${budgetCny}。费用取供应商余额增量，缺账单写未知；站点费用为保守预留增量。修补不算通过；各输入只证明登记的子任务，不能代替完整 G1 验收。`, '',
     '| case/input | surface | 站 | 现象 | 证据 | 初判层 | root_cause_cluster |', '|---|---|---|---|---|---|---|']
+  const status = runs.some(r => r.result === 'blocked') ? 'blocked' : 'collected'
+  const runFile = path.join(directory, 'run.json')
+  if (fs.existsSync(runFile)) writeJson(runFile, { ...JSON.parse(fs.readFileSync(runFile, 'utf8')), status })
+  lines.splice(3, 0, `运行状态：${status}`, ...runs.filter(r => r.result === 'blocked').map(r => `- ${r.id}：blocked (${r.credentialPrecheck?.reason})；[凭据收据](${r.id}/credential-precheck.json)，后续站未到达。`), '')
   const evidence = (r, d) => `[轨迹](${r.id}/${fs.existsSync(path.join(directory, r.id, 'trace.zip')) ? 'trace.zip' : 'trace-unavailable.md'}) / [断言](${r.id}/deviations.json)${d.screenshot ? ` / [截图](${r.id}/${d.screenshot})` : ''}`
   const feelGroups = new Map()
   for (const r of runs) for (const d of r.deviations) {
@@ -137,7 +141,7 @@ export function saveReport(directory, runs, skipped, budgetCny) {
     const stations = selected.flatMap(r => r.stations.filter(s => (s.surface ?? r.surface) === surface))
     const failures = selected.flatMap(r => r.deviations.filter(d => (d.surface ?? r.surface) === surface).map(d => ({ ...d, caseId: r.id })))
     const billed = runs.filter(r => r.surface === surface)
-    lines.push(`| ${surface} | ${selected.length} | ${stations.filter(s => s.status !== 'unreachable').length} | ${new Set(failures.filter(d => d.repaired).map(d => `${d.caseId}/${d.station}`)).size} | ${failures.length} | ${billed.some(r => r.costCny === null) ? '未知' : billed.reduce((n,r)=>n+(r.costCny ?? 0),0)} |`)
+    lines.push(`| ${surface} | ${selected.length} | ${stations.filter(s => !['unreachable', 'blocked'].includes(s.status)).length} | ${new Set(failures.filter(d => d.repaired).map(d => `${d.caseId}/${d.station}`)).size} | ${failures.length} | ${billed.some(r => r.costCny === null) ? '未知' : billed.reduce((n,r)=>n+(r.costCny ?? 0),0)} |`)
   }
   lines.push('', '跨页面 case 在触及的各 surface 分别计数；站点与问题按实际 surface 归属，费用只计入输入主 surface，避免重复记账。')
   lines.push('', '## 未跑输入', '', ...skipped.map(s => `- ${s.id}：${s.status}；${s.reason}`), '')

--- a/tests/ux/g1/sweep-real-main.mjs
+++ b/tests/ux/g1/sweep-real-main.mjs
@@ -1,3 +1,4 @@
+import { decryptForDispatch } from './credential-main.mjs'
 // Test-side main-process dispatch boundary; credentials never leave Electron.
 import fs from 'node:fs'
 import path from 'node:path'
@@ -5,7 +6,7 @@ import { createRequire } from 'node:module'
 import { CNY_PER_USD } from './c0-real-budget.mjs'
 import { reserveSweepRequest } from './sweep-budget.mjs'
 import { createResponseCapture } from './sweep-response.mjs'
-export async function attachSweepDispatch({ quote, ledgerPath, budgetCny, requestsPath }) {
+export async function attachSweepDispatch({ quote, ledgerPath, budgetCny, requestsPath, credentialMarker }) {
   const require = createRequire(import.meta.url), { app } = require('electron')
   const compiled = path.join(app.getAppPath(), 'dist-electron')
   const transport = require(path.join(compiled, 'appFetch.js'))
@@ -14,8 +15,7 @@ export async function attachSweepDispatch({ quote, ledgerPath, budgetCny, reques
   const persist = () => fs.writeFileSync(ledgerPath, JSON.stringify(ledger, null, 2), { mode: 0o600 })
   const { readCatalog } = require(path.join(compiled, 'catalog/catalogStore.js'))
   const { decryptApiKeyRecord } = require(path.join(compiled, 'catalog/secrets.js'))
-  const key = decryptApiKeyRecord(readCatalog().apiKeysByVendor.apimart)
-  if (!key) throw Error('SWEEP_CREDENTIAL_MISSING')
+  const key = decryptForDispatch({ record: readCatalog().apiKeysByVendor?.apimart, decrypt: decryptApiKeyRecord, credentialMarker })
   const balance = async () => {
     const response = await original('https://api.apimart.ai/v1/balance', { headers: { Authorization: `Bearer ${key}` }, signal: AbortSignal.timeout(20000), redirect: 'error' })
     const data = await response.json()

--- a/tests/ux/g1/sweep-real.mjs
+++ b/tests/ux/g1/sweep-real.mjs
@@ -1,6 +1,7 @@
+import { watchCredential } from './credential-precheck.mjs'
 import fs from 'node:fs'
 import path from 'node:path'
-import { prepareIsolation, realCatalogPath } from '../../../evals/lib/isoApp.mjs'
+import { prepareIsolation } from '../../../evals/lib/isoApp.mjs'
 import { publicPrices, REAL_MODELS } from './c0-real-budget.mjs'
 export async function prepareRealText(profile) {
   const response = await fetch('https://apimart.ai/pricing', { signal: AbortSignal.timeout(30000) })
@@ -26,10 +27,10 @@ export async function attachRealText(launched, { profile, quote, ledgerPath, bud
   const bridge = path.join(profile, 'sweep-main.cjs')
   fs.writeFileSync(bridge, `module.exports = import(${JSON.stringify(new URL('./sweep-real-main.mjs', import.meta.url).href)});`)
   try {
-    await launched.app.evaluate(async (_main, options) => {
+    await watchCredential({ directory: path.dirname(profile), kill: () => launched.app.process().kill('SIGKILL'), run: credentialMarker => launched.app.evaluate(async (_main, options) => {
       const module = await process.mainModule.require(options.bridge)
       globalThis.__sweepDispatch = await module.attachSweepDispatch(options)
-    }, { bridge, quote, ledgerPath, budgetCny, requestsPath })
+    }, { bridge, quote, ledgerPath, budgetCny, requestsPath, credentialMarker }) })
   } finally {
     // The one-shot loader is executable scratch, not case evidence.
     fs.rmSync(bridge, { force: true })
@@ -38,11 +39,4 @@ export async function attachRealText(launched, { profile, quote, ledgerPath, bud
     localStorage.setItem('nomi.assistantModel', JSON.stringify({ vendorKey: 'apimart', modelKey }))
     window.dispatchEvent(new CustomEvent('nomi:assistant-model-changed'))
   }, REAL_MODELS.text)
-}
-
-export function assertRealTextCredential(file = realCatalogPath()) {
-  let record
-  try { record = JSON.parse(fs.readFileSync(file, 'utf8')).apiKeysByVendor?.apimart } catch { /* Report only a safe configuration error. */ }
-  if (record?.enc !== 'safeStorage' || record.enabled === false || typeof record.apiKey !== 'string' || !record.apiKey.trim())
-    throw Error('SWEEP_REAL_TEXT_KEY_REQUIRED: --real-text requires an enabled APIMart key in Nomi settings; no loopback fallback')
 }


### PR DESCRIPTION
真实模型取样在 macOS 钥匙串同步阻塞时，现在由 Node 宿主以 9 秒期限终止隔离实例并写 blocked 收据。sweep/C0 共用原应用解密调用，不增加一次解密、不传出或缓存 key；收据包含 locked-screen/keychain-denied/no-key 和系统锁屏探测证据。依赖站记未到达，独立零额度输入继续，预算与装配错误仍保留原失败语义。仅修改测试、脚本与指定计划文档。

验证：
- 最终完整 `pnpm run gates` exit 0：76 contracts（0 阻断、3 advisory），1302 测试文件 / 12113 测试通过，Agent/runtime 和构建通过。收据：`artifacts/c14/gates-final.log`。
- 7 项新增凭据回归已纳入 check:walkthroughs；相关测试合计 22 项通过。旧入口模拟挂起只有外部超时、没有 blocked；新入口覆盖拒绝、缺 key、同步挂起、一次解密、状态汇总。
- 当前构建 C0 完整装配通过，合成 transport，付费调用 0。
- 打包实例同步阻塞注入 9037ms 返回 blocked/locked-screen；真实应用解密本次返回 ready，不能声称复现真实钥匙串挂死。已安装旧包缺 appFetch.js，未用它冒充当前完整 dispatch 装配通过。
- 缺凭据端到端 sweep：4 个真实输入 blocked、26 站未到达；9 个零额度输入继续到达 61 站，功能断言偏差 0，体感命中如实保留。报告：`artifacts/sweep/2026-09-09T04-06-06.422Z/report.md`。模型费用 ¥0。

计划与根因边界：docs/plan/2026-09-09-sweep-collect.md 的「凭据预检（C14）」。

Ponytail 明细复核已删除唯一未消费的 probing 标记写入，之后重新跑完整 gates exit 0；最终提交钩子 PASS。没有绕过 hooks，也没有修改生产代码。
