### PR TITLE
fix(ai): unbind the destroyed listener when a text stream ends normally

### DIFF
--- a/docs/fixes/2026-09-09-text-stream-destroyed-listener.root-cause.json
+++ b/docs/fixes/2026-09-09-text-stream-destroyed-listener.root-cause.json
@@ -1,0 +1,92 @@
+{
+  "schema_version": 3,
+  "id": "2026-09-09-text-stream-destroyed-listener",
+  "problem_type": "Text stream sessions leak destroyed listeners on the sender webContents",
+  "symptom": "Each text stream attaches a once(\"destroyed\") listener to the sender webContents; normally-finished streams leave the listener (and its closed-over session/abortController) attached until the webContents is destroyed, accumulating listeners across a long session and eventually tripping MaxListeners warnings.",
+  "direct_cause": "The listener is only removed implicitly when destroyed fires; the stream's finally block deletes the session from the map but never unbinds the listener.",
+  "class_root": "Any listener attached to a lifecycle longer than the operation that registered it must be unbound in that operation's cleanup path, not only in the listener's own trigger path.",
+  "affected_population": [
+    "Long-lived renderer sessions that open many text streams (agent conversations, text node generations)"
+  ],
+  "scope_paths": [
+    "electron/ai/textStreamIpc.ts"
+  ],
+  "entry_points": [
+    "nomi:tasks:text:stream handle"
+  ],
+  "external_sources": [],
+  "internal_only_reason": "Internal Electron IPC session lifecycle; no external format change.",
+  "invariants": [
+    "When a stream reaches its finally block, the sender carries zero listeners attributable to that stream.",
+    "A destroyed sender still aborts its in-flight sessions (unbind must not weaken the destroy path)."
+  ],
+  "generality_proof": "The finally block is the single completion point for done, error, and thrown paths, so unbinding there covers every stream termination; the destroy path keeps its own trigger semantics.",
+  "shared_boundaries": [
+    {
+      "path": "electron/ai/textStreamIpc.ts",
+      "symbol": "registerTextStreamIpc stream handle",
+      "responsibility": "Bind on stream start, unbind on stream end and on sender destruction."
+    }
+  ],
+  "same_class_entry_points": [
+    {
+      "path": "electron/ai/textStreamIpc.ts",
+      "entry_point": "nomi:tasks:text:cancel handle",
+      "disposition": "enforced",
+      "evidence": "Cancel only aborts the controller; session cleanup still flows through the runner's completion into the same finally block, which now unbinds."
+    },
+    {
+      "path": "electron/ai/textStreamIpc.ts",
+      "entry_point": "sendTextEvent",
+      "disposition": "enforced",
+      "evidence": "Reads webContents by id per event without attaching listeners, so it cannot contribute to the leak."
+    }
+  ],
+  "recurrence": {
+    "classification": "recurring",
+    "reason": "Every normally-completed text stream leaked one listener; accumulation is proportional to conversation length.",
+    "same_class_scan": [
+      "Checked the cancel handle: it does not attach listeners itself.",
+      "Checked sendTextEvent: it reads webContents by id without attaching listeners.",
+      "No other once(\"destroyed\") registrations exist in this file."
+    ]
+  },
+  "prevention": {
+    "kind": "centralized-boundary",
+    "enforcement_path": "electron/ai/textStreamIpc.ts",
+    "invariant": "Stream teardown removes both the session entry and its sender listener.",
+    "failure_mode": "removeListener is skipped only when the sender is already destroyed, in which case the listener died with it.",
+    "exception_policy": "none",
+    "strategy": "Keep a named handler reference; unbind it in the stream's finally block.",
+    "artifacts": [
+      "electron/ai/textStreamIpc.ts"
+    ]
+  },
+  "regression_tests": [
+    "electron/ai/textStreamIpc.test.ts"
+  ],
+  "class_regression_tests": [
+    "electron/ai/textStreamIpc.test.ts"
+  ],
+  "legacy_paths": {
+    "status": "not-applicable",
+    "removed_paths": [],
+    "rationale": "No legacy path removed; the destroy handler keeps identical semantics."
+  },
+  "dependency_lifecycle": {
+    "decision": "not-applicable",
+    "rationale": "No dependency change.",
+    "exit_criteria": []
+  },
+  "migration": "No persistence change.",
+  "residual_risks": [
+    "Streams whose runner promise never settles (a hang) still hold their listener; abort via cancel or destroy remains the recovery path."
+  ],
+  "invariant_owner_layer": {
+    "layer": "electron/ai/textStreamIpc.ts",
+    "tests": [
+      "electron/ai/textStreamIpc.test.ts"
+    ],
+    "note": "The IPC handler owns the stream session lifecycle; the regression pins listener count returning to zero and the destroy-abort path."
+  }
+}

--- a/electron/ai/textStreamIpc.test.ts
+++ b/electron/ai/textStreamIpc.test.ts
@@ -1,0 +1,70 @@
+// 回归：文本流正常结束后必须解绑挂在 sender 上的 once("destroyed") 监听。
+// 旧实现每个流挂一个 once，只在 webContents 销毁时才释放——正常结束的流把监听器和
+// 闭包引用的 session/abortController 留在 sender 上累积（MaxListeners 警告一族）。
+import { EventEmitter } from "node:events";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+type Sender = EventEmitter & { id: number; isDestroyed: () => boolean };
+type Handler = (event: { sender: Sender }, payload?: unknown) => unknown;
+const mocks = vi.hoisted(() => ({
+  handlers: new Map<string, Handler>(),
+  guard: vi.fn(),
+  runTextTaskStream: vi.fn(),
+  fromId: vi.fn(),
+}));
+
+vi.mock("electron", () => ({
+  ipcMain: { handle: (name: string, fn: Handler) => mocks.handlers.set(name, fn) },
+  webContents: { fromId: (id: number) => mocks.fromId(id) },
+}));
+vi.mock("../ipcSenderGuard", () => ({ assertTrustedSender: mocks.guard }));
+vi.mock("../textTaskRunner", () => ({ runTextTaskStream: (...args: unknown[]) => mocks.runTextTaskStream(...args) }));
+
+import { registerTextStreamIpc } from "./textStreamIpc";
+
+const sender = (id: number): Sender =>
+  Object.assign(new EventEmitter(), { id, isDestroyed: () => false });
+
+async function startStream(owner: Sender): Promise<string> {
+  const reply = (await mocks.handlers.get("nomi:tasks:text:stream")!({ sender: owner }, { prompt: "hi" })) as { streamId: string };
+  return reply.streamId;
+}
+
+describe("textStreamIpc destroyed listener lifecycle", () => {
+  beforeEach(() => {
+    mocks.handlers.clear();
+    mocks.guard.mockReset();
+    mocks.runTextTaskStream.mockReset();
+    mocks.runTextTaskStream.mockResolvedValue({ status: "succeeded", assets: [] });
+    mocks.fromId.mockReturnValue(undefined);
+    registerTextStreamIpc();
+  });
+
+  it("正常结束的流把 sender 上的 destroyed 监听解绑（不随会话数累积）", async () => {
+    const owner = sender(7);
+    await startStream(owner);
+    await vi.waitFor(() => expect(mocks.runTextTaskStream).toHaveBeenCalledOnce());
+    // 流结束（finally 已跑）：sender 上不该残留本流的 destroyed 监听。
+    await vi.waitFor(() => expect(owner.listenerCount("destroyed")).toBe(0));
+  });
+
+  it("连开 N 个流全部结束后，destroyed 监听数归零（修复前线性累积）", async () => {
+    const owner = sender(8);
+    for (let i = 0; i < 5; i += 1) await startStream(owner);
+    await vi.waitFor(() => expect(mocks.runTextTaskStream).toHaveBeenCalledTimes(5));
+    await vi.waitFor(() => expect(owner.listenerCount("destroyed")).toBe(0));
+  });
+
+  it("sender 真销毁时仍能中止会话（解绑不改变销毁路径语义）", async () => {
+    const owner = sender(9);
+    const abortSpy = vi.fn();
+    mocks.runTextTaskStream.mockImplementation((_payload: unknown, opts: { abortSignal: AbortSignal }) => {
+      opts.abortSignal.addEventListener("abort", abortSpy);
+      return new Promise(() => {});
+    });
+    await startStream(owner);
+    await vi.waitFor(() => expect(mocks.runTextTaskStream).toHaveBeenCalledOnce());
+    owner.emit("destroyed");
+    expect(abortSpy).toHaveBeenCalledOnce();
+  });
+});

--- a/electron/ai/textStreamIpc.ts
+++ b/electron/ai/textStreamIpc.ts
@@ -38,12 +38,15 @@ export function registerTextStreamIpc(): void {
     };
     textStreamSessions.set(streamId, session);
 
-    event.sender.once("destroyed", () => {
+    // once("destroyed") 挂在 sender 上、只在 webContents 销毁时触发；流正常结束后必须
+    // 显式解绑，否则监听器与闭包引用的 session/abortController 随会话数累积（MaxListeners 泄漏）。
+    const onSenderDestroyed = () => {
       const live = textStreamSessions.get(streamId);
       if (!live) return;
       live.abortController.abort();
       textStreamSessions.delete(streamId);
-    });
+    };
+    event.sender.once("destroyed", onSenderDestroyed);
 
     // 异步跑，让 handle 立刻返回 streamId（渲染层先订阅事件再收 delta）。
     queueMicrotask(() => {
@@ -67,6 +70,7 @@ export function registerTextStreamIpc(): void {
         })
         .finally(() => {
           textStreamSessions.delete(streamId);
+          if (!event.sender.isDestroyed()) event.sender.removeListener("destroyed", onSenderDestroyed);
         });
     });
 


### PR DESCRIPTION
每个文本流在 sender 上挂一个 once("destroyed")，正常结束后只在 map 里删
session、不解绑监听——监听器与闭包引用的 session/abortController 要挂到
webContents 销毁才释放，长会话高频对话线性累积（MaxListeners 警告一族）。

修复：destroyed handler 提为具名引用，流的 finally（done/error/throw 共用
的完成点）里 sender 未销毁则 removeListener；销毁路径语义不变。

回归测试：textStreamIpc.test.ts（新文件）——单流/连续 5 流结束后监听数归零
（修复前红），sender 真销毁仍中止在飞流。
root-cause 合同：docs/fixes/2026-09-09-text-stream-destroyed-listener.root-cause.json

---
来自全库 bug 猎查（2026-09-09/10）：19 条独立修复之一，每条独立分支/独立回归测试；本地 contracts 门岗全绿。