### PR TITLE
fix(migration): V51→V60 gate also checks meta.referenceImageUrls

### DIFF
--- a/src/workbench/generationCanvas/model/referenceImageUrlsToEdges.ts
+++ b/src/workbench/generationCanvas/model/referenceImageUrlsToEdges.ts
@@ -36,6 +36,31 @@ export type ReferenceImageUrlsMigration = {
 }
 
 /**
+ * 迁移闸用的预判：是否存在「能反查到画布内源节点」的 meta.referenceImageUrls。
+ * 反查口径与 migrateReferenceImageUrlsToEdges 同一套（本文件是唯一 owner）——V51→V60
+ * 迁移闸缺了它会把「其余字段干净、只剩数组参考」的记录误判 alreadyMigrated，永不收敛。
+ */
+export function hasMigratableReferenceImageUrls(nodes: readonly GenerationCanvasNode[]): boolean {
+  const sourceByUrl = new Map<string, string>()
+  for (const node of nodes) {
+    for (const url of resultUrlsOf(node)) {
+      if (!sourceByUrl.has(url)) sourceByUrl.set(url, node.id)
+    }
+  }
+  if (sourceByUrl.size === 0) return false
+  for (const node of nodes) {
+    const raw = ((node.meta || {}) as Record<string, unknown>).referenceImageUrls
+    if (!Array.isArray(raw) || raw.length === 0) continue
+    for (const value of raw) {
+      const url = typeof value === 'string' ? value.trim() : ''
+      const sourceId = url ? sourceByUrl.get(url) : undefined
+      if (sourceId && sourceId !== node.id) return true
+    }
+  }
+  return false
+}
+
+/**
  * 把所有节点 meta.referenceImageUrls 里「能反查到源节点」的 URL 还原成有序 character_ref 边。
  * 返回新的 nodes（被迁移节点的 meta.referenceImageUrls 清掉已建边的 URL）+ 新 edges。
  * 无任何可迁移 URL → 原样返回（edgesCreated=0）。

--- a/src/workbench/project/projectV51ToV60Migration.test.ts
+++ b/src/workbench/project/projectV51ToV60Migration.test.ts
@@ -245,5 +245,23 @@ describe('migrateProjectV51ToV60', () => {
       expect(second.diagnostic.referenceEdgesCreated).toBe(0)
       expect(second.record).toBe(first.record)
     })
+
+    it('其余字段全干净、只剩 meta.referenceImageUrls 待迁 → 闸必须放行（不因 renderKind/shotIndex 已齐而整段跳过）', () => {
+      // 回归：recordNeedsV51ToV60Migration 只查 renderKind/shotIndex/derivedFrom 时，
+      // 这份记录被误判 alreadyMigrated，referenceImageUrls 永不收敛成边。
+      const record = recordWithEdges([
+        { ...imgWithResult('a', 'https://cdn/a.png'), renderKind: 'character-card' },
+        {
+          ...omniShot('v1', ['https://cdn/a.png']),
+          renderKind: 'shot-frame',
+          shotIndex: 1,
+        },
+      ])
+      const { record: out, diagnostic } = migrateProjectV51ToV60(record)
+      expect(diagnostic.alreadyMigrated).toBe(false)
+      expect(diagnostic.referenceEdgesCreated).toBe(1)
+      const v1 = out.payload.generationCanvas.nodes.find((n) => n.id === 'v1')
+      expect((v1?.meta as Record<string, unknown>)?.referenceImageUrls).toBeUndefined()
+    })
   })
 })

--- a/src/workbench/project/projectV51ToV60Migration.ts
+++ b/src/workbench/project/projectV51ToV60Migration.ts
@@ -18,7 +18,7 @@
  */
 import type { WorkbenchProjectRecordV1 } from './projectRecordSchema'
 import type { GenerationCanvasNode } from '../generationCanvas/model/generationCanvasTypes'
-import { migrateReferenceImageUrlsToEdges } from '../generationCanvas/model/referenceImageUrlsToEdges'
+import { hasMigratableReferenceImageUrls, migrateReferenceImageUrlsToEdges } from '../generationCanvas/model/referenceImageUrlsToEdges'
 import {
   BUILTIN_CATEGORIES,
   type NodeRenderKind,
@@ -65,6 +65,9 @@ function recordNeedsV51ToV60Migration(nodes: readonly GenerationCanvasNode[]): b
     if (node.categoryId === 'shots' && typeof node.shotIndex !== 'number') return true
     if (node.derivedFrom && !node.regeneratedFrom) derivedFromCandidates.push(node)
   }
+  // 步骤 4 的目标数据：数组参考 meta.referenceImageUrls → 边。旧闸漏查它，导致
+  // 「其余字段干净、只剩数组参考」的记录被误判 alreadyMigrated、永不收敛成边。
+  if (hasMigratableReferenceImageUrls(nodes)) return true
   if (!derivedFromCandidates.length) return false
 
   const categoryById = new Map<string, string | undefined>()


### PR DESCRIPTION
recordNeedsV51ToV60Migration 只查 renderKind/shotIndex/derivedFrom，漏查步骤 4
的目标数据 meta.referenceImageUrls——一份其余字段都干净、只残留数组参考的旧记录
会被误判 alreadyMigrated，migrateReferenceImageUrlsToEdges 永不执行，meta 永不
收敛成有序边（顺序语义与边不同）。

修复：新增 hasMigratableReferenceImageUrls 预判（反查口径与迁移体同一文件、同一
套 resultUrlsOf——单一语义 owner），闸内放行。

回归测试：projectV51ToV60Migration.test.ts 新用例「其余字段干净只剩数组参考 →
闸必须放行」，修复前红（alreadyMigrated=true、不建边）。

---
来自全库 bug 猎查（2026-09-09/10）：19 条独立修复之一，每条独立分支/独立回归测试；本地 contracts 门岗全绿。