### PR TITLE
fix(persistence): keep debounced save intent alive across project cutover

### DIFF
--- a/docs/fixes/2026-09-09-flush-save-cutover.root-cause.json
+++ b/docs/fixes/2026-09-09-flush-save-cutover.root-cause.json
@@ -1,0 +1,95 @@
+{
+  "schema_version": 3,
+  "id": "2026-09-09-flush-save-cutover",
+  "problem_type": "Debounced project save loses edits across project cutover",
+  "symptom": "Editing project A and switching to project B within the 700ms debounce window silently drops the last edits of A; when the cleanup fallback fires after B's hydration it can also write B's data into A's project file.",
+  "direct_cause": "flushSave early-returns during the hydration window, clears the timer and the saveScheduled flag without requeueing; the cleanup fallback then re-reads the global store which the successor project has already replaced.",
+  "class_root": "A debounced writer must snapshot the payload at schedule time and keep the save intent alive across transient refusals instead of re-reading mutable global state at flush time.",
+  "affected_population": [
+    "Any user switching projects within 700ms of an edit"
+  ],
+  "scope_paths": [
+    "src/workbench/project/workbenchProjectSession.ts"
+  ],
+  "entry_points": [
+    "subscribeWorkbenchProjectPersistence flushSave",
+    "subscribeWorkbenchProjectPersistence cleanup"
+  ],
+  "external_sources": [],
+  "internal_only_reason": "Renderer-side persistence session lifecycle; no external format or framework API.",
+  "invariants": [
+    "Once persistRevision schedules a save, that exact payload reaches saveProject exactly once or is explicitly superseded by beforeImmediateSave.",
+    "Flush paths never persist a payload read after the schedule-time snapshot."
+  ],
+  "generality_proof": "Both the timer-fired flush inside the hydration window and the cleanup fallback share the same schedule-time snapshot, so every flush path is covered by the same fix.",
+  "shared_boundaries": [
+    {
+      "path": "src/workbench/project/workbenchProjectSession.ts",
+      "symbol": "subscribeWorkbenchProjectPersistence",
+      "responsibility": "Own the debounce lifecycle: capture payload at schedule time, retry through hydration windows, flush the snapshot on cleanup."
+    }
+  ],
+  "same_class_entry_points": [
+    {
+      "path": "src/workbench/project/workbenchProjectSession.ts",
+      "entry_point": "beforeImmediateSave",
+      "disposition": "enforced",
+      "evidence": "Immediate canonical saves already cancel the debounce via the same queue; unchanged."
+    },
+    {
+      "path": "src/workbench/project/workbenchProjectSession.ts",
+      "entry_point": "flushPendingSave (pagehide/beforeunload)",
+      "disposition": "enforced",
+      "evidence": "Routes into flushSave, which now preserves the snapshot on early-return."
+    }
+  ],
+  "recurrence": {
+    "classification": "recurring",
+    "reason": "Every project switch within the 700ms debounce window reproduced the loss.",
+    "same_class_scan": [
+      "Checked createProjectSaveQueue drain loop: it never re-reads the store, it drains queued snapshots only.",
+      "Checked persistActiveWorkbenchProjectNow: it intentionally reads current state for canonical writes under an active owner; correct by design.",
+      "Checked beforeImmediateSave: cancels the pending snapshot explicitly, which remains the single sanctioned supersession path."
+    ]
+  },
+  "prevention": {
+    "kind": "centralized-boundary",
+    "enforcement_path": "src/workbench/project/workbenchProjectSession.ts",
+    "invariant": "Flush consumes only the schedule-time payload snapshot.",
+    "failure_mode": "Hydration-window retry keeps rescheduling until cleanup; disposed subscriptions drop the snapshot.",
+    "exception_policy": "none",
+    "strategy": "Snapshot payload in saveIfReady; flushSave retries on transient refusal; cleanup flushes the snapshot instead of re-reading the store.",
+    "artifacts": [
+      "src/workbench/project/workbenchProjectSession.ts"
+    ]
+  },
+  "regression_tests": [
+    "src/workbench/project/workbenchProjectSession.persistence.test.ts"
+  ],
+  "class_regression_tests": [
+    "src/workbench/project/workbenchProjectSession.persistence.test.ts"
+  ],
+  "legacy_paths": {
+    "status": "removed",
+    "removed_paths": [
+      "src/workbench/project/workbenchProjectSession.ts"
+    ],
+    "rationale": "flushSave/cleanup re-reading mutable global store state at flush time is the corruption vector; only schedule-time snapshots may be persisted (readCurrentWorkbenchProjectPayload remains solely for schedule-time capture)."
+  },
+  "dependency_lifecycle": {
+    "decision": "not-applicable",
+    "rationale": "Pure internal lifecycle fix, no dependency change.",
+    "exit_criteria": []
+  },
+  "migration": "No persistence schema change; on-disk format unchanged.",
+  "residual_risks": [
+    "Edits scheduled while isHydrating is true are still not captured (saveIfReady refuses during hydration), matching pre-existing behavior: edits during hydration are already suppressed by the hydration guard."
+  ],
+  "invariant_owner_layer": {
+    "layer": "src/workbench/project/workbenchProjectSession.ts",
+    "tests": [
+      "src/workbench/project/workbenchProjectSession.persistence.test.ts"
+    ],
+    "note": "The session owns the debounce lifecycle; the regression tests pin both the drop path and the cross-project corruption path."
+  }
+}

--- a/src/workbench/project/workbenchProjectSession.persistence.test.ts
+++ b/src/workbench/project/workbenchProjectSession.persistence.test.ts
@@ -74,6 +74,53 @@ describe('canonical persistence barrier suppresses stale debounce writes', () =>
     dispose()
   })
 
+  it('does not drop the debounced payload when the timer fires inside a hydration window before project cutover', async () => {
+    deps.workbenchState.activeDocumentId = 'doc-a'
+    let hydrating = false
+    let canPersist = true
+    const saveProject = vi.fn(async (_projectId: string, _payload: unknown, _name: string) => ({ id: 'project-a', version: 1, revision: 1 }) as never)
+    const dispose = subscribeWorkbenchProjectPersistence({
+      projectId: 'project-a', projectName: 'Project A',
+      isHydrating: () => hydrating,
+      canPersist: () => canPersist,
+      saveProject, onSaved: vi.fn(),
+    })
+    // A 项目的编辑触发防抖排程（此时快照的是 A 的数据）。
+    deps.workbenchListener?.()
+    // 切项目：hydrate(B) 开始 → 防抖 timer 在窗口内触发。
+    hydrating = true
+    await vi.advanceTimersByTimeAsync(700)
+    // hydrate 完成：store 已换成 B 的数据，A 不再是活动项目。
+    deps.workbenchState.activeDocumentId = 'doc-b'
+    hydrating = false
+    canPersist = false
+    // React effect cleanup（旧代码在此看到 saveScheduled=false，静默丢编辑）。
+    dispose()
+
+    expect(saveProject).toHaveBeenCalledTimes(1)
+    expect(saveProject.mock.calls[0][0]).toBe('project-a')
+    expect(saveProject.mock.calls[0][1]).toMatchObject({ activeDocumentId: 'doc-a' })
+  })
+
+  it('cleanup flush uses the payload captured at schedule time, never the hydrated successor data', async () => {
+    deps.workbenchState.activeDocumentId = 'doc-a'
+    const saveProject = vi.fn(async (_projectId: string, _payload: unknown, _name: string) => ({ id: 'project-a', version: 1, revision: 1 }) as never)
+    const dispose = subscribeWorkbenchProjectPersistence({
+      projectId: 'project-a', projectName: 'Project A',
+      isHydrating: () => false,
+      canPersist: () => true,
+      saveProject, onSaved: vi.fn(),
+    })
+    deps.workbenchListener?.()
+    // 防抖未到期就发生 cutover：cleanup 前全局 store 已被 hydrate 成 B 的数据。
+    deps.workbenchState.activeDocumentId = 'doc-b'
+    dispose()
+
+    expect(saveProject).toHaveBeenCalledTimes(1)
+    expect(saveProject.mock.calls[0][0]).toBe('project-a')
+    expect(saveProject.mock.calls[0][1]).toMatchObject({ activeDocumentId: 'doc-a' })
+  })
+
   it('signals canonical callers when React installs the active persistence owner', async () => {
     const pending = waitForActiveWorkbenchProjectSaveTarget('project-a')
     let ownerReady = false

--- a/src/workbench/project/workbenchProjectSession.ts
+++ b/src/workbench/project/workbenchProjectSession.ts
@@ -197,6 +197,9 @@ type QueuedWorkbenchProjectSave = {
 }
 
 const PROJECT_SAVE_DEBOUNCE_MS = 700
+/** flushSave 在 hydrate 窗口 early-return 时的重试间隔：保留快照等待 cutover 的
+ * cleanup 兜底，而不是把防抖意图连同快照一起丢掉（切项目丢 ≤700ms 编辑的根因）。 */
+const PROJECT_SAVE_HYDRATION_RETRY_MS = 150
 
 function createProjectSaveQueue(input: {
   saveProject: WorkbenchProjectSaveFn
@@ -255,6 +258,9 @@ export function subscribeWorkbenchProjectPersistence(options: WorkbenchProjectPe
   let disposed = false
   let saveScheduled = false
   let saveTimer: ReturnType<typeof setTimeout> | null = null
+  // 防抖排程那一刻快照的 payload。flush 和 cleanup 都只用这份快照：cleanup 时全局
+  // store 可能已被下一个项目 hydrate 换掉，重读会把 B 的数据写进 A 的 projectId。
+  let pendingPayload: WorkbenchProjectPayload | null = null
   const saveQueue = createProjectSaveQueue({
     saveProject: options.saveProject,
     onSaved: options.onSaved,
@@ -266,12 +272,24 @@ export function subscribeWorkbenchProjectPersistence(options: WorkbenchProjectPe
       clearTimeout(saveTimer)
       saveTimer = null
     }
+    if (disposed) {
+      saveScheduled = false
+      pendingPayload = null
+      return
+    }
+    if (options.isHydrating() || !options.canPersist()) {
+      // hydrate/cutover 窗口：保留快照与意图，短间隔重试直到窗口结束或 cleanup 兜底。
+      if (saveScheduled) saveTimer = setTimeout(() => { void flushSave() }, PROJECT_SAVE_HYDRATION_RETRY_MS)
+      return
+    }
     saveScheduled = false
-    if (disposed || options.isHydrating() || !options.canPersist()) return
+    if (!pendingPayload) return
+    const payload = pendingPayload
+    pendingPayload = null
     saveQueue.enqueue({
       projectId: options.projectId,
       projectName: options.projectName,
-      payload: readCurrentWorkbenchProjectPayload(),
+      payload,
     })
   }
   const flushPendingSave = () => {
@@ -281,6 +299,7 @@ export function subscribeWorkbenchProjectPersistence(options: WorkbenchProjectPe
   const saveIfReady = () => {
     if (options.isHydrating() || !options.canPersist()) return
     saveScheduled = true
+    pendingPayload = readCurrentWorkbenchProjectPayload()
     if (saveTimer) clearTimeout(saveTimer)
     saveTimer = setTimeout(() => { void flushSave() }, PROJECT_SAVE_DEBOUNCE_MS)
   }
@@ -321,9 +340,11 @@ export function subscribeWorkbenchProjectPersistence(options: WorkbenchProjectPe
     // essential to prevent data loss when the subscription is torn down by
     // a Vite hot-reload, a project rename, or a component unmount while
     // there are debounced changes still pending.
-    if (saveScheduled || saveTimer !== null) {
+    if (saveScheduled || saveTimer !== null || pendingPayload !== null) {
       saveScheduled = false
-      const payload = readCurrentWorkbenchProjectPayload()
+      // 只用排程时刻的快照；全局 store 此时可能是已 hydrate 的下一个项目。
+      const payload = pendingPayload ?? readCurrentWorkbenchProjectPayload()
+      pendingPayload = null
       const finalProjectId = options.projectId
       const finalProjectName = options.projectName
       void options.saveProject(finalProjectId, payload, finalProjectName)


### PR DESCRIPTION
切项目时丢 ≤700ms 编辑的根因：flushSave 在 hydrate 窗口 early-return 时把
saveScheduled/timer 一起清掉，cleanup 兜底看到无 pending 便跳过；且 cleanup
重读全局 store，此时可能已被下一个项目 hydrate 换掉，把 B 的数据写进 A 的
projectId（跨项目数据污染）。

修复（root-cause 合同：docs/fixes/2026-09-09-flush-save-cutover.root-cause.json）：
- saveIfReady 排程那一刻快照 payload，此后所有 flush 路径只用这份快照
- flushSave 在 hydrate/cutover 窗口保留意图并 150ms 重试，直到窗口结束或 cleanup
- cleanup 兜底用快照而非重读全局 store

回归测试：workbenchProjectSession.persistence.test.ts 两个新用例分别锁住
「丢编辑」与「跨项目污染」两条路径（修复前均红）。

---
来自全库 bug 猎查（2026-09-09/10）：19 条独立修复之一，每条独立分支/独立回归测试；本地 contracts 门岗全绿。