### PR TITLE
fix(agent-lane): 会话中途导入的技能，模型下一个回合就该看得见——把装配期快照改成每回合求值

### DIFF
--- a/docs/audit/2026-09-11-skill-fact-projections-structure.md
+++ b/docs/audit/2026-09-11-skill-fact-projections-structure.md
@@ -1,0 +1,114 @@
+# 结构评审：技能这一份事实，和它的 N 条投影
+
+状态：单一评审者视角，不代表多位独立审批者。触发方式不是排期，是门岗——
+`check:symptom-cluster` 报出 `electron/skills` 在 2026-09-07 到 09-11 的 5 天里收到了第 6 份根因合同，
+`src` 收到第 3 份。**第三份合同是「这一层的结构不对」最便宜的证据**，所以本文回答的不是「这 6 个 bug 各自怎么修」，
+而是「它们是不是同一个结构缺口，缺口在哪一层，以及什么东西能拦住第 7 份」。
+
+范围：`electron/skills`（规范记录与落盘）、以及 `src` 里读它的那几个消费者。
+配套评审：[2026-09-11-agent-lane-live-vs-snapshot.md](2026-09-11-agent-lane-live-vs-snapshot.md)（lane 层的寿命裁决，本文第 §3 与它衔接）。
+
+## 1. 这 6 份合同是不是同一类
+
+| 合同 | 它说的根因 | 落在哪条边界上 |
+|---|---|---|
+| `2026-09-07-skill-manifest-two-owners` | 一个事实两个文件级 owner（SKILL.md frontmatter 与 skill.json），靠优先级选一个 | 记录的**产生**边界 |
+| `2026-09-08-curated-media-boundary` | 策展媒体在投影与包传输之间丢了绑定 | 记录 → 包 / 协议 |
+| `2026-09-09-skill-library-media-projection` | 展示层 DTO 没保住所有发现型消费者需要的媒体、全文与分类 | 记录 → 渲染层 DTO |
+| `2026-09-10-b6-mcp-skill-content` | MCP 投影没保住内容寻址的包边界 | 记录 → MCP 工具结果 |
+| `2026-09-11-lane-live-skills-snapshot`（本轮） | lane 的技能索引是开 lane 那一刻的快照，之后不再更新 | 记录 → 模型的系统提示词 |
+| `2026-09-07-agent-stage4-dead-file-removal` | 阶段 4 切换后的死文件清理 | —（不属本类，是一次性清理） |
+
+前 5 份是同一类，而且类的形状比每份合同自己说的更大：
+
+> **`SkillRecord` 是规范记录，它有至少 7 个消费者，每个消费者各自决定「带哪些字段、什么时候取」。
+> 这 5 份合同就是 5 个消费者各被单独修了一次。** 缺的不是某个字段——缺的是**「投影」这件事没有 owner**：
+> 没有一张表说得出每个消费者需要 `SkillRecord` 的哪几个字段、那份投影的寿命是什么、谁验证它没漏。
+
+实核的消费者清单（`git grep readSkillRecords|discoverSkillRecordsFromRoots`，2026-09-11）：
+
+| 消费者 | 入口 | 投影形状 | 寿命 |
+|---|---|---|---|
+| 渲染层技能库 / Agent 技能菜单 | `electron/skills/skillIpc.ts:106`（`listSkillsForRenderer`） | `SkillListItem` DTO | 每次调用现读；渲染层各存一份 `useState` |
+| 模型的技能索引（lane） | `electron/agentLane/laneInstalledSkills.mts` | `LaneSkillIndexEntry` + 可信读根 | **本轮之前是开 lane 一次**；现为每回合一次 |
+| MCP 技能资源 | `electron/capabilityCore/mcpSkillResources.ts` | 内容寻址包 | 每次调用现读 |
+| 技能写入回执 | `electron/capabilityCore/skillWriteTransportAdapters.ts:138` | 写后重读核对 | 每次写入现读 |
+| 提示词库 | `electron/promptLibrary/curatedPrompts.ts:6` | `LibraryPrompt` | 每次调用现读 |
+| 预览协议 | `electron/skills/skillPreview.ts:15` + `electron/protocol/localProtocol.ts` | 媒体 URL | 每次请求现读 |
+| 执行证据 | `electron/skills/skillExecutionEvidence.ts:14` | 证据条目 | 每次调用现读 |
+
+**好消息（不该被这轮红灯掩盖）**：发现这一层已经收敛成一个 owner
+（`discoverSkillRecordsFromRoots`，`electron/skills/skillStore.ts:129`，注释里写明「所有 transport 都调它」），
+`skill.json` 那个第二 owner 也已经在 09-07 删除并由 `check:skills-format` 守住。
+也就是说**记录的产生**已经只有一个真相源；反复出事的是记录**之后**的那一段。
+
+## 2. 为什么这一类不会自己停
+
+三个放大器，都不报错：
+
+1. **投影是减法，而减掉什么由每个消费者自己决定。** 少带一个字段不会抛异常，只会让某一个下游少知道一件事——
+   而发现它的人往往是用户（「卡片上没有封面」「MCP 拿到的包读不出正文」「Agent 说没有这个技能」）。
+2. **投影的寿命没有类型。** 一个数组和一个「每次都重读的数组」长得一模一样。lane 那条就是这么漏的，
+   而同一份 port 上其实已经有三个字段（`tasks` / `approval.policy` / `systemPrompt`）用注释写过这条纪律。
+3. **每条投影各有各的测试，而没有一条测试跨两条投影。** 09-07 真机实拍到的那一幕最能说明问题：
+   左边技能库的卡片好好地立着、右边 Agent 的技能菜单一个字都没有它——两边各自的测试都是绿的。
+
+## 3. 本轮做了什么（以及刻意没做什么）
+
+做了三件，都在「投影」这条线上，不是又修一个字段：
+
+- **lane 这条投影收了一个 owner**：`LaneSkillIndexSource`（`electron/agentLane/laneInstalledSkills.mts`）
+  同时产出索引、可信读根与提示词段，三样出自同一次刷新，于是「模型看得见」与「模型读得到」不可能分叉。
+- **寿命变成一条规则而不是一个字段的属性**：`laneHost` 的 `systemPromptForRun` 规定
+  「系统提示词在每个回合边界整体重新求值一次、回合内不变」，任何随设置/磁盘变化的段落自动跟上。
+- **写盘的变更信号收了一个发出点**：`electron/skills/skillLibraryBroadcast.ts` 挂在
+  `importSkillPackageToUserDir` / `deleteUserSkill` 上，于是三个写入者（面板导入、拖拽、Agent 的
+  `author_skill`）不必各自记得喊一声；`src` 那边原来两处本地派发同 commit 删除，只留 `NomiRouterApp` 一个接线点。
+
+**刻意没做**（避免把评审做成又一次逐件修补，也避免在一次 bug 修复里塞一个新框架）：
+
+- 没有给 `SkillRecord` 加一层「投影注册表」。它是正确方向，但它是一次结构改造，要自己的方案与拍板，
+  不该搭在一条 bug 修复的车上。见下一节的待派。
+- 没有给技能目录加 fs watcher：它会带来自己的一族问题（编辑器写临时文件引发的抖动），
+  而 lane 侧因为改成每回合重扫，实际上已经对外部改动实时了。
+
+## 4. 关于 `src` 这一簇：先说清它有多少是真的
+
+`src` 被报出三份合同（`2026-09-08-catalog-liveness`、`2026-09-11-mcp-onboarding-defects`、本轮），
+但 `src` 这个模块键 = **整个渲染层**，粒度太粗——三份分别落在模型目录、MCP 接入提示与技能库，
+子系统互不相干。**所以这一簇里有相当一部分是门岗粒度的产物，不是「渲染层结构不对」的证据，这一点必须先承认。**
+
+但它们之间确实有一条真的共线，而且只有两条（catalog 与 skills）共享：
+
+> **渲染层对主进程事实的缓存，失效信号各自发明一套 `window` 事件，而「谁负责派发」没有规定。**
+> `nomi-model-catalog-changed`（`src/NomiRouterApp.tsx:38`）与 `nomi-skill-library-changed`
+> （`src/workbench/skillLibrary/skillLibraryChanged.ts:15`）是同一个范式的两份实例。
+> 模型目录那一份的派发点在主进程（`electron/catalog/validateCandidateCredential.ts:92`），是对的；
+> 技能那一份此前只在渲染层派发，于是主进程里的第三个写入者一个字都传不出来——本轮把它对齐成前者。
+
+**这一条现在是两处一致的范式，但仍然只是范式，不是防线**：第三个需要失效信号的渲染层缓存出现时，
+没有任何东西逼人回答「你的派发点在哪一侧」。这也是下一节待派的第二条。
+
+## 5. 待派（本轮不做，单独派工 + 单独裁决）
+
+1. **技能投影登记表**：一张机器可读的表，登记每个 `SkillRecord` 消费者需要哪些字段、投影的寿命
+   （每次现读 / 每回合 / 装配期常量）、以及验证它的那条测试。现成的位置是 R29 的 framework-surface
+   逐字段裁决（`docs/engineering/framework-boundaries.json` + `pnpm run check:framework-surface`）——
+   它今天只登记框架公开的字段，把我们自己这份规范记录的字段也纳进去，`SkillRecord` 加字段即红。
+   这是唯一能拦住第 7 份合同的东西；在它落地之前，本轮留下的只是 lane 那一条投影的单点棘轮。
+2. **渲染层失效信号的派发侧规定**：凡是渲染层缓存主进程的事实，失效信号必须由主进程发出
+   （写那一层，不是某个调用入口）。两处已一致，写成门岗才算防线（R28）。
+3. **跨投影的一致性测试**：当前每条投影各有各的测试，没有一条跨两条。09-07 那一幕
+   （技能库有、Agent 菜单没有）与本轮那一幕（菜单有、模型索引没有）都是这条缝里漏出来的。
+   本轮的 `tests/ux/lane-live-skills.walk.mjs` 是第二条跨缝走查（第一条是 `skill-import-real-use.walk.mjs`），
+   但它们是按 bug 长出来的，不是按投影矩阵铺的。
+
+## 6. 证据与限制
+
+- 消费者清单来自 2026-09-11 的 `git grep`，是那一刻的实核；`electron/skills` 与 `src` 两簇的成员清单来自
+  `pnpm run check:symptom-cluster` 的输出，不是人工挑的。
+- 本文**没有**复核那 5 份合同各自的修复是否正确——它只判「它们是不是同一类」。
+- `2026-09-07-agent-stage4-dead-file-removal` 只是因为 scope 里带了 `electron/skills/skillStore.ts`
+  才落进这一簇，它是阶段 4 切换的死文件清理，不能拿它充当「这一层老在坏」的证据。
+- 第 4 节关于 `src` 的结论明确承认了粒度问题：那一簇不能整簇当作结构证据，只有 catalog 与 skills
+  这两份之间那条共线是真的。

--- a/docs/fixes/2026-09-11-lane-live-skills-snapshot.root-cause.json
+++ b/docs/fixes/2026-09-11-lane-live-skills-snapshot.root-cause.json
@@ -1,0 +1,226 @@
+{
+  "schema_version": 3,
+  "id": "2026-09-11-lane-live-skills-snapshot",
+  "problem_type": "一个长生命周期对象在装配时把「每一刻都可能变的事实」当成「装配期常量」收下：类型上两者长得一模一样（都是一个数组或一个字符串），于是没有任何东西逼人回答「这个字段是哪一种寿命」",
+  "symptom": "用户在 Agent 面板旁边的技能库里导入一个技能包，左边卡片立着、composer 的技能菜单里也选得到，但对着 Agent 说「用刚导入的那个技能」，模型回「我没有这个技能」——要关掉项目再打开才认得它。同族的第二处：用户在记忆折叠里删一条项目记忆、或锁一个画布节点，已经开着的这条 lane 直到冷启动前都还在用旧的那份。同族的第三处（渲染层）：Agent 自己用 author_skill 写完一个技能落盘后，技能库面板与技能菜单都不知道，要重启 App 才撞见。",
+  "direct_cause": "laneDesktopRuntime.ts 在 openWorkspace 时把 readSkillRecords() 求值一次、以数组传进 openDesktopLaneWorkspace；laneNativeDesktop.mts 据此算出 { skills, trustedSkillRoots } 两份快照，laneHost.mts 再据此渲染一次 skillSection 拼进系统提示词。lane 会跨很多回合活着，而这三样都停在开 lane 那一刻。项目记忆同理：memory 在 openWorkspace 里先算好，systemPrompt 那个函数闭包引用的是这个常量。渲染层那一处是另一种形状但同一个后果：技能盘的变更信号只由渲染层自己的导入/删除派发（useWorkbenchSkills.ts），主进程里写盘的第三个入口（author_skill）一个字都传不出来。",
+  "class_root": "**一个跨很多回合活着的宿主，它的装配参数里混着两种寿命完全不同的东西——「开 lane 那一刻的事实」和「每一刻都可能变的事实」——而类型系统里两者没有区别。** 这一层其实已经知道规则（`tasks` / `approval.policy` 的注释把「给函数不给快照」写得很清楚），但规则只住在注释里：下一个字段被加进来时没有任何东西逼人回答它是哪一种寿命。2026-09-11 的 systemPrompt（回复语言）和本次的 native.skills 就是这么先后漏过去的，两者都在「每回合重拼」的钩子下游、却都是装配期取的值。所以修法不是给技能加一条刷新路径，而是**把「什么时候求值」变成这一层唯一的一条规则**：系统提示词在每个回合边界整体重新求值一次，会变的事实一律由来源提供。",
+  "affected_population": [
+    "所有在会话进行中导入技能的用户：技能库与 composer 菜单都看得见它，模型的索引里却没有——用户不点菜单、只用嘴说「用刚才那个技能」时，模型一口咬定没有",
+    "所有让 Agent 自己写技能（author_skill）的用户：写完落盘了，模型下一轮不认得它，用户在技能菜单里也找不到，要重启 App",
+    "所有在会话进行中改项目记忆的用户（记忆折叠里删/纠正一条、锁一个画布节点）：已经开着的 lane 直到冷启动前都在用旧的那份，锁了的节点它照样提议改",
+    "所有在会话进行中导入带 scripts/ 的技能并立刻引用它的用户：coding 工具的解锁判定看的是旧索引，模型会说「我要跑它的 selftest」然后说自己没有工具"
+  ],
+  "scope_paths": [
+    "electron/agentLane/laneRuntimePort.ts",
+    "electron/agentLane/laneHost.mts",
+    "electron/agentLane/laneInstalledSkills.mts",
+    "electron/agentLane/laneNativeDesktop.mts",
+    "electron/agentLane/laneCodingPaths.mts",
+    "electron/agentLane/laneCodingTools.mts",
+    "electron/agentLane/laneDesktopRuntime.ts",
+    "electron/skills/skillLibraryBroadcast.ts",
+    "electron/skills/skillPackage.ts",
+    "electron/preload.ts",
+    "src/NomiRouterApp.tsx",
+    "src/workbench/skillLibrary/skillLibraryChanged.ts",
+    "src/workbench/skillLibrary/useWorkbenchSkills.ts"
+  ],
+  "entry_points": [
+    "laneHost 的 systemPromptForRun（electron/agentLane/laneHost.mts）— 这一层唯一的「什么时候求值」规则：按 runId 记账，一个回合整体重新求值一次（重扫技能库 + 重拼提示词），回合内不变。transform_context 每次模型请求都走它，既不会引用开 lane 时的常量，也不会在回合内改口",
+    "LaneSkillIndexSource（electron/agentLane/laneInstalledSkills.mts）— 「这条 lane 关于技能的全部事实」的唯一 owner：entries / trustedSkillRoots / promptSection 三样出自同一次刷新，所以「模型看得见」与「read 读得到」不可能分叉；指纹含 contentHash，记录集没变就连 pi 的渲染都不重跑",
+    "createLaneCodingPaths 的可信根解析（electron/agentLane/laneCodingPaths.mts）— 收 readonly string[] | (() => readonly string[])，按「根的集合」缓存 realpath；根消失（用户删了技能）时把它摘掉而不是让之后每次 read 都炸",
+    "openLane 的 native.skills（electron/agentLane/laneRuntimePort.ts）— 契约放宽成 readonly SkillRecord[] | (() => readonly SkillRecord[])，与同文件 systemPrompt / tasks / approval.policy 同一条纪律",
+    "laneDesktopRuntime 的 openWorkspace（electron/agentLane/laneDesktopRuntime.ts）— 三样会变的事实都传来源：技能库给函数、语言铁律在函数体里、项目记忆改由 currentProjectMemory() 在同一个函数体里现读",
+    "broadcastSkillLibraryChanged（electron/skills/skillLibraryBroadcast.ts）— 技能盘变更信号的唯一发出点，挂在落盘那两个函数上（importSkillPackageToUserDir / deleteUserSkill），所以三个写入者（面板导入、拖拽、author_skill）都不必记得喊一声"
+  ],
+  "invariants": [
+    "跨多个回合活着的宿主，其装配参数里「会变的事实」必须以来源（函数 / 索引源）传入，不能传快照——与同文件 tasks / approval.policy / systemPrompt 同一条纪律",
+    "一条 lane 的系统提示词在每个回合边界整体重新求值一次，回合内不变：既不能引用开 lane 时的常量（回合间不更新），也不能每次模型请求都重算（回合内会改口、且把全量重扫乘上回合内的请求数）",
+    "技能索引与 read 允许越出项目的可信根必须来自同一个 owner 的同一次刷新——「模型看得见」与「模型读得到」不许分叉",
+    "「这条技能要不要 coding 工具」判在准入那一刻，判之前索引必须已经刷到当前回合",
+    "共享磁盘状态的变更信号发自写盘那一层，不发自某一个调用入口——入口会长出第四个，而漏掉的那一个不会报错",
+    "扫描与校验之间被删掉的技能不是安全事件：它只是不在这一刻的索引里，不许让整条 lane 之后的每个回合都失败",
+    "可信读根的集合是活的，但**每个根只 canonicalize 一次，就在它第一次出现的那一刻**：已经认下的根被换成指向别处的软链时不许重新解析（否则「把根变活」就顺手把它变成一块可以被换掉的可读区）；根本身是软链的一律拒，判越界的那一层不依赖上游记得校验"
+  ],
+  "regression_tests": [
+    "tests/ux/lane-live-skills.walk.mjs",
+    "tests/agent-runtime/lane-live-skill-index.test.mts",
+    "electron/agentLane/laneDesktopStructure.test.ts",
+    "electron/skills/skillLibraryBroadcast.test.ts"
+  ],
+  "class_regression_tests": [
+    "tests/ux/lane-live-skills.walk.mjs",
+    "tests/agent-runtime/lane-live-skill-index.test.mts",
+    "electron/agentLane/laneDesktopStructure.test.ts",
+    "electron/skills/skillLibraryBroadcast.test.ts"
+  ],
+  "external_sources": [
+    {
+      "kind": "official-doc",
+      "url": "https://code.claude.com/docs/en/skills.md",
+      "checked_at": "2026-09-11",
+      "purpose": "确认 Claude Code 的技能索引是会话启动时装载、改了文件要重开会话——证明「启动一次」是生态现状，我们和它不一样是领域约束（导入入口就在面板旁边）而不是口味。"
+    },
+    {
+      "kind": "official-doc",
+      "url": "https://github.com/agentskills/agentskills",
+      "checked_at": "2026-09-11",
+      "purpose": "Agent Skills 标准：只规定「启动预载 name+description、正文按需读」，对发现时机与热加载不作规定——所以刷新时机是宿主的自由，索引格式仍须照标准（R31 无偏差）。"
+    },
+    {
+      "kind": "official-doc",
+      "url": "https://modelcontextprotocol.io/specification/2025-06-18/server/tools",
+      "checked_at": "2026-09-11",
+      "purpose": "MCP 的 notifications/tools/list_changed 是「能力集在会话中途变了」这件事唯一有标准解法的地方；我们这一层没有服务端可发通知，取它的等价物——在回合边界重查一次。"
+    },
+    {
+      "kind": "official-doc",
+      "url": "https://github.com/openai/codex/issues/8547",
+      "checked_at": "2026-09-11",
+      "purpose": "Codex 的 AGENTS.md 同样启动一次、热加载至今是 open issue——第三家佐证「启动一次」是现状而非最优解。"
+    },
+    {
+      "kind": "source-code",
+      "url": "https://www.npmjs.com/package/@earendil-works/pi-coding-agent/v/0.85.1",
+      "checked_at": "2026-09-11",
+      "purpose": "实读 dist/core/resource-loader.js:206 的 getSkills()（返回 load() 时的缓存）与 :263 的 reload()、dist/core/agent-session.js:755（一次性烘进 _baseSystemPromptOptions）：上游没有「每回合重读」的机制可借，刷新时机只能由宿主决定；渲染仍用 dist/core/skills.d.ts:44 的 formatSkillsForPrompt。"
+    }
+  ],
+  "internal_only_reason": "",
+  "invariant_owner_layer": {
+    "layer": "electron/agentLane/laneHost.mts",
+    "tests": [
+      "electron/agentLane/laneDesktopStructure.test.ts",
+      "tests/agent-runtime/lane-live-skill-index.test.mts",
+      "tests/ux/lane-live-skills.walk.mjs"
+    ]
+  },
+  "recurrence": {
+    "classification": "recurring",
+    "reason": "同一个形状在这一层已经连着出现两次：2026-09-11 上午是 systemPrompt（回复语言跟不上界面语言），当天的结构评审就把 native.skills 点名为「同类缺口，尚未修」（docs/audit/2026-09-11-agent-lane-live-vs-snapshot.md 的「待派」），本次是它。两次都不是手误，而是「装配参数里混着两种寿命、类型上没有区别」这个结构缺口在不同字段上的显形——它还会随下一个被加进 OpenLaneOptions 的字段回来。渲染层那一处（技能盘变更信号只由某一个调用入口派发）是同一个后果的另一种成因，同样会随第四个写入者回来。",
+    "same_class_scan": [
+      "逐字段扫 OpenLaneOptions 与 openWorkspace 的闭包（electron/agentLane/laneRuntimePort.ts + laneDesktopRuntime.ts）：装配期常量 = projectDir / laneName / sessionId / native.settingsRoot / tools / toolLifecycle / watchdog / limits / approval.hasUserInterface（工具集由代码拥有、目录换了就是换 lane，均正确）；有显式变更路径 = model（每次发送前 laneIpc 都调 configure，改了就 configureModel 重开 lane，凭据随之重解析）；已经是函数 = approval.policy / approval.workMode / tasks / input.capture / native.availableModels；**本次修的三个快照 = native.skills（含 trustedSkillRoots）、systemPrompt 闭包里的 memory、以及它们共同依赖的求值时机**",
+      "grep readSkillRecords 全仓（electron/ src/）：主进程读点为 skillIpc.listSkillsForRenderer / skillExecutionEvidence / skillPreview / curatedPrompts / skillRead 与 skillWrite 两个 transport adapter，全部是「每次调用现读」，构造上无快照问题；唯一把它求值一次交给长生命周期对象的就是 laneDesktopRuntime 的 openWorkspace（本次改成函数）",
+      "grep sandboxPolicyFor 的 allowedDomains（electron/agentLane/laneCodingSandbox.mts:73）：当前恒为空数组（没有调用方传它），所以还不是一份会过期的快照；技能一旦开始声明出网域名，它会立刻变成同一类——已在本合同的 residual_risks 里记名",
+      "grep webContents.send 全仓（electron/）：跨进程变更广播的既有用法为 model-catalog / assets / screenshot / browser / updater / production，技能是唯一一个只有渲染层本地总线、没有主进程广播的共享磁盘状态（本次补上）"
+    ]
+  },
+  "generality_proof": "修的是「什么时候求值」这条规则本身，不是技能这一个字段。①laneHost 只多了一条按 runId 记账的求值规则，任何随设置/磁盘变化的提示词段落（今天是技能索引、界面语言、项目记忆，明天可能是权限说明或项目档案）都自动跟上，不必各自发明一条刷新路径；②技能的三样事实（索引、可信读根、提示词段）收进一个 owner，于是「看得见却读不到」这种自相矛盾在结构上不可能发生，而不是靠两处记得同时刷；③可信根接受来源而不是数组，缓存键是根的集合，来源怎么变都不必改这一层；④渲染层的变更信号从「某个调用入口记得喊」搬到「写盘那一层必然喊」，第四个写入者出现时不必记得补一行（R28）。粒度选回合而不是请求，也是一条通用裁决：回合是用户能感知的最小原子，回合内不改口同时解决了「一句中文一句英文」和「把全量重扫乘以回合内请求数」两个问题。",
+  "shared_boundaries": [
+    {
+      "path": "electron/agentLane/laneHost.mts",
+      "symbol": "systemPromptForRun + composeSystemPrompt",
+      "responsibility": "一条 lane 每个回合的系统提示词由这里统一重新求值一次：按 runId 记账，回合内复用同一份；会变的事实在这一刻从来源取，不复用开 lane 时的闭包常量"
+    },
+    {
+      "path": "electron/agentLane/laneInstalledSkills.mts",
+      "symbol": "createLaneSkillIndexSource / LaneSkillIndexSource",
+      "responsibility": "这条 lane 关于技能的全部事实的唯一 owner：entries / trustedSkillRoots / promptSection 三样同一次刷新产出，指纹（含 contentHash）没变就整份复用"
+    },
+    {
+      "path": "electron/agentLane/laneCodingPaths.mts",
+      "symbol": "createLaneCodingPaths 的 skillRoots 解析",
+      "responsibility": "read 允许越出项目的可信根的唯一判定点：从来源取当前根集合，按集合缓存 realpath，根消失时摘掉而不是抛"
+    },
+    {
+      "path": "electron/skills/skillLibraryBroadcast.ts",
+      "symbol": "broadcastSkillLibraryChanged",
+      "responsibility": "技能盘变更信号的唯一发出点，挂在落盘那一层；渲染层只在 NomiRouterApp 一个接线点把它转成本地总线事件"
+    }
+  ],
+  "same_class_entry_points": [
+    {
+      "path": "tests/ux/lane-live-skills.walk.mjs",
+      "entry_point": "会话开着的时候导入技能 → 不重开项目/对话 → 下一轮的 system 里必须出现它的名字、描述与安装路径（阳性对照：导入前那一轮 <available_skills> 在、这个名字不在）",
+      "disposition": "enforced",
+      "evidence": "真机 Electron、隔离 profile、零额度 loopback：用户点侧栏「技能库」→ 面板里的导入 input 选一个 zip → 不碰任何重开动作 → 再发一轮。变异验证过会红：把 laneDesktopRuntime 的 skills 改回 readSkillRecords() 数组后，阳性对照仍绿而第 ④ 条当场红，报文里的 <available_skills> 只剩内置技能（2026-09-11 实跑）。刻意不在这一轮选中技能——选了走的是 composer chip 通路（正文随消息走），证不到索引。"
+    },
+    {
+      "path": "tests/agent-runtime/lane-live-skill-index.test.mts",
+      "entry_point": "索引源的四条不变量：refresh 才换代 / current() 回合内不动 / 记录集没变不重算（含 contentHash 变了要重算）/ 第一个技能半路进来时才加载渲染器；可信根跟着来源走且根消失只是摘掉；原生装配下「导入前 read 越界、刷新后 read 读得到」；以及「根的集合是活的、已认下的根不许被重新解析」这条安全性质",
+      "disposition": "enforced",
+      "evidence": "node:test 真跑真盘（临时目录 + 真 SKILL.md）。变异验证过会红：把 laneNativeDesktop 的 trustedSkillRoots 改回装配期快照后，最后一条当场红（read 仍判越界），前三条仍绿——证明它量的正是「索引与可信根同源」这一条（2026-09-11 实跑）。 另一条变异验证：把 pin 表改回「每次按集合重新 realpath」后，既有的 lane-native-paths「装配之后被换成软链」用例与本文件新增的那条同时红（2026-09-11 实跑先红后绿）。"
+    },
+    {
+      "path": "electron/agentLane/laneDesktopStructure.test.ts",
+      "entry_point": "结构棘轮四条：port 上会变的字段收来源不收快照 / laneHost 按 runId 求值且准入前先刷索引 / 桌面运行时三样事实都传来源（没有预先算好的 memory 常量）/ 索引与可信根是同一个 owner",
+      "disposition": "enforced",
+      "evidence": "变异验证过会红：把 transform_context 改回每请求 composeSystemPrompt() 当场红；把桌面运行时的 skills 改回数组当场红（两次均 2026-09-11 实跑）。它钉的是根因形状，不用等下一次真机走查才发现回归。"
+    },
+    {
+      "path": "electron/skills/skillLibraryBroadcast.test.ts",
+      "entry_point": "技能盘变更信号：广播只发给活着的窗口、没有窗口时是 no-op；两个落盘函数都发信号、频道名两头对得上、渲染层只有一个接线点且不再自己喊第二遍",
+      "disposition": "enforced",
+      "evidence": "变异验证过会红：删掉 deleteUserSkill 里的 broadcastSkillLibraryChanged() 后本用例当场红（2026-09-11 实跑）。广播本体用注入的窗口源观测，不需要起 Electron。"
+    },
+    {
+      "path": "electron/agentLane/laneSingleShot.mts",
+      "entry_point": "runLaneSingleShot 的 systemPrompt 与技能正文",
+      "disposition": "not-affected",
+      "evidence": "单发调用在 laneDesktopRuntime.singleShot 里现算（laneDesktopRuntime.ts 的 singleShot 分支每次都重新 buildLanguageRule() 并 resolveRequestedSkill()），生命周期只有这一次请求，构造上不存在「快照过期」。"
+    },
+    {
+      "path": "electron/agentLane/laneDesktopRuntime.ts",
+      "entry_point": "model / 供应商凭据（selectModel + configureModel）",
+      "disposition": "not-affected",
+      "evidence": "已有显式变更路径：laneIpc 在每一条 prompt / steer / follow-up 之前都调 dependencies.configure（electron/agentLane/laneIpc.ts:128），configure 重新 selectModel 并在配置有差异时走 opened.configureModel()，而 laneWorkspace.configureModel 是关掉再开一条 lane——凭据随之重新解析。这是评审表里「有显式换档路径」那一档，不是快照。"
+    },
+    {
+      "path": "electron/agentLane/laneCodingSandbox.mts",
+      "entry_point": "sandboxPolicyFor 的 allowedDomains",
+      "disposition": "not-affected",
+      "evidence": "当前没有任何调用方传它，恒为空数组（全拒出网），所以还不存在「一份会过期的快照」。它一旦开始由技能声明填充就属于同一类——已在 residual_risks 里记名，不是被忽略。"
+    }
+  ],
+  "prevention": {
+    "kind": "centralized-boundary",
+    "enforcement_path": "electron/agentLane/laneHost.mts",
+    "invariant": "一条 lane 的系统提示词在每个回合边界整体重新求值一次、回合内不变；会变的事实一律由来源提供（函数 / LaneSkillIndexSource），技能索引与可信读根出自同一次刷新；共享磁盘状态的变更信号发自写盘那一层",
+    "failure_mode": "把 transform_context 改回每请求重拼或改回引用开 lane 时的常量、把桌面运行时的 skills/systemPrompt 改回快照、把可信根改回装配期数组、把技能盘的变更信号搬回某一个调用入口——四种回退各被一条已变异验证过的断言当场钉红（laneDesktopStructure.test.ts / lane-live-skill-index.test.mts / skillLibraryBroadcast.test.ts），真机层再由 lane-live-skills 走查的第 ④ 条兜底",
+    "exception_policy": "none",
+    "strategy": "把「什么时候求值」收成这一层唯一的一条规则（回合边界求值一次），把「这条 lane 有哪些技能」收成唯一一个 owner（索引 + 可信根 + 提示词段同一次产出），把「技能盘变了」收成唯一一个发出点（写盘那一层）。三处旧写法同 commit 删除：装配期的 installed.skills 数组、laneHost 里的 skillSection 常量、渲染层 useWorkbenchSkills 的两处本地派发，都不留并行版。",
+    "artifacts": [
+      "electron/agentLane/laneHost.mts",
+      "electron/agentLane/laneInstalledSkills.mts",
+      "electron/agentLane/laneNativeDesktop.mts",
+      "electron/agentLane/laneCodingPaths.mts",
+      "electron/agentLane/laneCodingTools.mts",
+      "electron/agentLane/laneRuntimePort.ts",
+      "electron/agentLane/laneDesktopRuntime.ts",
+      "electron/skills/skillLibraryBroadcast.ts",
+      "electron/skills/skillPackage.ts",
+      "electron/preload.ts",
+      "src/desktop/bridge.ts",
+      "src/NomiRouterApp.tsx",
+      "src/workbench/skillLibrary/skillLibraryChanged.ts",
+      "src/workbench/skillLibrary/useWorkbenchSkills.ts",
+      "electron/agentLane/laneDesktopStructure.test.ts",
+      "electron/skills/skillLibraryBroadcast.test.ts",
+      "tests/agent-runtime/lane-live-skill-index.test.mts",
+      "tests/ux/lane-live-skills.walk.mjs",
+      "docs/plan/2026-09-11-lane-live-vs-snapshot-fix.md"
+    ]
+  },
+  "legacy_paths": {
+    "status": "removed",
+    "removed_paths": [
+      "electron/agentLane/laneNativeDesktop.mts",
+      "electron/agentLane/laneHost.mts",
+      "src/workbench/skillLibrary/useWorkbenchSkills.ts"
+    ],
+    "rationale": "三处旧写法同 commit 删除，不留并行版：① laneNativeDesktop 不再把 installed.skills 摊成数组交出去（那正是快照回来的形状），改为交出索引源本身；② laneHost 里开 lane 时算一次的 skillSection 常量没了，原生路径一律从索引源取当前值；③ useWorkbenchSkills 的两处 notifySkillLibraryChanged() 删除——信号现在只有主进程写盘那一层发，渲染层留第二个来源就等于「author_skill 那条路会继续缺席」。port 仍接受数组形式的 native.skills（影子夹具与单测在用、且它们的技能集本就不变），这不是并行版而是同一条纪律里「装配期常量」那一档的合法输入，与 systemPrompt 的 string 形式同理。"
+  },
+  "dependency_lifecycle": {
+    "decision": "not-applicable",
+    "rationale": "没有引入或升级任何依赖。R29 的四列表已登记 pi 在这一层提供什么：渲染仍然只用 pi 的 formatSkillsForPrompt（framework-boundaries.json 的 skill-prompt-format），发现仍然是 Nomi 自己那条（resource-loading 一格已登记我们不用 DefaultResourceLoader）。上游在这件事上没有可借的机制——DefaultResourceLoader 自己也是 load() 时的快照（dist/core/resource-loader.js:206），唯一出路是显式 reload()（:263），所以刷新时机只能由宿主决定。",
+    "exit_criteria": []
+  },
+  "migration": "无数据/状态迁移：改的是求值时机与变更通知。已安装的技能包、已存在的 lane 会话、项目记忆的落盘格式一字未动；已经开着的 lane 在下一个回合自动拿到当前的技能索引与项目记忆，不需要重开项目。",
+  "residual_risks": [
+    "刷新粒度是回合：回合**内**导入的技能要等这一轮说完才进索引。这是有意的（评审裁决③：正在跑的那一个回合不会中途改口），不是遗留缺口。",
+    "每个回合会做一次技能库全量重扫（readSkillRecords 会读每个包的文本文件算 contentHash，本机 88 个内置包实测 ~25ms 同步 fs）。回合是几秒量级的模型调用，代价可忽略；但如果技能库长到几百个包，这个数会跟着长——那时的正解是给 skillStore 一个按目录 mtime 的廉价指纹，而不是把粒度改回「开 lane 一次」。",
+    "技能盘的变更广播只覆盖走 importSkillPackageToUserDir / deleteUserSkill 的写入。用户在 App 外面直接往 skills 目录里丢文件夹仍然不会实时刷新渲染层——不过 lane 侧因为每回合重扫，反而是实时的。补渲染层需要一个 fs watcher，本轮不做（它会带来自己的一族问题：编辑器写临时文件引发的抖动）。",
+    "sandboxPolicyFor 的 allowedDomains 今天恒为空，所以不是快照；技能一旦开始声明出网域名，它会立刻变成同一类（沙箱策略在 openLaneSandbox 时 initialize 一次，不随回合走）。届时要连沙箱的重初始化一起裁决，不能只把字段改成函数。"
+  ]
+}

--- a/docs/plan/2026-09-11-lane-live-vs-snapshot-fix.md
+++ b/docs/plan/2026-09-11-lane-live-vs-snapshot-fix.md
@@ -1,0 +1,91 @@
+# 一条 lane 的「现在」：把装配期快照换成每回合求值
+
+日期：2026-09-11 ｜ 分支：`fix/lane-live-skills-snapshot-20260911` ｜ 承接评审：[docs/audit/2026-09-11-agent-lane-live-vs-snapshot.md](../audit/2026-09-11-agent-lane-live-vs-snapshot.md)
+
+## 用户那一刻卡在哪（D1）
+
+用户在 Agent 面板旁边的技能库里导入一个技能包，回到输入框——技能选择器里它在，**但 Agent 不知道它存在**。
+发一句「用刚导入的那个分镜技能」，模型回「我没有这个技能」。要关掉项目再打开，它才出现。
+
+同一个窗口里两步之内发生的事，产品却要求用户重启一次对话——这不是「功能缺失」，是「我明明刚加进去了」。
+
+## 要权衡的那一个东西（D6 ②）
+
+**一条 lane 会跨很多回合活着，它的装配参数里混着两种寿命完全不同的东西**：
+「开 lane 那一刻的事实」（项目目录、工具集）和「每一刻都可能变的事实」（界面语言、技能库、项目记忆）。
+两者在类型上长得一模一样——都是一个字符串或一个数组——所以谁也拦不住第二种被写成第一种。
+
+真正要权衡的不是「要不要刷新」，而是**「现在」的刷新粒度是每次模型请求还是每个回合**。
+本方案选**每个回合一次**：回合是用户能感知的最小原子（他按一次发送），回合内改口反而是 bug
+（评审裁决 ③：「正在跑的那一个回合不会中途改口」）。代价是一次回合内的技能库全量重扫（实测 ~25ms），
+收益是任何「会变的事实」不必各自发明一条刷新路径。
+
+## 先查别人
+
+1. **依赖里已有？pi 自己也是快照** — `node_modules/@earendil-works/pi-coding-agent/dist/core/resource-loader.js:206`
+   `getSkills()` 只返回 `load()` 时读进实例字段的那份缓存；`dist/core/agent-session.js:755` 又把它一次性烘进
+   `_baseSystemPromptOptions`。上游给的唯一出路是显式 `reload()`（同文件 `:263`）——**没有「每回合重读」的机制可借**，
+   刷新时机只能由宿主决定。渲染那一段仍只用 pi 的 `formatSkillsForPrompt`（`dist/core/skills.d.ts:44`），不自己拼 XML。
+2. **仓库里已有？同一份 port 已为另外三个字段解决过** — `electron/agentLane/laneRuntimePort.ts:137`
+   `systemPrompt` 2026-09-11 刚放宽成 `string | (() => string)`；`approval.policy`（`:110`）与 `tasks`（`:171`）
+   本来就是函数，注释里把「给函数不给快照」写得很清楚。渲染层的变更广播范式也早有两份：
+   `src/workbench/skillLibrary/skillLibraryChanged.ts:15` 与 `electron/catalog/validateCandidateCredential.ts:92`。
+   **本方案不发明新机制，只把已有的两条纪律铺满。** R29 登记见 `docs/engineering/framework-boundaries.json:513`。
+3. **生态里已有？三家都是启动一次** — Claude Code 的技能索引在会话启动时装载、改了要重开会话（https://code.claude.com/docs/en/skills.md ）；
+   Agent Skills 标准只规定「启动预载 name+description、正文按需读」，对发现时机与热加载不作规定（https://github.com/agentskills/agentskills ）；
+   Codex 的 AGENTS.md 同样启动一次，热加载至今是 open issue（https://github.com/openai/codex/issues/8547 ）。
+4. **唯一给出标准解法的是 MCP** — 能力集变化由服务端发 `notifications/tools/list_changed` / `notifications/resources/list_changed`，客户端重查：https://modelcontextprotocol.io/specification/2025-06-18/server/tools
+   我们这一层没有「服务端」可发通知（技能库就在同一个进程里），所以取它的等价物：**在每个回合边界重查一次**。
+5. **为什么我们要和 Claude Code 不一样？领域约束，不是口味** — 那三家的技能都在编辑器/终端**外面**改文件，「改完重开」符合当时的心智；
+   Nomi 的导入入口就在 Agent 面板旁边（`src/workbench/skillLibrary/SkillLibraryPanel.tsx:182`），
+   用户是在同一个窗口、两步之内加的技能，重开项目对他等于「刚才那一步没生效」。
+   这条差异只影响刷新时机，不影响格式——索引仍是 Agent Skills 标准的 `<available_skills>`、仍由 pi 渲染（R31 无偏差）。
+6. **TikHub 自媒体侧**：本条未查。它的用处是「真实用户怎么解决这件事」，而这是一个进程内部的求值时机问题，
+   用户侧看不到实现，查了也只会拿回「重启一下」。结论不依赖这一条。
+7. **结论：用已有 + 自研一条时机规则** — 用已有的是 pi 的渲染（`dist/core/skills.d.ts:44`）、本仓 port 的
+   「给函数不给快照」纪律、以及已有的变更广播范式；自研的只有「每回合求值一次」这条规则本身，因为上游三家都没有它。
+
+## 范围
+
+### 改（三处同一个根因）
+
+| # | 字段 | 现状 | 改成 |
+|---|---|---|---|
+| A | `native.skills`（技能索引 + 可信读根） | `readSkillRecords()` 在开 workspace 时取一次数组 | port 收 `readonly SkillRecord[] \| (() => readonly SkillRecord[])`；新增 `LaneSkillIndexSource` 作为**唯一 owner**，提示词段与 `read` 的可信根都从它取当前值 |
+| B | 系统提示词的求值粒度 | `transform_context` 每**请求**重拼 | 每**回合**（`runId` 变才重算），回合内不变——让评审裁决 ③ 真正成立 |
+| C | 项目记忆 `memory` | 开 workspace 时算一次，闭包常量 | 移进 `systemPrompt` 闭包，随 B 的粒度每回合重读 |
+
+### 也改（同族的第二半：AI 写完的技能，用户的选择器也看不见）
+
+| # | 字段 | 现状 | 改成 |
+|---|---|---|---|
+| D | 渲染层技能列表 | 只有渲染层自己的导入/删除会派发 `nomi-skill-library-changed`；`author_skill` 在主进程写盘，无人通知 | 广播搬到**落盘那一层**（`importSkillPackageToUserDir` / `deleteUserSkill`），经 IPC 到渲染层派发同一个事件；渲染层原来那两处派发同 commit 删除（P1，不留两套） |
+
+### 不动
+
+- owner 划分、审批次序、迁移、回执——评审已裁决不在本轮。
+- 工具集（装配期常量，工具由代码拥有）、`projectDir` / `settingsRoot` / watchdog / limits（装配期常量）。
+- 模型与供应商 key：已有显式变更路径（每次发送前 `laneIpc` 都调 `configure`，改了就 `configureModel` 重开 lane）。
+- 历史消息不重写、正在跑的回合不改口。
+
+## 不做的替代修法（以及为什么）
+
+- **给 lane 加 `refreshSkills()` 逃生口**：把「什么时候求值」换成「谁记得调用」，下一个会变的字段还要再加一条。
+- **导入后自动重开 lane**：用户会丢掉正在写的上下文，而他只是加了个技能。
+- **每次模型请求都重扫技能库**：一个回合最多 24 次请求，等于把 25ms 乘 24，且违反「回合内不改口」。
+- **把技能列表塞进 `composer.systemPrompt` 由渲染层每回合带上来**：技能索引的 owner 是主进程的技能库，
+  让渲染层携带等于多一个可能撒谎的来源。
+
+## 验收门
+
+1. 单测：`tests/agent-runtime/lane-live-skill-index.test.mts`（索引源：变了重算 / 没变复用同一份 / 空→非空才起渲染器 / 被删的技能只是不在索引里；可信根跟着索引源走**且已认下的根不许被重新解析**）、
+   `electron/agentLane/laneDesktopStructure.test.ts` 与 `electron/skills/skillLibraryBroadcast.test.ts`（结构棘轮，全部做变异验证）。
+   既有的 `tests/agent-runtime/lane-native-paths.test.mts`「装配之后被换成软链」必须保持绿——
+   「根的集合活」与「已认下的根不许重新解析」两条同时成立，见合同的 invariants。
+2. 真机走查：`tests/ux/lane-live-skills.walk.mjs`——会话中导入技能 → 不重开 → 选择器能选到 → 发送后 lane 里看得到技能 chip。
+3. `pnpm run gates` 全绿。
+
+## 回滚
+
+四处改动互不依赖，可逐个 revert：A/B/C 在 `electron/agentLane/`，D 在 `electron/skills/` + `electron/preload.ts` + 渲染层订阅点。
+port 仍接受数组形式（影子夹具与单发路径在用），所以 A 的回滚不会让调用方编译不过。

--- a/electron/agentLane/laneCodingPaths.mts
+++ b/electron/agentLane/laneCodingPaths.mts
@@ -39,15 +39,54 @@ async function canonicalTarget(target: string, missing: boolean): Promise<string
   }
 }
 
-export async function createLaneCodingPaths(projectDir: string, trustedSkillRoots: readonly string[] = []) {
+/**
+ * 可信技能包根：**可以给一个来源，不必给一份快照**（与 `OpenLaneOptions` 上 `tasks` / `systemPrompt`
+ * 同一条纪律）。理由是用户会在会话中途导入技能：那一刻模型的索引里多了一条，而
+ * `read` 允许越出项目的根如果还是开 lane 时那一份，就会出现「提示词里有这条技能、读它却越界」。
+ * 索引与根来自同一个 `LaneSkillIndexSource`，所以「看得见 = 读得到」是结构事实。
+ */
+export type LaneTrustedSkillRoots = readonly string[] | (() => readonly string[])
+
+export async function createLaneCodingPaths(projectDir: string, trustedSkillRoots: LaneTrustedSkillRoots = []) {
   const pin = async (root: string) => {
     if (!path.isAbsolute(root)) throw new Error('Coding roots must be trusted absolute paths.');
+    // 一个根本身就是软链，等于把它指向的任何地方变成可读区。索引层已经拒过一次
+    // （`laneInstalledSkills.mts`），这里再拒一次：这是判越界的那一层，它不该依赖上游记得校验。
+    if ((await lstat(root)).isSymbolicLink()) throw new Error('Coding roots must not be symbolic links.');
     return { lexical: path.resolve(root), canonical: await realpath(root) };
   };
   const project = await pin(projectDir);
-  const skills = await Promise.all([...new Set(trustedSkillRoots)].map(pin));
+  const listRoots = () => [...new Set(typeof trustedSkillRoots === 'function' ? trustedSkillRoots() : trustedSkillRoots)].sort();
+  /**
+   * **每个根只 canonicalize 一次，就在它第一次出现的那一刻。**
+   *
+   * 两条性质要同时成立，它们看起来打架但并不：
+   *   · 根的**集合**是活的——用户中途导入一个技能，新根下一个回合就该可读；
+   *   · 已经认下的那个根**不许重新解析**——把一个已信任的目录换成指向别处的软链，
+   *     不该让它悄悄变成一块新的可读区（`lane-native-paths` 里那条「装配之后被换成软链」的用例）。
+   * 所以这里是一张 `lexical → pinned` 的表：表里有的直接用，表里没有的现在 pin 一次，
+   * 不在当前名单里的移出去。realpath 只为真正新出现的根付一次。
+   */
+  const pinned = new Map<string, Awaited<ReturnType<typeof pin>>>();
+  const pinRoot = async (root: string) => {
+    // 一个刚被删掉的技能根解析不出来。它不是越权信号，是「它不在了」——把它从名单里去掉，
+    // 而不是让这条 lane 之后每一次 read 都炸。
+    try { pinned.set(root, await pin(root)); } catch (cause) {
+      if ((cause as NodeJS.ErrnoException).code !== 'ENOENT') throw cause;
+    }
+  };
+  // 装配期的那一批立刻 pin：晚一步 pin 就等于把「装配之后再换软链」这条路留着。
+  for (const root of listRoots()) await pinRoot(path.resolve(root));
+  const skillRoots = async () => {
+    const roots = listRoots().map((root) => path.resolve(root));
+    const current = new Set(roots);
+    for (const key of [...pinned.keys()]) if (!current.has(key)) pinned.delete(key);
+    for (const root of roots) if (!pinned.has(root)) await pinRoot(root);
+    return roots.flatMap((root) => { const entry = pinned.get(root); return entry ? [entry] : []; });
+  };
   const check = async (targetPath: string, writing: boolean, missing = false, skillsOnly = false): Promise<string> => {
     const target = path.resolve(targetPath);
+    const skills = await skillRoots();
     const allowed = writing ? [project] : skillsOnly ? skills : [project, ...skills];
     // Canonical aliases (e.g. /var -> /private/var) remain usable after pi resolves a previous path.
     const roots = allowed.filter((root) => within(target, root.lexical) || within(target, root.canonical));

--- a/electron/agentLane/laneCodingTools.mts
+++ b/electron/agentLane/laneCodingTools.mts
@@ -20,7 +20,7 @@ import { laneToolModelDescription } from '../shared/agentLane/laneToolContract.j
 // 与 pi 的 `description` 原样进请求，我们只在旁边挂一份 `LaneToolEffects`（审批闸与崩溃恢复
 // 要读它，而 pi 没有这个概念——**加一层注解不是重写一份实现**）。
 import path from 'node:path';
-import { createLaneCodingPaths } from './laneCodingPaths.mjs';
+import { createLaneCodingPaths, type LaneTrustedSkillRoots } from './laneCodingPaths.mjs';
 
 import type { AgentHarnessTool } from '@earendil-works/pi-agent-core';
 
@@ -140,8 +140,11 @@ export async function loadPiCodingToolFactories(): Promise<PiCodingToolFactories
 export interface LaneCodingToolsInput {
   /** 项目根。**同时**是工具的 cwd、包容的边界、沙箱的 allowWrite。三者是同一个值，不许各传各的。 */
   readonly projectDir: string
-  /** Main-process installed package roots. Read-only; never inferred from model arguments. */
-  readonly trustedSkillRoots?: readonly string[]
+  /**
+   * Main-process installed package roots. Read-only; never inferred from model arguments.
+   * 给来源不给快照：用户会在会话中途导入技能，索引与可信根必须同源同刷（`LaneTrustedSkillRoots`）。
+   */
+  readonly trustedSkillRoots?: LaneTrustedSkillRoots
   /** bash 用的沙箱（`openLaneSandbox` 的产物）。`active:false` 时策略层会把自动放行整档摘掉。 */
   readonly canReadProject?: () => Promise<boolean>
   readonly sandbox: LaneSandbox

--- a/electron/agentLane/laneDesktopRuntime.ts
+++ b/electron/agentLane/laneDesktopRuntime.ts
@@ -30,6 +30,14 @@ import { parseLaneCommand } from './laneCommandCodec'
 import { readSkillRecords, isSkillSelectableInWorkbench } from '../skills/skillStore'
 import { createDesktopLaneTasks } from './laneDesktopTasks'
 
+/**
+ * 这一刻的项目记忆。读不出来就当没有——记忆是锦上添花的事实，缺了它 lane 仍然要能说话，
+ * 而一个抛出去的异常会让整个回合失败（`getProjectMemory` 会回放事件日志，盘上坏一条就抛）。
+ */
+function currentProjectMemory(projectId: string): string {
+  try { return formatMemoryForPrompt(getProjectMemory(projectId).facts) } catch { return '' }
+}
+
 function selectModel(preference: LaneComposerContext['model']) {
   const selected = chooseTextModel(preference?.modelKey ?? '', false, preference?.vendorKey ?? '')
   const { vendor, model, apiKey } = selected
@@ -128,17 +136,22 @@ export function createDesktopLaneDependencies(surface: DesktopCanvasReadRuntime,
           await workspace.appendTaskNote({ productionRunId: runId, operationId: call.toolCallId })
         },
       }) } catch (error) { tasks.dispose(); throw error }
-      let memory = ''
-      try { memory = formatMemoryForPrompt(getProjectMemory(binding.projectId).facts) } catch { /* optional project facts */ }
+      // 项目记忆与技能库一样是「每一刻都可能变的事实」：用户在记忆折叠里删一条、锁一个节点，
+      // 或者 Agent 自己写下一条偏好，都发生在这条 lane 活着的时候。所以这里**不预先算好**——
+      // 读放在下面 `systemPrompt` 的函数体里，由宿主在每个回合边界求值一次。
       const input = createDesktopLaneInput({ projectId: binding.projectId,
         capture: () => composer, activate: (context) => { activeInput = context }, model: () => selected })
       try {
         const { openDesktopLaneWorkspace } = createRequire(__filename)('./laneNativeLoader.cjs') as { openDesktopLaneWorkspace: OpenDesktopLaneWorkspace }
         workspace = await openDesktopLaneWorkspace({ projectDir, fetch: appFetch,
-          native: { settingsRoot: getSettingsRoot(), skills: readSkillRecords().filter(isSkillSelectableInWorkbench) },
-          // 给函数不给快照：回复语言铁律跟界面语言走，用户中途在设置里切了语言，
-          // 这条已经开着的 lane 下一个回合就该改口，而不是等冷启动（2026-09-11 走查）。
-          systemPrompt: () => [buildLanguageRule(), NOMI_AGENT_IDENTITY, memory].filter(Boolean).join('\n\n'),
+          // 给函数不给快照（下同）：用户在 Agent 面板旁边导入一个技能包、或者让 Agent 自己写一个落盘，
+          // 都发生在这条 lane 活着的时候。传数组时那条技能要关掉项目重开才出现（2026-09-11 走查）。
+          native: { settingsRoot: getSettingsRoot(), skills: () => readSkillRecords().filter(isSkillSelectableInWorkbench) },
+          // 给函数不给快照：回复语言铁律跟界面语言走、项目记忆跟用户和 Agent 的改动走，
+          // 这条已经开着的 lane 下一个回合就该跟上，而不是等冷启动（2026-09-11 走查）。
+          // 宿主每个回合求值一次（`laneHost` 的 `systemPromptForRun`），不是每次模型请求。
+          systemPrompt: () => [buildLanguageRule(), NOMI_AGENT_IDENTITY, currentProjectMemory(binding.projectId)]
+            .filter(Boolean).join('\n\n'),
           tools: ports.tools, toolLifecycle: ports.toolLifecycle, input,
           tasks: tasks.resolve,
           approval: { hasUserInterface: true, policy: () => composer.approvalPolicy },

--- a/electron/agentLane/laneDesktopStructure.test.ts
+++ b/electron/agentLane/laneDesktopStructure.test.ts
@@ -137,21 +137,59 @@ describe("Agent lane production cutover structure", () => {
   });
 });
 
-describe("回复语言跟界面语言走：lane 的身份提示词不许是开 lane 那一刻的快照（2026-09-11 走查）", () => {
-  // 真机现象：用户在设置里把界面切成 English 后，同一个项目里连开新对话，助手仍整段中文——
-  // 只有冷启动才生效。根因是 `systemPrompt` 是**字符串快照**，而 lane 会跨很多回合活着。
-  // 端到端的证明在真机走查；这里钉住结构：宿主必须能拿到「现在的」那一段，且每回合重新求值。
-  it("port 允许传函数，laneHost 每回合重新拼，桌面运行时传的就是函数", () => {
+describe("一条 lane 的系统提示词每回合整体重新求值（2026-09-11 两轮走查）", () => {
+  // 第一轮（语言）：用户在设置里把界面切成 English 后，同一个项目里连开新对话，助手仍整段中文。
+  // 第二轮（技能）：用户在 Agent 面板旁边导入一个技能包，模型说它不存在——都要关掉项目再打开才生效。
+  // 同一个根因：一条 lane 会跨很多回合活着，而它的装配参数里混着两种寿命完全不同的东西。
+  // 端到端的证明在真机走查；这里钉住结构：会变的事实必须有来源，且宿主在回合边界求值。
+  it("port 上会变的字段收的是来源不是快照", () => {
     const port = source("electron/agentLane/laneRuntimePort.ts");
-    const host = source("electron/agentLane/laneHost.mts");
-    const runtime = source("electron/agentLane/laneDesktopRuntime.ts");
+    const paths = source("electron/agentLane/laneCodingPaths.mts");
 
     expect(port).toContain("systemPrompt: string | (() => string)");
-    // transform_context 每个回合都跑一次——它必须调 composeSystemPrompt()，不是引用开 lane 时的常量。
+    expect(port).toContain("skills: readonly SkillRecord[] | (() => readonly SkillRecord[])");
+    // 可信读根与索引同源：看得见就必须读得到，不许一个活一个死。
+    expect(paths).toContain("export type LaneTrustedSkillRoots = readonly string[] | (() => readonly string[])");
+  });
+
+  it("laneHost 在回合边界求值一次：runId 变才重扫技能库、重拼提示词；回合内不改口", () => {
+    const host = source("electron/agentLane/laneHost.mts");
+
+    const resolver = host.slice(host.indexOf("const systemPromptForRun"), host.indexOf("const systemPrompt = promptForRun"));
+    expect(resolver).toContain("if (runId === promptRunId) return promptForRun;");
+    expect(resolver).toContain("await native?.skillIndex.refresh();");
+    expect(resolver).toContain("promptForRun = composeSystemPrompt();");
+    // transform_context 每次模型请求都跑——它必须走那个按 runId 记账的解析器，
+    // 既不能引用开 lane 时的常量（回合间不更新），也不能每次都重拼（回合内会改口）。
     const transform = host.slice(host.indexOf("harness.hooks.on('transform_context'"), host.indexOf("harness.hooks.on('before_tool'"));
-    expect(transform).toContain("composeSystemPrompt()");
+    expect(transform).toContain("await systemPromptForRun(event.runId)");
     expect(transform).not.toMatch(/\{\s*systemPrompt:\s*\[systemPrompt,/);
-    // 桌面运行时：语言铁律必须在函数体里（每次求值都重读 locale），不是先算好再传。
+    expect(transform).not.toContain("composeSystemPrompt()");
+    // 「这条技能要不要 coding 工具」判在准入那一刻，而用户可能刚导入它——先刷再问。
+    const admission = host.slice(host.indexOf("if (command.kind === 'prompt' && !projection.running"), host.indexOf("const admission = await lane.accept"));
+    expect(admission).toContain("await native?.skillIndex.refresh();");
+    expect(admission).toContain("laneSkillUnlockReason(currentSkills()");
+  });
+
+  it("桌面运行时三样会变的事实都传来源，没有一样是先算好的闭包常量", () => {
+    const runtime = source("electron/agentLane/laneDesktopRuntime.ts");
+
+    // 语言铁律与项目记忆必须在函数体里（每次求值都重读），不是先算好再传。
     expect(runtime).toContain("systemPrompt: () => [buildLanguageRule()");
+    expect(runtime).toContain("currentProjectMemory(binding.projectId)");
+    expect(runtime).not.toMatch(/let memory = ''/);
+    // 技能库同理：给函数，宿主每回合重读一次。
+    expect(runtime).toContain("skills: () => readSkillRecords().filter(isSkillSelectableInWorkbench)");
+  });
+
+  it("技能索引与可信读根是同一个 owner 的同一份快照", () => {
+    const nativeDesktop = source("electron/agentLane/laneNativeDesktop.mts");
+    const host = source("electron/agentLane/laneHost.mts");
+
+    expect(nativeDesktop).toContain("createLaneSkillIndexSource");
+    expect(nativeDesktop).toContain("trustedSkillRoots: () => skillIndex.current().trustedSkillRoots");
+    // 装配层不许再把索引摊成一个数组交出去——那正是「快照」回来的形状。
+    expect(nativeDesktop).not.toMatch(/skills:\s*installed\.skills/);
+    expect(host).toContain("native?.skillIndex.current().promptSection");
   });
 });

--- a/electron/agentLane/laneHost.mts
+++ b/electron/agentLane/laneHost.mts
@@ -31,7 +31,7 @@ import { createNomiProvider } from './laneModelProvider.mjs';
 import {
   LANE_APPROVAL_NOTE_TYPE, LANE_TASK_NOTE_TYPE, LANE_UI_NOTE_PREFIX, laneNoteEntersModelContext,
   type LaneApprovalNote, type LaneCancelQueuedResult, type LaneCommand, type LaneCommandOutcome,
-  type LaneHandle, type LanePendingApproval, type LaneProjection, type LaneThinkingLevel,
+  type LaneHandle, type LanePendingApproval, type LaneProjection, type LaneSkillIndexEntry, type LaneThinkingLevel,
 } from '../shared/agentLane/laneContracts.js';
 import { createLaneApprovalGate } from './laneApprovalGate.js';
 import type { OpenLane, OpenLaneOptions } from './laneRuntimePort.js';
@@ -198,19 +198,43 @@ export const openLane: OpenLane = async (options: OpenLaneOptions): Promise<Lane
   // 2026-09-07 合并评审实核：`composeLaneSystemPrompt` 此前零生产调用者——通道②③写满了，
   // 一个字都到不了模型。拼接点放在这里，是因为这里是唯一知道「这条 lane 装了哪些工具」的地方。
   // 技能索引那一段用 pi 的 `formatSkillsForPrompt` 渲染（`laneSkillIndex.mts` 里一行渲染代码都没有）。
+  //
+  // 索引有两种来源，寿命不同：
+  //   · 桌面原生（`native.skillIndex`）**是活的**——每个回合重扫一次技能库，用户中途导入的技能
+  //     下一个回合就在索引里，而且 `read` 同时被允许读它（同一份快照，见 `laneInstalledSkills.mts`）。
+  //   · `options.skills` 是影子夹具/单测那条路：调用方自己给一份定死的索引，本来就不会变。
   // 没有技能时不去 import 那个包：一条 lane 不该为了拿一个空串付一次 ESM 解析。
-  const skills = native?.skills ?? options.skills ?? [];
-  const skillSection = skills.length > 0
-    ? renderLaneSkillSection(await loadPiSkillFormatter(), skills)
+  const staticSkills = options.skills ?? [];
+  const staticSection = !native && staticSkills.length > 0
+    ? renderLaneSkillSection(await loadPiSkillFormatter(), staticSkills)
     : '';
+  const currentSkills = (): readonly LaneSkillIndexEntry[] => native?.skillIndex.current().entries ?? staticSkills;
   const promptTools = [...options.tools, ...(native?.promptTools ?? [])];
-  // 每个回合重新求值（`transform_context` 里也调它）：跟着设置走的段落——现在是回复语言
-  // 铁律——必须是「现在的设置」，不是「开 lane 那一刻的设置」。工具段与技能段本来就是常量，
-  // 重拼一次只是字符串拼接，代价可忽略。
   const composeSystemPrompt = (): string => composeLaneSystemPrompt(
     typeof options.systemPrompt === 'function' ? options.systemPrompt() : options.systemPrompt,
-    promptTools, skillSection);
-  const systemPrompt = composeSystemPrompt();
+    promptTools, native?.skillIndex.current().promptSection ?? staticSection);
+  /**
+   * **一条 lane 的系统提示词，每个回合整体重新求值一次；回合内不变。**
+   *
+   * 这是这一层唯一的「什么时候求值」规则，替掉了此前「哪个字段自己记得刷新」的逐字段约定：
+   *   · 回合内不变——正在跑的那一个回合不会中途改口（技能、界面语言、项目记忆一视同仁）。
+   *     用户在模型说到一半时切了语言，这一轮说完再改，而不是一句中文一句英文。
+   *   · 每个回合都变——会变的事实由**来源**提供（函数 / `LaneSkillIndexSource`），
+   *     不是开 lane 那一刻的闭包常量；以后再加一个会变的段落，不必再发明一条刷新路径。
+   *
+   * 粒度是回合不是请求：一个回合最多 `LANE_MAX_MODEL_REQUESTS` 次模型请求，按请求刷等于
+   * 把技能库全量重扫乘 24，而且回合内会改口——那恰恰是评审裁决明确不要的行为。
+   */
+  let promptRunId: string | undefined;
+  let promptForRun = composeSystemPrompt();
+  const systemPromptForRun = async (runId: string): Promise<string> => {
+    if (runId === promptRunId) return promptForRun;
+    promptRunId = runId;
+    await native?.skillIndex.refresh();
+    promptForRun = composeSystemPrompt();
+    return promptForRun;
+  };
+  const systemPrompt = promptForRun;
   const { harness } = await AgentHarness.create<undefined>({
     session, models, model, systemPrompt, tools,
     compaction: laneCompactionSettings(model.contextWindow, options.limits?.contextTokenBudget),
@@ -346,7 +370,7 @@ export const openLane: OpenLane = async (options: OpenLaneOptions): Promise<Lane
           toolCallId: '', toolName: tool.name, args: value ? { operation: value } : {},
         })}`);
       }).join('\n') : '';
-    return { systemPrompt: [composeSystemPrompt(), catalogBase ? formatLaneModelIndex(catalogBase.context) : '', input?.context.systemPrompt, authority].filter(Boolean).join('\n\n') };
+    return { systemPrompt: [await systemPromptForRun(event.runId), catalogBase ? formatLaneModelIndex(catalogBase.context) : '', input?.context.systemPrompt, authority].filter(Boolean).join('\n\n') };
   });
 
   harness.hooks.on('before_tool', async (event, hookContext) => {
@@ -506,7 +530,10 @@ export const openLane: OpenLane = async (options: OpenLaneOptions): Promise<Lane
     execute: async (command: LaneCommand, executionOptions): Promise<LaneCommandOutcome> => {
       if (command.kind === 'prompt' && !projection.running && !pending) {
         const message = inputMessage(command.text);
-        const unlock = typeof message !== 'string' ? laneSkillUnlockReason(skills, [message.context.skillKey ?? '']) : null;
+        // 「这条技能要不要 coding 工具」判在准入这一刻，而用户可能就是刚导入它的——
+        // 所以先把索引刷到这个回合，再问。不刷的症状是模型说「我去跑它的 selftest」，然后说它没有工具。
+        await native?.skillIndex.refresh();
+        const unlock = typeof message !== 'string' ? laneSkillUnlockReason(currentSkills(), [message.context.skillKey ?? '']) : null;
         if (native && unlock) {
           await native.unlockCoding(context);
         }

--- a/electron/agentLane/laneInstalledSkills.mts
+++ b/electron/agentLane/laneInstalledSkills.mts
@@ -1,10 +1,23 @@
 // Skill discovery remains skillStore's job. This adapter consumes its trusted records only.
+//
+// ── 这个文件为什么是一个「来源」而不是一次「读取」（2026-09-11）──
+//
+// 一条 lane 会跨很多回合活着，而技能库是用户随时会动的东西：他在 Agent 面板旁边点两下
+// 导入一个技能包，或者让 Agent 自己写一个落盘。开 lane 那一刻取一次数组，等于把
+// 「这个项目有哪些技能」冻在那一刻——用户报的现象是「刚导入的技能，Agent 说它没有，
+// 要关掉项目再打开」（评审：docs/audit/2026-09-11-agent-lane-live-vs-snapshot.md）。
+//
+// 所以这里出的是 `LaneSkillIndexSource`：**一个回合刷新一次，回合内不变**。
+//   · 回合内不变，是因为「模型看到的技能索引」和「read 允许读的技能根」必须是同一份快照——
+//     两者各自刷新就会出现「提示词里有这条技能、read 它却越界」这种自相矛盾的一刻。
+//   · 回合是最小的刷新粒度，不是每次模型请求：一个回合最多 24 次请求，按请求刷等于把
+//     全量重扫乘 24，而且违反「正在跑的那一个回合不会中途改口」（评审裁决 ③）。
 import { lstat, readdir, realpath } from 'node:fs/promises';
 import path from 'node:path';
 import type { SkillRecord } from '../skills/skillStore.js';
 import { parseSkillFrontmatter } from '../skills/skillFrontmatter.js';
 import type { LaneSkillIndexEntry } from '../shared/agentLane/laneContracts.js';
-import { laneSkillRequiresCodingTools } from './laneSkillIndex.mjs';
+import { laneSkillRequiresCodingTools, loadPiSkillFormatter, renderLaneSkillSection, type PiSkillFormatter } from './laneSkillIndex.mjs';
 
 export async function createLaneInstalledSkills(records: readonly SkillRecord[]): Promise<{
   skills: readonly LaneSkillIndexEntry[];
@@ -17,7 +30,15 @@ export async function createLaneInstalledSkills(records: readonly SkillRecord[])
       throw new Error('Installed Skill records require an absolute SKILL.md path.');
     }
     const root = path.dirname(path.resolve(record.filePath));
-    const [rootStat, fileStat] = await Promise.all([lstat(root), lstat(record.filePath)]);
+    // 这份记录是在刚才那一次目录扫描里读到的，校验发生在之后一瞬——用户正好在这中间删掉了
+    // 那个技能，于是 lstat 报 ENOENT。**「它已经不在了」不是安全事件，是这一刻它不在索引里**：
+    // 跳过这一条，别让整条 lane 的下一个回合失败。其它错误（软链、越出包）照旧抛。
+    const stats = await Promise.all([lstat(root), lstat(record.filePath)]).catch((cause: NodeJS.ErrnoException) => {
+      if (cause.code === 'ENOENT') return undefined;
+      throw cause;
+    });
+    if (!stats) continue;
+    const [rootStat, fileStat] = stats;
     if (!rootStat.isDirectory() || rootStat.isSymbolicLink() || !fileStat.isFile() || fileStat.isSymbolicLink()) {
       throw new Error('Installed Skill package roots and SKILL.md must not be symbolic links.');
     }
@@ -38,4 +59,70 @@ export async function createLaneInstalledSkills(records: readonly SkillRecord[])
     trustedSkillRoots.add(root);
   }
   return { skills, trustedSkillRoots: [...trustedSkillRoots] };
+}
+
+/** 这一刻这条 lane 关于技能的**全部**事实。三样东西同一份快照，不许各刷各的。 */
+export interface LaneSkillIndex {
+  /** 模型索引（name + description + 绝对路径），正文不在里面。 */
+  readonly entries: readonly LaneSkillIndexEntry[];
+  /** `read` 允许越出项目去读的只读技能包根。与 `entries` 同源，所以「看得见 = 读得到」。 */
+  readonly trustedSkillRoots: readonly string[];
+  /** 系统提示词里的 `<available_skills>` 段（pi 的 `formatSkillsForPrompt` 渲染）。空索引 = 空串。 */
+  readonly promptSection: string;
+}
+
+/**
+ * 技能事实的唯一 owner。
+ *
+ * `current()` 不读盘——它返回上一次 `refresh()` 定下来的那一份，所以同一个回合里
+ * 提示词渲染与 `read` 的越界判定看到的是**同一个**索引。`refresh()` 在回合边界调，
+ * 记录集没变就连 pi 的渲染都不重跑（指纹里含 `contentHash`，改了技能正文也算变）。
+ */
+export interface LaneSkillIndexSource {
+  current(): LaneSkillIndex;
+  refresh(): Promise<LaneSkillIndex>;
+}
+
+const EMPTY_INDEX: LaneSkillIndex = Object.freeze({
+  entries: Object.freeze([]) as readonly LaneSkillIndexEntry[],
+  trustedSkillRoots: Object.freeze([]) as readonly string[],
+  promptSection: '',
+});
+
+/**
+ * 指纹只认「会改变模型看到什么 / 允许读什么」的那几样。`contentHash` 覆盖正文与包内脚本，
+ * 所以「技能没变」是真的没变，而不是「名字没变」。
+ */
+function fingerprint(records: readonly SkillRecord[]): string {
+  return records
+    .map((record) => [record.filePath, record.name, record.description,
+      record.disableModelInvocation === true ? '1' : '0', record.contentHash].join('\u0000'))
+    .join('\u0001');
+}
+
+export function createLaneSkillIndexSource(
+  read: () => readonly SkillRecord[],
+  deps: { loadFormatter?: () => Promise<PiSkillFormatter> } = {},
+): LaneSkillIndexSource {
+  const loadFormatter = deps.loadFormatter ?? loadPiSkillFormatter;
+  let index: LaneSkillIndex = EMPTY_INDEX;
+  let seen: string | undefined;
+  // 渲染器只在真的有技能时才 import 一次。**不能在开 lane 时决定「这条 lane 没有技能所以永远不加载」**：
+  // 用户会在半路导入第一个技能，那一刻才需要它。
+  let formatter: Promise<PiSkillFormatter> | undefined;
+  return {
+    current: () => index,
+    refresh: async () => {
+      const records = read();
+      const next = fingerprint(records);
+      if (seen === next) return index;
+      const { skills, trustedSkillRoots } = await createLaneInstalledSkills(records);
+      const promptSection = skills.length > 0
+        ? renderLaneSkillSection(await (formatter ??= loadFormatter()), skills)
+        : '';
+      index = Object.freeze({ entries: skills, trustedSkillRoots, promptSection });
+      seen = next;
+      return index;
+    },
+  };
 }

--- a/electron/agentLane/laneNativeDesktop.mts
+++ b/electron/agentLane/laneNativeDesktop.mts
@@ -5,17 +5,24 @@ import type { AgentModelEntry } from '../shared/agentCapabilities/availableModel
 import type { SkillRecord } from '../skills/skillStore.js';
 import { LANE_WRITE_TOOL_TIMEOUT_MS } from '../shared/agentLane/laneToolContract.js';
 import { openLaneSandbox, sandboxPolicyFor, type LaneBashOperations } from './laneCodingSandbox.mjs';
-import { createLaneInstalledSkills } from './laneInstalledSkills.mjs';
+import { createLaneSkillIndexSource } from './laneInstalledSkills.mjs';
 import { createLaneNativeAssembly, type LaneDeferredGroup } from './laneNativeAssembly.mjs';
 
 export async function openLaneNativeDesktop(input: {
   projectDir: string;
   settingsRoot: string;
-  skills: readonly SkillRecord[];
+  /**
+   * 已安装的技能。**给函数就是活的**：每个回合重读一次，用户会话中途导入的技能下一个回合就在
+   * （见 `laneInstalledSkills.mts` 头部）。给数组仍然合法——影子夹具与单测那样用，它们的技能集不变。
+   */
+  skills: readonly SkillRecord[] | (() => readonly SkillRecord[]);
   deferredGroups?: readonly LaneDeferredGroup[];
   availableModels?: () => readonly AgentModelEntry[];
 }) {
-  const installed = await createLaneInstalledSkills(input.skills);
+  const source = input.skills;
+  const skillIndex = createLaneSkillIndexSource(typeof source === 'function' ? source : () => source);
+  // 开 lane 那一刻先取一份：初始系统提示词与第一个回合之前的 `read` 都要用它。
+  await skillIndex.refresh();
   const local = createLocalBashOperations();
   // Nomi's operation boundary uses milliseconds; the upstream local backend accepts seconds.
   const localOperations: LaneBashOperations = {
@@ -28,13 +35,13 @@ export async function openLaneNativeDesktop(input: {
   try {
     const assembly = await createLaneNativeAssembly({
       projectDir: input.projectDir,
-      trustedSkillRoots: installed.trustedSkillRoots,
+      trustedSkillRoots: () => skillIndex.current().trustedSkillRoots,
       sandbox,
       bashTimeoutMs: LANE_WRITE_TOOL_TIMEOUT_MS,
       deferredGroups: input.deferredGroups,
       availableModels: input.availableModels,
     });
-    return { ...assembly, skills: installed.skills, sandboxActive: sandbox.active,
+    return { ...assembly, skillIndex, sandboxActive: sandbox.active,
       ...(sandbox.inactiveReason ? { sandboxInactiveReason: sandbox.inactiveReason } : {}),
       close: () => sandbox.close() };
   } catch (cause) {

--- a/electron/agentLane/laneRuntimePort.ts
+++ b/electron/agentLane/laneRuntimePort.ts
@@ -113,7 +113,16 @@ export interface LaneApprovalOptions {
 
 export interface OpenLaneOptions {
   fetch: typeof globalThis.fetch
-  native?: { settingsRoot: string; skills: readonly SkillRecord[] }
+  /**
+   * 桌面原生资源（沙箱、coding 工具、技能索引）。
+   *
+   * **`skills` 想跟着技能库变，就给函数不给快照**（与 `systemPrompt` / `tasks` 同一条纪律）：
+   * 用户在 Agent 面板旁边导入一个技能包、或者让 Agent 自己写一个落盘，都发生在这条 lane
+   * 活着的时候。2026-09-11 走查实锤：传数组时那条技能要关掉项目重开才出现在索引里。
+   * 给函数时每个回合重读一次（`laneInstalledSkills.mts` 的 `LaneSkillIndexSource`），
+   * 模型看到的索引与 `read` 允许越出项目的技能根始终是同一份。
+   */
+  native?: { settingsRoot: string; skills: readonly SkillRecord[] | (() => readonly SkillRecord[]) }
   /** 项目目录。会话落在 `<project>/.nomi/agent-sessions/` 下。 */
   projectDir: string
   /** 一条 lane = 一条独立的对话轨。默认 `main`。 */

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -724,6 +724,12 @@ contextBridge.exposeInMainWorld("nomiDesktop", {
     exportPackage: (dirName: string) => invokeSync("nomi:skill:export", dirName),
     importPackage: (payload: unknown) => invokeSync("nomi:skill:import", payload),
     deleteByDir: (dirName: string) => invokeSync("nomi:skill:delete", dirName),
+    /** 技能盘变了（导入/删除/Agent 写完落盘）。范式与 modelCatalog.onChanged 一致。 */
+    onChanged: (callback: () => void) => {
+      const listener = () => callback();
+      ipcRenderer.on("nomi:skill-library:changed", listener);
+      return () => { ipcRenderer.removeListener("nomi:skill-library:changed", listener); };
+    },
   },
   capability: {
     // 「接入 AI 编程助手」卡：读状态/配置 + 一键写入/撤销 ~/.claude.json。

--- a/electron/skills/skillLibraryBroadcast.test.ts
+++ b/electron/skills/skillLibraryBroadcast.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+
+import {
+  broadcastSkillLibraryChanged,
+  SKILL_LIBRARY_CHANGED_CHANNEL,
+  setSkillLibraryWindowSourceForTests,
+  type SkillLibraryWindow,
+} from "./skillLibraryBroadcast";
+
+function source(relativePath: string): string {
+  return fs.readFileSync(path.join(process.cwd(), relativePath), "utf8");
+}
+
+afterEach(() => setSkillLibraryWindowSourceForTests(null));
+
+describe("技能盘变了的唯一信号来自写盘那一层（2026-09-11）", () => {
+  it("广播发给活着的窗口，跳过已销毁的，没有窗口时什么都不做", () => {
+    const sent: string[] = [];
+    const live = (destroyed: boolean): SkillLibraryWindow => ({
+      isDestroyed: () => destroyed,
+      webContents: { send: (channel) => sent.push(`${destroyed ? "dead" : "live"}:${channel}`) },
+    });
+    setSkillLibraryWindowSourceForTests(() => [live(false), live(true), live(false)]);
+    broadcastSkillLibraryChanged();
+    expect(sent).toEqual([`live:${SKILL_LIBRARY_CHANGED_CHANNEL}`, `live:${SKILL_LIBRARY_CHANGED_CHANNEL}`]);
+
+    // 没有 Electron（MCP 宿主、单测）时是 no-op，不是异常。
+    setSkillLibraryWindowSourceForTests(() => []);
+    expect(() => broadcastSkillLibraryChanged()).not.toThrow();
+  });
+
+  it("两个写盘的函数都发信号，渲染层不再自己喊第二遍", () => {
+    const skillPackage = source("electron/skills/skillPackage.ts");
+    const preload = source("electron/preload.ts");
+    const router = source("src/NomiRouterApp.tsx");
+    const workbenchSkills = source("src/workbench/skillLibrary/useWorkbenchSkills.ts");
+
+    // 落盘的两条路——导入（含 Agent 的 author_skill）与删除——各发一次。
+    const importBody = skillPackage.slice(skillPackage.indexOf("export function importSkillPackageToUserDir"));
+    expect(importBody.slice(0, importBody.indexOf("\n}"))).toContain("broadcastSkillLibraryChanged()");
+    const deleteBody = skillPackage.slice(skillPackage.indexOf("export function deleteUserSkill"));
+    expect(deleteBody.slice(0, deleteBody.indexOf("\n}"))).toContain("broadcastSkillLibraryChanged()");
+
+    // 主进程 → 渲染层的那一段线：频道名两头必须对得上，且渲染层只在这一个接线点转发。
+    expect(preload).toContain(`ipcRenderer.on("${SKILL_LIBRARY_CHANGED_CHANNEL}", listener)`);
+    expect(router).toContain("getDesktopBridge()?.skill.onChanged?.(() => notifySkillLibraryChanged())");
+    expect(workbenchSkills).not.toContain("notifySkillLibraryChanged");
+  });
+});

--- a/electron/skills/skillLibraryBroadcast.ts
+++ b/electron/skills/skillLibraryBroadcast.ts
@@ -1,0 +1,50 @@
+/**
+ * 技能库变了，告诉所有窗口（2026-09-11）。
+ *
+ * ── 它在解决哪个真实摩擦 ──
+ * 渲染层已经有一条「技能库变了就重读」的总线（`src/workbench/skillLibrary/skillLibraryChanged.ts`），
+ * 但**派发它的只有渲染层自己的导入/删除**。技能还有第三个写入者：Agent 的 `author_skill`
+ * ——它在主进程里落盘，渲染层一无所知。于是「让 Agent 帮我写一个技能」写完了，
+ * 用户在技能菜单里找不到它，要重启 App 才撞见。
+ *
+ * ── 为什么装在这一层 ──
+ * 写盘的函数只有两个（`importSkillPackageToUserDir` / `deleteUserSkill`），而调用它们的入口
+ * 有三处以上且还会长。把通知挂在**写盘那一层**，新增一个入口不必记得补一行（R28：
+ * 防线建在最早能拦住的那层）。范式与 `nomi:model-catalog:changed` 完全一致，不另发明一套。
+ *
+ * 非 Electron 进程（MCP 的 node 宿主、单测）里拿不到窗口——那里没有人要通知，
+ * 静默 no-op 是正确行为，不是被吞掉的错误。
+ */
+
+export const SKILL_LIBRARY_CHANGED_CHANNEL = "nomi:skill-library:changed";
+
+/** 一个能收广播的窗口。只写我们真的用到的两个成员，不把 Electron 的类型拖进这一层。 */
+export interface SkillLibraryWindow {
+  isDestroyed(): boolean;
+  webContents: { send(channel: string): void };
+}
+
+function electronWindows(): readonly SkillLibraryWindow[] {
+  try {
+    // 动态 require：这个模块被 `skillPackage.ts` 引用，而它也跑在没有 Electron 的进程里
+    // （MCP 的 node 宿主、单测）。那里 `require` 本身可能就不存在，所以整段兜住。
+    const electron = require("electron") as { BrowserWindow?: { getAllWindows(): SkillLibraryWindow[] } };
+    return electron.BrowserWindow?.getAllWindows() ?? [];
+  } catch {
+    return [];
+  }
+}
+
+let windowSource: () => readonly SkillLibraryWindow[] = electronWindows;
+
+/** 测试替身。生产代码只走 `electronWindows`，这个口存在只是为了让广播这件事可被观测。 */
+export function setSkillLibraryWindowSourceForTests(source: (() => readonly SkillLibraryWindow[]) | null): void {
+  windowSource = source ?? electronWindows;
+}
+
+export function broadcastSkillLibraryChanged(): void {
+  for (const window of windowSource()) {
+    if (window.isDestroyed()) continue;
+    try { window.webContents.send(SKILL_LIBRARY_CHANGED_CHANNEL); } catch { /* a window closing mid-send is not an error */ }
+  }
+}

--- a/electron/skills/skillPackage.ts
+++ b/electron/skills/skillPackage.ts
@@ -12,6 +12,7 @@
 // 纯函数（打包/校验/冲突命名）与 FS 函数（显式目录，便于单测，不碰 electron app）分离；
 // runtimePaths 薄包装见末尾。
 import { createHash } from "node:crypto";
+import { broadcastSkillLibraryChanged } from "./skillLibraryBroadcast";
 import fs from "node:fs";
 import path from "node:path";
 
@@ -276,6 +277,7 @@ export function deleteUserSkill(directoryName: string): DeleteSkillResult {
     return { ok: false, error: "该技能不在用户目录（内置技能只读，不能删除）" };
   }
   fs.rmSync(target, { recursive: true, force: true });
+  broadcastSkillLibraryChanged();
   return { ok: true, dirName: name };
 }
 
@@ -293,5 +295,8 @@ export function importSkillPackageToUserDir(raw: unknown): ImportSkillResult {
   const validated = validateSkillPackage(normalizeSkillImportInput(raw));
   if (!validated.ok) return validated;
   const { dirName } = writeSkillImport(getUserSkillsRoot(), validated.pkg);
+  // 盘变了就说一声。挂在写盘这一层，是因为入口不止一个（渲染层导入、拖拽、Agent 的
+  // `author_skill`），而漏掉的那一个不会报错——它只是让用户在技能菜单里找不到刚加的东西。
+  broadcastSkillLibraryChanged();
   return { ok: true, dirName, skillName: validated.skillName || dirName };
 }

--- a/src/NomiRouterApp.tsx
+++ b/src/NomiRouterApp.tsx
@@ -8,6 +8,7 @@ import { getAppRoutePath } from './utils/routes'
 import { lazyWithChunkBoundary } from './ui/chunkBoundary'
 import { useTranslation } from 'react-i18next'
 import { useIntegrationConfirmationNotice } from './workbench/capability/useIntegrationConfirmationNotice'
+import { notifySkillLibraryChanged } from './workbench/skillLibrary/skillLibraryChanged'
 
 const NomiStudioApp = lazyWithChunkBoundary('i18n:router.mainInterface', () => import('./workbench/NomiStudioApp'))
 
@@ -37,7 +38,13 @@ export default function NomiRouterApp(): JSX.Element {
     const refresh = (): void => notifyModelOptionsRefresh('all')
     window.addEventListener('nomi-model-catalog-changed', refresh)
     const unsubscribe = getDesktopBridge()?.modelCatalog.onChanged?.(() => window.dispatchEvent(new Event('nomi-model-catalog-changed')))
-    return () => { unsubscribe?.(); window.removeEventListener('nomi-model-catalog-changed', refresh) }
+    // 技能盘同理：**唯一的派发点在主进程**（写盘那一层），渲染层只负责把它接进本地总线。
+    // 这样三个写入者（面板导入、拖拽、Agent 的 author_skill）不必各自记得喊一声。
+    const unsubscribeSkills = getDesktopBridge()?.skill.onChanged?.(() => notifySkillLibraryChanged())
+    return () => {
+      unsubscribe?.(); unsubscribeSkills?.()
+      window.removeEventListener('nomi-model-catalog-changed', refresh)
+    }
   }, [])
   return (
     <HashRouter>

--- a/src/desktop/bridge.ts
+++ b/src/desktop/bridge.ts
@@ -716,6 +716,8 @@ export type DesktopBridge = DesktopMediaBridge &
     exportPackage: (dirName: string) => unknown
     importPackage: (payload: unknown) => unknown
     deleteByDir: (dirName: string) => unknown
+    /** 技能盘变了（导入/删除/Agent 的 author_skill 写完落盘）。可选：老 preload 无此口。 */
+    onChanged?: (callback: () => void) => () => void
   }
   /** 即梦会员（dreamina CLI）：设备码登录/账户检测/安装（可选——老 preload 无此口）。 */
   dreamina?: {

--- a/src/workbench/skillLibrary/skillLibraryChanged.ts
+++ b/src/workbench/skillLibrary/skillLibraryChanged.ts
@@ -8,8 +8,13 @@
  * 用户导进来了，却在 Agent 里用不上，只能靠重启 App 撞见。
  *
  * 根因是「共享状态没有失效信号」，不是哪个组件写错了。所以修在最早的共享边界：
- * 写方（导入/删除）派发一次，所有读者监听同一个事件重读。范式与 `nomi-model-catalog-changed`
- * 完全一致，不另发明一套。
+ * 写方派发一次，所有读者监听同一个事件重读。范式与 `nomi-model-catalog-changed` 完全一致。
+ *
+ * **2026-09-11 更正：唯一的写方在主进程，不在这里。** 此前派发它的只有渲染层自己的导入/删除，
+ * 于是第三个写入者——Agent 的 `author_skill`，它在主进程里落盘——一个字都传不到渲染层，
+ * 用户「让 Agent 帮我写个技能」写完了却在菜单里找不到它。现在信号发自写盘那一层
+ * （`electron/skills/skillLibraryBroadcast.ts`），`NomiRouterApp` 把它接进这条本地总线；
+ * `notifySkillLibraryChanged` 只该由那个接线点调用，别在业务代码里再喊一次（那就是第二个来源）。
  */
 
 export const SKILL_LIBRARY_CHANGED_EVENT = 'nomi-skill-library-changed'

--- a/src/workbench/skillLibrary/useWorkbenchSkills.ts
+++ b/src/workbench/skillLibrary/useWorkbenchSkills.ts
@@ -11,7 +11,7 @@ import {
   type SkillListItemDto,
   type SkillProviderKind,
 } from '../api/skillApi'
-import { notifySkillLibraryChanged, onSkillLibraryChanged } from './skillLibraryChanged'
+import { onSkillLibraryChanged } from './skillLibraryChanged'
 
 export type UseWorkbenchSkills = {
   items: SkillListItemDto[]
@@ -56,8 +56,9 @@ export function useWorkbenchSkills(opened: boolean): UseWorkbenchSkills {
 
   const remove = React.useCallback(
     (dirName: string) => {
+      // 不在这里派发：技能盘的变更信号由主进程写盘那一层统一发出（`skillLibraryBroadcast.ts`），
+      // 渲染层再喊一次就是第二个来源——它会在「Agent 写的技能」那条路上继续缺席。
       const res = deleteWorkbenchSkill(dirName)
-      if (res.ok) notifySkillLibraryChanged()
       return { ok: res.ok, error: res.error }
     },
     [],
@@ -66,9 +67,6 @@ export function useWorkbenchSkills(opened: boolean): UseWorkbenchSkills {
   const importPackage = React.useCallback(
     (payload: unknown) => {
       const res = importWorkbenchSkill(payload)
-      // 派信号而不是只 reload 自己：Agent 面板的 `/` 技能菜单是同一份盘的另一个读者，
-      // 它读不到这次写入就等于「导进来了却用不上」（本轮走查抓到的那一幕）。
-      if (res.ok) notifySkillLibraryChanged()
       return { ok: res.ok, skillName: res.skillName, error: res.error }
     },
     [],

--- a/tests/agent-runtime/lane-live-skill-index.test.mts
+++ b/tests/agent-runtime/lane-live-skill-index.test.mts
@@ -1,0 +1,173 @@
+// 一条 lane 的技能索引是**活的**：会话中途导入的技能，下一个回合就在索引里、也读得到。
+//
+// 这一批断言钉的是三件「不报错、只会让用户以为坏了」的失败：
+//   ① 索引停在开 lane 那一刻——用户刚导入的技能，模型说它不存在，要关掉项目重开（用户原话）；
+//   ② 索引更新了、可信读根没跟上——提示词里写着那条技能的路径，模型 `read` 它却被判越界，
+//      于是模型看得见却读不到，症状比①更难懂；
+//   ③ 回合内改口——同一个回合里两次模型请求看到不同的技能集/语言，模型自相矛盾。
+// 对偶的那一条同样要钉：**没变就不许重算**，否则每个回合都要付一次 pi 的 ESM 渲染。
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { tmpdir } from 'node:os';
+import { test } from 'node:test';
+import { BACKGROUND_CONTEXT } from '@earendil-works/pi-agent-core/harness/context';
+import { createLaneSkillIndexSource } from '../../electron/agentLane/laneInstalledSkills.mjs';
+import { createLaneCodingPaths } from '../../electron/agentLane/laneCodingPaths.mjs';
+import { openLaneNativeDesktop } from '../../electron/agentLane/laneNativeDesktop.mjs';
+import { createLaneFixture } from './laneFixture.mjs';
+import type { SkillRecord } from '../../electron/skills/skillStore.js';
+
+async function landSkill(root: string, name: string, extra: { scripts?: boolean; body?: string } = {}): Promise<SkillRecord> {
+  const dir = path.join(root, name);
+  await mkdir(dir, { recursive: true });
+  if (extra.scripts) await mkdir(path.join(dir, 'scripts'), { recursive: true });
+  const body = extra.body ?? `---\nname: ${name}\ndescription: ${name} 的用途说明。\n---\n正文。`;
+  const filePath = path.join(dir, 'SKILL.md');
+  await writeFile(filePath, body);
+  return { name, directoryName: name, filePath, description: `${name} 的用途说明。`, body,
+    manifest: null, origin: 'user', audience: 'internal', packageVersion: 'nomi-skill-v1',
+    contentHash: `hash-${name}-${body.length}` };
+}
+
+async function skillsRoot(t: { after(fn: () => unknown): void }): Promise<string> {
+  const root = await mkdtemp(path.join(tmpdir(), 'nomi-live-skills-'));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  return root;
+}
+
+test('索引源：refresh 才换代，current() 在回合内不动；记录集没变就连渲染都不重跑', async (t) => {
+  const root = await skillsRoot(t);
+  const first = await landSkill(root, 'tone-guide');
+  let records: SkillRecord[] = [first];
+  let rendered = 0;
+  const source = createLaneSkillIndexSource(() => records, {
+    loadFormatter: async () => ({
+      formatSkillsForPrompt: (skills) => { rendered += 1; return `<available_skills>${skills.map((s) => s.name).join(',')}</available_skills>`; },
+    }),
+  });
+
+  assert.deepEqual(source.current().entries, [], 'refresh 之前是空的：开 lane 那一刻还没扫过盘');
+  await source.refresh();
+  assert.deepEqual(source.current().entries.map((entry) => entry.name), ['tone-guide']);
+  assert.match(source.current().promptSection, /tone-guide/);
+  assert.equal(rendered, 1);
+
+  // 用户在会话中途导入第二个技能。**在下一次 refresh 之前，这个回合看到的还是旧的那一份。**
+  records = [first, await landSkill(root, 'shuohao-storyboard')];
+  assert.equal(source.current().entries.length, 1, '回合内不许改口');
+  const before = source.current();
+  await source.refresh();
+  assert.deepEqual(source.current().entries.map((entry) => entry.name).sort(), ['shuohao-storyboard', 'tone-guide']);
+  assert.notEqual(source.current(), before, '换代了就该是另一份');
+  assert.equal(rendered, 2);
+
+  // 没变的那一次：同一份对象原样回来，pi 的渲染一次都没多跑。
+  const steady = source.current();
+  await source.refresh();
+  await source.refresh();
+  assert.equal(source.current(), steady, '记录集没变就不该重算');
+  assert.equal(rendered, 2);
+
+  // 技能正文改了（contentHash 变）→ 必须重算：description 与「要不要 coding 工具」都可能跟着变。
+  records = [{ ...records[0]!, contentHash: 'hash-tone-guide-changed' }, records[1]!];
+  await source.refresh();
+  assert.equal(rendered, 3);
+});
+
+test('索引源：第一个技能是半路导入的，渲染器那时才加载；扫描与校验之间被删掉的技能只是不在索引里', async (t) => {
+  const root = await skillsRoot(t);
+  let records: SkillRecord[] = [];
+  let loaded = 0;
+  const source = createLaneSkillIndexSource(() => records, {
+    loadFormatter: async () => { loaded += 1; return { formatSkillsForPrompt: (skills) => skills.map((s) => s.name).join(',') }; },
+  });
+  await source.refresh();
+  assert.equal(source.current().promptSection, '');
+  assert.equal(loaded, 0, '一条没有技能的 lane 不该为了拿一个空串付一次 ESM 解析');
+
+  records = [await landSkill(root, 'late-import')];
+  await source.refresh();
+  assert.equal(loaded, 1, '第一个技能半路进来时才加载渲染器');
+  assert.equal(source.current().promptSection, 'late-import');
+
+  // 用户在这一次扫描与校验之间把技能删了：它不在这一刻的索引里，但**不该让整个回合失败**。
+  const ghost = await landSkill(root, 'ghost');
+  records = [records[0]!, ghost];
+  await rm(path.join(root, 'ghost'), { recursive: true, force: true });
+  await source.refresh();
+  assert.deepEqual(source.current().entries.map((entry) => entry.name), ['late-import']);
+});
+
+test('可信读根跟着索引源走：根变了，pin 过的那份不许留着', async (t) => {
+  const root = await skillsRoot(t);
+  const project = await mkdtemp(path.join(tmpdir(), 'nomi-live-project-'));
+  t.after(() => rm(project, { recursive: true, force: true }));
+  await landSkill(root, 'alpha');
+  await landSkill(root, 'beta');
+  let roots: readonly string[] = [path.join(root, 'alpha')];
+  const paths = await createLaneCodingPaths(project, () => roots);
+
+  await paths.readSkill(path.join(root, 'alpha', 'SKILL.md'));
+  await assert.rejects(paths.readSkill(path.join(root, 'beta', 'SKILL.md')), /outside this project/);
+  roots = [path.join(root, 'alpha'), path.join(root, 'beta')];
+  await paths.readSkill(path.join(root, 'beta', 'SKILL.md'));
+  // 写仍然只许在项目里，可信技能包是只读的——把根变活不许顺手放宽这条。
+  await assert.rejects(paths.write(path.join(root, 'beta', 'SKILL.md')), /outside this project/);
+  // 根消失了（用户删了技能）：它退出名单，而不是让之后每一次 read 都炸。
+  await rm(path.join(root, 'beta'), { recursive: true, force: true });
+  roots = [path.join(root, 'alpha')];
+  await assert.rejects(paths.readSkill(path.join(root, 'beta', 'SKILL.md')), /outside this project/);
+  await paths.readSkill(path.join(root, 'alpha', 'SKILL.md'));
+});
+
+test('根的集合是活的，但已经认下的那个根不许被重新解析成别处', async (t) => {
+  const root = await skillsRoot(t);
+  const project = await mkdtemp(path.join(tmpdir(), 'nomi-live-project-'));
+  t.after(() => rm(project, { recursive: true, force: true }));
+  const outside = await mkdtemp(path.join(tmpdir(), 'nomi-live-outside-'));
+  t.after(() => rm(outside, { recursive: true, force: true }));
+  await writeFile(path.join(outside, 'secret.txt'), '不该被读到');
+  await landSkill(root, 'alpha');
+  const alpha = path.join(root, 'alpha');
+  const paths = await createLaneCodingPaths(project, () => [alpha]);
+  await paths.readSkill(path.join(alpha, 'SKILL.md'));
+
+  // 把一个**已经认下的**技能根换成指向别处的软链。集合没变，所以它不该被重新 canonicalize——
+  // 否则「把根变活」就顺手把它变成了一块可以被换掉的可读区。
+  await rm(alpha, { recursive: true, force: true });
+  await symlink(outside, alpha);
+  await assert.rejects(paths.readSkill(path.join(alpha, 'secret.txt')), /outside this project/);
+
+  // 而**新**出现的根仍然进得来——且它自己就是软链时当场拒，不靠上游记得校验。
+  const evil = path.join(root, 'evil');
+  await symlink(outside, evil);
+  await assert.rejects(createLaneCodingPaths(project, [evil]), /must not be symbolic links/);
+});
+
+test('原生装配：技能给函数时，会话中途导入的技能下一个回合既进索引也读得到', async (t) => {
+  const fixture = await createLaneFixture(t, []);
+  const settingsRoot = await mkdtemp(path.join(tmpdir(), 'nomi-live-settings-'));
+  t.after(() => rm(settingsRoot, { recursive: true, force: true }));
+  const root = path.join(settingsRoot, 'skills');
+  await mkdir(root, { recursive: true });
+  let records: SkillRecord[] = [];
+  const desktop = await openLaneNativeDesktop({ projectDir: fixture.projectDir, settingsRoot, skills: () => records });
+  t.after(() => desktop.close());
+  assert.deepEqual(desktop.skillIndex.current().entries, []);
+
+  const read = desktop.tools.find((tool) => tool.name === 'read')!;
+  const imported = await landSkill(root, 'mid-session');
+  // 落盘了，但这条 lane 还没跨过回合边界：索引与可信根都还是上一份。
+  assert.deepEqual(desktop.skillIndex.current().entries, []);
+  await assert.rejects(read.execute('too-early', { path: imported.filePath } as never,
+    (() => undefined) as never, undefined, {} as never, BACKGROUND_CONTEXT), /outside this project/);
+
+  records = [imported];
+  await desktop.skillIndex.refresh();
+  assert.deepEqual(desktop.skillIndex.current().entries.map((entry) => entry.name), ['mid-session']);
+  assert.match(desktop.skillIndex.current().promptSection, /mid-session/);
+  const content = await read.execute('after-refresh', { path: imported.filePath } as never,
+    (() => undefined) as never, undefined, {} as never, BACKGROUND_CONTEXT);
+  assert.match(JSON.stringify(content), /正文/, '看得见就必须读得到：索引与可信根同源');
+});

--- a/tests/agent-runtime/lane-native-desktop.test.mts
+++ b/tests/agent-runtime/lane-native-desktop.test.mts
@@ -22,7 +22,7 @@ test('production native resources read installed Skill metadata without widening
     manifest: null, origin: 'user', audience: 'internal', packageVersion: 'nomi-skill-v1', contentHash: 'fixture' };
   const desktop = await openLaneNativeDesktop({ projectDir: fixture.projectDir, settingsRoot, skills: [skill] });
   t.after(() => desktop.close());
-  assert.equal(desktop.skills.length, 1);
+  assert.equal(desktop.skillIndex.current().entries.length, 1);
   assert.equal(desktop.tools.length, 9);
   const read = desktop.tools.find((tool) => tool.name === 'read')!;
   const content = await read.execute('skill', { path: filePath } as never, (() => undefined) as never, undefined, {} as never, BACKGROUND_CONTEXT);

--- a/tests/ux/lane-live-skills.walk.mjs
+++ b/tests/ux/lane-live-skills.walk.mjs
@@ -1,0 +1,161 @@
+#!/usr/bin/env node
+// R16 真实用户任务走查：**「会话开着的时候我导入了一个技能，Agent 现在就该知道它存在」**。
+//
+// 与 `skill-import-real-use.walk.mjs` 的分工（别把两条看成同一条）：那条证的是「**我点了它**
+// 之后，这份方法论进没进模型」——走的是 composer 的技能 chip 通路，正文由渲染层随这一条消息带上，
+// 和技能索引是两条不同的线。这条证的是另一半，也是 2026-09-11 评审点名的那个缺口：
+//
+//   **模型的技能索引（系统提示词里的 `<available_skills>`）是不是活的。**
+//
+// 它决定的是「用户不点菜单，只说一句『用刚导入的那个分镜技能』时，模型知不知道有这么个东西」。
+// 修之前那份索引是开 lane 那一刻的快照：新导入的技能要关掉项目再打开才出现在里面，
+// 而技能库面板与 composer 的菜单**都已经看得见它了**——于是现象是「明明在列表里，Agent 却说没有」。
+//
+// 判定（硬证据，不靠截图也成立，且两端都可证伪）：
+//   ① 导入**之前**那一轮的 system 里有 `<available_skills>`（内置技能在里面 = 这一段是活的），
+//      但**没有**这个技能的名字——阳性对照，证明后面那条断言不是恒真。
+//   ② **不重开项目、不重开对话**，导入之后的下一轮 system 里出现它的名字、描述与安装路径。
+//   ③ 用户视角那一半：composer 的技能菜单里选得到它，选中后 composer 上出现技能 chip。
+//
+// 零额度：文本模型走 `agent-runtime-fixture` 的 loopback，不打任何真供应商。
+// 用法：pnpm run build && node tests/ux/lane-live-skills.walk.mjs [--packaged /abs/Nomi.app/Contents/MacOS/Nomi]
+import fs from 'node:fs'
+import path from 'node:path'
+import { zipSync, strToU8 } from 'fflate'
+import { clickOrFail, expect, proveProbe, screenshotSettled } from './_assert.mjs'
+import { FIXTURE_TEXT_MODEL_LABEL } from './agent-runtime-fixture.mjs'
+import {
+  CANVAS_PANEL, COMPOSER_CHIP, COMPOSER_SKILL, SKILL_POPOVER,
+  chooseAssistantModel, createRuntimeWalk, openCanvas, recorded, sendCanvas,
+} from './agent-runtime-walk-support.mjs'
+
+const SKILL_DIR = 'walk-live-index'
+const SKILL_NAME = 'walk-live-index'
+const SKILL_DESC = '走查·会话中途导入的技能索引'
+const SKILL_BODY = ['---', `name: ${SKILL_NAME}`, `description: ${SKILL_DESC}`, '---', '', '正文：先定调子再定镜头。'].join('\n')
+const REPLY_BEFORE = 'WALK_LIVE_BEFORE：好的。'
+const REPLY_AFTER = 'WALK_LIVE_AFTER：我看到那个技能了。'
+
+function systemTextOf(body) {
+  return (Array.isArray(body?.messages) ? body.messages : [])
+    .filter((message) => message?.role === 'system')
+    .map((message) => (typeof message.content === 'string' ? message.content : JSON.stringify(message.content)))
+    .join('\n')
+}
+
+const walk = await createRuntimeWalk('lane-live-skills')
+const shotDir = process.env.NOMI_WALK_SHOT_DIR || walk.report.outputDir
+fs.mkdirSync(shotDir, { recursive: true })
+
+const zipPath = path.join(walk.report.tempRoot, `${SKILL_DIR}.zip`)
+fs.writeFileSync(zipPath, Buffer.from(zipSync({ [`${SKILL_DIR}/SKILL.md`]: strToU8(SKILL_BODY) })))
+const userSkillsRoot = path.join(walk.report.tempRoot, 'settings', 'skills')
+
+/** 等的是盘上的真实结果，不是私有墙钟（R18）。 */
+async function waitForSkillOnDisk(win, dirName) {
+  const deadline = Date.now() + 15_000
+  for (;;) {
+    if (fs.existsSync(path.join(userSkillsRoot, dirName, 'SKILL.md'))) return path.join(userSkillsRoot, dirName, 'SKILL.md')
+    if (Date.now() > deadline) throw new Error(`等满 15s，${userSkillsRoot} 里没出现 ${dirName}`)
+    await win.waitForTimeout(200)
+  }
+}
+
+async function shot(win, name) {
+  const file = path.join(shotDir, `${name}.png`)
+  await screenshotSettled(win, { path: file })
+  console.log(`SHOT: ${file}`)
+  return file
+}
+
+let failure
+try {
+  const { win } = await walk.start({ first: true })
+  await walk.newProject()
+  await openCanvas(win)
+  await chooseAssistantModel(win, FIXTURE_TEXT_MODEL_LABEL, CANVAS_PANEL)
+  await shot(win, '01-agent-open')
+
+  // ── ① 阳性对照：这一刻索引是活的（内置技能在里面），但还没有这个技能 ──────────
+  const before = walk.fixture.expectText({
+    label: '导入之前的第一轮',
+    match: () => true,
+    reply: { type: 'text', text: REPLY_BEFORE },
+  })
+  await sendCanvas(win, '我们先聊一下这个项目。')
+  const beforeWire = await recorded(before.received, '导入前的模型请求')
+  const beforeSystem = systemTextOf(beforeWire.body)
+  expect(beforeSystem, '送往模型的消息里根本没有 system 段——比预期更糟，整层都没送').not.toBe('')
+  expect(
+    beforeSystem.includes('<available_skills>'),
+    '第一轮的 system 里就没有技能索引段——这一屏不是活的索引，下面「导入后出现了」的断言不作数',
+  ).toBe(true)
+  expect(
+    beforeSystem.includes(SKILL_NAME),
+    '还没导入就已经出现在索引里——断言认错了人（换一个更独特的技能名）',
+  ).toBe(false)
+  console.log(`  ✅ 阳性对照：system 长度 ${beforeSystem.length}，<available_skills> 在、${SKILL_NAME} 不在`)
+
+  // ── ② 用户在会话开着的时候导入一个技能（走真实入口：技能库面板的导入） ──────────
+  await clickOrFail(win.getByRole('button', { name: '技能库', exact: true }).first(), '侧栏「技能库」')
+  const panel = win.locator('[data-skill-drop-zone]')
+  await expect(panel, '技能库面板没渲染').toBeVisible()
+  // input 必须钉在技能库面板内部：这一屏上画布工具栏与 composer 各自还有一个 file input。
+  const fileInput = panel.locator('input[type="file"]').first()
+  await fileInput.waitFor({ state: 'attached' })
+  await fileInput.setInputFiles(zipPath)
+  const skillFilePath = await waitForSkillOnDisk(win, SKILL_DIR)
+  await expect(panel.getByText(SKILL_DESC, { exact: false }).first(), '导进来了但技能库面板里看不见').toBeVisible()
+  await shot(win, '02-skill-imported-mid-session')
+
+  // ── ③ 用户视角那一半：不重开任何东西，composer 的技能菜单里就该选得到 ──────────
+  await clickOrFail(win.locator(`${CANVAS_PANEL} ${COMPOSER_SKILL}`), 'Agent composer 的「技能」钮')
+  const popover = win.locator(`${CANVAS_PANEL} ${SKILL_POPOVER}`)
+  await expect(popover).toBeVisible()
+  await proveProbe(
+    popover.locator('[data-v4-command^="skill:"]'),
+    '技能菜单里连内置技能都没有——这一屏不是活的，下面的断言不作数',
+  )
+  await expect(
+    popover.getByText(SKILL_DESC, { exact: false }).first(),
+    '刚导入的技能没有出现在 Agent 的技能菜单里',
+  ).toBeVisible()
+  await shot(win, '03-skill-in-composer-menu')
+
+  // ── ④ 本条走查的正主：**同一条 lane、不重开**，下一轮的索引里必须有它 ──────────
+  // 这里刻意**不选**那个技能：选了就是 composer 的 chip 通路（正文随消息走），
+  // 证不到索引。要证的恰恰是「用户没点它，模型也知道有这么个东西」。
+  await win.keyboard.press('Escape')
+  const after = walk.fixture.expectText({
+    label: '导入之后的下一轮',
+    match: () => true,
+    reply: { type: 'text', text: REPLY_AFTER },
+  })
+  await sendCanvas(win, '你现在都有哪些技能可用？')
+  const afterWire = await recorded(after.received, '导入后的模型请求')
+  const afterSystem = systemTextOf(afterWire.body)
+  expect(
+    afterSystem.includes(SKILL_NAME),
+    `同一条 lane 的下一轮里，技能索引仍然没有「${SKILL_NAME}」——索引还是开 lane 那一刻的快照，`
+    + `用户只能关掉项目重开。system 里的索引段：${afterSystem.slice(afterSystem.indexOf('<available_skills>'), afterSystem.indexOf('<available_skills>') + 600)}`,
+  ).toBe(true)
+  expect(afterSystem, '索引里有名字却没有描述——模型没法据此判断什么时候该用它').toContain(SKILL_DESC)
+  expect(
+    afterSystem.includes(skillFilePath),
+    `索引里没有这条技能的安装路径（${skillFilePath}）——模型拿不到「去哪读正文」，看得见也读不到`,
+  ).toBe(true)
+  console.log(`  ✅ 不重开会话：索引里已经有 ${SKILL_NAME}（名字 + 描述 + 安装路径都在）`)
+  await shot(win, '04-index-live-next-turn')
+
+  // ── ⑤ 收口：选中它，chip 画得出来（用户真的用得上，不只是模型看得见） ──────────
+  await clickOrFail(win.locator(`${CANVAS_PANEL} ${COMPOSER_SKILL}`), 'Agent composer 的「技能」钮')
+  await clickOrFail(popover.getByText(SKILL_DESC, { exact: false }).first(), '菜单里刚导入的技能')
+  await expect(win.locator(`${CANVAS_PANEL} ${COMPOSER_CHIP}`), '选中技能后 composer 上没有出现技能 chip').toBeVisible()
+  await shot(win, '05-skill-chip-attached')
+
+  console.log('\n✅ 会话中途导入的技能：技能库看得见、composer 选得到、同一条 lane 的下一轮索引里也有它。')
+} catch (error) {
+  failure = error
+} finally {
+  await walk.finish(failure)
+}


### PR DESCRIPTION
## 用户那一刻卡在哪

在 Agent 面板旁边的技能库里导入一个技能包 → 左边卡片立着、composer 的技能菜单里也选得到 →
对 Agent 说「用刚导入的那个技能」→ **模型说它没有这个技能**。要关掉项目再打开才认得。

## 根因（一句话）

一条 lane 会跨很多回合活着，而它的装配参数里混着两种寿命完全不同的东西——「开 lane 那一刻的事实」
和「每一刻都可能变的事实」——**类型上两者长得一模一样**，所以没有任何东西逼人回答某个字段是哪一种。
`native.skills` 就是这么被当成常量收下的：索引、可信读根、提示词段三样全停在开 lane 那一刻。

这不是第一次：2026-09-11 上午的回复语言（`systemPrompt`）是同一个缺口在另一个字段上的显形，
当天的结构评审 `docs/audit/2026-09-11-agent-lane-live-vs-snapshot.md` 已经把 `native.skills` 点名为
「同类缺口，尚未修」。所以本轮修的是**「什么时候求值」这条规则本身**，不是再补一个字段。

## 同类扫描（逐字段过了 `OpenLaneOptions` 与 `openWorkspace` 的闭包）

| 档 | 字段 | 结论 |
|---|---|---|
| 装配期常量 | `projectDir` / `laneName` / `sessionId` / `native.settingsRoot` / `tools` / `toolLifecycle` / `watchdog` / `limits` | 正确，不动 |
| 有显式变更路径 | `model` + 供应商凭据 | 正确：每次发送前 `laneIpc` 都调 `configure`，改了就 `configureModel` 重开 lane |
| 已经是函数 | `approval.policy` / `approval.workMode` / `tasks` / `input.capture` / `native.availableModels` | 正确 |
| **快照（本轮修）** | `native.skills`（含 `trustedSkillRoots`） | 会话中途导入的技能模型看不见、也读不到 |
| **快照（本轮修）** | `systemPrompt` 闭包里的 `memory` | 用户删一条项目记忆 / 锁一个节点，lane 到冷启动前都用旧的 |
| 待观察 | `sandboxPolicyFor` 的 `allowedDomains` | 今天恒为空所以还不是快照；技能一旦声明出网域名会立刻变成同一类（已记进合同 residual_risks） |
| 另一层的同族 | 渲染层技能列表 | 变更信号只由渲染层自己的导入/删除派发，主进程里的 `author_skill` 静默（本轮一并修） |

## 改在哪一层

- **`laneHost.systemPromptForRun`** — 这一层唯一的「什么时候求值」规则：**系统提示词在每个回合边界
  整体重新求值一次、回合内不变**。既不引用开 lane 时的常量（回合间不更新），也不每次模型请求都重算
  （回合内会改口，那正是评审裁决③不要的行为）。以后再加会变的段落不必发明新的刷新路径。
- **`LaneSkillIndexSource`（`laneInstalledSkills.mts`）** — 这条 lane 关于技能的全部事实的唯一 owner：
  索引 / 可信读根 / 提示词段出自同一次刷新，于是「模型看得见」与「模型读得到」不可能分叉。
  指纹含 `contentHash`，记录集没变连 pi 的渲染都不重跑。
- **`laneCodingPaths`** — 可信读根收来源不收快照，但**每个根只 canonicalize 一次、就在它第一次出现
  那一刻**：集合是活的，已认下的根不许被换成软链后重新解析（既有的 `lane-native-paths`
  「装配之后被换成软链」安全用例保持绿），根本身是软链的当场拒。
- **`skillLibraryBroadcast`** — 技能盘的变更信号搬到落盘那一层，三个写入者（面板导入、拖拽、
  `author_skill`）都不必记得喊一声；渲染层原来两处本地派发同 commit 删除（P1）。

R29：pi 在这一层没有可借的机制——`DefaultResourceLoader` 自己也是 `load()` 时的快照
（`dist/core/resource-loader.js:206`），唯一出路是显式 `reload()`（`:263`）。渲染仍然只用
pi 的 `formatSkillsForPrompt`，发现仍是 Nomi 自己那条（两格都在 `framework-boundaries.json` 里已登记）。

## 证据

**真机零额度走查** `tests/ux/lane-live-skills.walk.mjs`：用户点侧栏「技能库」→ 面板的导入 input 选一个 zip
→ **不碰任何重开动作** → 再发一轮。两端都可证伪：

- 阳性对照：导入前那一轮的 system 里 `<available_skills>` 在（长度 43854）、这个技能名不在；
- 正主：导入后的下一轮，索引里出现它的名字 + 描述 + 安装路径。
- **变异验证**：把 `laneDesktopRuntime` 的 `skills` 改回数组快照 → 阳性对照仍绿、第 ④ 条当场红，
  报文里的 `<available_skills>` 只剩内置技能。也就是说这条走查量的正是这个 bug，不是恒真。

顺带实锤了评审说的那一幕：修之前**技能库面板与 composer 菜单都已经看得见它了**（走查的 ②③ 步通过），
只有模型的索引没有——「明明在列表里，Agent 却说没有」。

四条棘轮全部做过变异验证：`laneDesktopStructure.test.ts`（4 条）、`lane-live-skill-index.test.mts`（5 条，
含「已认下的根不许被重新解析」这条安全性质）、`skillLibraryBroadcast.test.ts`（2 条）。

`pnpm run gates` 全绿（77 个门岗 · 74 通过 · 0 阻断失败 · 3 advisory 由 docs-autosync 补齐）。

## 文档

- 方案（含「先查别人」：pi / Claude Code / Agent Skills / Codex / MCP 五处带 URL）：`docs/plan/2026-09-11-lane-live-vs-snapshot-fix.md`
- 根因合同（schema-v3，`recurring`，`invariant_owner_layer` = `electron/agentLane/laneHost.mts`）：`docs/fixes/2026-09-11-lane-live-skills-snapshot.root-cause.json`
- 结构评审（回答 `check:symptom-cluster` 报出的 `electron/skills` 第 6 份合同 + `src` 第 3 份）：`docs/audit/2026-09-11-skill-fact-projections-structure.md`

## 已知边界（不是遗留缺口）

- 刷新粒度是**回合**：回合内导入的技能要等这一轮说完才进索引（评审裁决③：正在跑的那一个回合不改口）。
- 每回合做一次技能库全量重扫（本机 88 个内置包实测 ~25ms）。技能库长到几百个包时正解是给
  `skillStore` 一个按目录 mtime 的廉价指纹，而不是把粒度改回「开 lane 一次」。
- 技能盘的广播只覆盖走 `importSkillPackageToUserDir` / `deleteUserSkill` 的写入；用户在 App 外面
  直接往 skills 目录丢文件夹，渲染层仍不实时（lane 侧因为每回合重扫反而是实时的）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
