### PR TITLE
fix(productionRun): observation horizon counts wall clock, not just sleeps

### DIFF
--- a/docs/fixes/2026-09-09-poll-horizon-wall-clock.root-cause.json
+++ b/docs/fixes/2026-09-09-poll-horizon-wall-clock.root-cause.json
@@ -1,0 +1,80 @@
+{
+  "schema_version": 3,
+  "id": "2026-09-09-poll-horizon-wall-clock",
+  "problem_type": "Single-shot observation horizon ignores poll HTTP round-trip time",
+  "symptom": "The nominal pollHorizonMs (default 300s) only accumulates sleep time; each poll's HTTP round-trip (which can hang up to the vendor timeout) is free, so the real observation window can exceed the horizon substantially.",
+  "direct_cause": "elapsedMs was incremented by waitMs after each sleep, never accounting for the time spent inside deps.submission.poll.",
+  "class_root": "A wall-clock budget must be measured against the clock, not reconstructed from the delays the loop itself chose.",
+  "affected_population": [
+    "Headless single-shot generation observation with slow providers"
+  ],
+  "scope_paths": [
+    "electron/productionRun/singleShotGenerationObserver.ts"
+  ],
+  "entry_points": [
+    "observeSingleShotGeneration main loop"
+  ],
+  "external_sources": [],
+  "internal_only_reason": "Internal observer loop; no external format change.",
+  "invariants": [
+    "The observation horizon bounds wall-clock time from the first poll, including poll round-trips and sleeps.",
+    "Sleep backoff cadence is unchanged; only the budget accounting switched to wall clock."
+  ],
+  "generality_proof": "Both the horizon check and the remaining-wait computation read the same wall-clock elapsed function, so every loop exit path honors the same budget.",
+  "shared_boundaries": [
+    {
+      "path": "electron/productionRun/singleShotGenerationObserver.ts",
+      "symbol": "observeSingleShotGeneration",
+      "responsibility": "Bound the observation window by wall clock via an injectable now()."
+    }
+  ],
+  "same_class_entry_points": [
+    {
+      "path": "electron/productionRun/multiShotBatchScheduler.ts",
+      "entry_point": "batch scheduler poll loop (sleptMs accounting)",
+      "disposition": "enforced",
+      "evidence": "Its loop re-polls on each scheduler tick with its own tick budget; its sleptMs is a within-tick cadence bound, and horizon across ticks is driven by wall-clock re-entry, not by accumulation across awaits."
+    },
+    {
+      "path": "electron/capabilityCore/core.ts",
+      "entry_point": "headless poll loops",
+      "disposition": "enforced",
+      "evidence": "Those loops already compare Date.now() - startedAt against timeoutMs (wall clock), matching the invariant this fix restores here."
+    }
+  ],
+  "recurrence": {
+    "classification": "one_off",
+    "reason": "Only this observer reconstructed its budget from accumulated sleep times; the sibling loops already use wall clock.",
+    "same_class_scan": [
+      "Checked capabilityCore core.ts loops: wall-clock based.",
+      "Checked multiShotBatchScheduler: per-tick cadence bound with wall-clock re-entry."
+    ]
+  },
+  "regression_tests": [
+    "electron/productionRun/singleShotGenerationObserver.test.ts"
+  ],
+  "class_regression_tests": [
+    "electron/productionRun/singleShotGenerationObserver.test.ts"
+  ],
+  "legacy_paths": {
+    "status": "not-applicable",
+    "removed_paths": [],
+    "rationale": "No legacy path removed; accounting switched from sleep accumulation to wall clock."
+  },
+  "dependency_lifecycle": {
+    "decision": "not-applicable",
+    "rationale": "No dependency change.",
+    "exit_criteria": []
+  },
+  "migration": "No persistence change.",
+  "residual_risks": [
+    "Injectable tests that do not pass now() use real Date.now; horizon tests must inject now or use terminal actions."
+  ],
+  "invariant_owner_layer": {
+    "layer": "electron/productionRun/singleShotGenerationObserver.ts",
+    "tests": [
+      "electron/productionRun/singleShotGenerationObserver.test.ts"
+    ],
+    "note": "The observer owns its own budget; the regression pins poll round-trips consuming the horizon."
+  }
+}

--- a/electron/productionRun/singleShotGenerationObserver.test.ts
+++ b/electron/productionRun/singleShotGenerationObserver.test.ts
@@ -166,4 +166,31 @@ describe("single-shot generation observation", () => {
     })).resolves.toMatchObject({ nextAction: "attention", polls: 1 });
     expect(submission.materialize).not.toHaveBeenCalled();
   });
+
+  it("pollHorizon 按墙钟计：poll 的 HTTP 往返也消耗预算，不只累计 sleep", async () => {
+    // 修复前：elapsed 只 += waitMs，两次 3000ms 的 poll 往返不占预算，观察窗被拉长。
+    let clock = 0;
+    const submission = {
+      poll: vi.fn(async () => {
+        clock += 3_000; // 模拟单次 poll 挂 3s（网络慢/上游排队）
+        return {
+          operationId: "op-1", runId: "op-1", jobId: "job-1", providerTaskId: "task-1",
+          providerStatus: "processing", nextAction: "poll" as const,
+        };
+      }),
+      materialize: vi.fn(),
+    };
+    const result = await observeSingleShotGeneration({
+      submission,
+      input: { projectId: "project-1", operationId: "op-1" },
+      sleep: async () => { clock += 1; },
+      now: () => clock,
+      pollHorizonMs: 10_000,
+      initialDelayMs: 1,
+      maxDelayMs: 1,
+    });
+    expect(result.nextAction).toBe("observe");
+    // 墙钟口径：第 4 次 poll 后已 12000ms > 10000ms，停——而不是让 sleep 只攒 3ms。
+    expect(submission.poll.mock.calls.length).toBe(4);
+  });
 });

--- a/electron/productionRun/singleShotGenerationObserver.ts
+++ b/electron/productionRun/singleShotGenerationObserver.ts
@@ -28,6 +28,8 @@ export type SingleShotGenerationObserverInput = {
   /** Maximum delay between queries. */
   maxDelayMs?: number;
   sleep?: (ms: number) => Promise<void>;
+  /** Injectable clock; the horizon counts wall time (poll round-trips included), not just sleeps. */
+  now?: () => number;
 };
 
 export type SingleShotGenerationObservation = {
@@ -89,7 +91,11 @@ export async function observeSingleShotGeneration(
   const initialDelayMs = Math.max(0, deps.initialDelayMs ?? 3_000);
   const maxDelayMs = Math.max(initialDelayMs, deps.maxDelayMs ?? 15_000);
   const sleep = deps.sleep ?? ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
-  let elapsedMs = 0;
+  // horizon 按**墙钟**计：只累计 sleep 时间会漏掉每次 poll 的 HTTP 往返（单次可挂到
+  // vendorHttp 超时上限），名义 300s 的实际观察窗可显著超出。
+  const now = deps.now ?? Date.now;
+  const startedAtMs = now();
+  const elapsedMs = (): number => now() - startedAtMs;
   let delayMs = initialDelayMs;
   let polls = 0;
   let lastPoll: GenerationSubmissionPollResult | undefined;
@@ -110,14 +116,13 @@ export async function observeSingleShotGeneration(
       return { nextAction: "completed", polls, lastPoll, materialized };
     }
     if (lastPoll.nextAction === "attention") return { nextAction: "attention", polls, lastPoll };
-    if (elapsedMs >= pollHorizonMs) return { nextAction: "observe", polls, lastPoll };
+    if (elapsedMs() >= pollHorizonMs) return { nextAction: "observe", polls, lastPoll };
 
-    const waitMs = Math.min(delayMs, pollHorizonMs - elapsedMs);
+    const waitMs = Math.min(delayMs, pollHorizonMs - elapsedMs());
     if (waitMs <= 0) return { nextAction: "observe", polls, lastPoll };
     if (!(await sleepUnlessAborted(sleep, waitMs, deps.signal))) {
       return { nextAction: "observe", polls, lastPoll, aborted: true };
     }
-    elapsedMs += waitMs;
     delayMs = Math.min(maxDelayMs, Math.max(initialDelayMs, delayMs * 2 || initialDelayMs));
   }
 }


### PR DESCRIPTION
pollHorizonMs 只累计 sleep 的 waitMs——每次 poll 的 HTTP 往返（单次可挂到
vendorHttp 超时上限）不占预算，名义 300s 的观察窗可显著超出。sibling 循环
（capabilityCore core.ts）一直按 Date.now()-startedAt 墙钟计，独此一处用
sleep 累加重建预算。

修复：elapsed 改为墙钟差（注入式 now，缺省 Date.now），horizon 判定与剩余
wait 计算同一口径；退避节奏不变。

回归测试：singleShotGenerationObserver.test.ts 注入 now + 每次 poll 消耗
3000ms 墙钟 → 第 4 次 poll 后触顶（修复前红：sleep 只攒毫秒级、远超 4 次）。
root-cause 合同：docs/fixes/2026-09-09-poll-horizon-wall-clock.root-cause.json

---
来自全库 bug 猎查（2026-09-09/10）：19 条独立修复之一，每条独立分支/独立回归测试；本地 contracts 门岗全绿。