### PR TITLE
fix(timeline): changing a text clip's font pushes undo and clears redo

### DIFF
--- a/src/workbench/timelineUndo.test.ts
+++ b/src/workbench/timelineUndo.test.ts
@@ -76,6 +76,18 @@ describe('时间轴撤销栈', () => {
     expect(useWorkbenchStore.getState().timeline.tracks.flatMap((t) => t.clips).length).toBe(splitCount)
   })
 
+  it('换字体压 undo 栈且清 redo 栈（⌘Z 回到换字体前，不再是更早一次编辑）', () => {
+    const s = useWorkbenchStore.getState()
+    const textClipId = s.addTimelineTextClip('caption', 0)
+    s.updateTimelineTextClip(textClipId, '第一版文案')
+    const beforeFont = useWorkbenchStore.getState().timeline
+    useWorkbenchStore.getState().updateTimelineTextClipFont(textClipId, 'font-b')
+    expect(useWorkbenchStore.getState().timelineUndoStack.length).toBeGreaterThan(0)
+    // undo → 字体回到换字体前（修复前：font 改动不压栈，undo 会退到更早一次编辑）
+    useWorkbenchStore.getState().undoTimeline()
+    expect(useWorkbenchStore.getState().timeline).toBe(beforeFont)
+  })
+
   it('新编辑清空 redo 栈（undo 后再做新编辑 → 不能 redo 回陈旧态）', () => {
     const s = useWorkbenchStore.getState()
     s.addTimelineClipAtFrame(imageClip('a', 0, 90), 'image', 0)

--- a/src/workbench/workbenchStore.ts
+++ b/src/workbench/workbenchStore.ts
@@ -781,7 +781,14 @@ export const useWorkbenchStore = create<WorkbenchState>()(subscribeWithSelector(
       const next = updateTextClipFont(state.timeline, id, fontId)
       return next === state.timeline
         ? state
-        : { timeline: next, persistRevision: state.persistRevision + 1 }
+        : {
+            timeline: next,
+            // 换字体是离散编辑：必须压 undo、清 redo（同 updateTimelineTextClip），
+            // 否则 ⌘Z 会回退到更早一次编辑、redo 栈语义被破坏。
+            timelineUndoStack: pushTimelineUndo(state.timelineUndoStack, state.timeline),
+            timelineRedoStack: [],
+            persistRevision: state.persistRevision + 1,
+          }
     })
   },
 })))


### PR DESCRIPTION
updateTimelineTextClipFont 改 timeline 并 bump persistRevision，但不压 undo 栈、
不清 redo 栈——换字体后 ⌘Z 会回退到更早一次编辑，redo 栈语义被破坏。同类离散
编辑（updateTimelineTextClip）都有 push undo，独此一处漏。

修复：照抄邻居写法（pushTimelineUndo + 清 redo）。

回归测试：timelineUndo.test.ts「换字体压 undo 栈且清 redo 栈」，修复前红
（undo 退到更早编辑、timeline !== beforeFont）。

---
来自全库 bug 猎查（2026-09-09/10）：19 条独立修复之一，每条独立分支/独立回归测试；本地 contracts 门岗全绿。