### PR TITLE
fix(runner): batch regeneration backfills timeline clips like single-shot paths

### DIFF
--- a/docs/fixes/2026-09-09-batch-regen-timeline-reconcile.root-cause.json
+++ b/docs/fixes/2026-09-09-batch-regen-timeline-reconcile.root-cause.json
@@ -1,0 +1,80 @@
+{
+  "schema_version": 3,
+  "id": "2026-09-09-batch-regen-timeline-reconcile",
+  "problem_type": "Batch regeneration does not backfill timeline clips referencing regenerated nodes",
+  "symptom": "Regenerating a node through the batch path while its clip sits on the timeline leaves the clip pointing at the old asset URL; the same regeneration through the single-shot paths updates the clip in place.",
+  "direct_cause": "runGenerationNodesBatch's worker collects successes without calling reconcileTimelineForUpdatedNodes, while both single-shot paths (regenerateNodeInPlace, confirmAndRunNodeVariants) call it after runGenerationNode.",
+  "class_root": "Every path that lands a new result on a node must pass through the same timeline backfill gate; the backfill gate is a property of the result-landing boundary, not of individual callers.",
+  "affected_population": [
+    "Users regenerating timeline-referenced nodes via multi-select batch run"
+  ],
+  "scope_paths": [
+    "src/workbench/generationCanvas/runner/generationRunController.ts"
+  ],
+  "entry_points": [
+    "runGenerationNodesBatch worker success path"
+  ],
+  "external_sources": [],
+  "internal_only_reason": "Internal runner-to-store reconciliation; no external format change.",
+  "invariants": [
+    "After a successful runGenerationNode lands a result, timeline clips referencing that node are backfilled (same position, new URL) regardless of which dispatch path ran it.",
+    "Nodes without timeline clips remain untouched (reconcile is a no-op)."
+  ],
+  "generality_proof": "The fix sits at the single success point shared by every batch worker, so all batch dispatches (plain batch, wave plan workers sharing this loop) reconcile; single-shot paths already reconcile at their own call sites.",
+  "shared_boundaries": [
+    {
+      "path": "src/workbench/generationCanvas/runner/generationRunController.ts",
+      "symbol": "runGenerationNodesBatch worker",
+      "responsibility": "Reconcile timeline for each successfully regenerated node before reporting success."
+    }
+  ],
+  "same_class_entry_points": [
+    {
+      "path": "src/workbench/generationCanvas/runner/generationRunController.ts",
+      "entry_point": "regenerateNodeInPlace",
+      "disposition": "enforced",
+      "evidence": "Already calls reconcileTimelineForUpdatedNodes after runGenerationNode; unchanged reference implementation."
+    },
+    {
+      "path": "src/workbench/generationCanvas/runner/generationRunController.ts",
+      "entry_point": "confirmAndRunNodeVariants",
+      "disposition": "enforced",
+      "evidence": "Already reconciles per-variant after runGenerationNode; unchanged."
+    }
+  ],
+  "recurrence": {
+    "classification": "one_off",
+    "reason": "The batch worker was the single dispatch path missing the reconcile call; both single-shot paths and the semantic scheduler's own loop were audited for the same omission.",
+    "same_class_scan": [
+      "Checked confirmAndRunNodeVariants and regenerateNodeInPlace: both reconcile.",
+      "Checked runGenerationNodesByPlan: it dispatches through runGenerationNodesBatch, so the worker fix covers it."
+    ]
+  },
+  "regression_tests": [
+    "src/workbench/generationCanvas/runner/generationQueue.test.ts"
+  ],
+  "class_regression_tests": [
+    "src/workbench/generationCanvas/runner/generationQueue.test.ts"
+  ],
+  "legacy_paths": {
+    "status": "not-applicable",
+    "removed_paths": [],
+    "rationale": "No legacy path removed; the reconcile call is added, not moved."
+  },
+  "dependency_lifecycle": {
+    "decision": "not-applicable",
+    "rationale": "No dependency change.",
+    "exit_criteria": []
+  },
+  "migration": "No persistence schema change.",
+  "residual_risks": [
+    "Failed nodes in a batch still do not reconcile (no new result to backfill), matching single-shot behavior."
+  ],
+  "invariant_owner_layer": {
+    "layer": "src/workbench/generationCanvas/runner/generationRunController.ts",
+    "tests": [
+      "src/workbench/generationCanvas/runner/generationQueue.test.ts"
+    ],
+    "note": "The batch worker owns result landing for batch dispatches; the regression pins a timeline-referencing clip being backfilled."
+  }
+}

--- a/src/workbench/generationCanvas/runner/generationQueue.test.ts
+++ b/src/workbench/generationCanvas/runner/generationQueue.test.ts
@@ -8,6 +8,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { runGenerationNodesBatch, runGenerationNodesByPlan } from './generationRunController'
 import { QUEUE_BRAKE_THRESHOLD, useGenerationQueueStore } from './generationQueueStore'
+import { useWorkbenchStore } from '../../workbenchStore'
+import { createDefaultTimeline } from '../../timeline/timelineMath'
 import { useGenerationCanvasStore } from '../store/generationCanvasStore'
 import { setCanvasEventSinkForTests } from '../events/canvasEventEmitter'
 import { __resetCanvasUndoJournalForTests } from '../events/canvasUndoJournal'
@@ -122,6 +124,31 @@ describe('生成队列外化', () => {
       useGenerationQueueStore.getState().markSettled(batchId, nodeId, 'error', { countsTowardBrake: false })
     }
     expect(useGenerationQueueStore.getState().batches[batchId]?.paused).toBe(false)
+  })
+
+  it('批量成功后回填时间轴：引用该节点的 clip 换成新产物 URL（对齐单发路径）', async () => {
+    const [id] = addImageNodes(1)
+    const staleClip = {
+      id: 'c-batch-1', type: 'image', sourceNodeId: id, label: id, url: 'https://example.com/old.png',
+      startFrame: 0, endFrame: 90, frameCount: 90,
+    } as never
+    const base = createDefaultTimeline()
+    // 生成模块树内不许直写 addTimelineClipAtFrame（adoption-bridge 铁律）——测试种子用 setState 直置。
+    useWorkbenchStore.setState({
+      timeline: { ...base, tracks: base.tracks.map((track) => track.type === 'image' ? { ...track, clips: [staleClip] } : track) },
+      timelineUndoStack: [], timelineRedoStack: [],
+    })
+
+    const result = await runGenerationNodesBatch([id], {
+      assetUploadConsent: 'not-needed',
+      concurrency: 1,
+      executor: async () => fakeResult(id),
+    })
+
+    expect(result.successes).toHaveLength(1)
+    const clip = useWorkbenchStore.getState().timeline.tracks.flatMap((track) => track.clips).find((entry) => entry.id === 'c-batch-1')
+    // 修复前：批量路径不回填，时间轴 clip 仍指旧 URL。
+    expect(clip?.url).toBe(`https://example.com/${id}.png`)
   })
 
   it('不变量③：不传 batchId 时行为不变（退化路径 = 回滚保险）', async () => {

--- a/src/workbench/generationCanvas/runner/generationRunController.ts
+++ b/src/workbench/generationCanvas/runner/generationRunController.ts
@@ -475,6 +475,8 @@ export async function runGenerationNodesBatch(
           ...(options.batchId ? { batchId: options.batchId } : {}),
         })
         successes.push({ nodeId, result })
+        // 批量重生成也要走回填闸（与单发路径同款）：位置不变、clip 换新产物 URL；无引用时 no-op。
+        useWorkbenchStore.getState().reconcileTimelineForUpdatedNodes(nodeId, result)
         options.onNodeResult?.({ ok: true, nodeId, result })
       } catch (error: unknown) {
         const normalizedError = error instanceof Error ? error : new Error(String(error))


### PR DESCRIPTION
runGenerationNodesBatch 的 worker 收集 successes 时不调
reconcileTimelineForUpdatedNodes；单发路径（regenerateNodeInPlace /
confirmAndRunNodeVariants）成功后都会回填。批量重生成已上时间轴的节点后，
clip 仍指旧 URL——同一动作两条路径行为不一致。

修复：worker 成功点补回填调用（无引用该节点的 clip 时 no-op）。

回归测试：generationQueue.test.ts「批量成功后回填时间轴」——种子 clip 指
旧 URL，批量跑完 clip 换新产物 URL（修复前红）。
root-cause 合同：docs/fixes/2026-09-09-batch-regen-timeline-reconcile.root-cause.json

---
来自全库 bug 猎查（2026-09-09/10）：19 条独立修复之一，每条独立分支/独立回归测试；本地 contracts 门岗全绿。