### PR TITLE
fix(tasks): query-op-only vendors must not persist empty successes

### DIFF
--- a/docs/fixes/2026-09-09-query-op-empty-success.root-cause.json
+++ b/docs/fixes/2026-09-09-query-op-empty-success.root-cause.json
@@ -1,0 +1,93 @@
+{
+  "schema_version": 3,
+  "id": "2026-09-09-query-op-empty-success",
+  "problem_type": "Async media task persists succeeded with zero assets when the query endpoint completes empty",
+  "symptom": "query-op-only vendors (kie/apimart family, mapping has query but no result op) that report COMPLETED while the asset path extracts empty get persisted as a succeeded task with 0 assets — a silent empty success the user sees as a node that 'finished' with nothing in it.",
+  "direct_cause": "ensureAsyncMediaOutput (COMPLETED-without-output must fail) is only applied on the result-op second-hop branch; the query-only return path bypasses it.",
+  "class_root": "Every terminal-result exit of the task query boundary must pass the same async-media output guard; terminal normalization and terminal validation are one boundary, not two.",
+  "affected_population": [
+    "All async media generations on vendors whose mapping lacks a result op (kie images, apimart video, runninghub family)"
+  ],
+  "scope_paths": [
+    "electron/tasks/taskResultQuery.ts"
+  ],
+  "entry_points": [
+    "executeTaskQuery terminal result construction"
+  ],
+  "external_sources": [],
+  "internal_only_reason": "Internal vendor task-result boundary; no external format change.",
+  "invariants": [
+    "A terminal async-media result that reports success with zero assets never leaves executeTaskQuery; it is downgraded to failed with the completedWithoutOutput reason.",
+    "Successful queries with real assets are unaffected (guard passes them through)."
+  ],
+  "generality_proof": "The guard now wraps the single terminal-result construction shared by the query branch (both unrecognized-status and normal outcomes), so every query-path terminal exits through the same validation; the result-op branch keeps its existing guard.",
+  "shared_boundaries": [
+    {
+      "path": "electron/tasks/taskResultQuery.ts",
+      "symbol": "executeTaskQuery",
+      "responsibility": "Apply ensureAsyncMediaOutput to every terminal result before persistence/return."
+    }
+  ],
+  "same_class_entry_points": [
+    {
+      "path": "electron/tasks/taskResultQuery.ts",
+      "entry_point": "result-op second-hop branch (ensureAsyncMediaOutput on resultNormalized)",
+      "disposition": "enforced",
+      "evidence": "Pre-existing guard on the second-hop result; unchanged and still active."
+    },
+    {
+      "path": "electron/tasks/taskResultQuery.ts",
+      "entry_point": "extractAssetUrl raw-asset branch",
+      "disposition": "enforced",
+      "evidence": "Only returns when an asset URL actually exists, so an empty success cannot be constructed there."
+    }
+  ],
+  "recurrence": {
+    "classification": "recurring",
+    "reason": "Every kie/apimart-style task whose upstream completes without output reproduced the silent empty success.",
+    "same_class_scan": [
+      "Checked the result-op branch: guard already present.",
+      "Checked the raw-asset branch: cannot produce an empty success (returns only on a found URL).",
+      "Checked the fallback no-query branch (unpollableTaskQuery path): already fails closed with an honest reason.",
+      "apimartVendor.ts:64-65 documents the bare-string video url case that lands in this hole."
+    ]
+  },
+  "prevention": {
+    "kind": "centralized-boundary",
+    "enforcement_path": "electron/tasks/taskResultQuery.ts",
+    "invariant": "Terminal result construction is wrapped by ensureAsyncMediaOutput on every path.",
+    "failure_mode": "Guard downgrades succeeded+0-assets media results to failed with tasks.completedWithoutOutput; text tasks and synchronous audio stay outside the guard's wantedKind filter, matching its documented boundary.",
+    "exception_policy": "none",
+    "strategy": "Wrap the shared terminal-result construction in ensureAsyncMediaOutput instead of guarding individual branches.",
+    "artifacts": [
+      "electron/tasks/taskResultQuery.ts"
+    ]
+  },
+  "regression_tests": [
+    "electron/tasks/queryOpEmptySuccess.test.ts"
+  ],
+  "class_regression_tests": [
+    "electron/tasks/queryOpEmptySuccess.test.ts"
+  ],
+  "legacy_paths": {
+    "status": "not-applicable",
+    "removed_paths": [],
+    "rationale": "No legacy path removed; the existing result-op guard remains and the new wrap covers the query path."
+  },
+  "dependency_lifecycle": {
+    "decision": "not-applicable",
+    "rationale": "No dependency change.",
+    "exit_criteria": []
+  },
+  "migration": "No persistence schema change.",
+  "residual_risks": [
+    "A vendor that genuinely emits a zero-asset success for media would now surface as an honest failure instead of an empty success; that is the intended semantic per the guard's own documentation."
+  ],
+  "invariant_owner_layer": {
+    "layer": "electron/tasks/taskResultQuery.ts",
+    "tests": [
+      "electron/tasks/queryOpEmptySuccess.test.ts"
+    ],
+    "note": "executeTaskQuery owns terminal-result validation; the regression pins both the empty-completion downgrade and the asset-bearing pass-through."
+  }
+}

--- a/electron/tasks/queryOpEmptySuccess.test.ts
+++ b/electron/tasks/queryOpEmptySuccess.test.ts
@@ -1,0 +1,79 @@
+// 端到端接线回归：mapping 只有 query op、没有 result op 的 vendor（kie/apimart 一族），
+// query 回「completed 但零产物」时必须落失败终态——不能持久化 succeeded + 0 assets 的静默空成功。
+//
+// ensureAsyncMediaOutput 守卫过去只挂在 result-op 二跳分支上，query-op-only 的返回路径够不着
+// （这正是本回归钉的洞）。与 unrecognizedTaskStatusQuery.test.ts 同源同风格：只桩 HTTP 边界
+// （executeProfileOperation）与模型解析，归一/缓存/受理全用真的。
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const executeProfileOperation = vi.fn();
+
+vi.mock("../runtime", async () => {
+  const actual = await vi.importActual<typeof import("../runtime")>("../runtime");
+  return {
+    ...actual,
+    executeProfileOperation: (...args: unknown[]) => executeProfileOperation(...args),
+    findExecutableModel: () => ({
+      vendor: { key: "acme", baseUrlHint: "https://acme.test" },
+      model: { modelKey: "acme-video", kind: "video" },
+      apiKey: "k",
+    }),
+  };
+});
+
+// 有 query、**没有 result** —— 与 electron/catalog/kieImages2026.ts / apimartVendor.ts 的
+// mapping 同形（result 资产直接在 query 响应里给，没有独立 result 端点）。
+const QUERY_ONLY_MAPPING = {
+  name: "acme video",
+  enabled: true,
+  create: { method: "POST", path: "/v1/video" },
+  query: { method: "GET", path: "/v1/video/{{query_id}}", response_mapping: { status: "status" } },
+};
+
+async function seedPendingTask(taskId: string) {
+  const { admitTask, taskCache } = await import("../runtime");
+  taskCache.delete(taskId);
+  admitTask(taskId, {
+    vendor: "acme",
+    request: { kind: "text_to_video", prompt: "a cat", extras: { modelKey: "acme-video" } },
+    raw: {},
+    mapping: QUERY_ONLY_MAPPING as never,
+    model: { modelKey: "acme-video", kind: "video" } as never,
+    providerMeta: { task_id: taskId, query_id: taskId },
+    wantedKind: "video",
+  });
+}
+
+describe("query-op-only vendor：COMPLETED 但零产物必须判失败（不落空成功）", () => {
+  beforeEach(() => {
+    executeProfileOperation.mockReset();
+  });
+
+  it("query 回 completed 无产物 → failed + 诚实文案，绝不持久化 succeeded+0 assets", async () => {
+    const { fetchTaskResult } = await import("./taskResultQuery");
+    await seedPendingTask("task-query-empty");
+    executeProfileOperation.mockResolvedValue({ response: { status: "completed" }, request: {} });
+
+    const polled = await fetchTaskResult({ taskId: "task-query-empty" });
+
+    expect(polled.result.status).toBe("failed");
+    expect(polled.result.error).toContain("没有返回可用产物");
+    // 没有 result op，本文件里 executeProfileOperation 只该被 query 打过（一跳），不碰磁盘资产。
+    expect(polled.result.assets).toHaveLength(0);
+  });
+
+  it("非回归：query 回 completed 且带产物 → 照旧 succeeded（守卫不许误杀正常路径）", async () => {
+    const { fetchTaskResult } = await import("./taskResultQuery");
+    await seedPendingTask("task-query-asset");
+    // 不给 projectId → 走 unlocalizedTaskAsset，不碰磁盘本地化。
+    executeProfileOperation.mockResolvedValue({
+      response: { status: "completed", video_url: "https://cdn.example.com/out.mp4" },
+      request: {},
+    });
+
+    const polled = await fetchTaskResult({ taskId: "task-query-asset" });
+
+    expect(polled.result.status).toBe("succeeded");
+    expect(polled.result.assets).toHaveLength(1);
+  });
+});

--- a/electron/tasks/taskResultQuery.ts
+++ b/electron/tasks/taskResultQuery.ts
@@ -228,17 +228,23 @@ async function executeTaskQuery(taskId: string, cached: CachedTask): Promise<{ v
     const now = Date.now();
     const streak = advanceUnrecognizedStatusStreak(cached.unrecognizedStatusStreak, normalized.unrecognizedStatus, now);
     if (normalized.unrecognizedStatus) reportUnrecognizedStatus(cached, taskId, normalized.unrecognizedStatus);
-    const result = unrecognizedStatusExhausted(streak, now)
-      ? {
-          ...normalized.result,
-          status: "failed" as const,
-          error: desktopT("tasks.unrecognizedStatus", {
-            status: streak?.verb || "",
-            polls: streak?.polls || 0,
-            seconds: Math.round((now - (streak?.firstSeenAt || now)) / 1000),
-          }),
-        }
-      : normalized.result;
+    // 「COMPLETED 但零产物判失败」守卫对 query 返回统一生效——不能只挂在 result-op 二跳分支：
+    // kie/apimart 一族 mapping 只有 query op（result 资产就在 query 响应里），query 回 completed
+    // 且取不到资产时同样必须落失败，否则持久化 succeeded+0 assets 的静默空成功。
+    const result = ensureAsyncMediaOutput(
+      unrecognizedStatusExhausted(streak, now)
+        ? {
+            ...normalized.result,
+            status: "failed" as const,
+            error: desktopT("tasks.unrecognizedStatus", {
+              status: streak?.verb || "",
+              polls: streak?.polls || 0,
+              seconds: Math.round((now - (streak?.firstSeenAt || now)) / 1000),
+            }),
+          }
+        : normalized.result,
+      cached.wantedKind || model.kind,
+    );
 
     if (result.status === "succeeded" || result.status === "failed") {
       // 终态才入日志(轮询 tick 不记);cache.delete 保证单次触发


### PR DESCRIPTION
「COMPLETED 但零产物判失败」守卫（ensureAsyncMediaOutput）只挂在 result-op
二跳分支上；kie/apimart 一族 mapping 只有 query op（result 资产就在 query
响应里），query 回 completed 且资产路径取空时会持久化 succeeded + 0 assets
的静默空成功——用户看到节点「完成」但里面什么都没有。apimartVendor.ts:64-65
注释承认的裸字符串 video url 场景正踩这个洞。

修复：守卫包在 query 分支共享的终态 result 构造点上（含未登记动词判定路径），
所有 query 终态出口统一过闸；result-op 分支原守卫不动。

回归测试：queryOpEmptySuccess.test.ts——completed+0 产物落 failed+诚实文案
（修复前红，落 succeeded）；completed+带产物照旧 succeeded（防误杀）。
root-cause 合同：docs/fixes/2026-09-09-query-op-empty-success.root-cause.json

---
来自全库 bug 猎查（2026-09-09/10）：19 条独立修复之一，每条独立分支/独立回归测试；本地 contracts 门岗全绿。