### PR TITLE
fix(timeline): deleting clips also drops transitions referencing them

### DIFF
--- a/src/workbench/timeline/timelineEdit.test.ts
+++ b/src/workbench/timeline/timelineEdit.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
-import type { TimelineClip, TimelineState } from './timelineTypes'
+import type { TimelineClip, TimelineState, TimelineTransition } from './timelineTypes'
 import { createDefaultTimeline } from './timelineMath'
-import { duplicateClipById, nudgeClipById } from './timelineEdit'
+import { duplicateClipById, nudgeClipById, removeClipById, removeClipsByIds, removeClipsBySourceNodeIds } from './timelineEdit'
 
 function clip(id: string, startFrame: number, endFrame: number): TimelineClip {
   return {
@@ -21,6 +21,38 @@ function timeline(clips: TimelineClip[]): TimelineState {
   const base = createDefaultTimeline()
   return { ...base, tracks: base.tracks.map((track) => track.type === 'video' ? { ...track, clips } : track) }
 }
+
+describe('remove clip drops transitions referencing the removed clip', () => {
+  const transition = (fromClipId: string, toClipId: string): TimelineTransition => ({ fromClipId, toClipId, type: 'dissolve' })
+
+  it('removeClipById clears transitions whose fromClipId/toClipId matches', () => {
+    const base = timeline([clip('a', 0, 90), clip('b', 90, 180), clip('c', 180, 270)])
+    base.transitions = [transition('a', 'b'), transition('b', 'c')]
+    const after = removeClipById(base, 'b')
+    expect(after.transitions).toEqual([])
+  })
+
+  it('removeClipById keeps untouched transitions and keeps the original reference when nothing matches', () => {
+    const base = timeline([clip('a', 0, 90), clip('b', 90, 180), clip('c', 180, 270)])
+    base.transitions = [transition('a', 'b')]
+    const after = removeClipById(base, 'c')
+    expect(after.transitions).toBe(base.transitions)
+  })
+
+  it('removeClipsByIds clears transitions for all removed ids', () => {
+    const base = timeline([clip('a', 0, 90), clip('b', 90, 180), clip('c', 180, 270)])
+    base.transitions = [transition('a', 'b'), transition('b', 'c')]
+    const after = removeClipsByIds(base, ['a', 'b'])
+    expect(after.transitions).toEqual([])
+  })
+
+  it('removeClipsBySourceNodeIds clears transitions of the clips it removed (canvas-node reconciliation path)', () => {
+    const base = timeline([clip('a', 0, 90), clip('b', 90, 180), clip('c', 180, 270)])
+    base.transitions = [transition('a', 'b'), transition('b', 'c')]
+    const after = removeClipsBySourceNodeIds(base, ['a'])
+    expect(after.transitions).toEqual([transition('b', 'c')])
+  })
+})
 
 describe('timeline clip placement strategy', () => {
   it('nudges an adjacent clip using the same nearest legal placement as dragging', () => {

--- a/src/workbench/timeline/timelineEdit.ts
+++ b/src/workbench/timeline/timelineEdit.ts
@@ -117,15 +117,33 @@ export function moveClipToLegalFrame(timeline: TimelineState, clipId: string, st
   return moved ? { ...timeline, tracks } : timeline
 }
 
+/**
+ * 删 clip 必须连带清掉引用它的转场（fromClipId/toClipId 悬空会随 normalizeTimeline
+ * 持久化进项目文件，转场标记/渲染指向不存在的接缝）。kernel 删除路径（timelineKernel）
+ * 一直这么做；这里给 timelineEdit 的三条删除入口同款清理。无命中保持原引用。
+ */
+function dropTransitionsForClipIds(
+  transitions: TimelineState['transitions'],
+  removedClipIds: ReadonlySet<string>,
+): TimelineState['transitions'] {
+  if (!transitions?.length || removedClipIds.size === 0) return transitions
+  const next = transitions.filter(
+    (transition) => !removedClipIds.has(transition.fromClipId) && !removedClipIds.has(transition.toClipId),
+  )
+  return next.length === transitions.length ? transitions : next
+}
+
 export function removeClipById(timeline: TimelineState, clipId: string): TimelineState {
   const id = String(clipId || '').trim()
   if (!id) return timeline
+  const transitions = dropTransitionsForClipIds(timeline.transitions, new Set([id]))
   return {
     ...timeline,
     tracks: timeline.tracks.map((track) => ({
       ...track,
       clips: track.clips.filter((clip) => clip.id !== id),
     })),
+    ...(transitions ? { transitions } : {}),
   }
 }
 
@@ -139,7 +157,9 @@ export function removeClipsByIds(timeline: TimelineState, clipIds: readonly stri
     removed = true
     return { ...track, clips: nextClips }
   })
-  return removed ? { ...timeline, tracks } : timeline
+  if (!removed) return timeline
+  const transitions = dropTransitionsForClipIds(timeline.transitions, idSet)
+  return { ...timeline, tracks, ...(transitions ? { transitions } : {}) }
 }
 
 /**
@@ -152,13 +172,20 @@ export function removeClipsBySourceNodeIds(timeline: TimelineState, nodeIds: rea
   const idSet = new Set(nodeIds.map((id) => String(id || '').trim()).filter(Boolean))
   if (idSet.size === 0) return timeline
   let removed = false
+  const removedClipIds = new Set<string>()
   const tracks = timeline.tracks.map((track) => {
-    const nextClips = track.clips.filter((clip) => !idSet.has(clip.sourceNodeId))
+    const nextClips = track.clips.filter((clip) => {
+      if (!idSet.has(clip.sourceNodeId)) return true
+      removedClipIds.add(clip.id)
+      return false
+    })
     if (nextClips.length === track.clips.length) return track
     removed = true
     return { ...track, clips: nextClips }
   })
-  return removed ? { ...timeline, tracks } : timeline
+  if (!removed) return timeline
+  const transitions = dropTransitionsForClipIds(timeline.transitions, removedClipIds)
+  return { ...timeline, tracks, ...(transitions ? { transitions } : {}) }
 }
 
 /**


### PR DESCRIPTION
timelineEdit 的三条删除入口（removeClipById/removeClipsByIds/
removeClipsBySourceNodeIds）只 filter tracks[].clips，不清理 timeline.transitions
中引用被删 clip 的转场；kernel 删除路径（timelineKernel.ts）一直有这段清理。
悬空 fromClipId/toClipId 会随 normalizeTimeline 持久化进项目文件，转场标记/
渲染指向不存在的接缝。

修复：新增 dropTransitionsForClipIds 共享清理（无命中保持原引用，store 据此
跳过 persistRevision 自增），三条入口同款接入。

回归测试：timelineEdit.test.ts 四个新用例（单删/批量删/画布节点对账路径/
无命中保持引用），修复前红（转场残留）。

---
来自全库 bug 猎查（2026-09-09/10）：19 条独立修复之一，每条独立分支/独立回归测试；本地 contracts 门岗全绿。