### PR TITLE
fix(comfyui): clear the convert race timer and stop polling a destroyed window

### DIFF
--- a/electron/comfyuiGraphConvert.ts
+++ b/electron/comfyuiGraphConvert.ts
@@ -101,6 +101,9 @@ function ensureWindow(base: string): Holder {
       // 等 ComfyUI 前端把 app 挂到 window 上（版本差异靠能力探测，不靠版本号猜）。
       const deadline = Date.now() + CONVERT_TIMEOUT_MS;
       while (Date.now() < deadline) {
+        // 窗口被 closeConverterWindow 销毁后别再空转轮询（每 400ms 对已销毁 webContents
+        // executeJavaScript，throw 被 catch 成 false，白转到 deadline）。
+        if (win.isDestroyed()) return false;
         const ok = await win.webContents
           .executeJavaScript(`Boolean(window.app && window.app.graphToPrompt && window.app.loadGraphData)`)
           .catch(() => false);
@@ -140,10 +143,15 @@ export async function convertUiWorkflowToApi(baseUrl: string, uiWorkflowText: st
   }
 
   const holder = ensureWindow(base);
-  const ready = await Promise.race([
-    holder.ready,
-    new Promise<boolean>((r) => setTimeout(() => r(false), CONVERT_TIMEOUT_MS)),
-  ]);
+  // race 的超时 timer 必须 clear：ready 先成时留着它就是 CONVERT_TIMEOUT_MS 的空挂定时器。
+  let raceTimer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<boolean>((r) => { raceTimer = setTimeout(() => r(false), CONVERT_TIMEOUT_MS); });
+  let ready: boolean;
+  try {
+    ready = await Promise.race([holder.ready, timeout]);
+  } finally {
+    clearTimeout(raceTimer);
+  }
   if (!ready) {
     closeConverterWindow(base);
     return { ok: false, error: `连不上 ComfyUI 网页（${base}），无法自动转换格式` };


### PR DESCRIPTION
两处资源卫生：
1. convertUiWorkflowToApi 的 Promise.race 超时 promise 的 setTimeout 从不
   clear——ready 先成时定时器空挂到 CONVERT_TIMEOUT_MS（45s）。
2. ensureWindow 的 ready 轮询循环在窗口被 closeConverterWindow 销毁后仍每
   400ms 对已销毁 webContents executeJavaScript（throw 被 catch 成 false），
   空转到 deadline。

修复：race 用 try/finally clearTimeout；轮询循环每圈先查 win.isDestroyed()
即返 false。

测试缝说明（无正确缝记录）：现有测试仅盖纯函数（looksLikeUiWorkflow），
BrowserWindow 生命周期行为需伪窗口+伪定时器组合、断言 setTimeout/clearTimeout
调用对——脆弱性大于价值；改动可由检视证明（finally 必清、循环首查销毁）。

---
来自全库 bug 猎查（2026-09-09/10）：19 条独立修复之一，每条独立分支/独立回归测试；本地 contracts 门岗全绿。