### PR TITLE
fix(capabilityCore): poll failures get a free 45s grace instead of aborting paid tasks

### DIFF
--- a/electron/capabilityCore/core.test.ts
+++ b/electron/capabilityCore/core.test.ts
@@ -59,6 +59,28 @@ describe('headless 轮询预算', () => {
     expect(resolveCapabilityPollTimeoutMs('text_to_image', undefined)).toBe(240_000)
     expect(resolveCapabilityPollTimeoutMs('image_to_video', '1234')).toBe(1234)
   })
+
+  // 回归：任务已提交（付费已发生）后，查结果的瞬时网络失败绝不能冒泡终止任务——
+  // 与渲染层 catalogTaskActions 的 POLL_FAILURE_GRACE_MS 免费宽限同策。
+  // 修复前：第一次 fetchTaskResult 抛错直接冒泡，generateOnProject reject、节点落 error。
+  it('查结果瞬时失败在宽限期内免费重试，恢复后照常落 succeeded', async () => {
+    const project = createNamedProject('轮询宽限测试')
+    let polls = 0
+    const out = await generateOnProject(
+      { projectId: project.id, intent: 'image', prompt: '一只赛博朋克猫', vendor: 'apimart', modelKey: 'seedream-4' },
+      createDiskGateway(project.id),
+      async () => ({ id: 't1', status: 'queued' }),
+      async () => {
+        polls += 1
+        if (polls <= 2) throw new Error('network blip')
+        return { result: { id: 't1', status: 'succeeded', assets: [{ type: 'image', url: 'nomi-local://gen.png' }] } }
+      },
+    )
+    expect(polls).toBe(3)
+    expect(out.status).toBe('succeeded')
+    const canvas = await readRawProjectCanvas(project.id)
+    expect(canvas.nodes.find((node) => node.id === out.nodeId)?.result).toBeTruthy()
+  })
 })
 
 const tempRoots: string[] = []

--- a/electron/capabilityCore/core.ts
+++ b/electron/capabilityCore/core.ts
@@ -86,6 +86,11 @@ export type FetchTaskResultFn = (payload: { taskId: string; vendor: string; task
 
 const TERMINAL_STATUSES = new Set(['succeeded', 'failed'])
 
+// 任务已提交（付费已发生）后，查结果连续失败多久才放弃轮询、落失败终态。短于此 = 网络
+// 抖动，免费重试查询（绝不冒泡终止已付费任务）；与渲染层 catalogTaskActions 的
+// POLL_FAILURE_GRACE_MS 同策——**配对常量，改一处必改另一处**。
+const POLL_FAILURE_GRACE_MS = 45_000
+
 /** Headless/MCP 轮询上限：视频 API 官方建议客户端最多等待 15 分钟，允许环境变量覆盖。 */
 export function resolveCapabilityPollTimeoutMs(kind: string, envValue: string | undefined = process.env.NOMI_POLL_TIMEOUT_MS): number {
   const override = Number(envValue)
@@ -513,14 +518,23 @@ export async function generateOnProject(
     let frame = out
     if (fetchTaskResultFn && frame.status && !TERMINAL_STATUSES.has(frame.status)) {
       const startedAt = Date.now()
+      let pollFailureStreakStartedAt: number | null = null
       while (frame.status && !TERMINAL_STATUSES.has(frame.status)) {
         if (Date.now() - startedAt > 240000) break // 首帧是增益，到点就放弃走一跳，不拖垮整镜
         await delay(1500)
-        const polled = await fetchTaskResultFn({
-          taskId: frame.id || '', vendor: painter.vendorKey, taskKind: frameKind,
-          prompt: framePrompt, modelKey: painter.modelKey,
-        })
-        frame = polled.result
+        try {
+          const polled = await fetchTaskResultFn({
+            taskId: frame.id || '', vendor: painter.vendorKey, taskKind: frameKind,
+            prompt: framePrompt, modelKey: painter.modelKey,
+          })
+          frame = polled.result
+          pollFailureStreakStartedAt = null
+        } catch {
+          // 查结果失败：免费重试（首帧是增益，不冒泡拖垮整镜）；持续失败超 grace 就放弃两跳。
+          const now = Date.now()
+          if (pollFailureStreakStartedAt == null) pollFailureStreakStartedAt = now
+          if (now - pollFailureStreakStartedAt > POLL_FAILURE_GRACE_MS) break
+        }
       }
     }
     const url = (frame.assets || [])[0]?.url
@@ -611,6 +625,7 @@ export async function generateOnProject(
       // 的 MARKER 约定）。本循环一次只跑一个任务，不存在批量同相位问题，故不叠抖动/退避。
       const pollIntervalMs = kind === 'text_to_video' || kind === 'image_to_video' ? 3000 : 1500
       const startedAt = Date.now()
+      let pollFailureStreakStartedAt: number | null = null
       while (result.status && !TERMINAL_STATUSES.has(result.status)) {
         if (Date.now() - startedAt > timeoutMs) {
           // 到点必须落**终态**：旧版直接 break，result 保持 queued/running 且不带 error —— 调用方
@@ -627,14 +642,33 @@ export async function generateOnProject(
           break
         }
         await delay(pollIntervalMs)
-        const polled = await fetchTaskResultFn({
-          taskId: result.id || '',
-          vendor: input.vendor,
-          taskKind: kind,
-          prompt,
-          modelKey: input.modelKey,
-        })
-        result = polled.result
+        try {
+          const polled = await fetchTaskResultFn({
+            taskId: result.id || '',
+            vendor: input.vendor,
+            taskKind: kind,
+            prompt,
+            modelKey: input.modelKey,
+          })
+          result = polled.result
+          pollFailureStreakStartedAt = null
+        } catch {
+          // 查结果失败：免费重试，绝不冒泡——任务已提交付费，一次网络抖动不能终止它。
+          // 持续失败超 grace → 落失败终态（不重发，文案明说任务可能仍在供应商侧）。
+          const now = Date.now()
+          if (pollFailureStreakStartedAt == null) pollFailureStreakStartedAt = now
+          if (now - pollFailureStreakStartedAt > POLL_FAILURE_GRACE_MS) {
+            result = {
+              ...result,
+              status: 'failed',
+              error: desktopT('tasks.pollFailed', {
+                seconds: Math.round((now - pollFailureStreakStartedAt) / 1000),
+                status: result.status || 'unknown',
+              }),
+            }
+            break
+          }
+        }
       }
     }
   } catch (error) {

--- a/electron/i18n.ts
+++ b/electron/i18n.ts
@@ -40,6 +40,7 @@ const translations = {
     "tasks.unknown": "未知任务：该任务不在本地待办缓存中（可能从未受理或 id 有误）。",
     "tasks.unrecognizedStatus": "上游返回了无法识别的任务状态：「{{status}}」。连续查询 {{polls}} 次、持续 {{seconds}} 秒都是这个状态，Nomi 按失败处理。该任务也可能仍在供应商侧运行——请到供应商后台核对。",
     "tasks.pollTimedOut": "等待生成结果超时（已等 {{seconds}} 秒，最后状态：{{status}}）。任务可能仍在供应商侧运行——请到供应商后台核对，或稍后重新拉取结果。",
+    "tasks.pollFailed": "连续 {{seconds}} 秒查询生成结果失败（最后状态：{{status}}）。任务可能仍在供应商侧运行——请到供应商后台核对，或稍后重新拉取结果。",
     // ⚠️ 长度纪律：错误卡大标题走 classifyError.truncateLine，**超 100 字会被截尾**（那正是
     // 「该怎么办」那半句）。这两条 key 因此写得短，完整上下文留在 raw / 上游原话里。
     "tasks.noQueryOperation": "这个模型没有配置「查询结果」接口，而本次创建也没有返回任何产物——没有第二次查询可发，已按失败处理。请检查该模型的接入配置。",
@@ -213,6 +214,7 @@ const translations = {
     "tasks.unknown": "Unknown task: it is not in the local pending-task cache. It may never have been accepted, or its ID may be incorrect.",
     "tasks.unrecognizedStatus": "The provider returned an unrecognized task status: “{{status}}”. It stayed that way for {{polls}} polls over {{seconds}}s, so Nomi is treating the task as failed. It may still be running on the provider side — check your provider dashboard.",
     "tasks.pollTimedOut": "Timed out waiting for the result (waited {{seconds}}s, last status: {{status}}). The task may still be running on the provider side — check your provider dashboard or fetch the result again later.",
+    "tasks.pollFailed": "Failed to fetch the generation result for {{seconds}}s in a row (last status: {{status}}). The task may still be running on the provider side — check your provider dashboard or fetch the result again later.",
     "tasks.noQueryOperation": "This model has no result-query operation and the create call returned nothing. Check its setup.",
     "outbound.fakeIpBlocked": "The download was blocked by Nomi's own network policy: {{host}} resolved to {{address}} (the RFC 2544 range that local fake-IP proxies use for synthetic addresses). Nomi could not confirm a proxy is running, so it refused the download. **Your paid task is not lost** - confirm your local proxy under Model settings > Network, then use \"Re-fetch result\" to retrieve it for free. Do not regenerate.",
     "outbound.privateAddress": "The download was blocked by Nomi's own network policy: {{host}} resolved to the private address {{address}}, and Nomi never downloads results from private networks. Your paid task is not lost - fix DNS or the proxy, then use \"Re-fetch result\" to retrieve it for free.",


### PR DESCRIPTION
headless/MCP 两条轮询循环（首帧 renderStaticFrame 与主循环）的
fetchTaskResultFn 无 try/catch：一次瞬时网络抖动直接冒泡，已付费任务被
终止、节点落 error。渲染层同款循环（catalogTaskActions）早有
POLL_FAILURE_GRACE_MS=45s 免费重试宽限且明写「查结果失败绝不冒泡触发
重发」——两条循环违反同一条自家铁律，行为不对称。

修复：两处循环包 try/catch，失败连击在 45s 宽限内免费重试（成功即复位
计数）；超宽限落 failed 终态 + 新 i18n 键 tasks.pollFailed（zh/en），文案
明说任务可能仍在供应商侧。POLL_FAILURE_GRACE_MS 与渲染层配对，改一处
必改另一处。

回归测试：core.test.ts「查结果瞬时失败在宽限期内免费重试」——修复前红
（第一次抛错即 reject），修复后绿且落盘节点有 result。

---
来自全库 bug 猎查（2026-09-09/10）：19 条独立修复之一，每条独立分支/独立回归测试；本地 contracts 门岗全绿。