### PR TITLE
fix(timeline): manual zoom no longer snaps back to fitted scale

### DIFF
--- a/src/workbench/timeline/TimelinePanel.tsx
+++ b/src/workbench/timeline/TimelinePanel.tsx
@@ -164,11 +164,13 @@ export default function TimelinePanel({ density = 'compact', regionLabel, action
     observer.observe(element)
     return () => observer.disconnect()
   }, [])
+  // 自动 fit 只在内容时长/视口宽度变化时执行——**不订阅 timeline.scale**。旧版把 scale
+  // 放进依赖，用户手动缩放（⌘±/滚轮）改 scale 即重跑本 effect、立即弹回 fittedScale，
+  // 手动缩放形同虚设。去掉 scale 依赖后：缩放不被回退；加片/删片/窗口 resize 仍自动 refit。
   React.useEffect(() => {
     if (durationFrame <= 0 || contentViewportWidth <= 0) return
-    const fittedScale = resolveTimelineFitScale(durationFrame, contentViewportWidth)
-    if (Math.abs(fittedScale - timeline.scale) > 0.001) setTimelineZoom(fittedScale)
-  }, [contentViewportWidth, durationFrame, setTimelineZoom, timeline.scale])
+    setTimelineZoom(resolveTimelineFitScale(durationFrame, contentViewportWidth))
+  }, [contentViewportWidth, durationFrame, setTimelineZoom])
   React.useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
       // 预览(full)与生成(compact)两个 TimelinePanel 因 keep-alive 同时挂载，各注册一个 window keydown。


### PR DESCRIPTION
自动 fit 的 effect 把 timeline.scale 放进依赖且无「用户已手动缩放」标记：⌘±
或滚轮改 scale 即重跑 effect，|fittedScale - scale| > 0.001 就 setTimelineZoom
弹回 fit——手动缩放形同虚设。

修复：effect 去掉 scale 依赖，自动 fit 只在内容时长/视口宽度变化（加删片、
窗口 resize）时执行一次；用户缩放不再被回退。

测试缝说明（diagnosing-bugs Phase 5「无正确缝」记录）：仓库无组件测试基建
（无 testing-library，tests/ 均为 node/e2e），该行为在 React effect 层、无纯
函数可抽。timeline 240 测全绿保非回归；行为验证走 R13 走查（⌘+ 后缩放保持）。

---
来自全库 bug 猎查（2026-09-09/10）：19 条独立修复之一，每条独立分支/独立回归测试；本地 contracts 门岗全绿。