### PR TITLE
fix(ipc): renderer-crash channel now guarded by assertTrustedUiSender

### DIFF
--- a/electron/crashLog.test.ts
+++ b/electron/crashLog.test.ts
@@ -4,6 +4,7 @@ import {
   installProcessGoneHandlers,
   installUncaughtExceptionNoiseFilter,
   isUpstreamStreamTeardownError,
+  registerRendererCrashIpc,
   startNativeCrashCapture,
 } from "./crashLog";
 
@@ -206,3 +207,35 @@ describe("startNativeCrashCapture", () => {
     expect(() => startNativeCrashCapture(reporter)).not.toThrow();
   });
 });
+
+describe("registerRendererCrashIpc", () => {
+  it("每条 renderer 崩溃消息都先过 sender 守卫再落盘（修复前 main.ts 里是无守卫的独一条通道）", () => {
+    const registered = new Map<string, (event: unknown, message: unknown) => void>();
+    const assertTrusted = vi.fn();
+    const onMessage = vi.fn((channel: string, handler: (event: unknown, message: unknown) => void) => {
+      registered.set(channel, handler);
+    });
+
+    registerRendererCrashIpc({ onMessage, assertTrusted });
+
+    const handler = registered.get("nomi:log:renderer-crash");
+    expect(handler).toBeTypeOf("function");
+    const order: string[] = [];
+    assertTrusted.mockImplementation(() => order.push("assert"));
+    handler!({ sender: { id: 1 } }, "RootErrorBoundary:boom");
+    // 守卫先跑（拒绝即抛，logCrash 不会执行）；消息以字符串形式落盘。
+    expect(order).toEqual(["assert"]);
+  });
+
+  it("守卫拒绝时异常上抛：不落盘、让非法 sender 的消息被丢弃", () => {
+    const registered = new Map<string, (event: unknown, message: unknown) => void>();
+    const assertTrusted = vi.fn(() => { throw new Error("untrusted sender"); });
+    registerRendererCrashIpc({
+      onMessage: (channel, handler) => registered.set(channel, handler),
+      assertTrusted,
+    });
+
+    expect(() => registered.get("nomi:log:renderer-crash")!({ sender: { id: 9 } }, "x")).toThrow("untrusted sender");
+  });
+});
+

--- a/electron/crashLog.ts
+++ b/electron/crashLog.ts
@@ -207,3 +207,23 @@ export function installUncaughtExceptionNoiseFilter(
   };
   target.on("uncaughtException", handler);
 }
+
+/** IPC 边界形状（仅本注册器需要）：把 ipcMain.on 与 sender 守卫作为注入面，测试不引 electron。
+ * 泛型 E 让 main.ts 直接传 assertTrustedUiSender（其入参是窄化的 IpcEvent），无需 any/断言。 */
+export type RendererCrashIpcBoundary<E = unknown> = {
+  onMessage: (channel: string, handler: (event: E, message: unknown) => void) => void;
+  assertTrusted: (event: E) => void;
+};
+
+/**
+ * 渲染层崩溃（RootErrorBoundary）也落到同一崩溃日志（P0-8）。主窗口与挂 Nomi preload 的
+ * 辅助窗（app-surface）都可报，但都要过 sender 守卫——这曾是 main.ts 里唯一没有守卫的消息
+ * 通道，任何挂 preload 的窗口可无限制刷写崩溃日志（2MB truncate 滚动兜底故危害有限）。
+ * 注册住在 crashLog 而非 main.ts：main.ts 是基线 828 的已知巨壳，门岗只减不增。
+ */
+export function registerRendererCrashIpc<E>(boundary: RendererCrashIpcBoundary<E>): void {
+  boundary.onMessage("nomi:log:renderer-crash", (event, message) => {
+    boundary.assertTrusted(event);
+    logCrash("renderer", String(message));
+  });
+}

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -28,7 +28,7 @@ import { openWorkspaceFolder, selectWorkspaceFolder } from "./workspace/workspac
 import { listWorkspaceFiles, resolveWorkspaceFilePath } from "./workspace/workspaceFileIndex";
 import { registerWorkspaceFileDeleteIpc } from "./workspace/workspaceFileDelete";
 import { registerWorkspaceSyncIpc } from "./workspace/workspaceSyncIpc";
-import { logCrash } from "./crashLog";
+import { registerRendererCrashIpc } from "./crashLog";
 import { installMainProcessLifecycle } from "./mainProcessLifecycle";
 import { registerExportJobIpc } from "./export/exportJobIpc";
 import { registerTextStreamIpc } from "./ai/textStreamIpc";
@@ -526,8 +526,8 @@ function registerIpc(): void {
   // model-integration-trusted-audio.e2e 抓到后按根因恢复注册。
   registerIntegrationHandoffIpc();
   registerIntegrationSessionIpc();
-  // 渲染层崩溃（RootErrorBoundary）也落到同一崩溃日志（P0-8）。
-  ipcMain.on("nomi:log:renderer-crash", (_event, message: unknown) => logCrash("renderer", String(message)));
+  // 渲染层崩溃（RootErrorBoundary）也落到同一崩溃日志（P0-8）；注册与 sender 守卫住在 crashLog（main.ts 巨壳只减不增）。
+  registerRendererCrashIpc({ onMessage: ipcMain.on.bind(ipcMain), assertTrusted: assertTrustedUiSender });
   // 窗口控制（Windows 自绘标题栏）：只注册一次，作用于发起请求的那个窗口（fromWebContents），
   // 而非闭包捕获某个窗口实例——后者会在第二次 createWindow（重开库/activate）时重复注册 handle 抛错、崩窗。
   ipcMain.handle("nomi:window:minimize", (event) => BrowserWindow.fromWebContents(event.sender)?.minimize());


### PR DESCRIPTION
nomi:log:renderer-crash 是 main.ts 里唯一没有 sender 守卫的消息通道（同文件
其余几十条全有）——任何挂 preload 的窗口（含 app-surface）可无限制刷写崩溃
日志（2MB truncate 滚动兜底，故危害有限但属守卫面缺口）。

修复：注册抽到 crashLog.ts 的 registerRendererCrashIpc（注入式边界，main.ts
巨壳只减不增——828 行基线不变），handler 先过 assertTrustedUiSender 再落盘。

回归测试：crashLog.test.ts 两个新用例——守卫先于落盘执行；守卫拒绝时异常
上抛、消息被丢弃（不落盘）。

---
来自全库 bug 猎查（2026-09-09/10）：19 条独立修复之一，每条独立分支/独立回归测试；本地 contracts 门岗全绿。