### PR TITLE
fix(audio): doubao TTS NDJSON response read through the byte-capped hardened fetch

### DIFF
--- a/electron/audioTaskRunner.test.ts
+++ b/electron/audioTaskRunner.test.ts
@@ -15,9 +15,17 @@ vi.mock("./catalog/profileHttpRequest", async (importOriginal) => ({
 vi.mock("./assets/localFileImport", () => ({
   importLocalFile: vi.fn(async () => ({ id: "asset-1", name: "tts.wav", data: { url: "nomi-local://asset/p/tts.wav" } })),
 }));
+// 豆包 NDJSON 回归用：真实现上套 vi.fn（可 mockResolvedValue 断言调用形状）——字节上限的流式
+// 实现归 hardenedFetch 自己的门岗；这里钉 runner 是否把 NDJSON 响应**路由进**带 maxBytes 的读体。
+vi.mock("./hardenedFetch", async (importOriginal) => ({
+  ...await importOriginal<typeof import("./hardenedFetch")>(),
+  hardenedFetch: vi.fn((...args: Parameters<typeof import("./hardenedFetch").hardenedFetch>) =>
+    importOriginal<typeof import("./hardenedFetch")>().then((m) => m.hardenedFetch(...args))),
+}));
 
 import { runAudioTask } from "./audioTaskRunner";
 import { importLocalFile } from "./assets/localFileImport";
+import { hardenedFetch } from "./hardenedFetch";
 import { buildProfileHttpRequest } from "./catalog/profileHttpRequest";
 import type { Model, Vendor } from "./catalog/types";
 
@@ -87,6 +95,47 @@ describe("runAudioTask（音频同步执行路径）", () => {
       contentType: "audio/mpeg",
       fileName: "tts-t-binary.mp3",
     }));
+  });
+
+  it("豆包 NDJSON：响应经 hardenedFetch 读体（限 30MB 上限，不再裸 response.text() 读爆主进程）", async () => {
+    const ndjson = [
+      JSON.stringify({ code: 0, data: Buffer.from("ID3fake-mp3-bytes").toString("base64") }),
+      JSON.stringify({ code: 20000000 }),
+    ].join("\n");
+    vi.mocked(hardenedFetch).mockResolvedValueOnce({
+      bytes: Buffer.from(ndjson, "utf8"), contentType: "application/json", status: 200, finalUrl: "", truncated: false,
+    });
+    const doubaoVendor = { ...vendor, key: "volcengine", baseUrlHint: "https://openspeech.bytedance.com" } as Vendor;
+    const result = await runAudioTask({
+      vendor: doubaoVendor, model: ttsModel, apiKey: "app-1:secret-key",
+      request: { kind: "text_to_audio", prompt: "你好", extras: { voice: "zh_female" } } as never,
+      kind: "text_to_audio", taskId: "t-doubao", projectId: "p", nodeId: "n",
+      mapping: { create: { method: "POST", path: "/api/v3/tts/unidirectional", audioResponse: "ndjson-base64" } } as never,
+    });
+
+    // 关键回归：出站响应必须走带字节上限的读体（修复前是 appFetch + 无上限 response.text()）。
+    expect(hardenedFetch).toHaveBeenCalledWith("https://openspeech.bytedance.com/api/v3/tts/unidirectional", expect.objectContaining({
+      method: "POST",
+      maxBytes: 30 * 1024 * 1024,
+      throwOnNon2xx: false,
+    }));
+    expect(result.status).toBe("succeeded");
+    expect(result.assets[0].type).toBe("audio");
+    expect(result.assets[0].url).toContain("nomi-local://");
+  });
+
+  it("豆包 NDJSON：非 2xx 用响应体拼错误详情（保持原 httpError 语义）", async () => {
+    vi.mocked(hardenedFetch).mockResolvedValueOnce({
+      bytes: Buffer.from(JSON.stringify({ code: 45000001, message: "quota exhausted" }), "utf8"),
+      contentType: "application/json", status: 429, finalUrl: "", truncated: false,
+    });
+    const doubaoVendor = { ...vendor, key: "volcengine", baseUrlHint: "https://openspeech.bytedance.com" } as Vendor;
+    await expect(runAudioTask({
+      vendor: doubaoVendor, model: ttsModel, apiKey: "app-1:secret-key",
+      request: { kind: "text_to_audio", prompt: "你好", extras: { voice: "zh_female" } } as never,
+      kind: "text_to_audio", taskId: "t-doubao-err", projectId: "p", nodeId: "n",
+      mapping: { create: { method: "POST", path: "/api/v3/tts/unidirectional", audioResponse: "ndjson-base64" } } as never,
+    })).rejects.toThrow(/429/);
   });
 
   it("声明的 JSON hex 音频按路径解码后落盘（MiniMax speech）", async () => {

--- a/electron/audioTaskRunner.ts
+++ b/electron/audioTaskRunner.ts
@@ -101,9 +101,13 @@ async function runDoubaoUnidirectionalTts(input: AudioTaskInput, op: HttpOperati
   const reqParams = buildDoubaoReqParams({ text, voice, emotion });
   const body = JSON.stringify({ user: { uid: "nomi" }, req_params: reqParams });
 
-  let response: Response;
+  let fetched: Awaited<ReturnType<typeof hardenedFetch>>;
   try {
-    response = await appFetch(url, {
+    // 走 hardenedFetch 读体（限 MAX_AUDIO_BYTES、带超时）：NDJSON 也是无限流，
+    // 异常/恶意端点可用超大响应撑爆主进程内存（入站参考音频同文件早就限 30MB，
+    // 出站响应此前是裸 response.text() 无上限）。SSRF/私网策略与全局出站口径一致。
+    // throwOnNon2xx=false：非 2xx 也要读 body 拼进错误文案（原语义），不读盘。
+    fetched = await hardenedFetch(url, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -112,14 +116,18 @@ async function runDoubaoUnidirectionalTts(input: AudioTaskInput, op: HttpOperati
         "X-Api-Resource-Id": resourceId,
       },
       body,
+      timeoutMs: 120_000,
+      maxBytes: MAX_AUDIO_BYTES,
+      throwOnNon2xx: false,
     });
   } catch (error: unknown) {
     throw new Error(desktopT("dubbing.networkError", { vendor: vendor.key, detail: (error instanceof Error ? error.message : String(error)).slice(0, 256) }));
   }
-  if (!response.ok) {
-    throw new Error(desktopT("dubbing.httpError", { vendor: vendor.key, status: response.status, detail: (await safeText(response)).slice(0, 300) || desktopT("common.noDetail") }));
+  if (fetched.status >= 400) {
+    const detail = fetched.bytes.byteLength > 0 ? fetched.bytes.toString("utf8").slice(0, 300) : "";
+    throw new Error(desktopT("dubbing.httpError", { vendor: vendor.key, status: fetched.status, detail: detail || desktopT("common.noDetail") }));
   }
-  const audio = decodeDoubaoNdjsonAudio(await response.text());
+  const audio = decodeDoubaoNdjsonAudio(fetched.bytes.toString("utf8"));
   if (audio.byteLength === 0) throw new Error(desktopT("dubbing.emptyAudio"));
   const ab = audio.buffer.slice(audio.byteOffset, audio.byteOffset + audio.byteLength) as ArrayBuffer;
   const saved = (await importLocalFile({


### PR DESCRIPTION
豆包 unidirectional TTS 出站响应用 appFetch + 无上限 response.text() 把整个
NDJSON 流读进主进程内存——异常/恶意端点可用超大响应撑爆主进程（主进程 OOM =
整个 app 消失）。同文件入站参考音频（readAudioBytes）早已用 hardenedFetch 限
30MB，出站响应却是裸读，防御不对称。

修复：改走 hardenedFetch（maxBytes=MAX_AUDIO_BYTES 30MB、120s 超时、
throwOnNon2xx=false 保持「非 2xx 读 body 拼错误文案」的原语义），SSRD/私网
策略与全局出站口径统一。

回归测试：audioTaskRunner.test.ts 两个豆包用例——①出站必须经 hardenedFetch
且带 maxBytes=30MB/POST/throwOnNon2xx=false，正常 NDJSON 照旧落 audio 资产；
②429 用响应体拼错误详情。修复前两用例均红。

---
来自全库 bug 猎查（2026-09-09/10）：19 条独立修复之一，每条独立分支/独立回归测试；本地 contracts 门岗全绿。