### PR TITLE
fix(ai): string error codes of any digit length count as logical errors

### DIFF
--- a/electron/ai/requestPipeline.test.ts
+++ b/electron/ai/requestPipeline.test.ts
@@ -154,6 +154,10 @@ describe("looksLikeLogicalError", () => {
     expect(looksLikeLogicalError({ code: 422, msg: "bad" })).toBe(422);
     expect(looksLikeLogicalError({ code: "404" })).toBe(404);
   });
+  it("字符串 code 不限 3 位：4 位业务码（如 \"1004\"）也是逻辑错，不许漏判成成功", () => {
+    // 修复前 /^\d{3}$/ 漏掉 4 位 → 200 空壳体当成功流进结果构造（errorCode 分支早有 /^\d+$/，同文件两分支口径不一）。
+    expect(looksLikeLogicalError({ code: "1004", msg: "quota denied" })).toBe(1004);
+  });
   it("ignores success codes", () => {
     expect(looksLikeLogicalError({ code: 200 })).toBeNull();
     expect(looksLikeLogicalError({ data: {} })).toBeNull();

--- a/electron/ai/requestPipeline.ts
+++ b/electron/ai/requestPipeline.ts
@@ -514,7 +514,8 @@ export function looksLikeLogicalError(body: unknown): number | null {
   if (!isRecord(body)) return null;
   const code = body.code;
   if (typeof code === "number" && code >= 400 && code < 600) return code;
-  if (typeof code === "string" && /^\d{3}$/.test(code) && Number(code) >= 400) return Number(code);
+  // 与下行 errorCode 分支同口径 /^\d+$/：4 位业务码（如 "1004"）也是逻辑错，3 位正则会漏判成成功。
+  if (typeof code === "string" && /^\d+$/.test(code) && Number(code) >= 400) return Number(code);
   // RunningHub 风格：errorCode 存在且非「成功」值（0 / "0" / 空）即逻辑错。
   const ec = body.errorCode;
   if (typeof ec === "number" && ec !== 0) return ec;


### PR DESCRIPTION
looksLikeLogicalError 的字符串 code 分支正则 /^\d{3}$/ 只认 3 位——非
RunningHub 家族返回字符串形如 "1004" 的 4 位业务码会被漏判为成功，200
空壳体流进结果构造。同函数 errorCode 分支早就是 /^\d+$/（注释明言不限
3 位），两分支口径不一。

修复：字符串 code 分支放宽为 /^\d+$/（保留 >=400 数值门槛，与 errorCode
分支同口径）。

回归测试：requestPipeline.test.ts「字符串 code 不限 3 位」（修复前红）。

---
来自全库 bug 猎查（2026-09-09/10）：19 条独立修复之一，每条独立分支/独立回归测试；本地 contracts 门岗全绿。