### PR TITLE
fix(video): heal outcomes never overwrite a regenerated result

### DIFF
--- a/src/media/useVideoPlaybackHeal.ts
+++ b/src/media/useVideoPlaybackHeal.ts
@@ -35,8 +35,10 @@ export function useVideoPlaybackHeal({
 }: {
   /** 节点 result.url 原值——诊断探针与自愈都要原始 URL，不要 buildVideoPlaybackUrl 之后的。 */
   rawUrl: string
-  /** 自愈成功回调：有持久化去处的面（画布节点/时间轴源节点）借此把新 URL 写回，下次开项目直接好。 */
-  onHealed?: (healedUrl: string) => void
+  /** 自愈成功回调：有持久化去处的面（画布节点/时间轴源节点）借此把新 URL 写回，下次开项目直接好。
+   * sourceUrl 是发起自愈时的原始 URL——持久化方必须校验节点当前 result.url 仍是它，防止旧自愈
+   * 结论覆盖期间重新生成的新结果。 */
+  onHealed?: (healedUrl: string, sourceUrl: string) => void
 }): VideoPlaybackHeal {
   const { t } = useTranslation()
   const [failureText, setFailureText] = React.useState('')
@@ -45,6 +47,9 @@ export function useVideoPlaybackHeal({
   const healAttemptedRef = React.useRef('')
   const onHealedRef = React.useRef(onHealed)
   onHealedRef.current = onHealed
+  // 最新 rawUrl 的只读锚点：await 之后用它比对「自愈发起时的 rawUrl」是否已被换掉。
+  const rawUrlRef = React.useRef(rawUrl)
+  rawUrlRef.current = rawUrl
 
   // rawUrl 换了（重新生成/换素材）→ 上一轮的失败与自愈结论全部作废，否则旧报错会盖在新视频上。
   React.useEffect(() => {
@@ -57,6 +62,8 @@ export function useVideoPlaybackHeal({
   const onError: React.ReactEventHandler<HTMLVideoElement> = (event) => {
     const mediaError = event.currentTarget.error
     void diagnoseVideoPlaybackFailure(rawUrl, mediaError).then(async (diagnostics) => {
+      // 诊断在飞时 rawUrl 已被换掉 → 旧结论作废（reset effect 只在换的那一刻跑，拦不住之后 resolve 的写回）。
+      if (rawUrlRef.current !== rawUrl) return
       logVideoPlaybackFailure(diagnostics)
       const decodeFailure = diagnostics.mediaErrorCode === 3 || diagnostics.mediaErrorCode === 4
       const ensurePlayable = getDesktopBridge()?.assets?.ensurePlayable
@@ -67,11 +74,13 @@ export function useVideoPlaybackHeal({
         setHealing(true)
         try {
           const healed = await ensurePlayable({ url: rawUrl })
+          // 自愈在飞时节点被重新生成（rawUrl 已换）→ 旧 healedUrl 不得写回，否则覆盖新结果。
+          if (rawUrlRef.current !== rawUrl) return
           const nextUrl = typeof healed?.data?.url === 'string' ? healed.data.url.trim() : ''
           if (nextUrl && nextUrl !== rawUrl) {
             // 本地先切过去，当场就能播；有持久化去处的面再把它写回节点，下次开项目直接好。
             setHealedUrl(nextUrl)
-            onHealedRef.current?.(nextUrl)
+            onHealedRef.current?.(nextUrl, rawUrl)
             setHealing(false)
             setFailureText('')
             return

--- a/src/workbench/generationCanvas/nodes/NodeVideoPlaybackGuard.tsx
+++ b/src/workbench/generationCanvas/nodes/NodeVideoPlaybackGuard.tsx
@@ -33,10 +33,13 @@ export function NodeVideoPlaybackGuard({
   ...rest
 }: Props): JSX.Element {
   const persistHealedUrl = React.useCallback(
-    (healedUrl: string) => {
+    (healedUrl: string, sourceUrl: string) => {
       const state = useGenerationCanvasStore.getState()
       const node = state.nodes.find((candidate) => candidate.id === nodeId)
-      if (node?.result) state.updateNode(nodeId, { result: { ...node.result, url: healedUrl } })
+      // 自愈期间节点重新生成（result.url 已不是发起自愈的那个）→ 不许旧 healedUrl 覆盖新结果。
+      if (node?.result && node.result.url === sourceUrl) {
+        state.updateNode(nodeId, { result: { ...node.result, url: healedUrl } })
+      }
     },
     [nodeId],
   )


### PR DESCRIPTION
视频自愈链无取消令牌的两层后果：
1. useVideoPlaybackHeal 的 onError 异步链（诊断→ensurePlayable）在飞时 rawUrl
   被换（重新生成/切节点），旧 promise resolve 后仍 setHealedUrl(旧产物)/
   setFailureText(旧诊断)——reset effect 只在 rawUrl 变更那一刻跑，拦不住之后
   resolve 的写回，旧结论盖在新视频上。
2. NodeVideoPlaybackGuard 的 persistHealedUrl 无条件把 node.result.url 覆写成
   healedUrl 并持久化——自愈期间重新生成的话，旧 healed URL 覆盖新结果。

修复：
- hook 加 rawUrlRef 锚点，诊断与自愈两个 await 之后都比对发起时的 rawUrl，
  已换则整段作废返回。
- onHealed 回调带 sourceUrl（发起自愈的原始 URL），persistHealedUrl 前校验
  node.result.url === sourceUrl，不匹配不写。

测试缝说明（无正确缝记录）：vitest environment=node、无 DOM/组件渲染器，
hook 行为在 React effect/闭包层无纯函数缝可抽；media 全部 9 测绿保非回归，
行为验证走 R13 走查（自愈期间重新生成 → 新结果不被覆盖）。

---
来自全库 bug 猎查（2026-09-09/10）：19 条独立修复之一，每条独立分支/独立回归测试；本地 contracts 门岗全绿。