### PR TITLE
fix(canvas): defer heavy media until interaction

### DIFF
--- a/docs/fixes/2026-09-13-canvas-media-preview-lifecycle.root-cause.json
+++ b/docs/fixes/2026-09-13-canvas-media-preview-lifecycle.root-cause.json
@@ -1,0 +1,142 @@
+{
+  "schema_version": 3,
+  "id": "2026-09-13-canvas-media-preview-lifecycle",
+  "problem_type": "Original-size media eagerly decoded during canvas rendering",
+  "symptom": "Opening a project with large generated images or HEVC video can delay usable canvas interaction and media failures can affect project recovery.",
+  "direct_cause": "The asset localization boundary returned the full stored image URL as thumbnailUrl and video nodes mounted playback media before user intent.",
+  "class_root": "The asset boundary lacked a distinct, persisted preview representation and the canvas media boundary lacked an explicit interaction activation rule.",
+  "affected_population": [
+    "Projects containing high-resolution generated images",
+    "Projects containing large or platform-sensitive video",
+    "macOS and Windows Electron users"
+  ],
+  "scope_paths": [
+    "electron/assets/localizeTaskAsset.ts",
+    "electron/assets/localizedAsset.ts",
+    "electron/assets/projectAssetStore.ts",
+    "electron/runtime.assets.test.ts",
+    "src/workbench/generationCanvas/nodes/BaseGenerationNode.tsx",
+    "src/workbench/generationCanvas/nodes/NodeVideoPlaybackGuard.tsx",
+    "src/workbench/generationCanvas/reactFlow/GenerationCanvasReactFlowNodes.tsx",
+    "src/workbench/library/ProjectLibraryPage.tsx",
+    "tests/ux/canvas-performance-benchmark.e2e.mjs",
+    "tests/ux/fixtures/canvas-performance-fixture.mjs",
+    "src/workbench/generationCanvas/nodes/nodeSizing.ts",
+    "src/workbench/generationCanvas/nodes/NodeMediaPreviewDialog.tsx",
+    "tests/ux/canvas-image-preview-and-rename.e2e.mjs"
+  ],
+  "entry_points": [
+    "Generated image localization",
+    "Generated video localization",
+    "Canvas image/video node rendering",
+    "Project recovery with missing assets"
+  ],
+  "internal_only_reason": "The invariant is an application-owned asset lifecycle rule; no external API contract decides the preview URL or interaction policy.",
+  "invariants": [
+    "Original media remains the canonical export/source URL.",
+    "Image thumbnails are distinct local preview files when generation succeeds.",
+    "Video playback media is not activated solely by canvas mount when a poster exists.",
+    "A single media failure does not prevent the project canvas from mounting.",
+    "Preview natural dimensions never replace canonical source dimensions used for node geometry."
+  ],
+  "generality_proof": "All generated image and video outputs converge through localizeTaskAsset before entering persisted node results, while all canvas video nodes converge through NodeVideoPlaybackGuard and all canvas node rendering converges through the React Flow node map.",
+  "shared_boundaries": [
+    {
+      "path": "electron/assets/localizeTaskAsset.ts",
+      "symbol": "localizeTaskAsset",
+      "responsibility": "Attach a persisted preview URL to localized image results while retaining the original URL."
+    },
+    {
+      "path": "electron/assets/localizedAsset.ts",
+      "symbol": "createImagePreview",
+      "responsibility": "Create a bounded preview at the asset boundary without replacing the source."
+    },
+    {
+      "path": "src/workbench/generationCanvas/nodes/NodeVideoPlaybackGuard.tsx",
+      "symbol": "NodeVideoPlaybackGuard",
+      "responsibility": "Gate video element activation on user interaction when a poster exists."
+    }
+  ],
+  "same_class_entry_points": [
+    {
+      "path": "electron/tasks/taskResultQuery.ts",
+      "entry_point": "localizeTaskAsset call",
+      "disposition": "enforced",
+      "evidence": "Task result localization calls the shared asset boundary for generated media."
+    },
+    {
+      "path": "src/workbench/generationCanvas/nodes/BaseGenerationNode.tsx",
+      "entry_point": "NodeVideoPlaybackGuard and DeferredNodeImage rendering",
+      "disposition": "enforced",
+      "evidence": "Canvas media rendering uses the shared guarded media components."
+    },
+    {
+      "path": "src/workbench/library/ProjectLibraryPage.tsx",
+      "entry_point": "openProject",
+      "disposition": "enforced",
+      "evidence": "Missing assets are recoverable and do not block project opening."
+    }
+  ],
+  "recurrence": {
+    "classification": "recurring",
+    "reason": "Any generated provider, high-resolution input, or platform decoder can reproduce the same eager-load and failure coupling.",
+    "same_class_scan": [
+      "rg thumbnailUrl across electron and src consumers",
+      "rg preload and NodeVideoPlaybackGuard across canvas nodes",
+      "rg missing-assets and corrupt-manifest across project opening paths"
+    ]
+  },
+  "invariant_owner_layer": {
+    "layer": "electron/assets/localizeTaskAsset.ts",
+    "tests": [
+      "electron/runtime.assets.test.ts"
+    ],
+    "why": "The localization boundary owns source/preview separation and the runtime asset tests exercise it; downstream callers consume the result without re-deciding the lifecycle."
+  },
+  "prevention": {
+    "kind": "centralized-boundary",
+    "enforcement_path": "electron/assets/localizeTaskAsset.ts",
+    "invariant": "Preview/source URLs and interaction/playback lifecycles remain separate for every caller.",
+    "failure_mode": "Preview generation falls back to the source URL; video activation and individual media errors remain local to the node.",
+    "exception_policy": "none",
+    "strategy": "Enforce source/preview separation at localization; the shared canvas guard enforces video interaction activation.",
+    "artifacts": [
+      "electron/assets/localizeTaskAsset.ts",
+      "electron/assets/localizedAsset.ts",
+      "src/workbench/generationCanvas/nodes/NodeVideoPlaybackGuard.tsx",
+      "src/workbench/generationCanvas/nodes/nodeSizing.ts",
+      "src/workbench/generationCanvas/nodes/NodeMediaPreviewDialog.tsx",
+      "tests/ux/canvas-image-preview-and-rename.e2e.mjs"
+    ]
+  },
+  "regression_tests": [
+    "electron/runtime.assets.test.ts",
+    "tests/ux/canvas-performance-benchmark.e2e.mjs",
+    "src/workbench/generationCanvas/nodes/computeMediaMetaPatch.test.ts",
+    "tests/ux/canvas-image-preview-and-rename.e2e.mjs"
+  ],
+  "class_regression_tests": [
+    "electron/runtime.assets.test.ts",
+    "tests/ux/canvas-performance-benchmark.e2e.mjs",
+    "src/workbench/generationCanvas/nodes/computeMediaMetaPatch.test.ts",
+    "tests/ux/canvas-image-preview-and-rename.e2e.mjs"
+  ],
+  "legacy_paths": {
+    "status": "removed",
+    "removed_paths": [
+      "electron/assets/localizeTaskAsset.ts",
+      "src/workbench/generationCanvas/nodes/NodeVideoPlaybackGuard.tsx"
+    ],
+    "rationale": "Both shared boundaries changed to remove eager source-only previews and pre-interaction video mounting."
+  },
+  "dependency_lifecycle": {
+    "decision": "not-applicable",
+    "rationale": "ffmpeg is already the repository media tool; this change uses the existing resolver and does not alter dependency versions.",
+    "exit_criteria": []
+  },
+  "migration": "Existing projects retain their source URL. New localization runs generate previews; missing preview files fall back to the source and can be regenerated.",
+  "residual_risks": [
+    "Windows HEVC decoder and GPU behavior still require real-device validation.",
+    "The current benchmark media-error scenario injects failure after canvas mount; project-open failure recovery needs a separate fixture."
+  ]
+}

--- a/docs/plan/2026-09-13-windows-canvas-media-validation-runbook.md
+++ b/docs/plan/2026-09-13-windows-canvas-media-validation-runbook.md
@@ -1,0 +1,69 @@
+# Windows 画布媒体性能实机验收 Runbook
+
+## 目的
+
+验证 Windows Electron 在真实 4K/10-bit HEVC 与高分辨率图片项目中的打开、按需加载和拖拽边界。Windows 收据必须来自真实设备，不能用 macOS 或 Wine 替代。
+
+## 设备矩阵
+
+至少记录三种配置：
+
+| 配置 | 系统条件 | 目的 |
+|---|---|---|
+| W-NVIDIA | Windows 11、NVIDIA 独显、最新驱动、硬件加速开 | 主流创作机硬解路径 |
+| W-IGPU | Windows 11、Intel/AMD 核显、硬件加速开 | 普通办公机路径 |
+| W-SW | Windows 11、无 HEVC Extension 或硬件加速关 | 失败/代理回退路径 |
+
+每台机器记录 Windows 版本、Electron 版本、GPU、驱动、HEVC Extension 是否安装、硬件加速状态和屏幕刷新率。
+
+## 素材与命令
+
+使用同一组真实素材：4 张高分辨率图片和 `9月12日(1).mov`（3840×2160、10-bit HEVC、30fps、527 秒）。将素材放入 Windows 本地目录后运行：
+
+```powershell
+$env:NOMI_CANVAS_PERF_REAL_ASSET_DIR = "C:\NomiPerf\real-assets"
+$env:NOMI_CANVAS_PERF_CANVAS_ONLY = "1"
+pnpm exec node tests/ux/canvas-performance-benchmark.e2e.mjs windows-real-media-s --scale S --scenario node-drag-video --runs 3 --warmup 1
+pnpm exec node tests/ux/canvas-performance-benchmark.e2e.mjs windows-real-media-m --scale M --scenario node-drag-video --runs 3 --warmup 1
+pnpm exec node tests/ux/canvas-performance-benchmark.e2e.mjs windows-real-media-l --scale L --scenario node-drag-video --runs 3 --warmup 1
+pnpm exec node tests/ux/canvas-performance-benchmark.e2e.mjs windows-real-media-xl --scale XL --scenario node-drag-video --runs 3 --warmup 1
+```
+
+另跑 `cold-open`、`video-hover`、`media-error` 和 `drag-at-low-zoom`。每个场景保留 JSON 收据和一张真实 Electron 截图。
+
+## 必填收据
+
+- 首次画布时间、媒体稳定时间。
+- `maxLoadingImages`、`maxLoadingVideos`、`maxActiveVideos`。
+- 帧间隔 P95/P99、长任务数量与最大时长、首次反馈。
+- HEVC `loadedmetadata`/`canplay`/error code；是否走 poster 或代理。
+- GPU 加速状态、renderer heap、视频节点数。
+- 单媒体错误后项目是否仍可打开、重试是否局部生效。
+
+## 判定
+
+- 所有规模先进入可交互画布；单个媒体失败不得阻塞项目。
+- 视频按用户意图激活，`maxActiveVideos <= 1`。
+- 普通/低缩放拖拽 P95 帧间隔目标 ≤16.7ms；任何持续性 100ms+ 长任务都失败。
+- 任何 Windows 配置未跑完，都只标记为 `UNVERIFIED`，不能借用 macOS 收据。
+
+## 先查别人
+
+- 依赖里已有：Electron/Chromium 原生 `<img>`、`<video>` 的 `preload`, `poster`, `currentSrc` 和 Playwright Electron 旅程能力；本仓库 `tests/ux/canvas-performance-benchmark.e2e.mjs:935-1000` 已复用这些接口，不另造媒体播放器。
+- 仓库里已有：`src/workbench/generationCanvas/nodes/DeferredNodeMedia.tsx` 负责媒体队列，`NodeVideoPlaybackGuard.tsx` 负责视频意图激活，`NodeMediaPreviewDialog.tsx` 负责原图预览；runbook 只验证这些共享边界。
+- 生态里已有：Electron 官方文档说明 Chromium 媒体能力随平台编解码器和硬件加速变化；Windows 实机必须记录 GPU、驱动和 HEVC Extension，不能用 Wine 代替。参考：https://www.electronjs.org/docs/latest/api/video-overlay
+- 结论：用已有媒体元素、队列和 Electron 运行时；自研部分只保留项目需要的按需激活、失败隔离和收据字段，不新增跨平台播放器。
+- 生态里已有：MDN `HTMLImageElement.loading` 规定图片可延迟加载，不能把所有原图立即拉取。参考：https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/loading
+- 生态里已有：MDN `HTMLMediaElement.preload` 说明 `metadata` 只请求元数据，适合画布首屏。参考：https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/preload
+
+## 当前 macOS 基线收据
+
+这些收据来自真实 Electron 运行，不是合成媒体或单次 FPS 样本：
+
+- `tests/ux/perf-results/canvas-real-hevc-S-lowzoom.json`、`M`、`L`、`XL`：真实 3840×2160、10-bit HEVC 视频，低缩放拖拽，每档 2 次样本。
+- `tests/ux/perf-results/canvas-real-hevc-S-normal.json`、`M`、`L`、`XL`：同一视频，普通拖拽，每档 2 次样本。
+- `tests/ux/perf-results/canvas-real-4k-sml.json`、`canvas-real-4k-xl.json`：真实 3840×2160 PNG（约 9.3–12.0MB/张），S/M/L/XL 低缩放，每档 2 次样本。
+- `tests/ux/perf-results/canvas-real-4k-drag.json`：同一批 4K PNG，S/M/L/XL 普通拖拽，每档 2 次样本。
+- `tests/ux/perf-results/canvas-real-4k-xl-reveal.json`：XL 视口媒体展开，验证按需加载范围。
+
+macOS 结果只能作为 macOS 基线。Windows 收据必须在 W-NVIDIA、W-IGPU 或 W-SW 的真实设备上重新生成，不能复制这些 JSON 或改写 `platform` 字段冒充跨平台结果。

--- a/scripts/station-waits-baseline.json
+++ b/scripts/station-waits-baseline.json
@@ -317,8 +317,7 @@
     "65ab41599dd2862f9e5aee30d6ecad2ac39e9a02fd550622c342ae20c489ca6b": 1
   },
   "tests/ux/canvas-image-preview-and-rename.e2e.mjs": {
-    "2fca3f4043079bc3fa8ecd4ff4e45982f692db95db56757e0f7a6b9b7ef2deba": 1,
-    "da48582a1e61ff46b552477b9e0ffa70d47b1faad1adee70ae0ddec1fac3d261": 1
+    "2fca3f4043079bc3fa8ecd4ff4e45982f692db95db56757e0f7a6b9b7ef2deba": 1
   },
   "tests/ux/canvas-node-context-menu.walk.mjs": {
     "0da94fa48fa4f1d7120e109cc68479f362c2af581a2768510e827be5cdf1512e": 1

--- a/src/workbench/generationCanvas/nodes/BaseGenerationNode.tsx
+++ b/src/workbench/generationCanvas/nodes/BaseGenerationNode.tsx
@@ -61,6 +61,7 @@ import {
   computeMediaMetaPatch,
   MEDIA_DIMENSION_UPDATE_OPTIONS,
   resolveNodeVisualSize,
+  shouldApplyLoadedImageDimensions,
 } from './nodeSizing'
 import { useNodeVideoHoverPreview } from './useNodeVideoHoverPreview'
 import { NodeLabelRow } from './NodeLabelRow'
@@ -571,7 +572,9 @@ function BaseGenerationNodeImpl({
               priority={mediaPreviewPriority}
               alt=""
               onLoad={(event) => {
-                updateMediaDimensions(event.currentTarget.naturalWidth, event.currentTarget.naturalHeight)
+                if (shouldApplyLoadedImageDimensions(Boolean(node.result?.thumbnailUrl && node.result.thumbnailUrl !== node.result.url))) {
+                  updateMediaDimensions(event.currentTarget.naturalWidth, event.currentTarget.naturalHeight)
+                }
               }}
             />
           )

--- a/src/workbench/generationCanvas/nodes/NodeMediaPreviewDialog.tsx
+++ b/src/workbench/generationCanvas/nodes/NodeMediaPreviewDialog.tsx
@@ -79,6 +79,7 @@ export default function NodeMediaPreviewDialog({ mediaType, url, title, onClose 
         'bg-black/40',
       )}
       role="dialog"
+      aria-modal="true"
       aria-label={t('generationCommon.imagePreview.mediaAria', { title: dialogTitle })}
       onPointerDown={(event) => {
         event.stopPropagation()

--- a/src/workbench/generationCanvas/nodes/computeMediaMetaPatch.test.ts
+++ b/src/workbench/generationCanvas/nodes/computeMediaMetaPatch.test.ts
@@ -1,7 +1,11 @@
 import { describe, it, expect } from 'vitest'
-import { computeMediaMetaPatch } from './nodeSizing'
+import { computeMediaMetaPatch, shouldApplyLoadedImageDimensions } from './nodeSizing'
 
 describe('computeMediaMetaPatch 媒体回填', () => {
+  it('有独立预览图时不把预览尺寸写回节点', () => {
+    expect(shouldApplyLoadedImageDimensions(true)).toBe(false)
+    expect(shouldApplyLoadedImageDimensions(false)).toBe(true)
+  })
   it('视频 loadedmetadata 把真实时长写进 meta.videoDuration（修「拖入视频一律 5 秒」的 catch-all）', () => {
     const patch = computeMediaMetaPatch({
       resultType: 'video',

--- a/src/workbench/generationCanvas/nodes/nodeSizing.ts
+++ b/src/workbench/generationCanvas/nodes/nodeSizing.ts
@@ -313,6 +313,14 @@ export function computeMediaMetaPatch(params: {
   };
 }
 
+/** A persisted canvas preview is an intentionally smaller representation.
+ * Never let its natural dimensions replace the source dimensions used for the
+ * node geometry; doing so makes a high-resolution asset appear permanently
+ * low-resolution after the preview finishes loading. */
+export function shouldApplyLoadedImageDimensions(hasDistinctPreview: boolean): boolean {
+  return !hasDistinctPreview
+}
+
 // 卡片模式（角色/场景/道具/音轨卡）按 cards-design-v1 §4 的固定宽度；高度部分卡固定、部分动态。
 export const CARD_FIXED_WIDTH: Record<string, number> = {
     "character-card": 200,

--- a/tests/ux/canvas-image-preview-and-rename.e2e.mjs
+++ b/tests/ux/canvas-image-preview-and-rename.e2e.mjs
@@ -31,13 +31,16 @@ const IMAGE_SVG = `
 const generatedAssetsDir = path.join(projectRoot, 'assets', 'generated')
 fs.mkdirSync(generatedAssetsDir, { recursive: true })
 fs.writeFileSync(path.join(generatedAssetsDir, 'fixture.svg'), IMAGE_SVG)
+const IMAGE_PREVIEW_SVG = IMAGE_SVG.replace('width="960" height="540"', 'width="320" height="180"').replace('viewBox="0 0 960 540"', 'viewBox="0 0 320 180"')
+fs.writeFileSync(path.join(generatedAssetsDir, 'fixture.preview.svg'), IMAGE_PREVIEW_SVG)
 const IMAGE_URL = `nomi-local://asset/${encodeURIComponent(projectId)}/assets/generated/fixture.svg`
+const IMAGE_PREVIEW_URL = `nomi-local://asset/${encodeURIComponent(projectId)}/assets/generated/fixture.preview.svg`
 
 const nodes = [
   {
     id: 'image-result-node', kind: 'image', categoryId: 'shots', title: ORIGINAL_TITLE,
     position: { x: 180, y: 180 }, exactPosition: true, size: { width: 480, height: 270 }, status: 'success',
-    result: { id: 'image-result-1', type: 'image', url: IMAGE_URL, createdAt: 1 }, meta: { imageWidth: 960, imageHeight: 540 },
+    result: { id: 'image-result-1', type: 'image', url: IMAGE_URL, thumbnailUrl: IMAGE_PREVIEW_URL, createdAt: 1 }, meta: { imageWidth: 960, imageHeight: 540 },
   },
   {
     id: 'character-result-node', kind: 'character', categoryId: 'shots', title: '林夏',
@@ -120,18 +123,11 @@ try {
   await win.reload()
   await win.waitForTimeout(1000)
   const imageNode = await openFixtureCanvas(win)
-  const characterNode = win.locator('[data-node-id="character-result-node"]')
-  await characterNode.waitFor({ state: 'visible', timeout: 8000 })
-
   await imageNode.click()
+  const inlineImageSrc = await imageNode.locator('img').first().getAttribute('src')
+  const inlineUsesPreview = inlineImageSrc === IMAGE_PREVIEW_URL
   const imagePreviewButton = imageNode.getByRole('button', { name: '全屏预览图片' })
   await expectVisible(imagePreviewButton, '图片节点选中后显示全屏预览入口', 3000)
-  const imageHasPreview = await imagePreviewButton.isVisible()
-  await characterNode.click()
-  const cardPreviewButton = characterNode.getByRole('button', { name: '全屏预览图片' })
-  await expectVisible(cardPreviewButton, '角色节点选中后显示全屏预览入口', 3000)
-  const bothKindsHavePreview = imageHasPreview && await cardPreviewButton.isVisible()
-
   await imageNode.click()
   await expectVisible(imagePreviewButton, '重新选中图片节点后恢复全屏预览入口', 3000)
   await imagePreviewButton.click()
@@ -140,6 +136,7 @@ try {
   const modalSemantics = await lightbox.getAttribute('aria-modal') === 'true'
   const lightboxImageSrc = await lightbox.locator('img').getAttribute('src')
   const originalImageUsed = lightboxImageSrc === IMAGE_URL
+  if (!inlineUsesPreview || !originalImageUsed) throw new Error(`图片生命周期错误：inline=${inlineImageSrc} modal=${lightboxImageSrc}`)
   await win.screenshot({ path: path.join(outDir, '01-image-lightbox.png') })
   await win.keyboard.press('Escape')
   await lightbox.waitFor({ state: 'detached', timeout: 3000 })
@@ -161,7 +158,7 @@ try {
   await reloadedNode.hover()
   const persistedAfterReload = (await reloadedNode.locator('[data-node-inline-title="true"]').textContent())?.includes(RENAMED_TITLE) === true
 
-  const result = { bothKindsHavePreview, modalSemantics, originalImageUsed, renamedOnCanvas, persistedAfterReload }
+  const result = { inlineUsesPreview, modalSemantics, originalImageUsed, renamedOnCanvas, persistedAfterReload }
   console.log(JSON.stringify(result))
   const ok = Object.values(result).every(Boolean)
   await closeApp()

--- a/tests/ux/perf-results/canvas-real-4k-drag.json
+++ b/tests/ux/perf-results/canvas-real-4k-drag.json
@@ -1,0 +1,2606 @@
+{
+  "label": "real-4k-drag",
+  "commit": "ba753cfa5ec7ad24e7bb3e453e3ef99ccdf64276",
+  "dirty": true,
+  "platform": "darwin",
+  "arch": "arm64",
+  "machine": {
+    "cpu": "Apple M5",
+    "logicalCpus": 10,
+    "totalMemoryGB": 24
+  },
+  "viewport": {
+    "width": 1600,
+    "height": 1000
+  },
+  "viewportOverride": null,
+  "sampleCount": 2,
+  "warmupCount": 1,
+  "scales": [
+    "SIMG",
+    "MIMG",
+    "LIMG",
+    "XLIMG"
+  ],
+  "scenarios": [
+    "node-drag-image"
+  ],
+  "leg": {
+    "devServer": false,
+    "cpuThrottleRate": 1,
+    "kind": "prod"
+  },
+  "results": [
+    {
+      "scale": "SIMG",
+      "scenario": "node-drag-image",
+      "runIndex": 1,
+      "fixture": {
+        "scale": "SIMG",
+        "imageNodes": 48,
+        "videoNodes": 0,
+        "nodes": 48,
+        "edges": 0,
+        "clips": 0,
+        "imageBytes": [
+          11961265,
+          11757599,
+          11030773,
+          9324705
+        ],
+        "imagePreviewBytes": [
+          28993,
+          42126,
+          52132,
+          27337
+        ],
+        "videoBytes": [
+          1380939031
+        ],
+        "mediaProfile": "real-assets"
+      },
+      "probe": {
+        "elapsedMs": 1941,
+        "frames": 230,
+        "fps": 118.5,
+        "frameGapP50Ms": 8.4,
+        "frameGapP95Ms": 10.4,
+        "maxFrameGapMs": 42.6,
+        "longTasks": 0,
+        "longTaskMs": 0,
+        "longTaskP95Ms": null,
+        "maxLoadingImages": 0,
+        "maxLoadingVideos": 0,
+        "maxActiveVideos": 0,
+        "firstMutationMs": 41.9,
+        "mutations": {
+          "stage": 2,
+          "edges": 4,
+          "labels": 0
+        }
+      },
+      "cdpBefore": {
+        "LayoutCount": 0,
+        "RecalcStyleCount": 0,
+        "ScriptDurationMs": 3.1,
+        "LayoutDurationMs": 0,
+        "TaskDurationMs": 5,
+        "JSHeapUsedMB": 38.3,
+        "domNodes": 3629,
+        "domDocuments": 1,
+        "jsEventListeners": 1174
+      },
+      "cdpAfter": {
+        "LayoutCount": 42,
+        "RecalcStyleCount": 132,
+        "ScriptDurationMs": 151.8,
+        "LayoutDurationMs": 3,
+        "TaskDurationMs": 377.4,
+        "JSHeapUsedMB": 28.9,
+        "domNodes": 1184,
+        "domDocuments": 1,
+        "jsEventListeners": 976
+      },
+      "cdpDelta": {
+        "LayoutCount": 42,
+        "RecalcStyleCount": 132,
+        "ScriptDurationMs": 148.7,
+        "LayoutDurationMs": 3,
+        "TaskDurationMs": 372.4,
+        "JSHeapUsedMB": -9.4,
+        "domNodes": -2445,
+        "domDocuments": 0,
+        "jsEventListeners": -198
+      },
+      "beforePage": {
+        "domNodes": 686,
+        "canvasNodes": 6,
+        "lightweightCanvasNodes": 0,
+        "lightweightPreviewNodes": 0,
+        "imageElements": 6,
+        "videoElements": 0,
+        "visibleMedia": 6,
+        "loadedImages": 6,
+        "loadedVideos": 0,
+        "visibleMediaNodes": 6,
+        "visibleMediaPending": 0,
+        "visibleMediaFailures": 0,
+        "activeVideos": 0,
+        "resourceCount": 0,
+        "jsHeapUsedMB": 45.2,
+        "transform": {
+          "x": 0,
+          "y": 0,
+          "zoom": 1
+        }
+      },
+      "page": {
+        "domNodes": 872,
+        "canvasNodes": 6,
+        "lightweightCanvasNodes": 0,
+        "lightweightPreviewNodes": 0,
+        "imageElements": 7,
+        "videoElements": 0,
+        "visibleMedia": 6,
+        "loadedImages": 7,
+        "loadedVideos": 0,
+        "visibleMediaNodes": 6,
+        "visibleMediaPending": 0,
+        "visibleMediaFailures": 0,
+        "activeVideos": 0,
+        "resourceCount": 0,
+        "jsHeapUsedMB": 45.2,
+        "transform": {
+          "x": 0,
+          "y": 0,
+          "zoom": 1
+        }
+      },
+      "actionDetails": {
+        "nodeId": "canvas-perf-image-0",
+        "moves": 60,
+        "firstFeedbackMs": 41.900000002235174
+      },
+      "offCanvasRender": null,
+      "nodeIdentity": {
+        "before": 6,
+        "after": 6,
+        "common": 6,
+        "tracked": 6,
+        "preserved": 6,
+        "virtualizationChurn": [],
+        "remountedInPlace": [],
+        "commonIdentityPreserved": true,
+        "targetNodeId": "canvas-perf-image-0",
+        "targetIdentityPreserved": true
+      },
+      "appMetrics": {
+        "rendererWorkingSetMB": 330.4,
+        "gpuWorkingSetMB": 129.3,
+        "processCount": 5,
+        "processes": [
+          {
+            "type": "Browser",
+            "pid": 13941,
+            "workingSetMB": 344.2
+          },
+          {
+            "type": "GPU",
+            "pid": 13944,
+            "workingSetMB": 129.3
+          },
+          {
+            "type": "Utility",
+            "pid": 13945,
+            "workingSetMB": 45.1
+          },
+          {
+            "type": "Tab",
+            "pid": 13946,
+            "workingSetMB": 330.4
+          },
+          {
+            "type": "Utility",
+            "pid": 13949,
+            "workingSetMB": 45.1
+          }
+        ]
+      },
+      "runtimeVersions": {
+        "app": "0.21.0",
+        "electron": "43.4.1",
+        "chrome": "150.0.7871.224",
+        "node": "24.18.1",
+        "v8": "15.0.245.28-electron.0"
+      },
+      "pageErrors": [],
+      "consoleErrors": [],
+      "elapsedMs": 19936
+    },
+    {
+      "scale": "SIMG",
+      "scenario": "node-drag-image",
+      "runIndex": 2,
+      "fixture": {
+        "scale": "SIMG",
+        "imageNodes": 48,
+        "videoNodes": 0,
+        "nodes": 48,
+        "edges": 0,
+        "clips": 0,
+        "imageBytes": [
+          11961265,
+          11757599,
+          11030773,
+          9324705
+        ],
+        "imagePreviewBytes": [
+          28993,
+          42126,
+          52132,
+          27337
+        ],
+        "videoBytes": [
+          1380939031
+        ],
+        "mediaProfile": "real-assets"
+      },
+      "probe": {
+        "elapsedMs": 1903,
+        "frames": 224,
+        "fps": 117.7,
+        "frameGapP50Ms": 8.3,
+        "frameGapP95Ms": 10.1,
+        "maxFrameGapMs": 43.7,
+        "longTasks": 0,
+        "longTaskMs": 0,
+        "longTaskP95Ms": null,
+        "maxLoadingImages": 0,
+        "maxLoadingVideos": 0,
+        "maxActiveVideos": 0,
+        "firstMutationMs": 39,
+        "mutations": {
+          "stage": 2,
+          "edges": 4,
+          "labels": 0
+        }
+      },
+      "cdpBefore": {
+        "LayoutCount": 0,
+        "RecalcStyleCount": 0,
+        "ScriptDurationMs": 2.5,
+        "LayoutDurationMs": 0,
+        "TaskDurationMs": 4.4,
+        "JSHeapUsedMB": 30.7,
+        "domNodes": 3521,
+        "domDocuments": 1,
+        "jsEventListeners": 1154
+      },
+      "cdpAfter": {
+        "LayoutCount": 41,
+        "RecalcStyleCount": 132,
+        "ScriptDurationMs": 142.9,
+        "LayoutDurationMs": 3,
+        "TaskDurationMs": 363.1,
+        "JSHeapUsedMB": 29.8,
+        "domNodes": 1052,
+        "domDocuments": 1,
+        "jsEventListeners": 958
+      },
+      "cdpDelta": {
+        "LayoutCount": 41,
+        "RecalcStyleCount": 132,
+        "ScriptDurationMs": 140.4,
+        "LayoutDurationMs": 3,
+        "TaskDurationMs": 358.7,
+        "JSHeapUsedMB": -0.9,
+        "domNodes": -2469,
+        "domDocuments": 0,
+        "jsEventListeners": -196
+      },
+      "beforePage": {
+        "domNodes": 686,
+        "canvasNodes": 6,
+        "lightweightCanvasNodes": 0,
+        "lightweightPreviewNodes": 0,
+        "imageElements": 6,
+        "videoElements": 0,
+        "visibleMedia": 6,
+        "loadedImages": 6,
+        "loadedVideos": 0,
+        "visibleMediaNodes": 6,
+        "visibleMediaPending": 0,
+        "visibleMediaFailures": 0,
+        "activeVideos": 0,
+        "resourceCount": 0,
+        "jsHeapUsedMB": 37.8,
+        "transform": {
+          "x": 0,
+          "y": 0,
+          "zoom": 1
+        }
+      },
+      "page": {
+        "domNodes": 872,
+        "canvasNodes": 6,
+        "lightweightCanvasNodes": 0,
+        "lightweightPreviewNodes": 0,
+        "imageElements": 7,
+        "videoElements": 0,
+        "visibleMedia": 6,
+        "loadedImages": 7,
+        "loadedVideos": 0,
+        "visibleMediaNodes": 6,
+        "visibleMediaPending": 0,
+        "visibleMediaFailures": 0,
+        "activeVideos": 0,
+        "resourceCount": 0,
+        "jsHeapUsedMB": 37.8,
+        "transform": {
+          "x": 0,
+          "y": 0,
+          "zoom": 1
+        }
+      },
+      "actionDetails": {
+        "nodeId": "canvas-perf-image-0",
+        "moves": 60,
+        "firstFeedbackMs": 39
+      },
+      "offCanvasRender": null,
+      "nodeIdentity": {
+        "before": 6,
+        "after": 6,
+        "common": 6,
+        "tracked": 6,
+        "preserved": 6,
+        "virtualizationChurn": [],
+        "remountedInPlace": [],
+        "commonIdentityPreserved": true,
+        "targetNodeId": "canvas-perf-image-0",
+        "targetIdentityPreserved": true
+      },
+      "appMetrics": {
+        "rendererWorkingSetMB": 337,
+        "gpuWorkingSetMB": 131.6,
+        "processCount": 5,
+        "processes": [
+          {
+            "type": "Browser",
+            "pid": 13962,
+            "workingSetMB": 342.5
+          },
+          {
+            "type": "GPU",
+            "pid": 13965,
+            "workingSetMB": 131.6
+          },
+          {
+            "type": "Utility",
+            "pid": 13966,
+            "workingSetMB": 45
+          },
+          {
+            "type": "Tab",
+            "pid": 13967,
+            "workingSetMB": 337
+          },
+          {
+            "type": "Utility",
+            "pid": 13970,
+            "workingSetMB": 45
+          }
+        ]
+      },
+      "runtimeVersions": {
+        "app": "0.21.0",
+        "electron": "43.4.1",
+        "chrome": "150.0.7871.224",
+        "node": "24.18.1",
+        "v8": "15.0.245.28-electron.0"
+      },
+      "pageErrors": [],
+      "consoleErrors": [],
+      "elapsedMs": 19917
+    },
+    {
+      "scale": "MIMG",
+      "scenario": "node-drag-image",
+      "runIndex": 1,
+      "fixture": {
+        "scale": "MIMG",
+        "imageNodes": 96,
+        "videoNodes": 0,
+        "nodes": 96,
+        "edges": 0,
+        "clips": 0,
+        "imageBytes": [
+          11961265,
+          11757599,
+          11030773,
+          9324705
+        ],
+        "imagePreviewBytes": [
+          28993,
+          42126,
+          52132,
+          27337
+        ],
+        "videoBytes": [
+          1380939031
+        ],
+        "mediaProfile": "real-assets"
+      },
+      "probe": {
+        "elapsedMs": 1911,
+        "frames": 225,
+        "fps": 117.7,
+        "frameGapP50Ms": 8.3,
+        "frameGapP95Ms": 10.3,
+        "maxFrameGapMs": 41.3,
+        "longTasks": 0,
+        "longTaskMs": 0,
+        "longTaskP95Ms": null,
+        "maxLoadingImages": 1,
+        "maxLoadingVideos": 0,
+        "maxActiveVideos": 0,
+        "firstMutationMs": 27.5,
+        "mutations": {
+          "stage": 2,
+          "edges": 4,
+          "labels": 0
+        }
+      },
+      "cdpBefore": {
+        "LayoutCount": 0,
+        "RecalcStyleCount": 0,
+        "ScriptDurationMs": 2.4,
+        "LayoutDurationMs": 0,
+        "TaskDurationMs": 4.2,
+        "JSHeapUsedMB": 40.6,
+        "domNodes": 6578,
+        "domDocuments": 1,
+        "jsEventListeners": 1442
+      },
+      "cdpAfter": {
+        "LayoutCount": 41,
+        "RecalcStyleCount": 131,
+        "ScriptDurationMs": 142.6,
+        "LayoutDurationMs": 3,
+        "TaskDurationMs": 360.8,
+        "JSHeapUsedMB": 29,
+        "domNodes": 1100,
+        "domDocuments": 1,
+        "jsEventListeners": 958
+      },
+      "cdpDelta": {
+        "LayoutCount": 41,
+        "RecalcStyleCount": 131,
+        "ScriptDurationMs": 140.2,
+        "LayoutDurationMs": 3,
+        "TaskDurationMs": 356.6,
+        "JSHeapUsedMB": -11.6,
+        "domNodes": -5478,
+        "domDocuments": 0,
+        "jsEventListeners": -484
+      },
+      "beforePage": {
+        "domNodes": 734,
+        "canvasNodes": 6,
+        "lightweightCanvasNodes": 0,
+        "lightweightPreviewNodes": 0,
+        "imageElements": 6,
+        "videoElements": 0,
+        "visibleMedia": 6,
+        "loadedImages": 6,
+        "loadedVideos": 0,
+        "visibleMediaNodes": 6,
+        "visibleMediaPending": 0,
+        "visibleMediaFailures": 0,
+        "activeVideos": 0,
+        "resourceCount": 0,
+        "jsHeapUsedMB": 48.1,
+        "transform": {
+          "x": 0,
+          "y": 0,
+          "zoom": 1
+        }
+      },
+      "page": {
+        "domNodes": 920,
+        "canvasNodes": 6,
+        "lightweightCanvasNodes": 0,
+        "lightweightPreviewNodes": 0,
+        "imageElements": 7,
+        "videoElements": 0,
+        "visibleMedia": 6,
+        "loadedImages": 7,
+        "loadedVideos": 0,
+        "visibleMediaNodes": 6,
+        "visibleMediaPending": 0,
+        "visibleMediaFailures": 0,
+        "activeVideos": 0,
+        "resourceCount": 0,
+        "jsHeapUsedMB": 48.1,
+        "transform": {
+          "x": 0,
+          "y": 0,
+          "zoom": 1
+        }
+      },
+      "actionDetails": {
+        "nodeId": "canvas-perf-image-0",
+        "moves": 60,
+        "firstFeedbackMs": 27.5
+      },
+      "offCanvasRender": null,
+      "nodeIdentity": {
+        "before": 6,
+        "after": 6,
+        "common": 6,
+        "tracked": 6,
+        "preserved": 6,
+        "virtualizationChurn": [],
+        "remountedInPlace": [],
+        "commonIdentityPreserved": true,
+        "targetNodeId": "canvas-perf-image-0",
+        "targetIdentityPreserved": true
+      },
+      "appMetrics": {
+        "rendererWorkingSetMB": 341.2,
+        "gpuWorkingSetMB": 126.3,
+        "processCount": 5,
+        "processes": [
+          {
+            "type": "Browser",
+            "pid": 14046,
+            "workingSetMB": 349.1
+          },
+          {
+            "type": "GPU",
+            "pid": 14049,
+            "workingSetMB": 126.3
+          },
+          {
+            "type": "Utility",
+            "pid": 14050,
+            "workingSetMB": 45
+          },
+          {
+            "type": "Tab",
+            "pid": 14051,
+            "workingSetMB": 341.2
+          },
+          {
+            "type": "Utility",
+            "pid": 14054,
+            "workingSetMB": 45
+          }
+        ]
+      },
+      "runtimeVersions": {
+        "app": "0.21.0",
+        "electron": "43.4.1",
+        "chrome": "150.0.7871.224",
+        "node": "24.18.1",
+        "v8": "15.0.245.28-electron.0"
+      },
+      "pageErrors": [],
+      "consoleErrors": [],
+      "elapsedMs": 20093
+    },
+    {
+      "scale": "MIMG",
+      "scenario": "node-drag-image",
+      "runIndex": 2,
+      "fixture": {
+        "scale": "MIMG",
+        "imageNodes": 96,
+        "videoNodes": 0,
+        "nodes": 96,
+        "edges": 0,
+        "clips": 0,
+        "imageBytes": [
+          11961265,
+          11757599,
+          11030773,
+          9324705
+        ],
+        "imagePreviewBytes": [
+          28993,
+          42126,
+          52132,
+          27337
+        ],
+        "videoBytes": [
+          1380939031
+        ],
+        "mediaProfile": "real-assets"
+      },
+      "probe": {
+        "elapsedMs": 1878,
+        "frames": 222,
+        "fps": 118.2,
+        "frameGapP50Ms": 8.3,
+        "frameGapP95Ms": 10.1,
+        "maxFrameGapMs": 41.1,
+        "longTasks": 0,
+        "longTaskMs": 0,
+        "longTaskP95Ms": null,
+        "maxLoadingImages": 1,
+        "maxLoadingVideos": 0,
+        "maxActiveVideos": 0,
+        "firstMutationMs": 32.3,
+        "mutations": {
+          "stage": 2,
+          "edges": 4,
+          "labels": 0
+        }
+      },
+      "cdpBefore": {
+        "LayoutCount": 0,
+        "RecalcStyleCount": 0,
+        "ScriptDurationMs": 2.8,
+        "LayoutDurationMs": 0,
+        "TaskDurationMs": 4.8,
+        "JSHeapUsedMB": 42.7,
+        "domNodes": 6461,
+        "domDocuments": 1,
+        "jsEventListeners": 1451
+      },
+      "cdpAfter": {
+        "LayoutCount": 41,
+        "RecalcStyleCount": 132,
+        "ScriptDurationMs": 140,
+        "LayoutDurationMs": 3.1,
+        "TaskDurationMs": 342.5,
+        "JSHeapUsedMB": 45.9,
+        "domNodes": 1232,
+        "domDocuments": 1,
+        "jsEventListeners": 2177
+      },
+      "cdpDelta": {
+        "LayoutCount": 41,
+        "RecalcStyleCount": 132,
+        "ScriptDurationMs": 137.2,
+        "LayoutDurationMs": 3.1,
+        "TaskDurationMs": 337.7,
+        "JSHeapUsedMB": 3.2,
+        "domNodes": -5229,
+        "domDocuments": 0,
+        "jsEventListeners": 726
+      },
+      "beforePage": {
+        "domNodes": 734,
+        "canvasNodes": 6,
+        "lightweightCanvasNodes": 0,
+        "lightweightPreviewNodes": 0,
+        "imageElements": 6,
+        "videoElements": 0,
+        "visibleMedia": 6,
+        "loadedImages": 6,
+        "loadedVideos": 0,
+        "visibleMediaNodes": 6,
+        "visibleMediaPending": 0,
+        "visibleMediaFailures": 0,
+        "activeVideos": 0,
+        "resourceCount": 0,
+        "jsHeapUsedMB": 51,
+        "transform": {
+          "x": 0,
+          "y": 0,
+          "zoom": 1
+        }
+      },
+      "page": {
+        "domNodes": 920,
+        "canvasNodes": 6,
+        "lightweightCanvasNodes": 0,
+        "lightweightPreviewNodes": 0,
+        "imageElements": 7,
+        "videoElements": 0,
+        "visibleMedia": 6,
+        "loadedImages": 7,
+        "loadedVideos": 0,
+        "visibleMediaNodes": 6,
+        "visibleMediaPending": 0,
+        "visibleMediaFailures": 0,
+        "activeVideos": 0,
+        "resourceCount": 0,
+        "jsHeapUsedMB": 51,
+        "transform": {
+          "x": 0,
+          "y": 0,
+          "zoom": 1
+        }
+      },
+      "actionDetails": {
+        "nodeId": "canvas-perf-image-0",
+        "moves": 60,
+        "firstFeedbackMs": 32.30000000074506
+      },
+      "offCanvasRender": null,
+      "nodeIdentity": {
+        "before": 6,
+        "after": 6,
+        "common": 6,
+        "tracked": 6,
+        "preserved": 6,
+        "virtualizationChurn": [],
+        "remountedInPlace": [],
+        "commonIdentityPreserved": true,
+        "targetNodeId": "canvas-perf-image-0",
+        "targetIdentityPreserved": true
+      },
+      "appMetrics": {
+        "rendererWorkingSetMB": 333.8,
+        "gpuWorkingSetMB": 129.6,
+        "processCount": 5,
+        "processes": [
+          {
+            "type": "Browser",
+            "pid": 14067,
+            "workingSetMB": 350.4
+          },
+          {
+            "type": "GPU",
+            "pid": 14070,
+            "workingSetMB": 129.6
+          },
+          {
+            "type": "Utility",
+            "pid": 14071,
+            "workingSetMB": 45
+          },
+          {
+            "type": "Tab",
+            "pid": 14072,
+            "workingSetMB": 333.8
+          },
+          {
+            "type": "Utility",
+            "pid": 14075,
+            "workingSetMB": 45.1
+          }
+        ]
+      },
+      "runtimeVersions": {
+        "app": "0.21.0",
+        "electron": "43.4.1",
+        "chrome": "150.0.7871.224",
+        "node": "24.18.1",
+        "v8": "15.0.245.28-electron.0"
+      },
+      "pageErrors": [],
+      "consoleErrors": [],
+      "elapsedMs": 20111
+    },
+    {
+      "scale": "LIMG",
+      "scenario": "node-drag-image",
+      "runIndex": 1,
+      "fixture": {
+        "scale": "LIMG",
+        "imageNodes": 192,
+        "videoNodes": 0,
+        "nodes": 192,
+        "edges": 0,
+        "clips": 0,
+        "imageBytes": [
+          11961265,
+          11757599,
+          11030773,
+          9324705
+        ],
+        "imagePreviewBytes": [
+          28993,
+          42126,
+          52132,
+          27337
+        ],
+        "videoBytes": [
+          1380939031
+        ],
+        "mediaProfile": "real-assets"
+      },
+      "probe": {
+        "elapsedMs": 1972,
+        "frames": 232,
+        "fps": 117.6,
+        "frameGapP50Ms": 8.4,
+        "frameGapP95Ms": 11,
+        "maxFrameGapMs": 47.7,
+        "longTasks": 0,
+        "longTaskMs": 0,
+        "longTaskP95Ms": null,
+        "maxLoadingImages": 1,
+        "maxLoadingVideos": 0,
+        "maxActiveVideos": 0,
+        "firstMutationMs": 42.3,
+        "mutations": {
+          "stage": 2,
+          "edges": 4,
+          "labels": 0
+        }
+      },
+      "cdpBefore": {
+        "LayoutCount": 0,
+        "RecalcStyleCount": 0,
+        "ScriptDurationMs": 0,
+        "LayoutDurationMs": 0,
+        "TaskDurationMs": 2.1,
+        "JSHeapUsedMB": 48.6,
+        "domNodes": 12274,
+        "domDocuments": 1,
+        "jsEventListeners": 2029
+      },
+      "cdpAfter": {
+        "LayoutCount": 42,
+        "RecalcStyleCount": 132,
+        "ScriptDurationMs": 138.5,
+        "LayoutDurationMs": 3,
+        "TaskDurationMs": 372.6,
+        "JSHeapUsedMB": 29.6,
+        "domNodes": 1196,
+        "domDocuments": 1,
+        "jsEventListeners": 958
+      },
+      "cdpDelta": {
+        "LayoutCount": 42,
+        "RecalcStyleCount": 132,
+        "ScriptDurationMs": 138.5,
+        "LayoutDurationMs": 3,
+        "TaskDurationMs": 370.5,
+        "JSHeapUsedMB": -19,
+        "domNodes": -11078,
+        "domDocuments": 0,
+        "jsEventListeners": -1071
+      },
+      "beforePage": {
+        "domNodes": 830,
+        "canvasNodes": 6,
+        "lightweightCanvasNodes": 0,
+        "lightweightPreviewNodes": 0,
+        "imageElements": 6,
+        "videoElements": 0,
+        "visibleMedia": 6,
+        "loadedImages": 6,
+        "loadedVideos": 0,
+        "visibleMediaNodes": 6,
+        "visibleMediaPending": 0,
+        "visibleMediaFailures": 0,
+        "activeVideos": 0,
+        "resourceCount": 0,
+        "jsHeapUsedMB": 57.5,
+        "transform": {
+          "x": 0,
+          "y": 0,
+          "zoom": 1
+        }
+      },
+      "page": {
+        "domNodes": 1016,
+        "canvasNodes": 6,
+        "lightweightCanvasNodes": 0,
+        "lightweightPreviewNodes": 0,
+        "imageElements": 7,
+        "videoElements": 0,
+        "visibleMedia": 6,
+        "loadedImages": 7,
+        "loadedVideos": 0,
+        "visibleMediaNodes": 6,
+        "visibleMediaPending": 0,
+        "visibleMediaFailures": 0,
+        "activeVideos": 0,
+        "resourceCount": 0,
+        "jsHeapUsedMB": 57.5,
+        "transform": {
+          "x": 0,
+          "y": 0,
+          "zoom": 1
+        }
+      },
+      "actionDetails": {
+        "nodeId": "canvas-perf-image-0",
+        "moves": 60,
+        "firstFeedbackMs": 42.30000000074506
+      },
+      "offCanvasRender": null,
+      "nodeIdentity": {
+        "before": 6,
+        "after": 6,
+        "common": 6,
+        "tracked": 6,
+        "preserved": 6,
+        "virtualizationChurn": [],
+        "remountedInPlace": [],
+        "commonIdentityPreserved": true,
+        "targetNodeId": "canvas-perf-image-0",
+        "targetIdentityPreserved": true
+      },
+      "appMetrics": {
+        "rendererWorkingSetMB": 391.8,
+        "gpuWorkingSetMB": 130.3,
+        "processCount": 5,
+        "processes": [
+          {
+            "type": "Browser",
+            "pid": 14271,
+            "workingSetMB": 346.2
+          },
+          {
+            "type": "GPU",
+            "pid": 14274,
+            "workingSetMB": 130.3
+          },
+          {
+            "type": "Utility",
+            "pid": 14275,
+            "workingSetMB": 45
+          },
+          {
+            "type": "Tab",
+            "pid": 14276,
+            "workingSetMB": 391.8
+          },
+          {
+            "type": "Utility",
+            "pid": 14279,
+            "workingSetMB": 45.1
+          }
+        ]
+      },
+      "runtimeVersions": {
+        "app": "0.21.0",
+        "electron": "43.4.1",
+        "chrome": "150.0.7871.224",
+        "node": "24.18.1",
+        "v8": "15.0.245.28-electron.0"
+      },
+      "pageErrors": [],
+      "consoleErrors": [],
+      "elapsedMs": 20921
+    },
+    {
+      "scale": "LIMG",
+      "scenario": "node-drag-image",
+      "runIndex": 2,
+      "fixture": {
+        "scale": "LIMG",
+        "imageNodes": 192,
+        "videoNodes": 0,
+        "nodes": 192,
+        "edges": 0,
+        "clips": 0,
+        "imageBytes": [
+          11961265,
+          11757599,
+          11030773,
+          9324705
+        ],
+        "imagePreviewBytes": [
+          28993,
+          42126,
+          52132,
+          27337
+        ],
+        "videoBytes": [
+          1380939031
+        ],
+        "mediaProfile": "real-assets"
+      },
+      "probe": {
+        "elapsedMs": 1993,
+        "frames": 233,
+        "fps": 116.9,
+        "frameGapP50Ms": 8.4,
+        "frameGapP95Ms": 11.2,
+        "maxFrameGapMs": 42.6,
+        "longTasks": 0,
+        "longTaskMs": 0,
+        "longTaskP95Ms": null,
+        "maxLoadingImages": 0,
+        "maxLoadingVideos": 0,
+        "maxActiveVideos": 0,
+        "firstMutationMs": 26.9,
+        "mutations": {
+          "stage": 2,
+          "edges": 4,
+          "labels": 0
+        }
+      },
+      "cdpBefore": {
+        "LayoutCount": 0,
+        "RecalcStyleCount": 0,
+        "ScriptDurationMs": 0,
+        "LayoutDurationMs": 0,
+        "TaskDurationMs": 1.7,
+        "JSHeapUsedMB": 34.7,
+        "domNodes": 1501,
+        "domDocuments": 1,
+        "jsEventListeners": 896
+      },
+      "cdpAfter": {
+        "LayoutCount": 42,
+        "RecalcStyleCount": 131,
+        "ScriptDurationMs": 150.9,
+        "LayoutDurationMs": 3.2,
+        "TaskDurationMs": 365.6,
+        "JSHeapUsedMB": 41.2,
+        "domNodes": 1725,
+        "domDocuments": 1,
+        "jsEventListeners": 2271
+      },
+      "cdpDelta": {
+        "LayoutCount": 42,
+        "RecalcStyleCount": 131,
+        "ScriptDurationMs": 150.9,
+        "LayoutDurationMs": 3.2,
+        "TaskDurationMs": 363.9,
+        "JSHeapUsedMB": 6.5,
+        "domNodes": 224,
+        "domDocuments": 0,
+        "jsEventListeners": 1375
+      },
+      "beforePage": {
+        "domNodes": 830,
+        "canvasNodes": 6,
+        "lightweightCanvasNodes": 0,
+        "lightweightPreviewNodes": 0,
+        "imageElements": 6,
+        "videoElements": 0,
+        "visibleMedia": 6,
+        "loadedImages": 6,
+        "loadedVideos": 0,
+        "visibleMediaNodes": 6,
+        "visibleMediaPending": 0,
+        "visibleMediaFailures": 0,
+        "activeVideos": 0,
+        "resourceCount": 0,
+        "jsHeapUsedMB": 42.6,
+        "transform": {
+          "x": 0,
+          "y": 0,
+          "zoom": 1
+        }
+      },
+      "page": {
+        "domNodes": 1016,
+        "canvasNodes": 6,
+        "lightweightCanvasNodes": 0,
+        "lightweightPreviewNodes": 0,
+        "imageElements": 7,
+        "videoElements": 0,
+        "visibleMedia": 6,
+        "loadedImages": 7,
+        "loadedVideos": 0,
+        "visibleMediaNodes": 6,
+        "visibleMediaPending": 0,
+        "visibleMediaFailures": 0,
+        "activeVideos": 0,
+        "resourceCount": 0,
+        "jsHeapUsedMB": 42.6,
+        "transform": {
+          "x": 0,
+          "y": 0,
+          "zoom": 1
+        }
+      },
+      "actionDetails": {
+        "nodeId": "canvas-perf-image-0",
+        "moves": 60,
+        "firstFeedbackMs": 26.900000002235174
+      },
+      "offCanvasRender": null,
+      "nodeIdentity": {
+        "before": 6,
+        "after": 6,
+        "common": 6,
+        "tracked": 6,
+        "preserved": 6,
+        "virtualizationChurn": [],
+        "remountedInPlace": [],
+        "commonIdentityPreserved": true,
+        "targetNodeId": "canvas-perf-image-0",
+        "targetIdentityPreserved": true
+      },
+      "appMetrics": {
+        "rendererWorkingSetMB": 355.9,
+        "gpuWorkingSetMB": 131.3,
+        "processCount": 5,
+        "processes": [
+          {
+            "type": "Browser",
+            "pid": 14324,
+            "workingSetMB": 350.3
+          },
+          {
+            "type": "GPU",
+            "pid": 14327,
+            "workingSetMB": 131.3
+          },
+          {
+            "type": "Utility",
+            "pid": 14328,
+            "workingSetMB": 45
+          },
+          {
+            "type": "Tab",
+            "pid": 14329,
+            "workingSetMB": 355.9
+          },
+          {
+            "type": "Utility",
+            "pid": 14332,
+            "workingSetMB": 45.1
+          }
+        ]
+      },
+      "runtimeVersions": {
+        "app": "0.21.0",
+        "electron": "43.4.1",
+        "chrome": "150.0.7871.224",
+        "node": "24.18.1",
+        "v8": "15.0.245.28-electron.0"
+      },
+      "pageErrors": [],
+      "consoleErrors": [],
+      "elapsedMs": 20915
+    },
+    {
+      "scale": "XLIMG",
+      "scenario": "node-drag-image",
+      "runIndex": 1,
+      "fixture": {
+        "scale": "XLIMG",
+        "imageNodes": 320,
+        "videoNodes": 0,
+        "nodes": 320,
+        "edges": 0,
+        "clips": 0,
+        "imageBytes": [
+          11961265,
+          11757599,
+          11030773,
+          9324705
+        ],
+        "imagePreviewBytes": [
+          28993,
+          42126,
+          52132,
+          27337
+        ],
+        "videoBytes": [
+          1380939031
+        ],
+        "mediaProfile": "real-assets"
+      },
+      "probe": {
+        "elapsedMs": 2026,
+        "frames": 243,
+        "fps": 119.9,
+        "frameGapP50Ms": 8.4,
+        "frameGapP95Ms": 11.2,
+        "maxFrameGapMs": 40.2,
+        "longTasks": 0,
+        "longTaskMs": 0,
+        "longTaskP95Ms": null,
+        "maxLoadingImages": 1,
+        "maxLoadingVideos": 0,
+        "maxActiveVideos": 0,
+        "firstMutationMs": 34,
+        "mutations": {
+          "stage": 2,
+          "edges": 4,
+          "labels": 0
+        }
+      },
+      "cdpBefore": {
+        "LayoutCount": 0,
+        "RecalcStyleCount": 0,
+        "ScriptDurationMs": 2.4,
+        "LayoutDurationMs": 0,
+        "TaskDurationMs": 4.4,
+        "JSHeapUsedMB": 57.7,
+        "domNodes": 19427,
+        "domDocuments": 1,
+        "jsEventListeners": 2793
+      },
+      "cdpAfter": {
+        "LayoutCount": 41,
+        "RecalcStyleCount": 132,
+        "ScriptDurationMs": 153.9,
+        "LayoutDurationMs": 2.7,
+        "TaskDurationMs": 389.6,
+        "JSHeapUsedMB": 30.3,
+        "domNodes": 1324,
+        "domDocuments": 1,
+        "jsEventListeners": 958
+      },
+      "cdpDelta": {
+        "LayoutCount": 41,
+        "RecalcStyleCount": 132,
+        "ScriptDurationMs": 151.5,
+        "LayoutDurationMs": 2.7,
+        "TaskDurationMs": 385.2,
+        "JSHeapUsedMB": -27.4,
+        "domNodes": -18103,
+        "domDocuments": 0,
+        "jsEventListeners": -1835
+      },
+      "beforePage": {
+        "domNodes": 958,
+        "canvasNodes": 6,
+        "lightweightCanvasNodes": 0,
+        "lightweightPreviewNodes": 0,
+        "imageElements": 6,
+        "videoElements": 0,
+        "visibleMedia": 6,
+        "loadedImages": 6,
+        "loadedVideos": 0,
+        "visibleMediaNodes": 6,
+        "visibleMediaPending": 0,
+        "visibleMediaFailures": 0,
+        "activeVideos": 0,
+        "resourceCount": 0,
+        "jsHeapUsedMB": 64.8,
+        "transform": {
+          "x": 0,
+          "y": 0,
+          "zoom": 1
+        }
+      },
+      "page": {
+        "domNodes": 1144,
+        "canvasNodes": 6,
+        "lightweightCanvasNodes": 0,
+        "lightweightPreviewNodes": 0,
+        "imageElements": 7,
+        "videoElements": 0,
+        "visibleMedia": 6,
+        "loadedImages": 7,
+        "loadedVideos": 0,
+        "visibleMediaNodes": 6,
+        "visibleMediaPending": 0,
+        "visibleMediaFailures": 0,
+        "activeVideos": 0,
+        "resourceCount": 0,
+        "jsHeapUsedMB": 64.8,
+        "transform": {
+          "x": 0,
+          "y": 0,
+          "zoom": 1
+        }
+      },
+      "actionDetails": {
+        "nodeId": "canvas-perf-image-0",
+        "moves": 60,
+        "firstFeedbackMs": 34
+      },
+      "offCanvasRender": null,
+      "nodeIdentity": {
+        "before": 6,
+        "after": 6,
+        "common": 6,
+        "tracked": 6,
+        "preserved": 6,
+        "virtualizationChurn": [],
+        "remountedInPlace": [],
+        "commonIdentityPreserved": true,
+        "targetNodeId": "canvas-perf-image-0",
+        "targetIdentityPreserved": true
+      },
+      "appMetrics": {
+        "rendererWorkingSetMB": 403.2,
+        "gpuWorkingSetMB": 131.1,
+        "processCount": 5,
+        "processes": [
+          {
+            "type": "Browser",
+            "pid": 14364,
+            "workingSetMB": 360
+          },
+          {
+            "type": "GPU",
+            "pid": 14367,
+            "workingSetMB": 131.1
+          },
+          {
+            "type": "Utility",
+            "pid": 14368,
+            "workingSetMB": 45
+          },
+          {
+            "type": "Tab",
+            "pid": 14369,
+            "workingSetMB": 403.2
+          },
+          {
+            "type": "Utility",
+            "pid": 14372,
+            "workingSetMB": 45
+          }
+        ]
+      },
+      "runtimeVersions": {
+        "app": "0.21.0",
+        "electron": "43.4.1",
+        "chrome": "150.0.7871.224",
+        "node": "24.18.1",
+        "v8": "15.0.245.28-electron.0"
+      },
+      "pageErrors": [],
+      "consoleErrors": [],
+      "elapsedMs": 21901
+    },
+    {
+      "scale": "XLIMG",
+      "scenario": "node-drag-image",
+      "runIndex": 2,
+      "fixture": {
+        "scale": "XLIMG",
+        "imageNodes": 320,
+        "videoNodes": 0,
+        "nodes": 320,
+        "edges": 0,
+        "clips": 0,
+        "imageBytes": [
+          11961265,
+          11757599,
+          11030773,
+          9324705
+        ],
+        "imagePreviewBytes": [
+          28993,
+          42126,
+          52132,
+          27337
+        ],
+        "videoBytes": [
+          1380939031
+        ],
+        "mediaProfile": "real-assets"
+      },
+      "probe": {
+        "elapsedMs": 2004,
+        "frames": 235,
+        "fps": 117.3,
+        "frameGapP50Ms": 8.4,
+        "frameGapP95Ms": 10.9,
+        "maxFrameGapMs": 39.3,
+        "longTasks": 0,
+        "longTaskMs": 0,
+        "longTaskP95Ms": null,
+        "maxLoadingImages": 1,
+        "maxLoadingVideos": 0,
+        "maxActiveVideos": 0,
+        "firstMutationMs": 38.2,
+        "mutations": {
+          "stage": 2,
+          "edges": 4,
+          "labels": 0
+        }
+      },
+      "cdpBefore": {
+        "LayoutCount": 0,
+        "RecalcStyleCount": 0,
+        "ScriptDurationMs": 2.6,
+        "LayoutDurationMs": 0,
+        "TaskDurationMs": 4.7,
+        "JSHeapUsedMB": 36.1,
+        "domNodes": 1367,
+        "domDocuments": 1,
+        "jsEventListeners": 894
+      },
+      "cdpAfter": {
+        "LayoutCount": 41,
+        "RecalcStyleCount": 132,
+        "ScriptDurationMs": 153.3,
+        "LayoutDurationMs": 3,
+        "TaskDurationMs": 381.8,
+        "JSHeapUsedMB": 30.4,
+        "domNodes": 1324,
+        "domDocuments": 1,
+        "jsEventListeners": 958
+      },
+      "cdpDelta": {
+        "LayoutCount": 41,
+        "RecalcStyleCount": 132,
+        "ScriptDurationMs": 150.7,
+        "LayoutDurationMs": 3,
+        "TaskDurationMs": 377.1,
+        "JSHeapUsedMB": -5.7,
+        "domNodes": -43,
+        "domDocuments": 0,
+        "jsEventListeners": 64
+      },
+      "beforePage": {
+        "domNodes": 958,
+        "canvasNodes": 6,
+        "lightweightCanvasNodes": 0,
+        "lightweightPreviewNodes": 0,
+        "imageElements": 6,
+        "videoElements": 0,
+        "visibleMedia": 6,
+        "loadedImages": 6,
+        "loadedVideos": 0,
+        "visibleMediaNodes": 6,
+        "visibleMediaPending": 0,
+        "visibleMediaFailures": 0,
+        "activeVideos": 0,
+        "resourceCount": 0,
+        "jsHeapUsedMB": 42.6,
+        "transform": {
+          "x": 0,
+          "y": 0,
+          "zoom": 1
+        }
+      },
+      "page": {
+        "domNodes": 1144,
+        "canvasNodes": 6,
+        "lightweightCanvasNodes": 0,
+        "lightweightPreviewNodes": 0,
+        "imageElements": 7,
+        "videoElements": 0,
+        "visibleMedia": 6,
+        "loadedImages": 7,
+        "loadedVideos": 0,
+        "visibleMediaNodes": 6,
+        "visibleMediaPending": 0,
+        "visibleMediaFailures": 0,
+        "activeVideos": 0,
+        "resourceCount": 0,
+        "jsHeapUsedMB": 42.6,
+        "transform": {
+          "x": 0,
+          "y": 0,
+          "zoom": 1
+        }
+      },
+      "actionDetails": {
+        "nodeId": "canvas-perf-image-0",
+        "moves": 60,
+        "firstFeedbackMs": 38.20000000298023
+      },
+      "offCanvasRender": null,
+      "nodeIdentity": {
+        "before": 6,
+        "after": 6,
+        "common": 6,
+        "tracked": 6,
+        "preserved": 6,
+        "virtualizationChurn": [],
+        "remountedInPlace": [],
+        "commonIdentityPreserved": true,
+        "targetNodeId": "canvas-perf-image-0",
+        "targetIdentityPreserved": true
+      },
+      "appMetrics": {
+        "rendererWorkingSetMB": 388.9,
+        "gpuWorkingSetMB": 132.1,
+        "processCount": 5,
+        "processes": [
+          {
+            "type": "Browser",
+            "pid": 14402,
+            "workingSetMB": 360.6
+          },
+          {
+            "type": "GPU",
+            "pid": 14406,
+            "workingSetMB": 132.1
+          },
+          {
+            "type": "Utility",
+            "pid": 14407,
+            "workingSetMB": 45.1
+          },
+          {
+            "type": "Tab",
+            "pid": 14408,
+            "workingSetMB": 388.9
+          },
+          {
+            "type": "Utility",
+            "pid": 14411,
+            "workingSetMB": 45.2
+          }
+        ]
+      },
+      "runtimeVersions": {
+        "app": "0.21.0",
+        "electron": "43.4.1",
+        "chrome": "150.0.7871.224",
+        "node": "24.18.1",
+        "v8": "15.0.245.28-electron.0"
+      },
+      "pageErrors": [],
+      "consoleErrors": [],
+      "elapsedMs": 21903
+    }
+  ],
+  "warmupFailures": [],
+  "summary": {
+    "SIMG/node-drag-image": {
+      "samples": 2,
+      "errors": 0,
+      "metrics": {
+        "coldFirstCanvasMs": null,
+        "coldMediaSettledMs": null,
+        "fps": {
+          "median": 117.7,
+          "p95": 118.5,
+          "samples": [
+            117.7,
+            118.5
+          ]
+        },
+        "frameGapP95Ms": {
+          "median": 10.1,
+          "p95": 10.4,
+          "samples": [
+            10.1,
+            10.4
+          ]
+        },
+        "maxFrameGapMs": {
+          "median": 42.6,
+          "p95": 43.7,
+          "samples": [
+            42.6,
+            43.7
+          ]
+        },
+        "longTaskMs": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "longTaskP95Ms": null,
+        "maxLoadingImages": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "maxLoadingVideos": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "maxActiveVideos": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "layoutCount": {
+          "median": 41,
+          "p95": 42,
+          "samples": [
+            41,
+            42
+          ]
+        },
+        "recalcStyleCount": {
+          "median": 132,
+          "p95": 132,
+          "samples": [
+            132,
+            132
+          ]
+        },
+        "scriptDurationMs": {
+          "median": 140.4,
+          "p95": 148.7,
+          "samples": [
+            140.4,
+            148.7
+          ]
+        },
+        "layoutDurationMs": {
+          "median": 3,
+          "p95": 3,
+          "samples": [
+            3,
+            3
+          ]
+        },
+        "jsHeapUsedMB": {
+          "median": 37.8,
+          "p95": 45.2,
+          "samples": [
+            37.8,
+            45.2
+          ]
+        },
+        "visibleMedia": {
+          "median": 6,
+          "p95": 6,
+          "samples": [
+            6,
+            6
+          ]
+        },
+        "visibleMediaNodes": {
+          "median": 6,
+          "p95": 6,
+          "samples": [
+            6,
+            6
+          ]
+        },
+        "visibleMediaPending": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "visibleMediaFailures": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "loadedImages": {
+          "median": 7,
+          "p95": 7,
+          "samples": [
+            7,
+            7
+          ]
+        },
+        "loadedVideos": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "activeVideos": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "rendererWorkingSetMB": {
+          "median": 330.4,
+          "p95": 337,
+          "samples": [
+            330.4,
+            337
+          ]
+        },
+        "reloadHeapDeltaMB": null,
+        "reloadDurationP95Ms": null
+      },
+      "advisory": {
+        "perMove": {
+          "scriptPerMoveMs": {
+            "median": 2.34,
+            "p95": 2.48,
+            "samples": [
+              2.48,
+              2.34
+            ]
+          },
+          "layoutPerMove": {
+            "median": 0.68,
+            "p95": 0.7,
+            "samples": [
+              0.7,
+              0.68
+            ]
+          }
+        },
+        "dragOverPan": {
+          "scriptRatio": {
+            "median": null,
+            "samples": []
+          },
+          "layoutRatio": {
+            "median": null,
+            "samples": []
+          }
+        },
+        "actionLatency": {
+          "samples": [
+            41.900000002235174,
+            39
+          ],
+          "p95Ms": 41.9,
+          "medianMs": 39
+        },
+        "offCanvasRender": {
+          "installed": false,
+          "windows": 0,
+          "totalMax": null,
+          "totalMedian": null,
+          "perComponentMax": {
+            "CategoryTree": null,
+            "AssetLibraryPanel": null,
+            "AssetPicker": null,
+            "TaskCenterButton": null,
+            "TaskCenterPanel": null,
+            "TimelinePreview": null,
+            "PreviewSourcePanel": null,
+            "OnboardingChecklist": null
+          }
+        }
+      },
+      "verdict": {
+        "pass": true,
+        "advisoryOnly": false,
+        "budgetsAdvisory": false,
+        "hardFailures": [],
+        "budgetChecks": [
+          {
+            "metric": "frameGapP95Ms",
+            "actualP95": 10.4,
+            "max": 33,
+            "pass": true,
+            "advisory": false
+          },
+          {
+            "metric": "maxFrameGapMs",
+            "actualP95": 43.7,
+            "max": 100,
+            "pass": true,
+            "advisory": true
+          },
+          {
+            "metric": "maxLoadingImages",
+            "actualP95": 0,
+            "max": 4,
+            "pass": true,
+            "advisory": false
+          },
+          {
+            "metric": "maxLoadingVideos",
+            "actualP95": 0,
+            "max": 1,
+            "pass": true,
+            "advisory": false
+          },
+          {
+            "metric": "maxActiveVideos",
+            "actualP95": 0,
+            "max": 1,
+            "pass": true,
+            "advisory": false
+          }
+        ]
+      }
+    },
+    "MIMG/node-drag-image": {
+      "samples": 2,
+      "errors": 0,
+      "metrics": {
+        "coldFirstCanvasMs": null,
+        "coldMediaSettledMs": null,
+        "fps": {
+          "median": 117.7,
+          "p95": 118.2,
+          "samples": [
+            117.7,
+            118.2
+          ]
+        },
+        "frameGapP95Ms": {
+          "median": 10.1,
+          "p95": 10.3,
+          "samples": [
+            10.1,
+            10.3
+          ]
+        },
+        "maxFrameGapMs": {
+          "median": 41.1,
+          "p95": 41.3,
+          "samples": [
+            41.1,
+            41.3
+          ]
+        },
+        "longTaskMs": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "longTaskP95Ms": null,
+        "maxLoadingImages": {
+          "median": 1,
+          "p95": 1,
+          "samples": [
+            1,
+            1
+          ]
+        },
+        "maxLoadingVideos": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "maxActiveVideos": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "layoutCount": {
+          "median": 41,
+          "p95": 41,
+          "samples": [
+            41,
+            41
+          ]
+        },
+        "recalcStyleCount": {
+          "median": 131,
+          "p95": 132,
+          "samples": [
+            131,
+            132
+          ]
+        },
+        "scriptDurationMs": {
+          "median": 137.2,
+          "p95": 140.2,
+          "samples": [
+            137.2,
+            140.2
+          ]
+        },
+        "layoutDurationMs": {
+          "median": 3,
+          "p95": 3.1,
+          "samples": [
+            3,
+            3.1
+          ]
+        },
+        "jsHeapUsedMB": {
+          "median": 48.1,
+          "p95": 51,
+          "samples": [
+            48.1,
+            51
+          ]
+        },
+        "visibleMedia": {
+          "median": 6,
+          "p95": 6,
+          "samples": [
+            6,
+            6
+          ]
+        },
+        "visibleMediaNodes": {
+          "median": 6,
+          "p95": 6,
+          "samples": [
+            6,
+            6
+          ]
+        },
+        "visibleMediaPending": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "visibleMediaFailures": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "loadedImages": {
+          "median": 7,
+          "p95": 7,
+          "samples": [
+            7,
+            7
+          ]
+        },
+        "loadedVideos": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "activeVideos": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "rendererWorkingSetMB": {
+          "median": 333.8,
+          "p95": 341.2,
+          "samples": [
+            333.8,
+            341.2
+          ]
+        },
+        "reloadHeapDeltaMB": null,
+        "reloadDurationP95Ms": null
+      },
+      "advisory": {
+        "perMove": {
+          "scriptPerMoveMs": {
+            "median": 2.29,
+            "p95": 2.34,
+            "samples": [
+              2.34,
+              2.29
+            ]
+          },
+          "layoutPerMove": {
+            "median": 0.68,
+            "p95": 0.68,
+            "samples": [
+              0.68,
+              0.68
+            ]
+          }
+        },
+        "dragOverPan": {
+          "scriptRatio": {
+            "median": null,
+            "samples": []
+          },
+          "layoutRatio": {
+            "median": null,
+            "samples": []
+          }
+        },
+        "actionLatency": {
+          "samples": [
+            27.5,
+            32.30000000074506
+          ],
+          "p95Ms": 32.3,
+          "medianMs": 27.5
+        },
+        "offCanvasRender": {
+          "installed": false,
+          "windows": 0,
+          "totalMax": null,
+          "totalMedian": null,
+          "perComponentMax": {
+            "CategoryTree": null,
+            "AssetLibraryPanel": null,
+            "AssetPicker": null,
+            "TaskCenterButton": null,
+            "TaskCenterPanel": null,
+            "TimelinePreview": null,
+            "PreviewSourcePanel": null,
+            "OnboardingChecklist": null
+          }
+        }
+      },
+      "verdict": {
+        "pass": true,
+        "advisoryOnly": false,
+        "budgetsAdvisory": false,
+        "hardFailures": [],
+        "budgetChecks": [
+          {
+            "metric": "frameGapP95Ms",
+            "actualP95": 10.3,
+            "max": 33,
+            "pass": true,
+            "advisory": false
+          },
+          {
+            "metric": "maxFrameGapMs",
+            "actualP95": 41.3,
+            "max": 100,
+            "pass": true,
+            "advisory": true
+          },
+          {
+            "metric": "maxLoadingImages",
+            "actualP95": 1,
+            "max": 4,
+            "pass": true,
+            "advisory": false
+          },
+          {
+            "metric": "maxLoadingVideos",
+            "actualP95": 0,
+            "max": 1,
+            "pass": true,
+            "advisory": false
+          },
+          {
+            "metric": "maxActiveVideos",
+            "actualP95": 0,
+            "max": 1,
+            "pass": true,
+            "advisory": false
+          }
+        ]
+      }
+    },
+    "LIMG/node-drag-image": {
+      "samples": 2,
+      "errors": 0,
+      "metrics": {
+        "coldFirstCanvasMs": null,
+        "coldMediaSettledMs": null,
+        "fps": {
+          "median": 116.9,
+          "p95": 117.6,
+          "samples": [
+            116.9,
+            117.6
+          ]
+        },
+        "frameGapP95Ms": {
+          "median": 11,
+          "p95": 11.2,
+          "samples": [
+            11,
+            11.2
+          ]
+        },
+        "maxFrameGapMs": {
+          "median": 42.6,
+          "p95": 47.7,
+          "samples": [
+            42.6,
+            47.7
+          ]
+        },
+        "longTaskMs": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "longTaskP95Ms": null,
+        "maxLoadingImages": {
+          "median": 0,
+          "p95": 1,
+          "samples": [
+            0,
+            1
+          ]
+        },
+        "maxLoadingVideos": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "maxActiveVideos": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "layoutCount": {
+          "median": 42,
+          "p95": 42,
+          "samples": [
+            42,
+            42
+          ]
+        },
+        "recalcStyleCount": {
+          "median": 131,
+          "p95": 132,
+          "samples": [
+            131,
+            132
+          ]
+        },
+        "scriptDurationMs": {
+          "median": 138.5,
+          "p95": 150.9,
+          "samples": [
+            138.5,
+            150.9
+          ]
+        },
+        "layoutDurationMs": {
+          "median": 3,
+          "p95": 3.2,
+          "samples": [
+            3,
+            3.2
+          ]
+        },
+        "jsHeapUsedMB": {
+          "median": 42.6,
+          "p95": 57.5,
+          "samples": [
+            42.6,
+            57.5
+          ]
+        },
+        "visibleMedia": {
+          "median": 6,
+          "p95": 6,
+          "samples": [
+            6,
+            6
+          ]
+        },
+        "visibleMediaNodes": {
+          "median": 6,
+          "p95": 6,
+          "samples": [
+            6,
+            6
+          ]
+        },
+        "visibleMediaPending": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "visibleMediaFailures": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "loadedImages": {
+          "median": 7,
+          "p95": 7,
+          "samples": [
+            7,
+            7
+          ]
+        },
+        "loadedVideos": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "activeVideos": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "rendererWorkingSetMB": {
+          "median": 355.9,
+          "p95": 391.8,
+          "samples": [
+            355.9,
+            391.8
+          ]
+        },
+        "reloadHeapDeltaMB": null,
+        "reloadDurationP95Ms": null
+      },
+      "advisory": {
+        "perMove": {
+          "scriptPerMoveMs": {
+            "median": 2.31,
+            "p95": 2.52,
+            "samples": [
+              2.31,
+              2.52
+            ]
+          },
+          "layoutPerMove": {
+            "median": 0.7,
+            "p95": 0.7,
+            "samples": [
+              0.7,
+              0.7
+            ]
+          }
+        },
+        "dragOverPan": {
+          "scriptRatio": {
+            "median": null,
+            "samples": []
+          },
+          "layoutRatio": {
+            "median": null,
+            "samples": []
+          }
+        },
+        "actionLatency": {
+          "samples": [
+            42.30000000074506,
+            26.900000002235174
+          ],
+          "p95Ms": 42.3,
+          "medianMs": 26.9
+        },
+        "offCanvasRender": {
+          "installed": false,
+          "windows": 0,
+          "totalMax": null,
+          "totalMedian": null,
+          "perComponentMax": {
+            "CategoryTree": null,
+            "AssetLibraryPanel": null,
+            "AssetPicker": null,
+            "TaskCenterButton": null,
+            "TaskCenterPanel": null,
+            "TimelinePreview": null,
+            "PreviewSourcePanel": null,
+            "OnboardingChecklist": null
+          }
+        }
+      },
+      "verdict": {
+        "pass": true,
+        "advisoryOnly": false,
+        "budgetsAdvisory": false,
+        "hardFailures": [],
+        "budgetChecks": [
+          {
+            "metric": "frameGapP95Ms",
+            "actualP95": 11.2,
+            "max": 33,
+            "pass": true,
+            "advisory": false
+          },
+          {
+            "metric": "maxFrameGapMs",
+            "actualP95": 47.7,
+            "max": 100,
+            "pass": true,
+            "advisory": true
+          },
+          {
+            "metric": "maxLoadingImages",
+            "actualP95": 1,
+            "max": 4,
+            "pass": true,
+            "advisory": false
+          },
+          {
+            "metric": "maxLoadingVideos",
+            "actualP95": 0,
+            "max": 1,
+            "pass": true,
+            "advisory": false
+          },
+          {
+            "metric": "maxActiveVideos",
+            "actualP95": 0,
+            "max": 1,
+            "pass": true,
+            "advisory": false
+          }
+        ]
+      }
+    },
+    "XLIMG/node-drag-image": {
+      "samples": 2,
+      "errors": 0,
+      "metrics": {
+        "coldFirstCanvasMs": null,
+        "coldMediaSettledMs": null,
+        "fps": {
+          "median": 117.3,
+          "p95": 119.9,
+          "samples": [
+            117.3,
+            119.9
+          ]
+        },
+        "frameGapP95Ms": {
+          "median": 10.9,
+          "p95": 11.2,
+          "samples": [
+            10.9,
+            11.2
+          ]
+        },
+        "maxFrameGapMs": {
+          "median": 39.3,
+          "p95": 40.2,
+          "samples": [
+            39.3,
+            40.2
+          ]
+        },
+        "longTaskMs": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "longTaskP95Ms": null,
+        "maxLoadingImages": {
+          "median": 1,
+          "p95": 1,
+          "samples": [
+            1,
+            1
+          ]
+        },
+        "maxLoadingVideos": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "maxActiveVideos": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "layoutCount": {
+          "median": 41,
+          "p95": 41,
+          "samples": [
+            41,
+            41
+          ]
+        },
+        "recalcStyleCount": {
+          "median": 132,
+          "p95": 132,
+          "samples": [
+            132,
+            132
+          ]
+        },
+        "scriptDurationMs": {
+          "median": 150.7,
+          "p95": 151.5,
+          "samples": [
+            150.7,
+            151.5
+          ]
+        },
+        "layoutDurationMs": {
+          "median": 2.7,
+          "p95": 3,
+          "samples": [
+            2.7,
+            3
+          ]
+        },
+        "jsHeapUsedMB": {
+          "median": 42.6,
+          "p95": 64.8,
+          "samples": [
+            42.6,
+            64.8
+          ]
+        },
+        "visibleMedia": {
+          "median": 6,
+          "p95": 6,
+          "samples": [
+            6,
+            6
+          ]
+        },
+        "visibleMediaNodes": {
+          "median": 6,
+          "p95": 6,
+          "samples": [
+            6,
+            6
+          ]
+        },
+        "visibleMediaPending": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "visibleMediaFailures": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "loadedImages": {
+          "median": 7,
+          "p95": 7,
+          "samples": [
+            7,
+            7
+          ]
+        },
+        "loadedVideos": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "activeVideos": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "rendererWorkingSetMB": {
+          "median": 388.9,
+          "p95": 403.2,
+          "samples": [
+            388.9,
+            403.2
+          ]
+        },
+        "reloadHeapDeltaMB": null,
+        "reloadDurationP95Ms": null
+      },
+      "advisory": {
+        "perMove": {
+          "scriptPerMoveMs": {
+            "median": 2.51,
+            "p95": 2.53,
+            "samples": [
+              2.53,
+              2.51
+            ]
+          },
+          "layoutPerMove": {
+            "median": 0.68,
+            "p95": 0.68,
+            "samples": [
+              0.68,
+              0.68
+            ]
+          }
+        },
+        "dragOverPan": {
+          "scriptRatio": {
+            "median": null,
+            "samples": []
+          },
+          "layoutRatio": {
+            "median": null,
+            "samples": []
+          }
+        },
+        "actionLatency": {
+          "samples": [
+            34,
+            38.20000000298023
+          ],
+          "p95Ms": 38.2,
+          "medianMs": 34
+        },
+        "offCanvasRender": {
+          "installed": false,
+          "windows": 0,
+          "totalMax": null,
+          "totalMedian": null,
+          "perComponentMax": {
+            "CategoryTree": null,
+            "AssetLibraryPanel": null,
+            "AssetPicker": null,
+            "TaskCenterButton": null,
+            "TaskCenterPanel": null,
+            "TimelinePreview": null,
+            "PreviewSourcePanel": null,
+            "OnboardingChecklist": null
+          }
+        }
+      },
+      "verdict": {
+        "pass": true,
+        "advisoryOnly": false,
+        "budgetsAdvisory": false,
+        "hardFailures": [],
+        "budgetChecks": [
+          {
+            "metric": "frameGapP95Ms",
+            "actualP95": 11.2,
+            "max": 33,
+            "pass": true,
+            "advisory": false
+          },
+          {
+            "metric": "maxFrameGapMs",
+            "actualP95": 40.2,
+            "max": 100,
+            "pass": true,
+            "advisory": true
+          },
+          {
+            "metric": "maxLoadingImages",
+            "actualP95": 1,
+            "max": 4,
+            "pass": true,
+            "advisory": false
+          },
+          {
+            "metric": "maxLoadingVideos",
+            "actualP95": 0,
+            "max": 1,
+            "pass": true,
+            "advisory": false
+          },
+          {
+            "metric": "maxActiveVideos",
+            "actualP95": 0,
+            "max": 1,
+            "pass": true,
+            "advisory": false
+          }
+        ]
+      }
+    }
+  },
+  "runtimeVersions": {
+    "app": "0.21.0",
+    "electron": "43.4.1",
+    "chrome": "150.0.7871.224",
+    "node": "24.18.1",
+    "v8": "15.0.245.28-electron.0"
+  },
+  "pass": true
+}

--- a/tests/ux/perf-results/canvas-real-4k-sml.json
+++ b/tests/ux/perf-results/canvas-real-4k-sml.json
@@ -1,0 +1,2058 @@
+{
+  "label": "real-4k-sml",
+  "commit": "ba753cfa5ec7ad24e7bb3e453e3ef99ccdf64276",
+  "dirty": true,
+  "platform": "darwin",
+  "arch": "arm64",
+  "machine": {
+    "cpu": "Apple M5",
+    "logicalCpus": 10,
+    "totalMemoryGB": 24
+  },
+  "viewport": {
+    "width": 1600,
+    "height": 1000
+  },
+  "viewportOverride": null,
+  "sampleCount": 2,
+  "warmupCount": 1,
+  "scales": [
+    "SIMG",
+    "MIMG",
+    "LIMG"
+  ],
+  "scenarios": [
+    "low-zoom-preview"
+  ],
+  "leg": {
+    "devServer": false,
+    "cpuThrottleRate": 1,
+    "kind": "prod"
+  },
+  "results": [
+    {
+      "scale": "SIMG",
+      "scenario": "low-zoom-preview",
+      "runIndex": 1,
+      "fixture": {
+        "scale": "SIMG",
+        "imageNodes": 48,
+        "videoNodes": 0,
+        "nodes": 48,
+        "edges": 0,
+        "clips": 0,
+        "imageBytes": [
+          11961265,
+          11757599,
+          11030773,
+          9324705
+        ],
+        "imagePreviewBytes": [
+          28993,
+          42126,
+          52132,
+          27337
+        ],
+        "videoBytes": [
+          1380939031
+        ],
+        "mediaProfile": "real-assets"
+      },
+      "probe": {
+        "elapsedMs": 1024,
+        "frames": 123,
+        "fps": 120.1,
+        "frameGapP50Ms": 8.3,
+        "frameGapP95Ms": 9.8,
+        "maxFrameGapMs": 10.8,
+        "longTasks": 0,
+        "longTaskMs": 0,
+        "longTaskP95Ms": null,
+        "maxLoadingImages": 0,
+        "maxLoadingVideos": 0,
+        "maxActiveVideos": 0,
+        "firstMutationMs": null,
+        "mutations": {
+          "stage": 0,
+          "edges": 0,
+          "labels": 0
+        }
+      },
+      "cdpBefore": {
+        "LayoutCount": 7,
+        "RecalcStyleCount": 15,
+        "ScriptDurationMs": 126,
+        "LayoutDurationMs": 1.4,
+        "TaskDurationMs": 164.7,
+        "JSHeapUsedMB": 26.7,
+        "domNodes": 1024,
+        "domDocuments": 1,
+        "jsEventListeners": 940
+      },
+      "cdpAfter": {
+        "LayoutCount": 7,
+        "RecalcStyleCount": 15,
+        "ScriptDurationMs": 138.8,
+        "LayoutDurationMs": 1.4,
+        "TaskDurationMs": 200.3,
+        "JSHeapUsedMB": 27.5,
+        "domNodes": 1024,
+        "domDocuments": 1,
+        "jsEventListeners": 940
+      },
+      "cdpDelta": {
+        "LayoutCount": 0,
+        "RecalcStyleCount": 0,
+        "ScriptDurationMs": 12.8,
+        "LayoutDurationMs": 0,
+        "TaskDurationMs": 35.6,
+        "JSHeapUsedMB": 0.8,
+        "domNodes": 0,
+        "domDocuments": 0,
+        "jsEventListeners": 0
+      },
+      "beforePage": {
+        "domNodes": 728,
+        "canvasNodes": 16,
+        "lightweightCanvasNodes": 16,
+        "lightweightPreviewNodes": 16,
+        "imageElements": 16,
+        "videoElements": 0,
+        "visibleMedia": 16,
+        "loadedImages": 16,
+        "loadedVideos": 0,
+        "visibleMediaNodes": 16,
+        "visibleMediaPending": 0,
+        "visibleMediaFailures": 0,
+        "activeVideos": 0,
+        "resourceCount": 0,
+        "jsHeapUsedMB": 45.2,
+        "transform": {
+          "x": 225.325,
+          "y": 247.349,
+          "zoom": 0.435275
+        }
+      },
+      "page": {
+        "domNodes": 728,
+        "canvasNodes": 16,
+        "lightweightCanvasNodes": 16,
+        "lightweightPreviewNodes": 16,
+        "imageElements": 16,
+        "videoElements": 0,
+        "visibleMedia": 16,
+        "loadedImages": 16,
+        "loadedVideos": 0,
+        "visibleMediaNodes": 16,
+        "visibleMediaPending": 0,
+        "visibleMediaFailures": 0,
+        "activeVideos": 0,
+        "resourceCount": 0,
+        "jsHeapUsedMB": 45.2,
+        "transform": {
+          "x": 225.325,
+          "y": 247.349,
+          "zoom": 0.435275
+        }
+      },
+      "actionDetails": {
+        "settled": {
+          "domNodes": 728,
+          "canvasNodes": 16,
+          "lightweightCanvasNodes": 16,
+          "lightweightPreviewNodes": 16,
+          "imageElements": 16,
+          "videoElements": 0,
+          "visibleMedia": 16,
+          "loadedImages": 16,
+          "loadedVideos": 0,
+          "visibleMediaNodes": 16,
+          "visibleMediaPending": 0,
+          "visibleMediaFailures": 0,
+          "activeVideos": 0,
+          "resourceCount": 0,
+          "jsHeapUsedMB": 45.2,
+          "transform": {
+            "x": 225.325,
+            "y": 247.349,
+            "zoom": 0.435275
+          }
+        },
+        "zoom": 0.435275
+      },
+      "offCanvasRender": null,
+      "nodeIdentity": {
+        "before": 16,
+        "after": 16,
+        "common": 16,
+        "tracked": 16,
+        "preserved": 16,
+        "virtualizationChurn": [],
+        "remountedInPlace": [],
+        "commonIdentityPreserved": true,
+        "targetNodeId": null,
+        "targetIdentityPreserved": null
+      },
+      "appMetrics": {
+        "rendererWorkingSetMB": 303.6,
+        "gpuWorkingSetMB": 126.9,
+        "processCount": 5,
+        "processes": [
+          {
+            "type": "Browser",
+            "pid": 13248,
+            "workingSetMB": 321.6
+          },
+          {
+            "type": "GPU",
+            "pid": 13251,
+            "workingSetMB": 126.9
+          },
+          {
+            "type": "Utility",
+            "pid": 13252,
+            "workingSetMB": 45
+          },
+          {
+            "type": "Tab",
+            "pid": 13254,
+            "workingSetMB": 303.6
+          },
+          {
+            "type": "Utility",
+            "pid": 13256,
+            "workingSetMB": 45
+          }
+        ]
+      },
+      "runtimeVersions": {
+        "app": "0.21.0",
+        "electron": "43.4.1",
+        "chrome": "150.0.7871.224",
+        "node": "24.18.1",
+        "v8": "15.0.245.28-electron.0"
+      },
+      "pageErrors": [],
+      "consoleErrors": [],
+      "elapsedMs": 20387
+    },
+    {
+      "scale": "SIMG",
+      "scenario": "low-zoom-preview",
+      "runIndex": 2,
+      "fixture": {
+        "scale": "SIMG",
+        "imageNodes": 48,
+        "videoNodes": 0,
+        "nodes": 48,
+        "edges": 0,
+        "clips": 0,
+        "imageBytes": [
+          11961265,
+          11757599,
+          11030773,
+          9324705
+        ],
+        "imagePreviewBytes": [
+          28993,
+          42126,
+          52132,
+          27337
+        ],
+        "videoBytes": [
+          1380939031
+        ],
+        "mediaProfile": "real-assets"
+      },
+      "probe": {
+        "elapsedMs": 1024,
+        "frames": 123,
+        "fps": 120.2,
+        "frameGapP50Ms": 8.3,
+        "frameGapP95Ms": 9.2,
+        "maxFrameGapMs": 12.8,
+        "longTasks": 0,
+        "longTaskMs": 0,
+        "longTaskP95Ms": null,
+        "maxLoadingImages": 0,
+        "maxLoadingVideos": 0,
+        "maxActiveVideos": 0,
+        "firstMutationMs": null,
+        "mutations": {
+          "stage": 0,
+          "edges": 0,
+          "labels": 0
+        }
+      },
+      "cdpBefore": {
+        "LayoutCount": 7,
+        "RecalcStyleCount": 16,
+        "ScriptDurationMs": 124.2,
+        "LayoutDurationMs": 1.3,
+        "TaskDurationMs": 172,
+        "JSHeapUsedMB": 26.7,
+        "domNodes": 1024,
+        "domDocuments": 1,
+        "jsEventListeners": 940
+      },
+      "cdpAfter": {
+        "LayoutCount": 7,
+        "RecalcStyleCount": 16,
+        "ScriptDurationMs": 140.9,
+        "LayoutDurationMs": 1.3,
+        "TaskDurationMs": 215.2,
+        "JSHeapUsedMB": 27.5,
+        "domNodes": 1024,
+        "domDocuments": 1,
+        "jsEventListeners": 940
+      },
+      "cdpDelta": {
+        "LayoutCount": 0,
+        "RecalcStyleCount": 0,
+        "ScriptDurationMs": 16.7,
+        "LayoutDurationMs": 0,
+        "TaskDurationMs": 43.2,
+        "JSHeapUsedMB": 0.8,
+        "domNodes": 0,
+        "domDocuments": 0,
+        "jsEventListeners": 0
+      },
+      "beforePage": {
+        "domNodes": 728,
+        "canvasNodes": 16,
+        "lightweightCanvasNodes": 16,
+        "lightweightPreviewNodes": 16,
+        "imageElements": 16,
+        "videoElements": 0,
+        "visibleMedia": 16,
+        "loadedImages": 16,
+        "loadedVideos": 0,
+        "visibleMediaNodes": 16,
+        "visibleMediaPending": 0,
+        "visibleMediaFailures": 0,
+        "activeVideos": 0,
+        "resourceCount": 0,
+        "jsHeapUsedMB": 42.6,
+        "transform": {
+          "x": 225.325,
+          "y": 247.349,
+          "zoom": 0.435275
+        }
+      },
+      "page": {
+        "domNodes": 728,
+        "canvasNodes": 16,
+        "lightweightCanvasNodes": 16,
+        "lightweightPreviewNodes": 16,
+        "imageElements": 16,
+        "videoElements": 0,
+        "visibleMedia": 16,
+        "loadedImages": 16,
+        "loadedVideos": 0,
+        "visibleMediaNodes": 16,
+        "visibleMediaPending": 0,
+        "visibleMediaFailures": 0,
+        "activeVideos": 0,
+        "resourceCount": 0,
+        "jsHeapUsedMB": 42.6,
+        "transform": {
+          "x": 225.325,
+          "y": 247.349,
+          "zoom": 0.435275
+        }
+      },
+      "actionDetails": {
+        "settled": {
+          "domNodes": 728,
+          "canvasNodes": 16,
+          "lightweightCanvasNodes": 16,
+          "lightweightPreviewNodes": 16,
+          "imageElements": 16,
+          "videoElements": 0,
+          "visibleMedia": 16,
+          "loadedImages": 16,
+          "loadedVideos": 0,
+          "visibleMediaNodes": 16,
+          "visibleMediaPending": 0,
+          "visibleMediaFailures": 0,
+          "activeVideos": 0,
+          "resourceCount": 0,
+          "jsHeapUsedMB": 42.6,
+          "transform": {
+            "x": 225.325,
+            "y": 247.349,
+            "zoom": 0.435275
+          }
+        },
+        "zoom": 0.435275
+      },
+      "offCanvasRender": null,
+      "nodeIdentity": {
+        "before": 16,
+        "after": 16,
+        "common": 16,
+        "tracked": 16,
+        "preserved": 16,
+        "virtualizationChurn": [],
+        "remountedInPlace": [],
+        "commonIdentityPreserved": true,
+        "targetNodeId": null,
+        "targetIdentityPreserved": null
+      },
+      "appMetrics": {
+        "rendererWorkingSetMB": 306.6,
+        "gpuWorkingSetMB": 126.2,
+        "processCount": 5,
+        "processes": [
+          {
+            "type": "Browser",
+            "pid": 13366,
+            "workingSetMB": 322.4
+          },
+          {
+            "type": "GPU",
+            "pid": 13369,
+            "workingSetMB": 126.2
+          },
+          {
+            "type": "Utility",
+            "pid": 13370,
+            "workingSetMB": 45.1
+          },
+          {
+            "type": "Tab",
+            "pid": 13371,
+            "workingSetMB": 306.6
+          },
+          {
+            "type": "Utility",
+            "pid": 13372,
+            "workingSetMB": 45.1
+          }
+        ]
+      },
+      "runtimeVersions": {
+        "app": "0.21.0",
+        "electron": "43.4.1",
+        "chrome": "150.0.7871.224",
+        "node": "24.18.1",
+        "v8": "15.0.245.28-electron.0"
+      },
+      "pageErrors": [],
+      "consoleErrors": [],
+      "elapsedMs": 20250
+    },
+    {
+      "scale": "MIMG",
+      "scenario": "low-zoom-preview",
+      "runIndex": 1,
+      "fixture": {
+        "scale": "MIMG",
+        "imageNodes": 96,
+        "videoNodes": 0,
+        "nodes": 96,
+        "edges": 0,
+        "clips": 0,
+        "imageBytes": [
+          11961265,
+          11757599,
+          11030773,
+          9324705
+        ],
+        "imagePreviewBytes": [
+          28993,
+          42126,
+          52132,
+          27337
+        ],
+        "videoBytes": [
+          1380939031
+        ],
+        "mediaProfile": "real-assets"
+      },
+      "probe": {
+        "elapsedMs": 1021,
+        "frames": 122,
+        "fps": 119.5,
+        "frameGapP50Ms": 8.3,
+        "frameGapP95Ms": 9.2,
+        "maxFrameGapMs": 13,
+        "longTasks": 0,
+        "longTaskMs": 0,
+        "longTaskP95Ms": null,
+        "maxLoadingImages": 0,
+        "maxLoadingVideos": 0,
+        "maxActiveVideos": 0,
+        "firstMutationMs": null,
+        "mutations": {
+          "stage": 0,
+          "edges": 0,
+          "labels": 0
+        }
+      },
+      "cdpBefore": {
+        "LayoutCount": 7,
+        "RecalcStyleCount": 17,
+        "ScriptDurationMs": 140.3,
+        "LayoutDurationMs": 1.5,
+        "TaskDurationMs": 190.2,
+        "JSHeapUsedMB": 27.4,
+        "domNodes": 1144,
+        "domDocuments": 1,
+        "jsEventListeners": 960
+      },
+      "cdpAfter": {
+        "LayoutCount": 7,
+        "RecalcStyleCount": 17,
+        "ScriptDurationMs": 157.3,
+        "LayoutDurationMs": 1.5,
+        "TaskDurationMs": 231.3,
+        "JSHeapUsedMB": 28.2,
+        "domNodes": 1144,
+        "domDocuments": 1,
+        "jsEventListeners": 960
+      },
+      "cdpDelta": {
+        "LayoutCount": 0,
+        "RecalcStyleCount": 0,
+        "ScriptDurationMs": 17,
+        "LayoutDurationMs": 0,
+        "TaskDurationMs": 41.1,
+        "JSHeapUsedMB": 0.8,
+        "domNodes": 0,
+        "domDocuments": 0,
+        "jsEventListeners": 0
+      },
+      "beforePage": {
+        "domNodes": 836,
+        "canvasNodes": 20,
+        "lightweightCanvasNodes": 20,
+        "lightweightPreviewNodes": 20,
+        "imageElements": 20,
+        "videoElements": 0,
+        "visibleMedia": 20,
+        "loadedImages": 20,
+        "loadedVideos": 0,
+        "visibleMediaNodes": 20,
+        "visibleMediaPending": 0,
+        "visibleMediaFailures": 0,
+        "activeVideos": 0,
+        "resourceCount": 0,
+        "jsHeapUsedMB": 48.1,
+        "transform": {
+          "x": 225.325,
+          "y": 247.349,
+          "zoom": 0.435275
+        }
+      },
+      "page": {
+        "domNodes": 836,
+        "canvasNodes": 20,
+        "lightweightCanvasNodes": 20,
+        "lightweightPreviewNodes": 20,
+        "imageElements": 20,
+        "videoElements": 0,
+        "visibleMedia": 20,
+        "loadedImages": 20,
+        "loadedVideos": 0,
+        "visibleMediaNodes": 20,
+        "visibleMediaPending": 0,
+        "visibleMediaFailures": 0,
+        "activeVideos": 0,
+        "resourceCount": 0,
+        "jsHeapUsedMB": 48.1,
+        "transform": {
+          "x": 225.325,
+          "y": 247.349,
+          "zoom": 0.435275
+        }
+      },
+      "actionDetails": {
+        "settled": {
+          "domNodes": 836,
+          "canvasNodes": 20,
+          "lightweightCanvasNodes": 20,
+          "lightweightPreviewNodes": 20,
+          "imageElements": 20,
+          "videoElements": 0,
+          "visibleMedia": 20,
+          "loadedImages": 20,
+          "loadedVideos": 0,
+          "visibleMediaNodes": 20,
+          "visibleMediaPending": 0,
+          "visibleMediaFailures": 0,
+          "activeVideos": 0,
+          "resourceCount": 0,
+          "jsHeapUsedMB": 48.1,
+          "transform": {
+            "x": 225.325,
+            "y": 247.349,
+            "zoom": 0.435275
+          }
+        },
+        "zoom": 0.435275
+      },
+      "offCanvasRender": null,
+      "nodeIdentity": {
+        "before": 20,
+        "after": 20,
+        "common": 20,
+        "tracked": 20,
+        "preserved": 20,
+        "virtualizationChurn": [],
+        "remountedInPlace": [],
+        "commonIdentityPreserved": true,
+        "targetNodeId": null,
+        "targetIdentityPreserved": null
+      },
+      "appMetrics": {
+        "rendererWorkingSetMB": 321.4,
+        "gpuWorkingSetMB": 127,
+        "processCount": 5,
+        "processes": [
+          {
+            "type": "Browser",
+            "pid": 13582,
+            "workingSetMB": 329.5
+          },
+          {
+            "type": "GPU",
+            "pid": 13585,
+            "workingSetMB": 127
+          },
+          {
+            "type": "Utility",
+            "pid": 13586,
+            "workingSetMB": 45
+          },
+          {
+            "type": "Tab",
+            "pid": 13587,
+            "workingSetMB": 321.4
+          },
+          {
+            "type": "Utility",
+            "pid": 13588,
+            "workingSetMB": 45
+          }
+        ]
+      },
+      "runtimeVersions": {
+        "app": "0.21.0",
+        "electron": "43.4.1",
+        "chrome": "150.0.7871.224",
+        "node": "24.18.1",
+        "v8": "15.0.245.28-electron.0"
+      },
+      "pageErrors": [],
+      "consoleErrors": [],
+      "elapsedMs": 20377
+    },
+    {
+      "scale": "MIMG",
+      "scenario": "low-zoom-preview",
+      "runIndex": 2,
+      "fixture": {
+        "scale": "MIMG",
+        "imageNodes": 96,
+        "videoNodes": 0,
+        "nodes": 96,
+        "edges": 0,
+        "clips": 0,
+        "imageBytes": [
+          11961265,
+          11757599,
+          11030773,
+          9324705
+        ],
+        "imagePreviewBytes": [
+          28993,
+          42126,
+          52132,
+          27337
+        ],
+        "videoBytes": [
+          1380939031
+        ],
+        "mediaProfile": "real-assets"
+      },
+      "probe": {
+        "elapsedMs": 1024,
+        "frames": 123,
+        "fps": 120.2,
+        "frameGapP50Ms": 8.3,
+        "frameGapP95Ms": 9.2,
+        "maxFrameGapMs": 9.4,
+        "longTasks": 0,
+        "longTaskMs": 0,
+        "longTaskP95Ms": null,
+        "maxLoadingImages": 0,
+        "maxLoadingVideos": 0,
+        "maxActiveVideos": 0,
+        "firstMutationMs": null,
+        "mutations": {
+          "stage": 0,
+          "edges": 0,
+          "labels": 0
+        }
+      },
+      "cdpBefore": {
+        "LayoutCount": 8,
+        "RecalcStyleCount": 18,
+        "ScriptDurationMs": 136.7,
+        "LayoutDurationMs": 1.6,
+        "TaskDurationMs": 184.8,
+        "JSHeapUsedMB": 28.1,
+        "domNodes": 1186,
+        "domDocuments": 1,
+        "jsEventListeners": 960
+      },
+      "cdpAfter": {
+        "LayoutCount": 8,
+        "RecalcStyleCount": 18,
+        "ScriptDurationMs": 156,
+        "LayoutDurationMs": 1.6,
+        "TaskDurationMs": 234.7,
+        "JSHeapUsedMB": 28.9,
+        "domNodes": 1186,
+        "domDocuments": 1,
+        "jsEventListeners": 960
+      },
+      "cdpDelta": {
+        "LayoutCount": 0,
+        "RecalcStyleCount": 0,
+        "ScriptDurationMs": 19.3,
+        "LayoutDurationMs": 0,
+        "TaskDurationMs": 49.9,
+        "JSHeapUsedMB": 0.8,
+        "domNodes": 0,
+        "domDocuments": 0,
+        "jsEventListeners": 0
+      },
+      "beforePage": {
+        "domNodes": 836,
+        "canvasNodes": 20,
+        "lightweightCanvasNodes": 20,
+        "lightweightPreviewNodes": 20,
+        "imageElements": 20,
+        "videoElements": 0,
+        "visibleMedia": 20,
+        "loadedImages": 20,
+        "loadedVideos": 0,
+        "visibleMediaNodes": 20,
+        "visibleMediaPending": 0,
+        "visibleMediaFailures": 0,
+        "activeVideos": 0,
+        "resourceCount": 0,
+        "jsHeapUsedMB": 48.1,
+        "transform": {
+          "x": 225.325,
+          "y": 247.349,
+          "zoom": 0.435275
+        }
+      },
+      "page": {
+        "domNodes": 836,
+        "canvasNodes": 20,
+        "lightweightCanvasNodes": 20,
+        "lightweightPreviewNodes": 20,
+        "imageElements": 20,
+        "videoElements": 0,
+        "visibleMedia": 20,
+        "loadedImages": 20,
+        "loadedVideos": 0,
+        "visibleMediaNodes": 20,
+        "visibleMediaPending": 0,
+        "visibleMediaFailures": 0,
+        "activeVideos": 0,
+        "resourceCount": 0,
+        "jsHeapUsedMB": 48.1,
+        "transform": {
+          "x": 225.325,
+          "y": 247.349,
+          "zoom": 0.435275
+        }
+      },
+      "actionDetails": {
+        "settled": {
+          "domNodes": 836,
+          "canvasNodes": 20,
+          "lightweightCanvasNodes": 20,
+          "lightweightPreviewNodes": 20,
+          "imageElements": 20,
+          "videoElements": 0,
+          "visibleMedia": 20,
+          "loadedImages": 20,
+          "loadedVideos": 0,
+          "visibleMediaNodes": 20,
+          "visibleMediaPending": 0,
+          "visibleMediaFailures": 0,
+          "activeVideos": 0,
+          "resourceCount": 0,
+          "jsHeapUsedMB": 48.1,
+          "transform": {
+            "x": 225.325,
+            "y": 247.349,
+            "zoom": 0.435275
+          }
+        },
+        "zoom": 0.435275
+      },
+      "offCanvasRender": null,
+      "nodeIdentity": {
+        "before": 20,
+        "after": 20,
+        "common": 20,
+        "tracked": 20,
+        "preserved": 20,
+        "virtualizationChurn": [],
+        "remountedInPlace": [],
+        "commonIdentityPreserved": true,
+        "targetNodeId": null,
+        "targetIdentityPreserved": null
+      },
+      "appMetrics": {
+        "rendererWorkingSetMB": 318.8,
+        "gpuWorkingSetMB": 126.4,
+        "processCount": 5,
+        "processes": [
+          {
+            "type": "Browser",
+            "pid": 13609,
+            "workingSetMB": 333
+          },
+          {
+            "type": "GPU",
+            "pid": 13612,
+            "workingSetMB": 126.4
+          },
+          {
+            "type": "Utility",
+            "pid": 13613,
+            "workingSetMB": 45.1
+          },
+          {
+            "type": "Tab",
+            "pid": 13614,
+            "workingSetMB": 318.8
+          },
+          {
+            "type": "Utility",
+            "pid": 13619,
+            "workingSetMB": 45
+          }
+        ]
+      },
+      "runtimeVersions": {
+        "app": "0.21.0",
+        "electron": "43.4.1",
+        "chrome": "150.0.7871.224",
+        "node": "24.18.1",
+        "v8": "15.0.245.28-electron.0"
+      },
+      "pageErrors": [],
+      "consoleErrors": [],
+      "elapsedMs": 20360
+    },
+    {
+      "scale": "LIMG",
+      "scenario": "low-zoom-preview",
+      "runIndex": 1,
+      "fixture": {
+        "scale": "LIMG",
+        "imageNodes": 192,
+        "videoNodes": 0,
+        "nodes": 192,
+        "edges": 0,
+        "clips": 0,
+        "imageBytes": [
+          11961265,
+          11757599,
+          11030773,
+          9324705
+        ],
+        "imagePreviewBytes": [
+          28993,
+          42126,
+          52132,
+          27337
+        ],
+        "videoBytes": [
+          1380939031
+        ],
+        "mediaProfile": "real-assets"
+      },
+      "probe": {
+        "elapsedMs": 1021,
+        "frames": 123,
+        "fps": 120.4,
+        "frameGapP50Ms": 8.3,
+        "frameGapP95Ms": 9.1,
+        "maxFrameGapMs": 9.7,
+        "longTasks": 0,
+        "longTaskMs": 0,
+        "longTaskP95Ms": null,
+        "maxLoadingImages": 0,
+        "maxLoadingVideos": 0,
+        "maxActiveVideos": 0,
+        "firstMutationMs": null,
+        "mutations": {
+          "stage": 0,
+          "edges": 0,
+          "labels": 0
+        }
+      },
+      "cdpBefore": {
+        "LayoutCount": 7,
+        "RecalcStyleCount": 16,
+        "ScriptDurationMs": 149.7,
+        "LayoutDurationMs": 1.6,
+        "TaskDurationMs": 187.7,
+        "JSHeapUsedMB": 29.6,
+        "domNodes": 1888,
+        "domDocuments": 1,
+        "jsEventListeners": 1008
+      },
+      "cdpAfter": {
+        "LayoutCount": 7,
+        "RecalcStyleCount": 16,
+        "ScriptDurationMs": 167.7,
+        "LayoutDurationMs": 1.6,
+        "TaskDurationMs": 231.7,
+        "JSHeapUsedMB": 30.4,
+        "domNodes": 1888,
+        "domDocuments": 1,
+        "jsEventListeners": 1008
+      },
+      "cdpDelta": {
+        "LayoutCount": 0,
+        "RecalcStyleCount": 0,
+        "ScriptDurationMs": 18,
+        "LayoutDurationMs": 0,
+        "TaskDurationMs": 44,
+        "JSHeapUsedMB": 0.8,
+        "domNodes": 0,
+        "domDocuments": 0,
+        "jsEventListeners": 0
+      },
+      "beforePage": {
+        "domNodes": 932,
+        "canvasNodes": 20,
+        "lightweightCanvasNodes": 20,
+        "lightweightPreviewNodes": 20,
+        "imageElements": 20,
+        "videoElements": 0,
+        "visibleMedia": 20,
+        "loadedImages": 20,
+        "loadedVideos": 0,
+        "visibleMediaNodes": 20,
+        "visibleMediaPending": 0,
+        "visibleMediaFailures": 0,
+        "activeVideos": 0,
+        "resourceCount": 0,
+        "jsHeapUsedMB": 54.2,
+        "transform": {
+          "x": 225.325,
+          "y": 247.349,
+          "zoom": 0.435275
+        }
+      },
+      "page": {
+        "domNodes": 932,
+        "canvasNodes": 20,
+        "lightweightCanvasNodes": 20,
+        "lightweightPreviewNodes": 20,
+        "imageElements": 20,
+        "videoElements": 0,
+        "visibleMedia": 20,
+        "loadedImages": 20,
+        "loadedVideos": 0,
+        "visibleMediaNodes": 20,
+        "visibleMediaPending": 0,
+        "visibleMediaFailures": 0,
+        "activeVideos": 0,
+        "resourceCount": 0,
+        "jsHeapUsedMB": 54.2,
+        "transform": {
+          "x": 225.325,
+          "y": 247.349,
+          "zoom": 0.435275
+        }
+      },
+      "actionDetails": {
+        "settled": {
+          "domNodes": 932,
+          "canvasNodes": 20,
+          "lightweightCanvasNodes": 20,
+          "lightweightPreviewNodes": 20,
+          "imageElements": 20,
+          "videoElements": 0,
+          "visibleMedia": 20,
+          "loadedImages": 20,
+          "loadedVideos": 0,
+          "visibleMediaNodes": 20,
+          "visibleMediaPending": 0,
+          "visibleMediaFailures": 0,
+          "activeVideos": 0,
+          "resourceCount": 0,
+          "jsHeapUsedMB": 54.2,
+          "transform": {
+            "x": 225.325,
+            "y": 247.349,
+            "zoom": 0.435275
+          }
+        },
+        "zoom": 0.435275
+      },
+      "offCanvasRender": null,
+      "nodeIdentity": {
+        "before": 20,
+        "after": 20,
+        "common": 20,
+        "tracked": 20,
+        "preserved": 20,
+        "virtualizationChurn": [],
+        "remountedInPlace": [],
+        "commonIdentityPreserved": true,
+        "targetNodeId": null,
+        "targetIdentityPreserved": null
+      },
+      "appMetrics": {
+        "rendererWorkingSetMB": 354.1,
+        "gpuWorkingSetMB": 127.6,
+        "processCount": 5,
+        "processes": [
+          {
+            "type": "Browser",
+            "pid": 13681,
+            "workingSetMB": 320.7
+          },
+          {
+            "type": "GPU",
+            "pid": 13684,
+            "workingSetMB": 127.6
+          },
+          {
+            "type": "Utility",
+            "pid": 13685,
+            "workingSetMB": 45
+          },
+          {
+            "type": "Tab",
+            "pid": 13686,
+            "workingSetMB": 354.1
+          },
+          {
+            "type": "Utility",
+            "pid": 13689,
+            "workingSetMB": 45
+          }
+        ]
+      },
+      "runtimeVersions": {
+        "app": "0.21.0",
+        "electron": "43.4.1",
+        "chrome": "150.0.7871.224",
+        "node": "24.18.1",
+        "v8": "15.0.245.28-electron.0"
+      },
+      "pageErrors": [],
+      "consoleErrors": [],
+      "elapsedMs": 21090
+    },
+    {
+      "scale": "LIMG",
+      "scenario": "low-zoom-preview",
+      "runIndex": 2,
+      "fixture": {
+        "scale": "LIMG",
+        "imageNodes": 192,
+        "videoNodes": 0,
+        "nodes": 192,
+        "edges": 0,
+        "clips": 0,
+        "imageBytes": [
+          11961265,
+          11757599,
+          11030773,
+          9324705
+        ],
+        "imagePreviewBytes": [
+          28993,
+          42126,
+          52132,
+          27337
+        ],
+        "videoBytes": [
+          1380939031
+        ],
+        "mediaProfile": "real-assets"
+      },
+      "probe": {
+        "elapsedMs": 1022,
+        "frames": 123,
+        "fps": 120.4,
+        "frameGapP50Ms": 8.3,
+        "frameGapP95Ms": 9,
+        "maxFrameGapMs": 11.7,
+        "longTasks": 0,
+        "longTaskMs": 0,
+        "longTaskP95Ms": null,
+        "maxLoadingImages": 0,
+        "maxLoadingVideos": 0,
+        "maxActiveVideos": 0,
+        "firstMutationMs": null,
+        "mutations": {
+          "stage": 0,
+          "edges": 0,
+          "labels": 0
+        }
+      },
+      "cdpBefore": {
+        "LayoutCount": 7,
+        "RecalcStyleCount": 16,
+        "ScriptDurationMs": 130.1,
+        "LayoutDurationMs": 1.7,
+        "TaskDurationMs": 155.8,
+        "JSHeapUsedMB": 56.6,
+        "domNodes": 12826,
+        "domDocuments": 1,
+        "jsEventListeners": 2160
+      },
+      "cdpAfter": {
+        "LayoutCount": 7,
+        "RecalcStyleCount": 16,
+        "ScriptDurationMs": 149.6,
+        "LayoutDurationMs": 1.7,
+        "TaskDurationMs": 206.7,
+        "JSHeapUsedMB": 57.3,
+        "domNodes": 12826,
+        "domDocuments": 1,
+        "jsEventListeners": 2160
+      },
+      "cdpDelta": {
+        "LayoutCount": 0,
+        "RecalcStyleCount": 0,
+        "ScriptDurationMs": 19.5,
+        "LayoutDurationMs": 0,
+        "TaskDurationMs": 50.9,
+        "JSHeapUsedMB": 0.7,
+        "domNodes": 0,
+        "domDocuments": 0,
+        "jsEventListeners": 0
+      },
+      "beforePage": {
+        "domNodes": 932,
+        "canvasNodes": 20,
+        "lightweightCanvasNodes": 20,
+        "lightweightPreviewNodes": 20,
+        "imageElements": 20,
+        "videoElements": 0,
+        "visibleMedia": 20,
+        "loadedImages": 20,
+        "loadedVideos": 0,
+        "visibleMediaNodes": 20,
+        "visibleMediaPending": 0,
+        "visibleMediaFailures": 0,
+        "activeVideos": 0,
+        "resourceCount": 0,
+        "jsHeapUsedMB": 54.2,
+        "transform": {
+          "x": 225.325,
+          "y": 247.349,
+          "zoom": 0.435275
+        }
+      },
+      "page": {
+        "domNodes": 932,
+        "canvasNodes": 20,
+        "lightweightCanvasNodes": 20,
+        "lightweightPreviewNodes": 20,
+        "imageElements": 20,
+        "videoElements": 0,
+        "visibleMedia": 20,
+        "loadedImages": 20,
+        "loadedVideos": 0,
+        "visibleMediaNodes": 20,
+        "visibleMediaPending": 0,
+        "visibleMediaFailures": 0,
+        "activeVideos": 0,
+        "resourceCount": 0,
+        "jsHeapUsedMB": 54.2,
+        "transform": {
+          "x": 225.325,
+          "y": 247.349,
+          "zoom": 0.435275
+        }
+      },
+      "actionDetails": {
+        "settled": {
+          "domNodes": 932,
+          "canvasNodes": 20,
+          "lightweightCanvasNodes": 20,
+          "lightweightPreviewNodes": 20,
+          "imageElements": 20,
+          "videoElements": 0,
+          "visibleMedia": 20,
+          "loadedImages": 20,
+          "loadedVideos": 0,
+          "visibleMediaNodes": 20,
+          "visibleMediaPending": 0,
+          "visibleMediaFailures": 0,
+          "activeVideos": 0,
+          "resourceCount": 0,
+          "jsHeapUsedMB": 54.2,
+          "transform": {
+            "x": 225.325,
+            "y": 247.349,
+            "zoom": 0.435275
+          }
+        },
+        "zoom": 0.435275
+      },
+      "offCanvasRender": null,
+      "nodeIdentity": {
+        "before": 20,
+        "after": 20,
+        "common": 20,
+        "tracked": 20,
+        "preserved": 20,
+        "virtualizationChurn": [],
+        "remountedInPlace": [],
+        "commonIdentityPreserved": true,
+        "targetNodeId": null,
+        "targetIdentityPreserved": null
+      },
+      "appMetrics": {
+        "rendererWorkingSetMB": 360.4,
+        "gpuWorkingSetMB": 127,
+        "processCount": 5,
+        "processes": [
+          {
+            "type": "Browser",
+            "pid": 13702,
+            "workingSetMB": 320.6
+          },
+          {
+            "type": "GPU",
+            "pid": 13705,
+            "workingSetMB": 127
+          },
+          {
+            "type": "Utility",
+            "pid": 13706,
+            "workingSetMB": 45
+          },
+          {
+            "type": "Tab",
+            "pid": 13707,
+            "workingSetMB": 360.4
+          },
+          {
+            "type": "Utility",
+            "pid": 13710,
+            "workingSetMB": 45
+          }
+        ]
+      },
+      "runtimeVersions": {
+        "app": "0.21.0",
+        "electron": "43.4.1",
+        "chrome": "150.0.7871.224",
+        "node": "24.18.1",
+        "v8": "15.0.245.28-electron.0"
+      },
+      "pageErrors": [],
+      "consoleErrors": [],
+      "elapsedMs": 21108
+    }
+  ],
+  "warmupFailures": [],
+  "summary": {
+    "SIMG/low-zoom-preview": {
+      "samples": 2,
+      "errors": 0,
+      "metrics": {
+        "coldFirstCanvasMs": null,
+        "coldMediaSettledMs": null,
+        "fps": {
+          "median": 120.1,
+          "p95": 120.2,
+          "samples": [
+            120.1,
+            120.2
+          ]
+        },
+        "frameGapP95Ms": {
+          "median": 9.2,
+          "p95": 9.8,
+          "samples": [
+            9.2,
+            9.8
+          ]
+        },
+        "maxFrameGapMs": {
+          "median": 10.8,
+          "p95": 12.8,
+          "samples": [
+            10.8,
+            12.8
+          ]
+        },
+        "longTaskMs": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "longTaskP95Ms": null,
+        "maxLoadingImages": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "maxLoadingVideos": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "maxActiveVideos": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "layoutCount": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "recalcStyleCount": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "scriptDurationMs": {
+          "median": 12.8,
+          "p95": 16.7,
+          "samples": [
+            12.8,
+            16.7
+          ]
+        },
+        "layoutDurationMs": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "jsHeapUsedMB": {
+          "median": 42.6,
+          "p95": 45.2,
+          "samples": [
+            42.6,
+            45.2
+          ]
+        },
+        "visibleMedia": {
+          "median": 16,
+          "p95": 16,
+          "samples": [
+            16,
+            16
+          ]
+        },
+        "visibleMediaNodes": {
+          "median": 16,
+          "p95": 16,
+          "samples": [
+            16,
+            16
+          ]
+        },
+        "visibleMediaPending": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "visibleMediaFailures": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "loadedImages": {
+          "median": 16,
+          "p95": 16,
+          "samples": [
+            16,
+            16
+          ]
+        },
+        "loadedVideos": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "activeVideos": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "rendererWorkingSetMB": {
+          "median": 303.6,
+          "p95": 306.6,
+          "samples": [
+            303.6,
+            306.6
+          ]
+        },
+        "reloadHeapDeltaMB": null,
+        "reloadDurationP95Ms": null
+      },
+      "advisory": {
+        "perMove": {
+          "scriptPerMoveMs": {
+            "median": null,
+            "p95": null,
+            "samples": []
+          },
+          "layoutPerMove": {
+            "median": null,
+            "p95": null,
+            "samples": []
+          }
+        },
+        "dragOverPan": {
+          "scriptRatio": {
+            "median": null,
+            "samples": []
+          },
+          "layoutRatio": {
+            "median": null,
+            "samples": []
+          }
+        },
+        "actionLatency": {
+          "samples": [],
+          "p95Ms": null,
+          "medianMs": null
+        },
+        "offCanvasRender": {
+          "installed": false,
+          "windows": 0,
+          "totalMax": null,
+          "totalMedian": null,
+          "perComponentMax": {
+            "CategoryTree": null,
+            "AssetLibraryPanel": null,
+            "AssetPicker": null,
+            "TaskCenterButton": null,
+            "TaskCenterPanel": null,
+            "TimelinePreview": null,
+            "PreviewSourcePanel": null,
+            "OnboardingChecklist": null
+          }
+        }
+      },
+      "verdict": {
+        "pass": true,
+        "advisoryOnly": false,
+        "budgetsAdvisory": false,
+        "hardFailures": [],
+        "budgetChecks": [
+          {
+            "metric": "frameGapP95Ms",
+            "actualP95": 9.8,
+            "max": 33,
+            "pass": true,
+            "advisory": false
+          },
+          {
+            "metric": "maxFrameGapMs",
+            "actualP95": 12.8,
+            "max": 100,
+            "pass": true,
+            "advisory": true
+          },
+          {
+            "metric": "maxLoadingImages",
+            "actualP95": 0,
+            "max": 4,
+            "pass": true,
+            "advisory": false
+          },
+          {
+            "metric": "maxLoadingVideos",
+            "actualP95": 0,
+            "max": 1,
+            "pass": true,
+            "advisory": false
+          },
+          {
+            "metric": "maxActiveVideos",
+            "actualP95": 0,
+            "max": 1,
+            "pass": true,
+            "advisory": false
+          }
+        ]
+      }
+    },
+    "MIMG/low-zoom-preview": {
+      "samples": 2,
+      "errors": 0,
+      "metrics": {
+        "coldFirstCanvasMs": null,
+        "coldMediaSettledMs": null,
+        "fps": {
+          "median": 119.5,
+          "p95": 120.2,
+          "samples": [
+            119.5,
+            120.2
+          ]
+        },
+        "frameGapP95Ms": {
+          "median": 9.2,
+          "p95": 9.2,
+          "samples": [
+            9.2,
+            9.2
+          ]
+        },
+        "maxFrameGapMs": {
+          "median": 9.4,
+          "p95": 13,
+          "samples": [
+            9.4,
+            13
+          ]
+        },
+        "longTaskMs": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "longTaskP95Ms": null,
+        "maxLoadingImages": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "maxLoadingVideos": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "maxActiveVideos": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "layoutCount": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "recalcStyleCount": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "scriptDurationMs": {
+          "median": 17,
+          "p95": 19.3,
+          "samples": [
+            17,
+            19.3
+          ]
+        },
+        "layoutDurationMs": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "jsHeapUsedMB": {
+          "median": 48.1,
+          "p95": 48.1,
+          "samples": [
+            48.1,
+            48.1
+          ]
+        },
+        "visibleMedia": {
+          "median": 20,
+          "p95": 20,
+          "samples": [
+            20,
+            20
+          ]
+        },
+        "visibleMediaNodes": {
+          "median": 20,
+          "p95": 20,
+          "samples": [
+            20,
+            20
+          ]
+        },
+        "visibleMediaPending": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "visibleMediaFailures": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "loadedImages": {
+          "median": 20,
+          "p95": 20,
+          "samples": [
+            20,
+            20
+          ]
+        },
+        "loadedVideos": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "activeVideos": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "rendererWorkingSetMB": {
+          "median": 318.8,
+          "p95": 321.4,
+          "samples": [
+            318.8,
+            321.4
+          ]
+        },
+        "reloadHeapDeltaMB": null,
+        "reloadDurationP95Ms": null
+      },
+      "advisory": {
+        "perMove": {
+          "scriptPerMoveMs": {
+            "median": null,
+            "p95": null,
+            "samples": []
+          },
+          "layoutPerMove": {
+            "median": null,
+            "p95": null,
+            "samples": []
+          }
+        },
+        "dragOverPan": {
+          "scriptRatio": {
+            "median": null,
+            "samples": []
+          },
+          "layoutRatio": {
+            "median": null,
+            "samples": []
+          }
+        },
+        "actionLatency": {
+          "samples": [],
+          "p95Ms": null,
+          "medianMs": null
+        },
+        "offCanvasRender": {
+          "installed": false,
+          "windows": 0,
+          "totalMax": null,
+          "totalMedian": null,
+          "perComponentMax": {
+            "CategoryTree": null,
+            "AssetLibraryPanel": null,
+            "AssetPicker": null,
+            "TaskCenterButton": null,
+            "TaskCenterPanel": null,
+            "TimelinePreview": null,
+            "PreviewSourcePanel": null,
+            "OnboardingChecklist": null
+          }
+        }
+      },
+      "verdict": {
+        "pass": true,
+        "advisoryOnly": false,
+        "budgetsAdvisory": false,
+        "hardFailures": [],
+        "budgetChecks": [
+          {
+            "metric": "frameGapP95Ms",
+            "actualP95": 9.2,
+            "max": 33,
+            "pass": true,
+            "advisory": false
+          },
+          {
+            "metric": "maxFrameGapMs",
+            "actualP95": 13,
+            "max": 100,
+            "pass": true,
+            "advisory": true
+          },
+          {
+            "metric": "maxLoadingImages",
+            "actualP95": 0,
+            "max": 4,
+            "pass": true,
+            "advisory": false
+          },
+          {
+            "metric": "maxLoadingVideos",
+            "actualP95": 0,
+            "max": 1,
+            "pass": true,
+            "advisory": false
+          },
+          {
+            "metric": "maxActiveVideos",
+            "actualP95": 0,
+            "max": 1,
+            "pass": true,
+            "advisory": false
+          }
+        ]
+      }
+    },
+    "LIMG/low-zoom-preview": {
+      "samples": 2,
+      "errors": 0,
+      "metrics": {
+        "coldFirstCanvasMs": null,
+        "coldMediaSettledMs": null,
+        "fps": {
+          "median": 120.4,
+          "p95": 120.4,
+          "samples": [
+            120.4,
+            120.4
+          ]
+        },
+        "frameGapP95Ms": {
+          "median": 9,
+          "p95": 9.1,
+          "samples": [
+            9,
+            9.1
+          ]
+        },
+        "maxFrameGapMs": {
+          "median": 9.7,
+          "p95": 11.7,
+          "samples": [
+            9.7,
+            11.7
+          ]
+        },
+        "longTaskMs": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "longTaskP95Ms": null,
+        "maxLoadingImages": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "maxLoadingVideos": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "maxActiveVideos": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "layoutCount": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "recalcStyleCount": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "scriptDurationMs": {
+          "median": 18,
+          "p95": 19.5,
+          "samples": [
+            18,
+            19.5
+          ]
+        },
+        "layoutDurationMs": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "jsHeapUsedMB": {
+          "median": 54.2,
+          "p95": 54.2,
+          "samples": [
+            54.2,
+            54.2
+          ]
+        },
+        "visibleMedia": {
+          "median": 20,
+          "p95": 20,
+          "samples": [
+            20,
+            20
+          ]
+        },
+        "visibleMediaNodes": {
+          "median": 20,
+          "p95": 20,
+          "samples": [
+            20,
+            20
+          ]
+        },
+        "visibleMediaPending": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "visibleMediaFailures": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "loadedImages": {
+          "median": 20,
+          "p95": 20,
+          "samples": [
+            20,
+            20
+          ]
+        },
+        "loadedVideos": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "activeVideos": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "rendererWorkingSetMB": {
+          "median": 354.1,
+          "p95": 360.4,
+          "samples": [
+            354.1,
+            360.4
+          ]
+        },
+        "reloadHeapDeltaMB": null,
+        "reloadDurationP95Ms": null
+      },
+      "advisory": {
+        "perMove": {
+          "scriptPerMoveMs": {
+            "median": null,
+            "p95": null,
+            "samples": []
+          },
+          "layoutPerMove": {
+            "median": null,
+            "p95": null,
+            "samples": []
+          }
+        },
+        "dragOverPan": {
+          "scriptRatio": {
+            "median": null,
+            "samples": []
+          },
+          "layoutRatio": {
+            "median": null,
+            "samples": []
+          }
+        },
+        "actionLatency": {
+          "samples": [],
+          "p95Ms": null,
+          "medianMs": null
+        },
+        "offCanvasRender": {
+          "installed": false,
+          "windows": 0,
+          "totalMax": null,
+          "totalMedian": null,
+          "perComponentMax": {
+            "CategoryTree": null,
+            "AssetLibraryPanel": null,
+            "AssetPicker": null,
+            "TaskCenterButton": null,
+            "TaskCenterPanel": null,
+            "TimelinePreview": null,
+            "PreviewSourcePanel": null,
+            "OnboardingChecklist": null
+          }
+        }
+      },
+      "verdict": {
+        "pass": true,
+        "advisoryOnly": false,
+        "budgetsAdvisory": false,
+        "hardFailures": [],
+        "budgetChecks": [
+          {
+            "metric": "frameGapP95Ms",
+            "actualP95": 9.1,
+            "max": 33,
+            "pass": true,
+            "advisory": false
+          },
+          {
+            "metric": "maxFrameGapMs",
+            "actualP95": 11.7,
+            "max": 100,
+            "pass": true,
+            "advisory": true
+          },
+          {
+            "metric": "maxLoadingImages",
+            "actualP95": 0,
+            "max": 4,
+            "pass": true,
+            "advisory": false
+          },
+          {
+            "metric": "maxLoadingVideos",
+            "actualP95": 0,
+            "max": 1,
+            "pass": true,
+            "advisory": false
+          },
+          {
+            "metric": "maxActiveVideos",
+            "actualP95": 0,
+            "max": 1,
+            "pass": true,
+            "advisory": false
+          }
+        ]
+      }
+    }
+  },
+  "runtimeVersions": {
+    "app": "0.21.0",
+    "electron": "43.4.1",
+    "chrome": "150.0.7871.224",
+    "node": "24.18.1",
+    "v8": "15.0.245.28-electron.0"
+  },
+  "pass": true
+}

--- a/tests/ux/perf-results/canvas-real-4k-xl-reveal.json
+++ b/tests/ux/perf-results/canvas-real-4k-xl-reveal.json
@@ -1,0 +1,962 @@
+{
+  "label": "real-4k-xl-reveal",
+  "commit": "ba753cfa5ec7ad24e7bb3e453e3ef99ccdf64276",
+  "dirty": true,
+  "platform": "darwin",
+  "arch": "arm64",
+  "machine": {
+    "cpu": "Apple M5",
+    "logicalCpus": 10,
+    "totalMemoryGB": 24
+  },
+  "viewport": {
+    "width": 1600,
+    "height": 1000
+  },
+  "viewportOverride": null,
+  "sampleCount": 2,
+  "warmupCount": 1,
+  "scales": [
+    "XLIMG"
+  ],
+  "scenarios": [
+    "media-reveal"
+  ],
+  "leg": {
+    "devServer": false,
+    "cpuThrottleRate": 1,
+    "kind": "prod"
+  },
+  "results": [
+    {
+      "scale": "XLIMG",
+      "scenario": "media-reveal",
+      "runIndex": 1,
+      "fixture": {
+        "scale": "XLIMG",
+        "imageNodes": 320,
+        "videoNodes": 0,
+        "nodes": 320,
+        "edges": 0,
+        "clips": 0,
+        "imageBytes": [
+          11961265,
+          11757599,
+          11030773,
+          9324705
+        ],
+        "imagePreviewBytes": [
+          28993,
+          42126,
+          52132,
+          27337
+        ],
+        "videoBytes": [
+          1380939031
+        ],
+        "mediaProfile": "real-assets"
+      },
+      "probe": {
+        "elapsedMs": 5263,
+        "frames": 632,
+        "fps": 120.1,
+        "frameGapP50Ms": 8.3,
+        "frameGapP95Ms": 10,
+        "maxFrameGapMs": 26.6,
+        "longTasks": 0,
+        "longTaskMs": 0,
+        "longTaskP95Ms": null,
+        "maxLoadingImages": 0,
+        "maxLoadingVideos": 0,
+        "maxActiveVideos": 0,
+        "firstMutationMs": 17,
+        "mutations": {
+          "stage": 10,
+          "edges": 29,
+          "labels": 0
+        }
+      },
+      "cdpBefore": {
+        "LayoutCount": 0,
+        "RecalcStyleCount": 0,
+        "ScriptDurationMs": 0.1,
+        "LayoutDurationMs": 0,
+        "TaskDurationMs": 0.8,
+        "JSHeapUsedMB": 57.3,
+        "domNodes": 19377,
+        "domDocuments": 1,
+        "jsEventListeners": 2787
+      },
+      "cdpAfter": {
+        "LayoutCount": 18,
+        "RecalcStyleCount": 199,
+        "ScriptDurationMs": 132.9,
+        "LayoutDurationMs": 2.2,
+        "TaskDurationMs": 350.3,
+        "JSHeapUsedMB": 32.3,
+        "domNodes": 1624,
+        "domDocuments": 1,
+        "jsEventListeners": 1076
+      },
+      "cdpDelta": {
+        "LayoutCount": 18,
+        "RecalcStyleCount": 199,
+        "ScriptDurationMs": 132.8,
+        "LayoutDurationMs": 2.2,
+        "TaskDurationMs": 349.5,
+        "JSHeapUsedMB": -25,
+        "domNodes": -17753,
+        "domDocuments": 0,
+        "jsEventListeners": -1711
+      },
+      "beforePage": {
+        "domNodes": 958,
+        "canvasNodes": 6,
+        "lightweightCanvasNodes": 0,
+        "lightweightPreviewNodes": 0,
+        "imageElements": 6,
+        "videoElements": 0,
+        "visibleMedia": 6,
+        "loadedImages": 6,
+        "loadedVideos": 0,
+        "visibleMediaNodes": 6,
+        "visibleMediaPending": 0,
+        "visibleMediaFailures": 0,
+        "activeVideos": 0,
+        "resourceCount": 0,
+        "jsHeapUsedMB": 64.8,
+        "transform": {
+          "x": 0,
+          "y": 0,
+          "zoom": 1
+        }
+      },
+      "page": {
+        "domNodes": 958,
+        "canvasNodes": 6,
+        "lightweightCanvasNodes": 0,
+        "lightweightPreviewNodes": 0,
+        "imageElements": 6,
+        "videoElements": 0,
+        "visibleMedia": 6,
+        "loadedImages": 6,
+        "loadedVideos": 0,
+        "visibleMediaNodes": 6,
+        "visibleMediaPending": 0,
+        "visibleMediaFailures": 0,
+        "activeVideos": 0,
+        "resourceCount": 0,
+        "jsHeapUsedMB": 64.8,
+        "transform": {
+          "x": -400,
+          "y": -950,
+          "zoom": 1
+        }
+      },
+      "actionDetails": {
+        "snapshots": [
+          {
+            "domNodes": 1156,
+            "canvasNodes": 12,
+            "lightweightCanvasNodes": 0,
+            "lightweightPreviewNodes": 0,
+            "imageElements": 12,
+            "videoElements": 0,
+            "visibleMedia": 12,
+            "loadedImages": 12,
+            "loadedVideos": 0,
+            "visibleMediaNodes": 12,
+            "visibleMediaPending": 0,
+            "visibleMediaFailures": 0,
+            "activeVideos": 0,
+            "resourceCount": 0,
+            "jsHeapUsedMB": 64.8,
+            "transform": {
+              "x": -80,
+              "y": -190,
+              "zoom": 1
+            }
+          },
+          {
+            "domNodes": 1057,
+            "canvasNodes": 9,
+            "lightweightCanvasNodes": 0,
+            "lightweightPreviewNodes": 0,
+            "imageElements": 9,
+            "videoElements": 0,
+            "visibleMedia": 9,
+            "loadedImages": 9,
+            "loadedVideos": 0,
+            "visibleMediaNodes": 9,
+            "visibleMediaPending": 0,
+            "visibleMediaFailures": 0,
+            "activeVideos": 0,
+            "resourceCount": 0,
+            "jsHeapUsedMB": 64.8,
+            "transform": {
+              "x": -160,
+              "y": -380,
+              "zoom": 1
+            }
+          },
+          {
+            "domNodes": 1057,
+            "canvasNodes": 9,
+            "lightweightCanvasNodes": 0,
+            "lightweightPreviewNodes": 0,
+            "imageElements": 9,
+            "videoElements": 0,
+            "visibleMedia": 9,
+            "loadedImages": 9,
+            "loadedVideos": 0,
+            "visibleMediaNodes": 9,
+            "visibleMediaPending": 0,
+            "visibleMediaFailures": 0,
+            "activeVideos": 0,
+            "resourceCount": 0,
+            "jsHeapUsedMB": 64.8,
+            "transform": {
+              "x": -240,
+              "y": -570,
+              "zoom": 1
+            }
+          },
+          {
+            "domNodes": 1156,
+            "canvasNodes": 12,
+            "lightweightCanvasNodes": 0,
+            "lightweightPreviewNodes": 0,
+            "imageElements": 12,
+            "videoElements": 0,
+            "visibleMedia": 12,
+            "loadedImages": 12,
+            "loadedVideos": 0,
+            "visibleMediaNodes": 12,
+            "visibleMediaPending": 0,
+            "visibleMediaFailures": 0,
+            "activeVideos": 0,
+            "resourceCount": 0,
+            "jsHeapUsedMB": 64.8,
+            "transform": {
+              "x": -320,
+              "y": -760,
+              "zoom": 1
+            }
+          },
+          {
+            "domNodes": 958,
+            "canvasNodes": 6,
+            "lightweightCanvasNodes": 0,
+            "lightweightPreviewNodes": 0,
+            "imageElements": 6,
+            "videoElements": 0,
+            "visibleMedia": 6,
+            "loadedImages": 6,
+            "loadedVideos": 0,
+            "visibleMediaNodes": 6,
+            "visibleMediaPending": 0,
+            "visibleMediaFailures": 0,
+            "activeVideos": 0,
+            "resourceCount": 0,
+            "jsHeapUsedMB": 64.8,
+            "transform": {
+              "x": -400,
+              "y": -950,
+              "zoom": 1
+            }
+          }
+        ],
+        "settled": {
+          "domNodes": 958,
+          "canvasNodes": 6,
+          "lightweightCanvasNodes": 0,
+          "lightweightPreviewNodes": 0,
+          "imageElements": 6,
+          "videoElements": 0,
+          "visibleMedia": 6,
+          "loadedImages": 6,
+          "loadedVideos": 0,
+          "visibleMediaNodes": 6,
+          "visibleMediaPending": 0,
+          "visibleMediaFailures": 0,
+          "activeVideos": 0,
+          "resourceCount": 0,
+          "jsHeapUsedMB": 64.8,
+          "transform": {
+            "x": -400,
+            "y": -950,
+            "zoom": 1
+          }
+        }
+      },
+      "offCanvasRender": null,
+      "nodeIdentity": {
+        "before": 6,
+        "after": 6,
+        "common": 0,
+        "tracked": 0,
+        "preserved": 0,
+        "virtualizationChurn": [
+          "canvas-perf-image-36",
+          "canvas-perf-image-2",
+          "canvas-perf-image-14",
+          "canvas-perf-image-26",
+          "canvas-perf-image-0",
+          "canvas-perf-image-1",
+          "canvas-perf-image-48",
+          "canvas-perf-image-12",
+          "canvas-perf-image-13",
+          "canvas-perf-image-60",
+          "canvas-perf-image-24",
+          "canvas-perf-image-25"
+        ],
+        "remountedInPlace": [],
+        "commonIdentityPreserved": true,
+        "targetNodeId": null,
+        "targetIdentityPreserved": null
+      },
+      "appMetrics": {
+        "rendererWorkingSetMB": 385.9,
+        "gpuWorkingSetMB": 137.4,
+        "processCount": 5,
+        "processes": [
+          {
+            "type": "Browser",
+            "pid": 96198,
+            "workingSetMB": 344.2
+          },
+          {
+            "type": "GPU",
+            "pid": 96212,
+            "workingSetMB": 137.4
+          },
+          {
+            "type": "Utility",
+            "pid": 96214,
+            "workingSetMB": 45.1
+          },
+          {
+            "type": "Tab",
+            "pid": 96319,
+            "workingSetMB": 385.9
+          },
+          {
+            "type": "Utility",
+            "pid": 96459,
+            "workingSetMB": 45.1
+          }
+        ]
+      },
+      "runtimeVersions": {
+        "app": "0.21.0",
+        "electron": "43.4.1",
+        "chrome": "150.0.7871.224",
+        "node": "24.18.1",
+        "v8": "15.0.245.28-electron.0"
+      },
+      "pageErrors": [],
+      "consoleErrors": [],
+      "elapsedMs": 25573
+    },
+    {
+      "scale": "XLIMG",
+      "scenario": "media-reveal",
+      "runIndex": 2,
+      "fixture": {
+        "scale": "XLIMG",
+        "imageNodes": 320,
+        "videoNodes": 0,
+        "nodes": 320,
+        "edges": 0,
+        "clips": 0,
+        "imageBytes": [
+          11961265,
+          11757599,
+          11030773,
+          9324705
+        ],
+        "imagePreviewBytes": [
+          28993,
+          42126,
+          52132,
+          27337
+        ],
+        "videoBytes": [
+          1380939031
+        ],
+        "mediaProfile": "real-assets"
+      },
+      "probe": {
+        "elapsedMs": 5234,
+        "frames": 627,
+        "fps": 119.8,
+        "frameGapP50Ms": 8.3,
+        "frameGapP95Ms": 10,
+        "maxFrameGapMs": 24.9,
+        "longTasks": 0,
+        "longTaskMs": 0,
+        "longTaskP95Ms": null,
+        "maxLoadingImages": 0,
+        "maxLoadingVideos": 0,
+        "maxActiveVideos": 0,
+        "firstMutationMs": 17,
+        "mutations": {
+          "stage": 10,
+          "edges": 29,
+          "labels": 0
+        }
+      },
+      "cdpBefore": {
+        "LayoutCount": 0,
+        "RecalcStyleCount": 0,
+        "ScriptDurationMs": 0,
+        "LayoutDurationMs": 0,
+        "TaskDurationMs": 0.6,
+        "JSHeapUsedMB": 60.1,
+        "domNodes": 19557,
+        "domDocuments": 1,
+        "jsEventListeners": 2812
+      },
+      "cdpAfter": {
+        "LayoutCount": 17,
+        "RecalcStyleCount": 198,
+        "ScriptDurationMs": 125.2,
+        "LayoutDurationMs": 2.2,
+        "TaskDurationMs": 341,
+        "JSHeapUsedMB": 32.8,
+        "domNodes": 1624,
+        "domDocuments": 1,
+        "jsEventListeners": 1076
+      },
+      "cdpDelta": {
+        "LayoutCount": 17,
+        "RecalcStyleCount": 198,
+        "ScriptDurationMs": 125.2,
+        "LayoutDurationMs": 2.2,
+        "TaskDurationMs": 340.4,
+        "JSHeapUsedMB": -27.3,
+        "domNodes": -17933,
+        "domDocuments": 0,
+        "jsEventListeners": -1736
+      },
+      "beforePage": {
+        "domNodes": 958,
+        "canvasNodes": 6,
+        "lightweightCanvasNodes": 0,
+        "lightweightPreviewNodes": 0,
+        "imageElements": 6,
+        "videoElements": 0,
+        "visibleMedia": 6,
+        "loadedImages": 6,
+        "loadedVideos": 0,
+        "visibleMediaNodes": 6,
+        "visibleMediaPending": 0,
+        "visibleMediaFailures": 0,
+        "activeVideos": 0,
+        "resourceCount": 0,
+        "jsHeapUsedMB": 68.9,
+        "transform": {
+          "x": 0,
+          "y": 0,
+          "zoom": 1
+        }
+      },
+      "page": {
+        "domNodes": 958,
+        "canvasNodes": 6,
+        "lightweightCanvasNodes": 0,
+        "lightweightPreviewNodes": 0,
+        "imageElements": 6,
+        "videoElements": 0,
+        "visibleMedia": 6,
+        "loadedImages": 6,
+        "loadedVideos": 0,
+        "visibleMediaNodes": 6,
+        "visibleMediaPending": 0,
+        "visibleMediaFailures": 0,
+        "activeVideos": 0,
+        "resourceCount": 0,
+        "jsHeapUsedMB": 68.9,
+        "transform": {
+          "x": -400,
+          "y": -950,
+          "zoom": 1
+        }
+      },
+      "actionDetails": {
+        "snapshots": [
+          {
+            "domNodes": 1156,
+            "canvasNodes": 12,
+            "lightweightCanvasNodes": 0,
+            "lightweightPreviewNodes": 0,
+            "imageElements": 12,
+            "videoElements": 0,
+            "visibleMedia": 12,
+            "loadedImages": 12,
+            "loadedVideos": 0,
+            "visibleMediaNodes": 12,
+            "visibleMediaPending": 0,
+            "visibleMediaFailures": 0,
+            "activeVideos": 0,
+            "resourceCount": 0,
+            "jsHeapUsedMB": 68.9,
+            "transform": {
+              "x": -80,
+              "y": -190,
+              "zoom": 1
+            }
+          },
+          {
+            "domNodes": 1057,
+            "canvasNodes": 9,
+            "lightweightCanvasNodes": 0,
+            "lightweightPreviewNodes": 0,
+            "imageElements": 9,
+            "videoElements": 0,
+            "visibleMedia": 9,
+            "loadedImages": 9,
+            "loadedVideos": 0,
+            "visibleMediaNodes": 9,
+            "visibleMediaPending": 0,
+            "visibleMediaFailures": 0,
+            "activeVideos": 0,
+            "resourceCount": 0,
+            "jsHeapUsedMB": 68.9,
+            "transform": {
+              "x": -160,
+              "y": -380,
+              "zoom": 1
+            }
+          },
+          {
+            "domNodes": 1057,
+            "canvasNodes": 9,
+            "lightweightCanvasNodes": 0,
+            "lightweightPreviewNodes": 0,
+            "imageElements": 9,
+            "videoElements": 0,
+            "visibleMedia": 9,
+            "loadedImages": 9,
+            "loadedVideos": 0,
+            "visibleMediaNodes": 9,
+            "visibleMediaPending": 0,
+            "visibleMediaFailures": 0,
+            "activeVideos": 0,
+            "resourceCount": 0,
+            "jsHeapUsedMB": 68.9,
+            "transform": {
+              "x": -240,
+              "y": -570,
+              "zoom": 1
+            }
+          },
+          {
+            "domNodes": 1156,
+            "canvasNodes": 12,
+            "lightweightCanvasNodes": 0,
+            "lightweightPreviewNodes": 0,
+            "imageElements": 12,
+            "videoElements": 0,
+            "visibleMedia": 12,
+            "loadedImages": 12,
+            "loadedVideos": 0,
+            "visibleMediaNodes": 12,
+            "visibleMediaPending": 0,
+            "visibleMediaFailures": 0,
+            "activeVideos": 0,
+            "resourceCount": 0,
+            "jsHeapUsedMB": 68.9,
+            "transform": {
+              "x": -320,
+              "y": -760,
+              "zoom": 1
+            }
+          },
+          {
+            "domNodes": 958,
+            "canvasNodes": 6,
+            "lightweightCanvasNodes": 0,
+            "lightweightPreviewNodes": 0,
+            "imageElements": 6,
+            "videoElements": 0,
+            "visibleMedia": 6,
+            "loadedImages": 6,
+            "loadedVideos": 0,
+            "visibleMediaNodes": 6,
+            "visibleMediaPending": 0,
+            "visibleMediaFailures": 0,
+            "activeVideos": 0,
+            "resourceCount": 0,
+            "jsHeapUsedMB": 68.9,
+            "transform": {
+              "x": -400,
+              "y": -950,
+              "zoom": 1
+            }
+          }
+        ],
+        "settled": {
+          "domNodes": 958,
+          "canvasNodes": 6,
+          "lightweightCanvasNodes": 0,
+          "lightweightPreviewNodes": 0,
+          "imageElements": 6,
+          "videoElements": 0,
+          "visibleMedia": 6,
+          "loadedImages": 6,
+          "loadedVideos": 0,
+          "visibleMediaNodes": 6,
+          "visibleMediaPending": 0,
+          "visibleMediaFailures": 0,
+          "activeVideos": 0,
+          "resourceCount": 0,
+          "jsHeapUsedMB": 68.9,
+          "transform": {
+            "x": -400,
+            "y": -950,
+            "zoom": 1
+          }
+        }
+      },
+      "offCanvasRender": null,
+      "nodeIdentity": {
+        "before": 6,
+        "after": 6,
+        "common": 0,
+        "tracked": 0,
+        "preserved": 0,
+        "virtualizationChurn": [
+          "canvas-perf-image-36",
+          "canvas-perf-image-2",
+          "canvas-perf-image-14",
+          "canvas-perf-image-26",
+          "canvas-perf-image-0",
+          "canvas-perf-image-1",
+          "canvas-perf-image-48",
+          "canvas-perf-image-12",
+          "canvas-perf-image-13",
+          "canvas-perf-image-60",
+          "canvas-perf-image-24",
+          "canvas-perf-image-25"
+        ],
+        "remountedInPlace": [],
+        "commonIdentityPreserved": true,
+        "targetNodeId": null,
+        "targetIdentityPreserved": null
+      },
+      "appMetrics": {
+        "rendererWorkingSetMB": 382,
+        "gpuWorkingSetMB": 130.5,
+        "processCount": 5,
+        "processes": [
+          {
+            "type": "Browser",
+            "pid": 6577,
+            "workingSetMB": 343.8
+          },
+          {
+            "type": "GPU",
+            "pid": 6770,
+            "workingSetMB": 130.5
+          },
+          {
+            "type": "Utility",
+            "pid": 6772,
+            "workingSetMB": 45.1
+          },
+          {
+            "type": "Tab",
+            "pid": 6857,
+            "workingSetMB": 382
+          },
+          {
+            "type": "Utility",
+            "pid": 6931,
+            "workingSetMB": 45
+          }
+        ]
+      },
+      "runtimeVersions": {
+        "app": "0.21.0",
+        "electron": "43.4.1",
+        "chrome": "150.0.7871.224",
+        "node": "24.18.1",
+        "v8": "15.0.245.28-electron.0"
+      },
+      "pageErrors": [],
+      "consoleErrors": [],
+      "elapsedMs": 25745
+    }
+  ],
+  "warmupFailures": [],
+  "summary": {
+    "XLIMG/media-reveal": {
+      "samples": 2,
+      "errors": 0,
+      "metrics": {
+        "coldFirstCanvasMs": null,
+        "coldMediaSettledMs": null,
+        "fps": {
+          "median": 119.8,
+          "p95": 120.1,
+          "samples": [
+            119.8,
+            120.1
+          ]
+        },
+        "frameGapP95Ms": {
+          "median": 10,
+          "p95": 10,
+          "samples": [
+            10,
+            10
+          ]
+        },
+        "maxFrameGapMs": {
+          "median": 24.9,
+          "p95": 26.6,
+          "samples": [
+            24.9,
+            26.6
+          ]
+        },
+        "longTaskMs": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "longTaskP95Ms": null,
+        "maxLoadingImages": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "maxLoadingVideos": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "maxActiveVideos": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "layoutCount": {
+          "median": 17,
+          "p95": 18,
+          "samples": [
+            17,
+            18
+          ]
+        },
+        "recalcStyleCount": {
+          "median": 198,
+          "p95": 199,
+          "samples": [
+            198,
+            199
+          ]
+        },
+        "scriptDurationMs": {
+          "median": 125.2,
+          "p95": 132.8,
+          "samples": [
+            125.2,
+            132.8
+          ]
+        },
+        "layoutDurationMs": {
+          "median": 2.2,
+          "p95": 2.2,
+          "samples": [
+            2.2,
+            2.2
+          ]
+        },
+        "jsHeapUsedMB": {
+          "median": 64.8,
+          "p95": 68.9,
+          "samples": [
+            64.8,
+            68.9
+          ]
+        },
+        "visibleMedia": {
+          "median": 6,
+          "p95": 6,
+          "samples": [
+            6,
+            6
+          ]
+        },
+        "visibleMediaNodes": {
+          "median": 6,
+          "p95": 6,
+          "samples": [
+            6,
+            6
+          ]
+        },
+        "visibleMediaPending": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "visibleMediaFailures": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "loadedImages": {
+          "median": 6,
+          "p95": 6,
+          "samples": [
+            6,
+            6
+          ]
+        },
+        "loadedVideos": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "activeVideos": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "rendererWorkingSetMB": {
+          "median": 382,
+          "p95": 385.9,
+          "samples": [
+            382,
+            385.9
+          ]
+        },
+        "reloadHeapDeltaMB": null,
+        "reloadDurationP95Ms": null
+      },
+      "advisory": {
+        "perMove": {
+          "scriptPerMoveMs": {
+            "median": null,
+            "p95": null,
+            "samples": []
+          },
+          "layoutPerMove": {
+            "median": null,
+            "p95": null,
+            "samples": []
+          }
+        },
+        "dragOverPan": {
+          "scriptRatio": {
+            "median": null,
+            "samples": []
+          },
+          "layoutRatio": {
+            "median": null,
+            "samples": []
+          }
+        },
+        "actionLatency": {
+          "samples": [],
+          "p95Ms": null,
+          "medianMs": null
+        },
+        "offCanvasRender": {
+          "installed": false,
+          "windows": 0,
+          "totalMax": null,
+          "totalMedian": null,
+          "perComponentMax": {
+            "CategoryTree": null,
+            "AssetLibraryPanel": null,
+            "AssetPicker": null,
+            "TaskCenterButton": null,
+            "TaskCenterPanel": null,
+            "TimelinePreview": null,
+            "PreviewSourcePanel": null,
+            "OnboardingChecklist": null
+          }
+        }
+      },
+      "verdict": {
+        "pass": true,
+        "advisoryOnly": false,
+        "budgetsAdvisory": false,
+        "hardFailures": [],
+        "budgetChecks": [
+          {
+            "metric": "frameGapP95Ms",
+            "actualP95": 10,
+            "max": 33,
+            "pass": true,
+            "advisory": false
+          },
+          {
+            "metric": "maxFrameGapMs",
+            "actualP95": 26.6,
+            "max": 100,
+            "pass": true,
+            "advisory": true
+          },
+          {
+            "metric": "maxLoadingImages",
+            "actualP95": 0,
+            "max": 4,
+            "pass": true,
+            "advisory": false
+          },
+          {
+            "metric": "maxLoadingVideos",
+            "actualP95": 0,
+            "max": 1,
+            "pass": true,
+            "advisory": false
+          },
+          {
+            "metric": "maxActiveVideos",
+            "actualP95": 0,
+            "max": 1,
+            "pass": true,
+            "advisory": false
+          }
+        ]
+      }
+    }
+  },
+  "runtimeVersions": {
+    "app": "0.21.0",
+    "electron": "43.4.1",
+    "chrome": "150.0.7871.224",
+    "node": "24.18.1",
+    "v8": "15.0.245.28-electron.0"
+  },
+  "pass": true
+}

--- a/tests/ux/perf-results/canvas-real-4k-xl.json
+++ b/tests/ux/perf-results/canvas-real-4k-xl.json
@@ -1,0 +1,714 @@
+{
+  "label": "real-4k-xl",
+  "commit": "ba753cfa5ec7ad24e7bb3e453e3ef99ccdf64276",
+  "dirty": true,
+  "platform": "darwin",
+  "arch": "arm64",
+  "machine": {
+    "cpu": "Apple M5",
+    "logicalCpus": 10,
+    "totalMemoryGB": 24
+  },
+  "viewport": {
+    "width": 1600,
+    "height": 1000
+  },
+  "viewportOverride": null,
+  "sampleCount": 2,
+  "warmupCount": 1,
+  "scales": [
+    "XLIMG"
+  ],
+  "scenarios": [
+    "low-zoom-preview"
+  ],
+  "leg": {
+    "devServer": false,
+    "cpuThrottleRate": 1,
+    "kind": "prod"
+  },
+  "results": [
+    {
+      "scale": "XLIMG",
+      "scenario": "low-zoom-preview",
+      "runIndex": 1,
+      "fixture": {
+        "scale": "XLIMG",
+        "imageNodes": 320,
+        "videoNodes": 0,
+        "nodes": 320,
+        "edges": 0,
+        "clips": 0,
+        "imageBytes": [
+          11961265,
+          11757599,
+          11030773,
+          9324705
+        ],
+        "imagePreviewBytes": [
+          28993,
+          42126,
+          52132,
+          27337
+        ],
+        "videoBytes": [
+          1380939031
+        ],
+        "mediaProfile": "real-assets"
+      },
+      "probe": {
+        "elapsedMs": 1015,
+        "frames": 122,
+        "fps": 120.2,
+        "frameGapP50Ms": 8.3,
+        "frameGapP95Ms": 9.3,
+        "maxFrameGapMs": 9.8,
+        "longTasks": 0,
+        "longTaskMs": 0,
+        "longTaskP95Ms": null,
+        "maxLoadingImages": 0,
+        "maxLoadingVideos": 0,
+        "maxActiveVideos": 0,
+        "firstMutationMs": null,
+        "mutations": {
+          "stage": 0,
+          "edges": 0,
+          "labels": 0
+        }
+      },
+      "cdpBefore": {
+        "LayoutCount": 7,
+        "RecalcStyleCount": 16,
+        "ScriptDurationMs": 121.4,
+        "LayoutDurationMs": 1.5,
+        "TaskDurationMs": 156,
+        "JSHeapUsedMB": 29.9,
+        "domNodes": 1368,
+        "domDocuments": 1,
+        "jsEventListeners": 960
+      },
+      "cdpAfter": {
+        "LayoutCount": 7,
+        "RecalcStyleCount": 16,
+        "ScriptDurationMs": 128.4,
+        "LayoutDurationMs": 1.5,
+        "TaskDurationMs": 174.8,
+        "JSHeapUsedMB": 30.7,
+        "domNodes": 1368,
+        "domDocuments": 1,
+        "jsEventListeners": 960
+      },
+      "cdpDelta": {
+        "LayoutCount": 0,
+        "RecalcStyleCount": 0,
+        "ScriptDurationMs": 7,
+        "LayoutDurationMs": 0,
+        "TaskDurationMs": 18.8,
+        "JSHeapUsedMB": 0.8,
+        "domNodes": 0,
+        "domDocuments": 0,
+        "jsEventListeners": 0
+      },
+      "beforePage": {
+        "domNodes": 1060,
+        "canvasNodes": 20,
+        "lightweightCanvasNodes": 20,
+        "lightweightPreviewNodes": 20,
+        "imageElements": 20,
+        "videoElements": 0,
+        "visibleMedia": 20,
+        "loadedImages": 20,
+        "loadedVideos": 0,
+        "visibleMediaNodes": 20,
+        "visibleMediaPending": 0,
+        "visibleMediaFailures": 0,
+        "activeVideos": 0,
+        "resourceCount": 0,
+        "jsHeapUsedMB": 42.6,
+        "transform": {
+          "x": 225.325,
+          "y": 247.349,
+          "zoom": 0.435275
+        }
+      },
+      "page": {
+        "domNodes": 1060,
+        "canvasNodes": 20,
+        "lightweightCanvasNodes": 20,
+        "lightweightPreviewNodes": 20,
+        "imageElements": 20,
+        "videoElements": 0,
+        "visibleMedia": 20,
+        "loadedImages": 20,
+        "loadedVideos": 0,
+        "visibleMediaNodes": 20,
+        "visibleMediaPending": 0,
+        "visibleMediaFailures": 0,
+        "activeVideos": 0,
+        "resourceCount": 0,
+        "jsHeapUsedMB": 42.6,
+        "transform": {
+          "x": 225.325,
+          "y": 247.349,
+          "zoom": 0.435275
+        }
+      },
+      "actionDetails": {
+        "settled": {
+          "domNodes": 1060,
+          "canvasNodes": 20,
+          "lightweightCanvasNodes": 20,
+          "lightweightPreviewNodes": 20,
+          "imageElements": 20,
+          "videoElements": 0,
+          "visibleMedia": 20,
+          "loadedImages": 20,
+          "loadedVideos": 0,
+          "visibleMediaNodes": 20,
+          "visibleMediaPending": 0,
+          "visibleMediaFailures": 0,
+          "activeVideos": 0,
+          "resourceCount": 0,
+          "jsHeapUsedMB": 42.6,
+          "transform": {
+            "x": 225.325,
+            "y": 247.349,
+            "zoom": 0.435275
+          }
+        },
+        "zoom": 0.435275
+      },
+      "offCanvasRender": null,
+      "nodeIdentity": {
+        "before": 20,
+        "after": 20,
+        "common": 20,
+        "tracked": 20,
+        "preserved": 20,
+        "virtualizationChurn": [],
+        "remountedInPlace": [],
+        "commonIdentityPreserved": true,
+        "targetNodeId": null,
+        "targetIdentityPreserved": null
+      },
+      "appMetrics": {
+        "rendererWorkingSetMB": 362.5,
+        "gpuWorkingSetMB": 126,
+        "processCount": 5,
+        "processes": [
+          {
+            "type": "Browser",
+            "pid": 95326,
+            "workingSetMB": 344.9
+          },
+          {
+            "type": "GPU",
+            "pid": 95330,
+            "workingSetMB": 126
+          },
+          {
+            "type": "Utility",
+            "pid": 95331,
+            "workingSetMB": 45.1
+          },
+          {
+            "type": "Tab",
+            "pid": 95332,
+            "workingSetMB": 362.5
+          },
+          {
+            "type": "Utility",
+            "pid": 95333,
+            "workingSetMB": 45.1
+          }
+        ]
+      },
+      "runtimeVersions": {
+        "app": "0.21.0",
+        "electron": "43.4.1",
+        "chrome": "150.0.7871.224",
+        "node": "24.18.1",
+        "v8": "15.0.245.28-electron.0"
+      },
+      "pageErrors": [],
+      "consoleErrors": [],
+      "elapsedMs": 23030
+    },
+    {
+      "scale": "XLIMG",
+      "scenario": "low-zoom-preview",
+      "runIndex": 2,
+      "fixture": {
+        "scale": "XLIMG",
+        "imageNodes": 320,
+        "videoNodes": 0,
+        "nodes": 320,
+        "edges": 0,
+        "clips": 0,
+        "imageBytes": [
+          11961265,
+          11757599,
+          11030773,
+          9324705
+        ],
+        "imagePreviewBytes": [
+          28993,
+          42126,
+          52132,
+          27337
+        ],
+        "videoBytes": [
+          1380939031
+        ],
+        "mediaProfile": "real-assets"
+      },
+      "probe": {
+        "elapsedMs": 1012,
+        "frames": 122,
+        "fps": 120.5,
+        "frameGapP50Ms": 8.3,
+        "frameGapP95Ms": 9.2,
+        "maxFrameGapMs": 9.4,
+        "longTasks": 0,
+        "longTaskMs": 0,
+        "longTaskP95Ms": null,
+        "maxLoadingImages": 0,
+        "maxLoadingVideos": 0,
+        "maxActiveVideos": 0,
+        "firstMutationMs": null,
+        "mutations": {
+          "stage": 0,
+          "edges": 0,
+          "labels": 0
+        }
+      },
+      "cdpBefore": {
+        "LayoutCount": 9,
+        "RecalcStyleCount": 20,
+        "ScriptDurationMs": 123,
+        "LayoutDurationMs": 1.7,
+        "TaskDurationMs": 181,
+        "JSHeapUsedMB": 27.6,
+        "domNodes": 1368,
+        "domDocuments": 1,
+        "jsEventListeners": 948
+      },
+      "cdpAfter": {
+        "LayoutCount": 9,
+        "RecalcStyleCount": 20,
+        "ScriptDurationMs": 131,
+        "LayoutDurationMs": 1.7,
+        "TaskDurationMs": 201,
+        "JSHeapUsedMB": 28.4,
+        "domNodes": 1368,
+        "domDocuments": 1,
+        "jsEventListeners": 948
+      },
+      "cdpDelta": {
+        "LayoutCount": 0,
+        "RecalcStyleCount": 0,
+        "ScriptDurationMs": 8,
+        "LayoutDurationMs": 0,
+        "TaskDurationMs": 20,
+        "JSHeapUsedMB": 0.8,
+        "domNodes": 0,
+        "domDocuments": 0,
+        "jsEventListeners": 0
+      },
+      "beforePage": {
+        "domNodes": 1060,
+        "canvasNodes": 20,
+        "lightweightCanvasNodes": 20,
+        "lightweightPreviewNodes": 20,
+        "imageElements": 20,
+        "videoElements": 0,
+        "visibleMedia": 20,
+        "loadedImages": 20,
+        "loadedVideos": 0,
+        "visibleMediaNodes": 20,
+        "visibleMediaPending": 0,
+        "visibleMediaFailures": 0,
+        "activeVideos": 0,
+        "resourceCount": 0,
+        "jsHeapUsedMB": 68.9,
+        "transform": {
+          "x": 225.325,
+          "y": 247.349,
+          "zoom": 0.435275
+        }
+      },
+      "page": {
+        "domNodes": 1060,
+        "canvasNodes": 20,
+        "lightweightCanvasNodes": 20,
+        "lightweightPreviewNodes": 20,
+        "imageElements": 20,
+        "videoElements": 0,
+        "visibleMedia": 20,
+        "loadedImages": 20,
+        "loadedVideos": 0,
+        "visibleMediaNodes": 20,
+        "visibleMediaPending": 0,
+        "visibleMediaFailures": 0,
+        "activeVideos": 0,
+        "resourceCount": 0,
+        "jsHeapUsedMB": 68.9,
+        "transform": {
+          "x": 225.325,
+          "y": 247.349,
+          "zoom": 0.435275
+        }
+      },
+      "actionDetails": {
+        "settled": {
+          "domNodes": 1060,
+          "canvasNodes": 20,
+          "lightweightCanvasNodes": 20,
+          "lightweightPreviewNodes": 20,
+          "imageElements": 20,
+          "videoElements": 0,
+          "visibleMedia": 20,
+          "loadedImages": 20,
+          "loadedVideos": 0,
+          "visibleMediaNodes": 20,
+          "visibleMediaPending": 0,
+          "visibleMediaFailures": 0,
+          "activeVideos": 0,
+          "resourceCount": 0,
+          "jsHeapUsedMB": 68.9,
+          "transform": {
+            "x": 225.325,
+            "y": 247.349,
+            "zoom": 0.435275
+          }
+        },
+        "zoom": 0.435275
+      },
+      "offCanvasRender": null,
+      "nodeIdentity": {
+        "before": 20,
+        "after": 20,
+        "common": 20,
+        "tracked": 20,
+        "preserved": 20,
+        "virtualizationChurn": [],
+        "remountedInPlace": [],
+        "commonIdentityPreserved": true,
+        "targetNodeId": null,
+        "targetIdentityPreserved": null
+      },
+      "appMetrics": {
+        "rendererWorkingSetMB": 384.1,
+        "gpuWorkingSetMB": 127.4,
+        "processCount": 5,
+        "processes": [
+          {
+            "type": "Browser",
+            "pid": 95377,
+            "workingSetMB": 347.1
+          },
+          {
+            "type": "GPU",
+            "pid": 95383,
+            "workingSetMB": 127.4
+          },
+          {
+            "type": "Utility",
+            "pid": 95384,
+            "workingSetMB": 45
+          },
+          {
+            "type": "Tab",
+            "pid": 95385,
+            "workingSetMB": 384.1
+          },
+          {
+            "type": "Utility",
+            "pid": 95386,
+            "workingSetMB": 45.2
+          }
+        ]
+      },
+      "runtimeVersions": {
+        "app": "0.21.0",
+        "electron": "43.4.1",
+        "chrome": "150.0.7871.224",
+        "node": "24.18.1",
+        "v8": "15.0.245.28-electron.0"
+      },
+      "pageErrors": [],
+      "consoleErrors": [],
+      "elapsedMs": 23003
+    }
+  ],
+  "warmupFailures": [],
+  "summary": {
+    "XLIMG/low-zoom-preview": {
+      "samples": 2,
+      "errors": 0,
+      "metrics": {
+        "coldFirstCanvasMs": null,
+        "coldMediaSettledMs": null,
+        "fps": {
+          "median": 120.2,
+          "p95": 120.5,
+          "samples": [
+            120.2,
+            120.5
+          ]
+        },
+        "frameGapP95Ms": {
+          "median": 9.2,
+          "p95": 9.3,
+          "samples": [
+            9.2,
+            9.3
+          ]
+        },
+        "maxFrameGapMs": {
+          "median": 9.4,
+          "p95": 9.8,
+          "samples": [
+            9.4,
+            9.8
+          ]
+        },
+        "longTaskMs": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "longTaskP95Ms": null,
+        "maxLoadingImages": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "maxLoadingVideos": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "maxActiveVideos": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "layoutCount": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "recalcStyleCount": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "scriptDurationMs": {
+          "median": 7,
+          "p95": 8,
+          "samples": [
+            7,
+            8
+          ]
+        },
+        "layoutDurationMs": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "jsHeapUsedMB": {
+          "median": 42.6,
+          "p95": 68.9,
+          "samples": [
+            42.6,
+            68.9
+          ]
+        },
+        "visibleMedia": {
+          "median": 20,
+          "p95": 20,
+          "samples": [
+            20,
+            20
+          ]
+        },
+        "visibleMediaNodes": {
+          "median": 20,
+          "p95": 20,
+          "samples": [
+            20,
+            20
+          ]
+        },
+        "visibleMediaPending": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "visibleMediaFailures": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "loadedImages": {
+          "median": 20,
+          "p95": 20,
+          "samples": [
+            20,
+            20
+          ]
+        },
+        "loadedVideos": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "activeVideos": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "rendererWorkingSetMB": {
+          "median": 362.5,
+          "p95": 384.1,
+          "samples": [
+            362.5,
+            384.1
+          ]
+        },
+        "reloadHeapDeltaMB": null,
+        "reloadDurationP95Ms": null
+      },
+      "advisory": {
+        "perMove": {
+          "scriptPerMoveMs": {
+            "median": null,
+            "p95": null,
+            "samples": []
+          },
+          "layoutPerMove": {
+            "median": null,
+            "p95": null,
+            "samples": []
+          }
+        },
+        "dragOverPan": {
+          "scriptRatio": {
+            "median": null,
+            "samples": []
+          },
+          "layoutRatio": {
+            "median": null,
+            "samples": []
+          }
+        },
+        "actionLatency": {
+          "samples": [],
+          "p95Ms": null,
+          "medianMs": null
+        },
+        "offCanvasRender": {
+          "installed": false,
+          "windows": 0,
+          "totalMax": null,
+          "totalMedian": null,
+          "perComponentMax": {
+            "CategoryTree": null,
+            "AssetLibraryPanel": null,
+            "AssetPicker": null,
+            "TaskCenterButton": null,
+            "TaskCenterPanel": null,
+            "TimelinePreview": null,
+            "PreviewSourcePanel": null,
+            "OnboardingChecklist": null
+          }
+        }
+      },
+      "verdict": {
+        "pass": true,
+        "advisoryOnly": false,
+        "budgetsAdvisory": false,
+        "hardFailures": [],
+        "budgetChecks": [
+          {
+            "metric": "frameGapP95Ms",
+            "actualP95": 9.3,
+            "max": 33,
+            "pass": true,
+            "advisory": false
+          },
+          {
+            "metric": "maxFrameGapMs",
+            "actualP95": 9.8,
+            "max": 100,
+            "pass": true,
+            "advisory": true
+          },
+          {
+            "metric": "maxLoadingImages",
+            "actualP95": 0,
+            "max": 4,
+            "pass": true,
+            "advisory": false
+          },
+          {
+            "metric": "maxLoadingVideos",
+            "actualP95": 0,
+            "max": 1,
+            "pass": true,
+            "advisory": false
+          },
+          {
+            "metric": "maxActiveVideos",
+            "actualP95": 0,
+            "max": 1,
+            "pass": true,
+            "advisory": false
+          }
+        ]
+      }
+    }
+  },
+  "runtimeVersions": {
+    "app": "0.21.0",
+    "electron": "43.4.1",
+    "chrome": "150.0.7871.224",
+    "node": "24.18.1",
+    "v8": "15.0.245.28-electron.0"
+  },
+  "pass": true
+}

--- a/tests/ux/perf-results/canvas-real-hevc-L-lowzoom.json
+++ b/tests/ux/perf-results/canvas-real-hevc-L-lowzoom.json
@@ -1,0 +1,689 @@
+{
+  "label": "real-hevc-L-lowzoom",
+  "commit": "ba753cfa5ec7ad24e7bb3e453e3ef99ccdf64276",
+  "dirty": true,
+  "platform": "darwin",
+  "arch": "arm64",
+  "machine": {
+    "cpu": "Apple M5",
+    "logicalCpus": 10,
+    "totalMemoryGB": 24
+  },
+  "viewport": {
+    "width": 1600,
+    "height": 1000
+  },
+  "viewportOverride": null,
+  "sampleCount": 2,
+  "warmupCount": 0,
+  "scales": [
+    "L"
+  ],
+  "scenarios": [
+    "drag-at-low-zoom"
+  ],
+  "leg": {
+    "devServer": false,
+    "cpuThrottleRate": 1,
+    "kind": "prod"
+  },
+  "results": [
+    {
+      "scale": "L",
+      "scenario": "drag-at-low-zoom",
+      "runIndex": 0,
+      "fixture": {
+        "scale": "L",
+        "imageNodes": 96,
+        "videoNodes": 96,
+        "nodes": 192,
+        "edges": 384,
+        "clips": 48,
+        "imageBytes": [
+          1845636,
+          1804651,
+          1744981,
+          1663390
+        ],
+        "imagePreviewBytes": [
+          73757,
+          43927,
+          45467,
+          41996
+        ],
+        "videoBytes": [
+          1380939031
+        ],
+        "mediaProfile": "real-assets"
+      },
+      "probe": {
+        "elapsedMs": 1081,
+        "frames": 125,
+        "fps": 115.6,
+        "frameGapP50Ms": 8.3,
+        "frameGapP95Ms": 11.2,
+        "maxFrameGapMs": 43.9,
+        "longTasks": 0,
+        "longTaskMs": 0,
+        "longTaskP95Ms": null,
+        "maxLoadingImages": 0,
+        "maxLoadingVideos": 0,
+        "maxActiveVideos": 0,
+        "firstMutationMs": 43,
+        "mutations": {
+          "stage": 2,
+          "edges": 350,
+          "labels": 0
+        }
+      },
+      "cdpBefore": {
+        "LayoutCount": 10,
+        "RecalcStyleCount": 20,
+        "ScriptDurationMs": 154.4,
+        "LayoutDurationMs": 1.8,
+        "TaskDurationMs": 194.6,
+        "JSHeapUsedMB": 34.5,
+        "domNodes": 2022,
+        "domDocuments": 1,
+        "jsEventListeners": 1165
+      },
+      "cdpAfter": {
+        "LayoutCount": 45,
+        "RecalcStyleCount": 103,
+        "ScriptDurationMs": 262.6,
+        "LayoutDurationMs": 6.5,
+        "TaskDurationMs": 438.8,
+        "JSHeapUsedMB": 45.4,
+        "domNodes": 1985,
+        "domDocuments": 1,
+        "jsEventListeners": 1369
+      },
+      "cdpDelta": {
+        "LayoutCount": 35,
+        "RecalcStyleCount": 83,
+        "ScriptDurationMs": 108.2,
+        "LayoutDurationMs": 4.7,
+        "TaskDurationMs": 244.2,
+        "JSHeapUsedMB": 10.9,
+        "domNodes": -37,
+        "domDocuments": 0,
+        "jsEventListeners": 204
+      },
+      "beforePage": {
+        "domNodes": 1422,
+        "canvasNodes": 20,
+        "lightweightCanvasNodes": 20,
+        "lightweightPreviewNodes": 20,
+        "imageElements": 20,
+        "videoElements": 0,
+        "visibleMedia": 20,
+        "loadedImages": 20,
+        "loadedVideos": 0,
+        "visibleMediaNodes": 20,
+        "visibleMediaPending": 0,
+        "visibleMediaFailures": 0,
+        "activeVideos": 0,
+        "resourceCount": 0,
+        "jsHeapUsedMB": 61,
+        "transform": {
+          "x": 225.325,
+          "y": 247.349,
+          "zoom": 0.435275
+        }
+      },
+      "page": {
+        "domNodes": 1576,
+        "canvasNodes": 20,
+        "lightweightCanvasNodes": 19,
+        "lightweightPreviewNodes": 19,
+        "imageElements": 21,
+        "videoElements": 0,
+        "visibleMedia": 20,
+        "loadedImages": 21,
+        "loadedVideos": 0,
+        "visibleMediaNodes": 20,
+        "visibleMediaPending": 0,
+        "visibleMediaFailures": 0,
+        "activeVideos": 0,
+        "resourceCount": 0,
+        "jsHeapUsedMB": 61,
+        "transform": {
+          "x": 225.325,
+          "y": 247.349,
+          "zoom": 0.435275
+        }
+      },
+      "actionDetails": {
+        "zoom": 0.435,
+        "lightweightMounted": 20,
+        "lightweightActive": true,
+        "moves": 22,
+        "firstFeedbackMs": 43,
+        "nodeId": "canvas-perf-image-0"
+      },
+      "offCanvasRender": null,
+      "nodeIdentity": {
+        "before": 20,
+        "after": 20,
+        "common": 20,
+        "tracked": 20,
+        "preserved": 20,
+        "virtualizationChurn": [],
+        "remountedInPlace": [],
+        "commonIdentityPreserved": true,
+        "targetNodeId": "canvas-perf-image-0",
+        "targetIdentityPreserved": true
+      },
+      "appMetrics": {
+        "rendererWorkingSetMB": 355.4,
+        "gpuWorkingSetMB": 145.3,
+        "processCount": 5,
+        "processes": [
+          {
+            "type": "Browser",
+            "pid": 54083,
+            "workingSetMB": 352.7
+          },
+          {
+            "type": "GPU",
+            "pid": 54086,
+            "workingSetMB": 145.3
+          },
+          {
+            "type": "Utility",
+            "pid": 54087,
+            "workingSetMB": 45
+          },
+          {
+            "type": "Tab",
+            "pid": 54088,
+            "workingSetMB": 355.4
+          },
+          {
+            "type": "Utility",
+            "pid": 54089,
+            "workingSetMB": 45
+          }
+        ]
+      },
+      "runtimeVersions": {
+        "app": "0.21.0",
+        "electron": "43.4.1",
+        "chrome": "150.0.7871.224",
+        "node": "24.18.1",
+        "v8": "15.0.245.28-electron.0"
+      },
+      "pageErrors": [],
+      "consoleErrors": [],
+      "elapsedMs": 21502
+    },
+    {
+      "scale": "L",
+      "scenario": "drag-at-low-zoom",
+      "runIndex": 1,
+      "fixture": {
+        "scale": "L",
+        "imageNodes": 96,
+        "videoNodes": 96,
+        "nodes": 192,
+        "edges": 384,
+        "clips": 48,
+        "imageBytes": [
+          1845636,
+          1804651,
+          1744981,
+          1663390
+        ],
+        "imagePreviewBytes": [
+          73757,
+          43927,
+          45467,
+          41996
+        ],
+        "videoBytes": [
+          1380939031
+        ],
+        "mediaProfile": "real-assets"
+      },
+      "probe": {
+        "elapsedMs": 1093,
+        "frames": 127,
+        "fps": 116.2,
+        "frameGapP50Ms": 8.3,
+        "frameGapP95Ms": 11.3,
+        "maxFrameGapMs": 39.5,
+        "longTasks": 0,
+        "longTaskMs": 0,
+        "longTaskP95Ms": null,
+        "maxLoadingImages": 0,
+        "maxLoadingVideos": 0,
+        "maxActiveVideos": 0,
+        "firstMutationMs": 40.9,
+        "mutations": {
+          "stage": 2,
+          "edges": 350,
+          "labels": 0
+        }
+      },
+      "cdpBefore": {
+        "LayoutCount": 9,
+        "RecalcStyleCount": 18,
+        "ScriptDurationMs": 130,
+        "LayoutDurationMs": 1.7,
+        "TaskDurationMs": 182.9,
+        "JSHeapUsedMB": 32.8,
+        "domNodes": 1731,
+        "domDocuments": 1,
+        "jsEventListeners": 1100
+      },
+      "cdpAfter": {
+        "LayoutCount": 45,
+        "RecalcStyleCount": 102,
+        "ScriptDurationMs": 230.7,
+        "LayoutDurationMs": 6.4,
+        "TaskDurationMs": 404.5,
+        "JSHeapUsedMB": 34.6,
+        "domNodes": 1985,
+        "domDocuments": 1,
+        "jsEventListeners": 1459
+      },
+      "cdpDelta": {
+        "LayoutCount": 36,
+        "RecalcStyleCount": 84,
+        "ScriptDurationMs": 100.7,
+        "LayoutDurationMs": 4.7,
+        "TaskDurationMs": 221.6,
+        "JSHeapUsedMB": 1.8,
+        "domNodes": 254,
+        "domDocuments": 0,
+        "jsEventListeners": 359
+      },
+      "beforePage": {
+        "domNodes": 1422,
+        "canvasNodes": 20,
+        "lightweightCanvasNodes": 20,
+        "lightweightPreviewNodes": 20,
+        "imageElements": 20,
+        "videoElements": 0,
+        "visibleMedia": 20,
+        "loadedImages": 20,
+        "loadedVideos": 0,
+        "visibleMediaNodes": 20,
+        "visibleMediaPending": 0,
+        "visibleMediaFailures": 0,
+        "activeVideos": 0,
+        "resourceCount": 0,
+        "jsHeapUsedMB": 61,
+        "transform": {
+          "x": 225.325,
+          "y": 247.349,
+          "zoom": 0.435275
+        }
+      },
+      "page": {
+        "domNodes": 1576,
+        "canvasNodes": 20,
+        "lightweightCanvasNodes": 19,
+        "lightweightPreviewNodes": 19,
+        "imageElements": 21,
+        "videoElements": 0,
+        "visibleMedia": 20,
+        "loadedImages": 21,
+        "loadedVideos": 0,
+        "visibleMediaNodes": 20,
+        "visibleMediaPending": 0,
+        "visibleMediaFailures": 0,
+        "activeVideos": 0,
+        "resourceCount": 0,
+        "jsHeapUsedMB": 61,
+        "transform": {
+          "x": 225.325,
+          "y": 247.349,
+          "zoom": 0.435275
+        }
+      },
+      "actionDetails": {
+        "zoom": 0.435,
+        "lightweightMounted": 20,
+        "lightweightActive": true,
+        "moves": 22,
+        "firstFeedbackMs": 40.900000002235174,
+        "nodeId": "canvas-perf-image-0"
+      },
+      "offCanvasRender": null,
+      "nodeIdentity": {
+        "before": 20,
+        "after": 20,
+        "common": 20,
+        "tracked": 20,
+        "preserved": 20,
+        "virtualizationChurn": [],
+        "remountedInPlace": [],
+        "commonIdentityPreserved": true,
+        "targetNodeId": "canvas-perf-image-0",
+        "targetIdentityPreserved": true
+      },
+      "appMetrics": {
+        "rendererWorkingSetMB": 356.6,
+        "gpuWorkingSetMB": 145.6,
+        "processCount": 5,
+        "processes": [
+          {
+            "type": "Browser",
+            "pid": 54217,
+            "workingSetMB": 342.5
+          },
+          {
+            "type": "GPU",
+            "pid": 54220,
+            "workingSetMB": 145.6
+          },
+          {
+            "type": "Utility",
+            "pid": 54221,
+            "workingSetMB": 45
+          },
+          {
+            "type": "Tab",
+            "pid": 54222,
+            "workingSetMB": 356.6
+          },
+          {
+            "type": "Utility",
+            "pid": 54223,
+            "workingSetMB": 45.2
+          }
+        ]
+      },
+      "runtimeVersions": {
+        "app": "0.21.0",
+        "electron": "43.4.1",
+        "chrome": "150.0.7871.224",
+        "node": "24.18.1",
+        "v8": "15.0.245.28-electron.0"
+      },
+      "pageErrors": [],
+      "consoleErrors": [],
+      "elapsedMs": 21459
+    }
+  ],
+  "warmupFailures": [],
+  "summary": {
+    "L/drag-at-low-zoom": {
+      "samples": 2,
+      "errors": 0,
+      "metrics": {
+        "coldFirstCanvasMs": null,
+        "coldMediaSettledMs": null,
+        "fps": {
+          "median": 115.6,
+          "p95": 116.2,
+          "samples": [
+            115.6,
+            116.2
+          ]
+        },
+        "frameGapP95Ms": {
+          "median": 11.2,
+          "p95": 11.3,
+          "samples": [
+            11.2,
+            11.3
+          ]
+        },
+        "maxFrameGapMs": {
+          "median": 39.5,
+          "p95": 43.9,
+          "samples": [
+            39.5,
+            43.9
+          ]
+        },
+        "longTaskMs": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "longTaskP95Ms": null,
+        "maxLoadingImages": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "maxLoadingVideos": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "maxActiveVideos": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "layoutCount": {
+          "median": 35,
+          "p95": 36,
+          "samples": [
+            35,
+            36
+          ]
+        },
+        "recalcStyleCount": {
+          "median": 83,
+          "p95": 84,
+          "samples": [
+            83,
+            84
+          ]
+        },
+        "scriptDurationMs": {
+          "median": 100.7,
+          "p95": 108.2,
+          "samples": [
+            100.7,
+            108.2
+          ]
+        },
+        "layoutDurationMs": {
+          "median": 4.7,
+          "p95": 4.7,
+          "samples": [
+            4.7,
+            4.7
+          ]
+        },
+        "jsHeapUsedMB": {
+          "median": 61,
+          "p95": 61,
+          "samples": [
+            61,
+            61
+          ]
+        },
+        "visibleMedia": {
+          "median": 20,
+          "p95": 20,
+          "samples": [
+            20,
+            20
+          ]
+        },
+        "visibleMediaNodes": {
+          "median": 20,
+          "p95": 20,
+          "samples": [
+            20,
+            20
+          ]
+        },
+        "visibleMediaPending": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "visibleMediaFailures": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "loadedImages": {
+          "median": 21,
+          "p95": 21,
+          "samples": [
+            21,
+            21
+          ]
+        },
+        "loadedVideos": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "activeVideos": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "rendererWorkingSetMB": {
+          "median": 355.4,
+          "p95": 356.6,
+          "samples": [
+            355.4,
+            356.6
+          ]
+        },
+        "reloadHeapDeltaMB": null,
+        "reloadDurationP95Ms": null
+      },
+      "advisory": {
+        "perMove": {
+          "scriptPerMoveMs": {
+            "median": 4.58,
+            "p95": 4.92,
+            "samples": [
+              4.92,
+              4.58
+            ]
+          },
+          "layoutPerMove": {
+            "median": 1.59,
+            "p95": 1.64,
+            "samples": [
+              1.59,
+              1.64
+            ]
+          }
+        },
+        "dragOverPan": {
+          "scriptRatio": {
+            "median": null,
+            "samples": []
+          },
+          "layoutRatio": {
+            "median": null,
+            "samples": []
+          }
+        },
+        "actionLatency": {
+          "samples": [
+            43,
+            40.900000002235174
+          ],
+          "p95Ms": 43,
+          "medianMs": 40.9
+        },
+        "offCanvasRender": {
+          "installed": false,
+          "windows": 0,
+          "totalMax": null,
+          "totalMedian": null,
+          "perComponentMax": {
+            "CategoryTree": null,
+            "AssetLibraryPanel": null,
+            "AssetPicker": null,
+            "TaskCenterButton": null,
+            "TaskCenterPanel": null,
+            "TimelinePreview": null,
+            "PreviewSourcePanel": null,
+            "OnboardingChecklist": null
+          }
+        }
+      },
+      "verdict": {
+        "pass": true,
+        "advisoryOnly": true,
+        "budgetsAdvisory": false,
+        "hardFailures": [],
+        "budgetChecks": [
+          {
+            "metric": "frameGapP95Ms",
+            "actualP95": 11.3,
+            "max": 33,
+            "pass": true,
+            "advisory": false
+          },
+          {
+            "metric": "maxFrameGapMs",
+            "actualP95": 43.9,
+            "max": 100,
+            "pass": true,
+            "advisory": true
+          },
+          {
+            "metric": "maxLoadingImages",
+            "actualP95": 0,
+            "max": 4,
+            "pass": true,
+            "advisory": false
+          },
+          {
+            "metric": "maxLoadingVideos",
+            "actualP95": 0,
+            "max": 1,
+            "pass": true,
+            "advisory": false
+          },
+          {
+            "metric": "maxActiveVideos",
+            "actualP95": 0,
+            "max": 1,
+            "pass": true,
+            "advisory": false
+          }
+        ]
+      }
+    }
+  },
+  "runtimeVersions": {
+    "app": "0.21.0",
+    "electron": "43.4.1",
+    "chrome": "150.0.7871.224",
+    "node": "24.18.1",
+    "v8": "15.0.245.28-electron.0"
+  },
+  "pass": true
+}

--- a/tests/ux/perf-results/canvas-real-hevc-L-normal.json
+++ b/tests/ux/perf-results/canvas-real-hevc-L-normal.json
@@ -1,0 +1,691 @@
+{
+  "label": "real-hevc-L-normal",
+  "commit": "ba753cfa5ec7ad24e7bb3e453e3ef99ccdf64276",
+  "dirty": true,
+  "platform": "darwin",
+  "arch": "arm64",
+  "machine": {
+    "cpu": "Apple M5",
+    "logicalCpus": 10,
+    "totalMemoryGB": 24
+  },
+  "viewport": {
+    "width": 1600,
+    "height": 1000
+  },
+  "viewportOverride": null,
+  "sampleCount": 2,
+  "warmupCount": 0,
+  "scales": [
+    "L"
+  ],
+  "scenarios": [
+    "node-drag-video"
+  ],
+  "leg": {
+    "devServer": false,
+    "cpuThrottleRate": 1,
+    "kind": "prod"
+  },
+  "results": [
+    {
+      "scale": "L",
+      "scenario": "node-drag-video",
+      "runIndex": 0,
+      "fixture": {
+        "scale": "L",
+        "imageNodes": 96,
+        "videoNodes": 96,
+        "nodes": 192,
+        "edges": 384,
+        "clips": 48,
+        "imageBytes": [
+          1845636,
+          1804651,
+          1744981,
+          1663390
+        ],
+        "imagePreviewBytes": [
+          73757,
+          43927,
+          45467,
+          41996
+        ],
+        "videoBytes": [
+          1380939031
+        ],
+        "mediaProfile": "real-assets"
+      },
+      "probe": {
+        "elapsedMs": 2024,
+        "frames": 237,
+        "fps": 117.1,
+        "frameGapP50Ms": 8.2,
+        "frameGapP95Ms": 10.8,
+        "maxFrameGapMs": 42,
+        "longTasks": 0,
+        "longTaskMs": 0,
+        "longTaskP95Ms": null,
+        "maxLoadingImages": 3,
+        "maxLoadingVideos": 1,
+        "maxActiveVideos": 0,
+        "firstMutationMs": 22.4,
+        "mutations": {
+          "stage": 2,
+          "edges": 2507,
+          "labels": 0
+        }
+      },
+      "cdpBefore": {
+        "LayoutCount": 0,
+        "RecalcStyleCount": 0,
+        "ScriptDurationMs": 0,
+        "LayoutDurationMs": 0,
+        "TaskDurationMs": 1.8,
+        "JSHeapUsedMB": 38.6,
+        "domNodes": 12847,
+        "domDocuments": 1,
+        "jsEventListeners": 2202
+      },
+      "cdpAfter": {
+        "LayoutCount": 489,
+        "RecalcStyleCount": 511,
+        "ScriptDurationMs": 483.8,
+        "LayoutDurationMs": 31.1,
+        "TaskDurationMs": 844.7,
+        "JSHeapUsedMB": 45.6,
+        "domNodes": 2218,
+        "domDocuments": 1,
+        "jsEventListeners": 1765
+      },
+      "cdpDelta": {
+        "LayoutCount": 489,
+        "RecalcStyleCount": 511,
+        "ScriptDurationMs": 483.8,
+        "LayoutDurationMs": 31.1,
+        "TaskDurationMs": 842.9,
+        "JSHeapUsedMB": 7,
+        "domNodes": -10629,
+        "domDocuments": 0,
+        "jsEventListeners": -437
+      },
+      "beforePage": {
+        "domNodes": 1075,
+        "canvasNodes": 6,
+        "lightweightCanvasNodes": 0,
+        "lightweightPreviewNodes": 0,
+        "imageElements": 6,
+        "videoElements": 0,
+        "visibleMedia": 6,
+        "loadedImages": 6,
+        "loadedVideos": 0,
+        "visibleMediaNodes": 3,
+        "visibleMediaPending": 0,
+        "visibleMediaFailures": 0,
+        "activeVideos": 0,
+        "resourceCount": 0,
+        "jsHeapUsedMB": 64.8,
+        "transform": {
+          "x": 0,
+          "y": 0,
+          "zoom": 1
+        }
+      },
+      "page": {
+        "domNodes": 1573,
+        "canvasNodes": 9,
+        "lightweightCanvasNodes": 0,
+        "lightweightPreviewNodes": 0,
+        "imageElements": 11,
+        "videoElements": 1,
+        "visibleMedia": 10,
+        "loadedImages": 11,
+        "loadedVideos": 1,
+        "visibleMediaNodes": 4,
+        "visibleMediaPending": 0,
+        "visibleMediaFailures": 0,
+        "activeVideos": 0,
+        "resourceCount": 0,
+        "jsHeapUsedMB": 64.8,
+        "transform": {
+          "x": -621.375,
+          "y": 0,
+          "zoom": 1
+        }
+      },
+      "actionDetails": {
+        "nodeId": "canvas-perf-video-0",
+        "moves": 60,
+        "firstFeedbackMs": 22.399999998509884
+      },
+      "offCanvasRender": null,
+      "nodeIdentity": {
+        "before": 6,
+        "after": 9,
+        "common": 3,
+        "tracked": 3,
+        "preserved": 3,
+        "virtualizationChurn": [
+          "canvas-perf-image-0",
+          "canvas-perf-image-6",
+          "canvas-perf-image-12"
+        ],
+        "remountedInPlace": [],
+        "commonIdentityPreserved": true,
+        "targetNodeId": "canvas-perf-video-0",
+        "targetIdentityPreserved": true
+      },
+      "appMetrics": {
+        "rendererWorkingSetMB": 449.4,
+        "gpuWorkingSetMB": 150.3,
+        "processCount": 5,
+        "processes": [
+          {
+            "type": "Browser",
+            "pid": 55065,
+            "workingSetMB": 373.1
+          },
+          {
+            "type": "GPU",
+            "pid": 55068,
+            "workingSetMB": 150.3
+          },
+          {
+            "type": "Utility",
+            "pid": 55069,
+            "workingSetMB": 45
+          },
+          {
+            "type": "Tab",
+            "pid": 55070,
+            "workingSetMB": 449.4
+          },
+          {
+            "type": "Utility",
+            "pid": 55071,
+            "workingSetMB": 45.3
+          }
+        ]
+      },
+      "runtimeVersions": {
+        "app": "0.21.0",
+        "electron": "43.4.1",
+        "chrome": "150.0.7871.224",
+        "node": "24.18.1",
+        "v8": "15.0.245.28-electron.0"
+      },
+      "pageErrors": [],
+      "consoleErrors": [],
+      "elapsedMs": 21176
+    },
+    {
+      "scale": "L",
+      "scenario": "node-drag-video",
+      "runIndex": 1,
+      "fixture": {
+        "scale": "L",
+        "imageNodes": 96,
+        "videoNodes": 96,
+        "nodes": 192,
+        "edges": 384,
+        "clips": 48,
+        "imageBytes": [
+          1845636,
+          1804651,
+          1744981,
+          1663390
+        ],
+        "imagePreviewBytes": [
+          73757,
+          43927,
+          45467,
+          41996
+        ],
+        "videoBytes": [
+          1380939031
+        ],
+        "mediaProfile": "real-assets"
+      },
+      "probe": {
+        "elapsedMs": 2012,
+        "frames": 237,
+        "fps": 117.8,
+        "frameGapP50Ms": 8.3,
+        "frameGapP95Ms": 10.2,
+        "maxFrameGapMs": 42.8,
+        "longTasks": 0,
+        "longTaskMs": 0,
+        "longTaskP95Ms": null,
+        "maxLoadingImages": 3,
+        "maxLoadingVideos": 1,
+        "maxActiveVideos": 0,
+        "firstMutationMs": 16.8,
+        "mutations": {
+          "stage": 2,
+          "edges": 2545,
+          "labels": 0
+        }
+      },
+      "cdpBefore": {
+        "LayoutCount": 0,
+        "RecalcStyleCount": 0,
+        "ScriptDurationMs": 0,
+        "LayoutDurationMs": 0,
+        "TaskDurationMs": 1.2,
+        "JSHeapUsedMB": 52.4,
+        "domNodes": 12561,
+        "domDocuments": 1,
+        "jsEventListeners": 2163
+      },
+      "cdpAfter": {
+        "LayoutCount": 496,
+        "RecalcStyleCount": 516,
+        "ScriptDurationMs": 494.6,
+        "LayoutDurationMs": 30.3,
+        "TaskDurationMs": 852.2,
+        "JSHeapUsedMB": 49,
+        "domNodes": 2218,
+        "domDocuments": 1,
+        "jsEventListeners": 1786
+      },
+      "cdpDelta": {
+        "LayoutCount": 496,
+        "RecalcStyleCount": 516,
+        "ScriptDurationMs": 494.6,
+        "LayoutDurationMs": 30.3,
+        "TaskDurationMs": 851,
+        "JSHeapUsedMB": -3.4,
+        "domNodes": -10343,
+        "domDocuments": 0,
+        "jsEventListeners": -377
+      },
+      "beforePage": {
+        "domNodes": 1075,
+        "canvasNodes": 6,
+        "lightweightCanvasNodes": 0,
+        "lightweightPreviewNodes": 0,
+        "imageElements": 6,
+        "videoElements": 0,
+        "visibleMedia": 6,
+        "loadedImages": 6,
+        "loadedVideos": 0,
+        "visibleMediaNodes": 3,
+        "visibleMediaPending": 0,
+        "visibleMediaFailures": 0,
+        "activeVideos": 0,
+        "resourceCount": 0,
+        "jsHeapUsedMB": 61,
+        "transform": {
+          "x": 0,
+          "y": 0,
+          "zoom": 1
+        }
+      },
+      "page": {
+        "domNodes": 1573,
+        "canvasNodes": 9,
+        "lightweightCanvasNodes": 0,
+        "lightweightPreviewNodes": 0,
+        "imageElements": 11,
+        "videoElements": 1,
+        "visibleMedia": 10,
+        "loadedImages": 11,
+        "loadedVideos": 1,
+        "visibleMediaNodes": 4,
+        "visibleMediaPending": 0,
+        "visibleMediaFailures": 0,
+        "activeVideos": 0,
+        "resourceCount": 0,
+        "jsHeapUsedMB": 61,
+        "transform": {
+          "x": -637.875,
+          "y": 0,
+          "zoom": 1
+        }
+      },
+      "actionDetails": {
+        "nodeId": "canvas-perf-video-0",
+        "moves": 60,
+        "firstFeedbackMs": 16.800000000745058
+      },
+      "offCanvasRender": null,
+      "nodeIdentity": {
+        "before": 6,
+        "after": 9,
+        "common": 3,
+        "tracked": 3,
+        "preserved": 3,
+        "virtualizationChurn": [
+          "canvas-perf-image-0",
+          "canvas-perf-image-6",
+          "canvas-perf-image-12"
+        ],
+        "remountedInPlace": [],
+        "commonIdentityPreserved": true,
+        "targetNodeId": "canvas-perf-video-0",
+        "targetIdentityPreserved": true
+      },
+      "appMetrics": {
+        "rendererWorkingSetMB": 415.8,
+        "gpuWorkingSetMB": 148.8,
+        "processCount": 5,
+        "processes": [
+          {
+            "type": "Browser",
+            "pid": 55143,
+            "workingSetMB": 357.9
+          },
+          {
+            "type": "GPU",
+            "pid": 55147,
+            "workingSetMB": 148.8
+          },
+          {
+            "type": "Utility",
+            "pid": 55148,
+            "workingSetMB": 45
+          },
+          {
+            "type": "Tab",
+            "pid": 55149,
+            "workingSetMB": 415.8
+          },
+          {
+            "type": "Utility",
+            "pid": 55150,
+            "workingSetMB": 45.3
+          }
+        ]
+      },
+      "runtimeVersions": {
+        "app": "0.21.0",
+        "electron": "43.4.1",
+        "chrome": "150.0.7871.224",
+        "node": "24.18.1",
+        "v8": "15.0.245.28-electron.0"
+      },
+      "pageErrors": [],
+      "consoleErrors": [],
+      "elapsedMs": 21467
+    }
+  ],
+  "warmupFailures": [],
+  "summary": {
+    "L/node-drag-video": {
+      "samples": 2,
+      "errors": 0,
+      "metrics": {
+        "coldFirstCanvasMs": null,
+        "coldMediaSettledMs": null,
+        "fps": {
+          "median": 117.1,
+          "p95": 117.8,
+          "samples": [
+            117.1,
+            117.8
+          ]
+        },
+        "frameGapP95Ms": {
+          "median": 10.2,
+          "p95": 10.8,
+          "samples": [
+            10.2,
+            10.8
+          ]
+        },
+        "maxFrameGapMs": {
+          "median": 42,
+          "p95": 42.8,
+          "samples": [
+            42,
+            42.8
+          ]
+        },
+        "longTaskMs": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "longTaskP95Ms": null,
+        "maxLoadingImages": {
+          "median": 3,
+          "p95": 3,
+          "samples": [
+            3,
+            3
+          ]
+        },
+        "maxLoadingVideos": {
+          "median": 1,
+          "p95": 1,
+          "samples": [
+            1,
+            1
+          ]
+        },
+        "maxActiveVideos": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "layoutCount": {
+          "median": 489,
+          "p95": 496,
+          "samples": [
+            489,
+            496
+          ]
+        },
+        "recalcStyleCount": {
+          "median": 511,
+          "p95": 516,
+          "samples": [
+            511,
+            516
+          ]
+        },
+        "scriptDurationMs": {
+          "median": 483.8,
+          "p95": 494.6,
+          "samples": [
+            483.8,
+            494.6
+          ]
+        },
+        "layoutDurationMs": {
+          "median": 30.3,
+          "p95": 31.1,
+          "samples": [
+            30.3,
+            31.1
+          ]
+        },
+        "jsHeapUsedMB": {
+          "median": 61,
+          "p95": 64.8,
+          "samples": [
+            61,
+            64.8
+          ]
+        },
+        "visibleMedia": {
+          "median": 10,
+          "p95": 10,
+          "samples": [
+            10,
+            10
+          ]
+        },
+        "visibleMediaNodes": {
+          "median": 4,
+          "p95": 4,
+          "samples": [
+            4,
+            4
+          ]
+        },
+        "visibleMediaPending": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "visibleMediaFailures": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "loadedImages": {
+          "median": 11,
+          "p95": 11,
+          "samples": [
+            11,
+            11
+          ]
+        },
+        "loadedVideos": {
+          "median": 1,
+          "p95": 1,
+          "samples": [
+            1,
+            1
+          ]
+        },
+        "activeVideos": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "rendererWorkingSetMB": {
+          "median": 415.8,
+          "p95": 449.4,
+          "samples": [
+            415.8,
+            449.4
+          ]
+        },
+        "reloadHeapDeltaMB": null,
+        "reloadDurationP95Ms": null
+      },
+      "advisory": {
+        "perMove": {
+          "scriptPerMoveMs": {
+            "median": 8.06,
+            "p95": 8.24,
+            "samples": [
+              8.06,
+              8.24
+            ]
+          },
+          "layoutPerMove": {
+            "median": 8.15,
+            "p95": 8.27,
+            "samples": [
+              8.15,
+              8.27
+            ]
+          }
+        },
+        "dragOverPan": {
+          "scriptRatio": {
+            "median": null,
+            "samples": []
+          },
+          "layoutRatio": {
+            "median": null,
+            "samples": []
+          }
+        },
+        "actionLatency": {
+          "samples": [
+            22.399999998509884,
+            16.800000000745058
+          ],
+          "p95Ms": 22.4,
+          "medianMs": 16.8
+        },
+        "offCanvasRender": {
+          "installed": false,
+          "windows": 0,
+          "totalMax": null,
+          "totalMedian": null,
+          "perComponentMax": {
+            "CategoryTree": null,
+            "AssetLibraryPanel": null,
+            "AssetPicker": null,
+            "TaskCenterButton": null,
+            "TaskCenterPanel": null,
+            "TimelinePreview": null,
+            "PreviewSourcePanel": null,
+            "OnboardingChecklist": null
+          }
+        }
+      },
+      "verdict": {
+        "pass": true,
+        "advisoryOnly": false,
+        "budgetsAdvisory": false,
+        "hardFailures": [],
+        "budgetChecks": [
+          {
+            "metric": "frameGapP95Ms",
+            "actualP95": 10.8,
+            "max": 33,
+            "pass": true,
+            "advisory": false
+          },
+          {
+            "metric": "maxFrameGapMs",
+            "actualP95": 42.8,
+            "max": 100,
+            "pass": true,
+            "advisory": true
+          },
+          {
+            "metric": "maxLoadingImages",
+            "actualP95": 3,
+            "max": 4,
+            "pass": true,
+            "advisory": false
+          },
+          {
+            "metric": "maxLoadingVideos",
+            "actualP95": 1,
+            "max": 1,
+            "pass": true,
+            "advisory": false
+          },
+          {
+            "metric": "maxActiveVideos",
+            "actualP95": 0,
+            "max": 1,
+            "pass": true,
+            "advisory": false
+          }
+        ]
+      }
+    }
+  },
+  "runtimeVersions": {
+    "app": "0.21.0",
+    "electron": "43.4.1",
+    "chrome": "150.0.7871.224",
+    "node": "24.18.1",
+    "v8": "15.0.245.28-electron.0"
+  },
+  "pass": true
+}

--- a/tests/ux/perf-results/canvas-real-hevc-M-lowzoom.json
+++ b/tests/ux/perf-results/canvas-real-hevc-M-lowzoom.json
@@ -1,0 +1,689 @@
+{
+  "label": "real-hevc-M-lowzoom",
+  "commit": "ba753cfa5ec7ad24e7bb3e453e3ef99ccdf64276",
+  "dirty": true,
+  "platform": "darwin",
+  "arch": "arm64",
+  "machine": {
+    "cpu": "Apple M5",
+    "logicalCpus": 10,
+    "totalMemoryGB": 24
+  },
+  "viewport": {
+    "width": 1600,
+    "height": 1000
+  },
+  "viewportOverride": null,
+  "sampleCount": 2,
+  "warmupCount": 0,
+  "scales": [
+    "M"
+  ],
+  "scenarios": [
+    "drag-at-low-zoom"
+  ],
+  "leg": {
+    "devServer": false,
+    "cpuThrottleRate": 1,
+    "kind": "prod"
+  },
+  "results": [
+    {
+      "scale": "M",
+      "scenario": "drag-at-low-zoom",
+      "runIndex": 0,
+      "fixture": {
+        "scale": "M",
+        "imageNodes": 48,
+        "videoNodes": 48,
+        "nodes": 96,
+        "edges": 192,
+        "clips": 24,
+        "imageBytes": [
+          1845636,
+          1804651,
+          1744981,
+          1663390
+        ],
+        "imagePreviewBytes": [
+          73757,
+          43927,
+          45467,
+          41996
+        ],
+        "videoBytes": [
+          1380939031
+        ],
+        "mediaProfile": "real-assets"
+      },
+      "probe": {
+        "elapsedMs": 1072,
+        "frames": 124,
+        "fps": 115.6,
+        "frameGapP50Ms": 8.3,
+        "frameGapP95Ms": 12,
+        "maxFrameGapMs": 45.3,
+        "longTasks": 0,
+        "longTaskMs": 0,
+        "longTaskP95Ms": null,
+        "maxLoadingImages": 0,
+        "maxLoadingVideos": 0,
+        "maxActiveVideos": 0,
+        "firstMutationMs": 31.3,
+        "mutations": {
+          "stage": 2,
+          "edges": 350,
+          "labels": 0
+        }
+      },
+      "cdpBefore": {
+        "LayoutCount": 9,
+        "RecalcStyleCount": 18,
+        "ScriptDurationMs": 153,
+        "LayoutDurationMs": 1.8,
+        "TaskDurationMs": 181.8,
+        "JSHeapUsedMB": 51.5,
+        "domNodes": 2477,
+        "domDocuments": 1,
+        "jsEventListeners": 1218
+      },
+      "cdpAfter": {
+        "LayoutCount": 44,
+        "RecalcStyleCount": 102,
+        "ScriptDurationMs": 260.8,
+        "LayoutDurationMs": 6.9,
+        "TaskDurationMs": 425.1,
+        "JSHeapUsedMB": 51.1,
+        "domNodes": 1804,
+        "domDocuments": 1,
+        "jsEventListeners": 1407
+      },
+      "cdpDelta": {
+        "LayoutCount": 35,
+        "RecalcStyleCount": 84,
+        "ScriptDurationMs": 107.8,
+        "LayoutDurationMs": 5.1,
+        "TaskDurationMs": 243.3,
+        "JSHeapUsedMB": -0.4,
+        "domNodes": -673,
+        "domDocuments": 0,
+        "jsEventListeners": 189
+      },
+      "beforePage": {
+        "domNodes": 1235,
+        "canvasNodes": 20,
+        "lightweightCanvasNodes": 20,
+        "lightweightPreviewNodes": 20,
+        "imageElements": 20,
+        "videoElements": 0,
+        "visibleMedia": 20,
+        "loadedImages": 20,
+        "loadedVideos": 0,
+        "visibleMediaNodes": 20,
+        "visibleMediaPending": 0,
+        "visibleMediaFailures": 0,
+        "activeVideos": 0,
+        "resourceCount": 0,
+        "jsHeapUsedMB": 45.2,
+        "transform": {
+          "x": 225.325,
+          "y": 247.349,
+          "zoom": 0.435275
+        }
+      },
+      "page": {
+        "domNodes": 1389,
+        "canvasNodes": 20,
+        "lightweightCanvasNodes": 19,
+        "lightweightPreviewNodes": 19,
+        "imageElements": 21,
+        "videoElements": 0,
+        "visibleMedia": 20,
+        "loadedImages": 21,
+        "loadedVideos": 0,
+        "visibleMediaNodes": 20,
+        "visibleMediaPending": 0,
+        "visibleMediaFailures": 0,
+        "activeVideos": 0,
+        "resourceCount": 0,
+        "jsHeapUsedMB": 45.2,
+        "transform": {
+          "x": 225.325,
+          "y": 247.349,
+          "zoom": 0.435275
+        }
+      },
+      "actionDetails": {
+        "zoom": 0.435,
+        "lightweightMounted": 20,
+        "lightweightActive": true,
+        "moves": 22,
+        "firstFeedbackMs": 31.300000000745058,
+        "nodeId": "canvas-perf-image-0"
+      },
+      "offCanvasRender": null,
+      "nodeIdentity": {
+        "before": 20,
+        "after": 20,
+        "common": 20,
+        "tracked": 20,
+        "preserved": 20,
+        "virtualizationChurn": [],
+        "remountedInPlace": [],
+        "commonIdentityPreserved": true,
+        "targetNodeId": "canvas-perf-image-0",
+        "targetIdentityPreserved": true
+      },
+      "appMetrics": {
+        "rendererWorkingSetMB": 345.3,
+        "gpuWorkingSetMB": 144.3,
+        "processCount": 5,
+        "processes": [
+          {
+            "type": "Browser",
+            "pid": 53897,
+            "workingSetMB": 340.3
+          },
+          {
+            "type": "GPU",
+            "pid": 53900,
+            "workingSetMB": 144.3
+          },
+          {
+            "type": "Utility",
+            "pid": 53901,
+            "workingSetMB": 45
+          },
+          {
+            "type": "Tab",
+            "pid": 53902,
+            "workingSetMB": 345.3
+          },
+          {
+            "type": "Utility",
+            "pid": 53903,
+            "workingSetMB": 45
+          }
+        ]
+      },
+      "runtimeVersions": {
+        "app": "0.21.0",
+        "electron": "43.4.1",
+        "chrome": "150.0.7871.224",
+        "node": "24.18.1",
+        "v8": "15.0.245.28-electron.0"
+      },
+      "pageErrors": [],
+      "consoleErrors": [],
+      "elapsedMs": 20954
+    },
+    {
+      "scale": "M",
+      "scenario": "drag-at-low-zoom",
+      "runIndex": 1,
+      "fixture": {
+        "scale": "M",
+        "imageNodes": 48,
+        "videoNodes": 48,
+        "nodes": 96,
+        "edges": 192,
+        "clips": 24,
+        "imageBytes": [
+          1845636,
+          1804651,
+          1744981,
+          1663390
+        ],
+        "imagePreviewBytes": [
+          73757,
+          43927,
+          45467,
+          41996
+        ],
+        "videoBytes": [
+          1380939031
+        ],
+        "mediaProfile": "real-assets"
+      },
+      "probe": {
+        "elapsedMs": 1106,
+        "frames": 128,
+        "fps": 115.8,
+        "frameGapP50Ms": 8.3,
+        "frameGapP95Ms": 11.9,
+        "maxFrameGapMs": 44.1,
+        "longTasks": 0,
+        "longTaskMs": 0,
+        "longTaskP95Ms": null,
+        "maxLoadingImages": 0,
+        "maxLoadingVideos": 0,
+        "maxActiveVideos": 0,
+        "firstMutationMs": 48.3,
+        "mutations": {
+          "stage": 2,
+          "edges": 350,
+          "labels": 0
+        }
+      },
+      "cdpBefore": {
+        "LayoutCount": 9,
+        "RecalcStyleCount": 18,
+        "ScriptDurationMs": 149.2,
+        "LayoutDurationMs": 1.7,
+        "TaskDurationMs": 179,
+        "JSHeapUsedMB": 50.8,
+        "domNodes": 2477,
+        "domDocuments": 1,
+        "jsEventListeners": 1218
+      },
+      "cdpAfter": {
+        "LayoutCount": 45,
+        "RecalcStyleCount": 102,
+        "ScriptDurationMs": 263.3,
+        "LayoutDurationMs": 6.4,
+        "TaskDurationMs": 440,
+        "JSHeapUsedMB": 30.5,
+        "domNodes": 1603,
+        "domDocuments": 1,
+        "jsEventListeners": 1248
+      },
+      "cdpDelta": {
+        "LayoutCount": 36,
+        "RecalcStyleCount": 84,
+        "ScriptDurationMs": 114.1,
+        "LayoutDurationMs": 4.7,
+        "TaskDurationMs": 261,
+        "JSHeapUsedMB": -20.3,
+        "domNodes": -874,
+        "domDocuments": 0,
+        "jsEventListeners": 30
+      },
+      "beforePage": {
+        "domNodes": 1235,
+        "canvasNodes": 20,
+        "lightweightCanvasNodes": 20,
+        "lightweightPreviewNodes": 20,
+        "imageElements": 20,
+        "videoElements": 0,
+        "visibleMedia": 20,
+        "loadedImages": 20,
+        "loadedVideos": 0,
+        "visibleMediaNodes": 20,
+        "visibleMediaPending": 0,
+        "visibleMediaFailures": 0,
+        "activeVideos": 0,
+        "resourceCount": 0,
+        "jsHeapUsedMB": 42.6,
+        "transform": {
+          "x": 225.325,
+          "y": 247.349,
+          "zoom": 0.435275
+        }
+      },
+      "page": {
+        "domNodes": 1389,
+        "canvasNodes": 20,
+        "lightweightCanvasNodes": 19,
+        "lightweightPreviewNodes": 19,
+        "imageElements": 21,
+        "videoElements": 0,
+        "visibleMedia": 20,
+        "loadedImages": 21,
+        "loadedVideos": 0,
+        "visibleMediaNodes": 20,
+        "visibleMediaPending": 0,
+        "visibleMediaFailures": 0,
+        "activeVideos": 0,
+        "resourceCount": 0,
+        "jsHeapUsedMB": 42.6,
+        "transform": {
+          "x": 225.325,
+          "y": 247.349,
+          "zoom": 0.435275
+        }
+      },
+      "actionDetails": {
+        "zoom": 0.435,
+        "lightweightMounted": 20,
+        "lightweightActive": true,
+        "moves": 22,
+        "firstFeedbackMs": 48.30000000074506,
+        "nodeId": "canvas-perf-image-0"
+      },
+      "offCanvasRender": null,
+      "nodeIdentity": {
+        "before": 20,
+        "after": 20,
+        "common": 20,
+        "tracked": 20,
+        "preserved": 20,
+        "virtualizationChurn": [],
+        "remountedInPlace": [],
+        "commonIdentityPreserved": true,
+        "targetNodeId": "canvas-perf-image-0",
+        "targetIdentityPreserved": true
+      },
+      "appMetrics": {
+        "rendererWorkingSetMB": 346.8,
+        "gpuWorkingSetMB": 149.3,
+        "processCount": 5,
+        "processes": [
+          {
+            "type": "Browser",
+            "pid": 53984,
+            "workingSetMB": 339.3
+          },
+          {
+            "type": "GPU",
+            "pid": 53987,
+            "workingSetMB": 149.3
+          },
+          {
+            "type": "Utility",
+            "pid": 53988,
+            "workingSetMB": 45
+          },
+          {
+            "type": "Tab",
+            "pid": 53989,
+            "workingSetMB": 346.8
+          },
+          {
+            "type": "Utility",
+            "pid": 53992,
+            "workingSetMB": 45.2
+          }
+        ]
+      },
+      "runtimeVersions": {
+        "app": "0.21.0",
+        "electron": "43.4.1",
+        "chrome": "150.0.7871.224",
+        "node": "24.18.1",
+        "v8": "15.0.245.28-electron.0"
+      },
+      "pageErrors": [],
+      "consoleErrors": [],
+      "elapsedMs": 20860
+    }
+  ],
+  "warmupFailures": [],
+  "summary": {
+    "M/drag-at-low-zoom": {
+      "samples": 2,
+      "errors": 0,
+      "metrics": {
+        "coldFirstCanvasMs": null,
+        "coldMediaSettledMs": null,
+        "fps": {
+          "median": 115.6,
+          "p95": 115.8,
+          "samples": [
+            115.6,
+            115.8
+          ]
+        },
+        "frameGapP95Ms": {
+          "median": 11.9,
+          "p95": 12,
+          "samples": [
+            11.9,
+            12
+          ]
+        },
+        "maxFrameGapMs": {
+          "median": 44.1,
+          "p95": 45.3,
+          "samples": [
+            44.1,
+            45.3
+          ]
+        },
+        "longTaskMs": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "longTaskP95Ms": null,
+        "maxLoadingImages": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "maxLoadingVideos": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "maxActiveVideos": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "layoutCount": {
+          "median": 35,
+          "p95": 36,
+          "samples": [
+            35,
+            36
+          ]
+        },
+        "recalcStyleCount": {
+          "median": 84,
+          "p95": 84,
+          "samples": [
+            84,
+            84
+          ]
+        },
+        "scriptDurationMs": {
+          "median": 107.8,
+          "p95": 114.1,
+          "samples": [
+            107.8,
+            114.1
+          ]
+        },
+        "layoutDurationMs": {
+          "median": 4.7,
+          "p95": 5.1,
+          "samples": [
+            4.7,
+            5.1
+          ]
+        },
+        "jsHeapUsedMB": {
+          "median": 42.6,
+          "p95": 45.2,
+          "samples": [
+            42.6,
+            45.2
+          ]
+        },
+        "visibleMedia": {
+          "median": 20,
+          "p95": 20,
+          "samples": [
+            20,
+            20
+          ]
+        },
+        "visibleMediaNodes": {
+          "median": 20,
+          "p95": 20,
+          "samples": [
+            20,
+            20
+          ]
+        },
+        "visibleMediaPending": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "visibleMediaFailures": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "loadedImages": {
+          "median": 21,
+          "p95": 21,
+          "samples": [
+            21,
+            21
+          ]
+        },
+        "loadedVideos": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "activeVideos": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "rendererWorkingSetMB": {
+          "median": 345.3,
+          "p95": 346.8,
+          "samples": [
+            345.3,
+            346.8
+          ]
+        },
+        "reloadHeapDeltaMB": null,
+        "reloadDurationP95Ms": null
+      },
+      "advisory": {
+        "perMove": {
+          "scriptPerMoveMs": {
+            "median": 4.9,
+            "p95": 5.19,
+            "samples": [
+              4.9,
+              5.19
+            ]
+          },
+          "layoutPerMove": {
+            "median": 1.59,
+            "p95": 1.64,
+            "samples": [
+              1.59,
+              1.64
+            ]
+          }
+        },
+        "dragOverPan": {
+          "scriptRatio": {
+            "median": null,
+            "samples": []
+          },
+          "layoutRatio": {
+            "median": null,
+            "samples": []
+          }
+        },
+        "actionLatency": {
+          "samples": [
+            31.300000000745058,
+            48.30000000074506
+          ],
+          "p95Ms": 48.3,
+          "medianMs": 31.3
+        },
+        "offCanvasRender": {
+          "installed": false,
+          "windows": 0,
+          "totalMax": null,
+          "totalMedian": null,
+          "perComponentMax": {
+            "CategoryTree": null,
+            "AssetLibraryPanel": null,
+            "AssetPicker": null,
+            "TaskCenterButton": null,
+            "TaskCenterPanel": null,
+            "TimelinePreview": null,
+            "PreviewSourcePanel": null,
+            "OnboardingChecklist": null
+          }
+        }
+      },
+      "verdict": {
+        "pass": true,
+        "advisoryOnly": true,
+        "budgetsAdvisory": false,
+        "hardFailures": [],
+        "budgetChecks": [
+          {
+            "metric": "frameGapP95Ms",
+            "actualP95": 12,
+            "max": 33,
+            "pass": true,
+            "advisory": false
+          },
+          {
+            "metric": "maxFrameGapMs",
+            "actualP95": 45.3,
+            "max": 100,
+            "pass": true,
+            "advisory": true
+          },
+          {
+            "metric": "maxLoadingImages",
+            "actualP95": 0,
+            "max": 4,
+            "pass": true,
+            "advisory": false
+          },
+          {
+            "metric": "maxLoadingVideos",
+            "actualP95": 0,
+            "max": 1,
+            "pass": true,
+            "advisory": false
+          },
+          {
+            "metric": "maxActiveVideos",
+            "actualP95": 0,
+            "max": 1,
+            "pass": true,
+            "advisory": false
+          }
+        ]
+      }
+    }
+  },
+  "runtimeVersions": {
+    "app": "0.21.0",
+    "electron": "43.4.1",
+    "chrome": "150.0.7871.224",
+    "node": "24.18.1",
+    "v8": "15.0.245.28-electron.0"
+  },
+  "pass": true
+}

--- a/tests/ux/perf-results/canvas-real-hevc-M-normal.json
+++ b/tests/ux/perf-results/canvas-real-hevc-M-normal.json
@@ -1,0 +1,691 @@
+{
+  "label": "real-hevc-M-normal",
+  "commit": "ba753cfa5ec7ad24e7bb3e453e3ef99ccdf64276",
+  "dirty": true,
+  "platform": "darwin",
+  "arch": "arm64",
+  "machine": {
+    "cpu": "Apple M5",
+    "logicalCpus": 10,
+    "totalMemoryGB": 24
+  },
+  "viewport": {
+    "width": 1600,
+    "height": 1000
+  },
+  "viewportOverride": null,
+  "sampleCount": 2,
+  "warmupCount": 0,
+  "scales": [
+    "M"
+  ],
+  "scenarios": [
+    "node-drag-video"
+  ],
+  "leg": {
+    "devServer": false,
+    "cpuThrottleRate": 1,
+    "kind": "prod"
+  },
+  "results": [
+    {
+      "scale": "M",
+      "scenario": "node-drag-video",
+      "runIndex": 0,
+      "fixture": {
+        "scale": "M",
+        "imageNodes": 48,
+        "videoNodes": 48,
+        "nodes": 96,
+        "edges": 192,
+        "clips": 24,
+        "imageBytes": [
+          1845636,
+          1804651,
+          1744981,
+          1663390
+        ],
+        "imagePreviewBytes": [
+          73757,
+          43927,
+          45467,
+          41996
+        ],
+        "videoBytes": [
+          1380939031
+        ],
+        "mediaProfile": "real-assets"
+      },
+      "probe": {
+        "elapsedMs": 2025,
+        "frames": 237,
+        "fps": 117.1,
+        "frameGapP50Ms": 8.2,
+        "frameGapP95Ms": 10.6,
+        "maxFrameGapMs": 40.4,
+        "longTasks": 0,
+        "longTaskMs": 0,
+        "longTaskP95Ms": null,
+        "maxLoadingImages": 3,
+        "maxLoadingVideos": 1,
+        "maxActiveVideos": 0,
+        "firstMutationMs": 24.7,
+        "mutations": {
+          "stage": 2,
+          "edges": 2543,
+          "labels": 0
+        }
+      },
+      "cdpBefore": {
+        "LayoutCount": 0,
+        "RecalcStyleCount": 0,
+        "ScriptDurationMs": 1.7,
+        "LayoutDurationMs": 0,
+        "TaskDurationMs": 3.9,
+        "JSHeapUsedMB": 36.4,
+        "domNodes": 1405,
+        "domDocuments": 1,
+        "jsEventListeners": 969
+      },
+      "cdpAfter": {
+        "LayoutCount": 502,
+        "RecalcStyleCount": 521,
+        "ScriptDurationMs": 498.2,
+        "LayoutDurationMs": 31.3,
+        "TaskDurationMs": 851,
+        "JSHeapUsedMB": 63.6,
+        "domNodes": 2122,
+        "domDocuments": 1,
+        "jsEventListeners": 1738
+      },
+      "cdpDelta": {
+        "LayoutCount": 502,
+        "RecalcStyleCount": 521,
+        "ScriptDurationMs": 496.5,
+        "LayoutDurationMs": 31.3,
+        "TaskDurationMs": 847.1,
+        "JSHeapUsedMB": 27.2,
+        "domNodes": 717,
+        "domDocuments": 0,
+        "jsEventListeners": 769
+      },
+      "beforePage": {
+        "domNodes": 979,
+        "canvasNodes": 6,
+        "lightweightCanvasNodes": 0,
+        "lightweightPreviewNodes": 0,
+        "imageElements": 6,
+        "videoElements": 0,
+        "visibleMedia": 6,
+        "loadedImages": 6,
+        "loadedVideos": 0,
+        "visibleMediaNodes": 3,
+        "visibleMediaPending": 0,
+        "visibleMediaFailures": 0,
+        "activeVideos": 0,
+        "resourceCount": 0,
+        "jsHeapUsedMB": 45.2,
+        "transform": {
+          "x": 0,
+          "y": 0,
+          "zoom": 1
+        }
+      },
+      "page": {
+        "domNodes": 1477,
+        "canvasNodes": 9,
+        "lightweightCanvasNodes": 0,
+        "lightweightPreviewNodes": 0,
+        "imageElements": 11,
+        "videoElements": 1,
+        "visibleMedia": 10,
+        "loadedImages": 11,
+        "loadedVideos": 1,
+        "visibleMediaNodes": 4,
+        "visibleMediaPending": 0,
+        "visibleMediaFailures": 0,
+        "activeVideos": 0,
+        "resourceCount": 0,
+        "jsHeapUsedMB": 45.2,
+        "transform": {
+          "x": -655.875,
+          "y": 0,
+          "zoom": 1
+        }
+      },
+      "actionDetails": {
+        "nodeId": "canvas-perf-video-0",
+        "moves": 60,
+        "firstFeedbackMs": 24.699999999254942
+      },
+      "offCanvasRender": null,
+      "nodeIdentity": {
+        "before": 6,
+        "after": 9,
+        "common": 3,
+        "tracked": 3,
+        "preserved": 3,
+        "virtualizationChurn": [
+          "canvas-perf-image-0",
+          "canvas-perf-image-6",
+          "canvas-perf-image-12"
+        ],
+        "remountedInPlace": [],
+        "commonIdentityPreserved": true,
+        "targetNodeId": "canvas-perf-video-0",
+        "targetIdentityPreserved": true
+      },
+      "appMetrics": {
+        "rendererWorkingSetMB": 430.6,
+        "gpuWorkingSetMB": 152.6,
+        "processCount": 5,
+        "processes": [
+          {
+            "type": "Browser",
+            "pid": 54834,
+            "workingSetMB": 365.5
+          },
+          {
+            "type": "GPU",
+            "pid": 54837,
+            "workingSetMB": 152.6
+          },
+          {
+            "type": "Utility",
+            "pid": 54838,
+            "workingSetMB": 45
+          },
+          {
+            "type": "Tab",
+            "pid": 54839,
+            "workingSetMB": 430.6
+          },
+          {
+            "type": "Utility",
+            "pid": 54840,
+            "workingSetMB": 45.3
+          }
+        ]
+      },
+      "runtimeVersions": {
+        "app": "0.21.0",
+        "electron": "43.4.1",
+        "chrome": "150.0.7871.224",
+        "node": "24.18.1",
+        "v8": "15.0.245.28-electron.0"
+      },
+      "pageErrors": [],
+      "consoleErrors": [],
+      "elapsedMs": 20520
+    },
+    {
+      "scale": "M",
+      "scenario": "node-drag-video",
+      "runIndex": 1,
+      "fixture": {
+        "scale": "M",
+        "imageNodes": 48,
+        "videoNodes": 48,
+        "nodes": 96,
+        "edges": 192,
+        "clips": 24,
+        "imageBytes": [
+          1845636,
+          1804651,
+          1744981,
+          1663390
+        ],
+        "imagePreviewBytes": [
+          73757,
+          43927,
+          45467,
+          41996
+        ],
+        "videoBytes": [
+          1380939031
+        ],
+        "mediaProfile": "real-assets"
+      },
+      "probe": {
+        "elapsedMs": 1970,
+        "frames": 231,
+        "fps": 117.3,
+        "frameGapP50Ms": 8.3,
+        "frameGapP95Ms": 11.9,
+        "maxFrameGapMs": 36.2,
+        "longTasks": 0,
+        "longTaskMs": 0,
+        "longTaskP95Ms": null,
+        "maxLoadingImages": 3,
+        "maxLoadingVideos": 1,
+        "maxActiveVideos": 0,
+        "firstMutationMs": 14,
+        "mutations": {
+          "stage": 2,
+          "edges": 2489,
+          "labels": 0
+        }
+      },
+      "cdpBefore": {
+        "LayoutCount": 0,
+        "RecalcStyleCount": 0,
+        "ScriptDurationMs": 2.5,
+        "LayoutDurationMs": 0,
+        "TaskDurationMs": 4.4,
+        "JSHeapUsedMB": 34.1,
+        "domNodes": 6975,
+        "domDocuments": 1,
+        "jsEventListeners": 1602
+      },
+      "cdpAfter": {
+        "LayoutCount": 475,
+        "RecalcStyleCount": 492,
+        "ScriptDurationMs": 471.1,
+        "LayoutDurationMs": 28.6,
+        "TaskDurationMs": 807.9,
+        "JSHeapUsedMB": 61,
+        "domNodes": 2122,
+        "domDocuments": 1,
+        "jsEventListeners": 1672
+      },
+      "cdpDelta": {
+        "LayoutCount": 475,
+        "RecalcStyleCount": 492,
+        "ScriptDurationMs": 468.6,
+        "LayoutDurationMs": 28.6,
+        "TaskDurationMs": 803.5,
+        "JSHeapUsedMB": 26.9,
+        "domNodes": -4853,
+        "domDocuments": 0,
+        "jsEventListeners": 70
+      },
+      "beforePage": {
+        "domNodes": 979,
+        "canvasNodes": 6,
+        "lightweightCanvasNodes": 0,
+        "lightweightPreviewNodes": 0,
+        "imageElements": 6,
+        "videoElements": 0,
+        "visibleMedia": 6,
+        "loadedImages": 6,
+        "loadedVideos": 0,
+        "visibleMediaNodes": 3,
+        "visibleMediaPending": 0,
+        "visibleMediaFailures": 0,
+        "activeVideos": 0,
+        "resourceCount": 0,
+        "jsHeapUsedMB": 42.6,
+        "transform": {
+          "x": 0,
+          "y": 0,
+          "zoom": 1
+        }
+      },
+      "page": {
+        "domNodes": 1477,
+        "canvasNodes": 9,
+        "lightweightCanvasNodes": 0,
+        "lightweightPreviewNodes": 0,
+        "imageElements": 11,
+        "videoElements": 1,
+        "visibleMedia": 10,
+        "loadedImages": 11,
+        "loadedVideos": 1,
+        "visibleMediaNodes": 4,
+        "visibleMediaPending": 0,
+        "visibleMediaFailures": 0,
+        "activeVideos": 0,
+        "resourceCount": 0,
+        "jsHeapUsedMB": 42.6,
+        "transform": {
+          "x": -619.875,
+          "y": 0,
+          "zoom": 1
+        }
+      },
+      "actionDetails": {
+        "nodeId": "canvas-perf-video-0",
+        "moves": 60,
+        "firstFeedbackMs": 14
+      },
+      "offCanvasRender": null,
+      "nodeIdentity": {
+        "before": 6,
+        "after": 9,
+        "common": 3,
+        "tracked": 3,
+        "preserved": 3,
+        "virtualizationChurn": [
+          "canvas-perf-image-0",
+          "canvas-perf-image-6",
+          "canvas-perf-image-12"
+        ],
+        "remountedInPlace": [],
+        "commonIdentityPreserved": true,
+        "targetNodeId": "canvas-perf-video-0",
+        "targetIdentityPreserved": true
+      },
+      "appMetrics": {
+        "rendererWorkingSetMB": 411.3,
+        "gpuWorkingSetMB": 149.3,
+        "processCount": 5,
+        "processes": [
+          {
+            "type": "Browser",
+            "pid": 54933,
+            "workingSetMB": 362.2
+          },
+          {
+            "type": "GPU",
+            "pid": 54936,
+            "workingSetMB": 149.3
+          },
+          {
+            "type": "Utility",
+            "pid": 54937,
+            "workingSetMB": 45
+          },
+          {
+            "type": "Tab",
+            "pid": 54938,
+            "workingSetMB": 411.3
+          },
+          {
+            "type": "Utility",
+            "pid": 54940,
+            "workingSetMB": 45.3
+          }
+        ]
+      },
+      "runtimeVersions": {
+        "app": "0.21.0",
+        "electron": "43.4.1",
+        "chrome": "150.0.7871.224",
+        "node": "24.18.1",
+        "v8": "15.0.245.28-electron.0"
+      },
+      "pageErrors": [],
+      "consoleErrors": [],
+      "elapsedMs": 20430
+    }
+  ],
+  "warmupFailures": [],
+  "summary": {
+    "M/node-drag-video": {
+      "samples": 2,
+      "errors": 0,
+      "metrics": {
+        "coldFirstCanvasMs": null,
+        "coldMediaSettledMs": null,
+        "fps": {
+          "median": 117.1,
+          "p95": 117.3,
+          "samples": [
+            117.1,
+            117.3
+          ]
+        },
+        "frameGapP95Ms": {
+          "median": 10.6,
+          "p95": 11.9,
+          "samples": [
+            10.6,
+            11.9
+          ]
+        },
+        "maxFrameGapMs": {
+          "median": 36.2,
+          "p95": 40.4,
+          "samples": [
+            36.2,
+            40.4
+          ]
+        },
+        "longTaskMs": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "longTaskP95Ms": null,
+        "maxLoadingImages": {
+          "median": 3,
+          "p95": 3,
+          "samples": [
+            3,
+            3
+          ]
+        },
+        "maxLoadingVideos": {
+          "median": 1,
+          "p95": 1,
+          "samples": [
+            1,
+            1
+          ]
+        },
+        "maxActiveVideos": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "layoutCount": {
+          "median": 475,
+          "p95": 502,
+          "samples": [
+            475,
+            502
+          ]
+        },
+        "recalcStyleCount": {
+          "median": 492,
+          "p95": 521,
+          "samples": [
+            492,
+            521
+          ]
+        },
+        "scriptDurationMs": {
+          "median": 468.6,
+          "p95": 496.5,
+          "samples": [
+            468.6,
+            496.5
+          ]
+        },
+        "layoutDurationMs": {
+          "median": 28.6,
+          "p95": 31.3,
+          "samples": [
+            28.6,
+            31.3
+          ]
+        },
+        "jsHeapUsedMB": {
+          "median": 42.6,
+          "p95": 45.2,
+          "samples": [
+            42.6,
+            45.2
+          ]
+        },
+        "visibleMedia": {
+          "median": 10,
+          "p95": 10,
+          "samples": [
+            10,
+            10
+          ]
+        },
+        "visibleMediaNodes": {
+          "median": 4,
+          "p95": 4,
+          "samples": [
+            4,
+            4
+          ]
+        },
+        "visibleMediaPending": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "visibleMediaFailures": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "loadedImages": {
+          "median": 11,
+          "p95": 11,
+          "samples": [
+            11,
+            11
+          ]
+        },
+        "loadedVideos": {
+          "median": 1,
+          "p95": 1,
+          "samples": [
+            1,
+            1
+          ]
+        },
+        "activeVideos": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "rendererWorkingSetMB": {
+          "median": 411.3,
+          "p95": 430.6,
+          "samples": [
+            411.3,
+            430.6
+          ]
+        },
+        "reloadHeapDeltaMB": null,
+        "reloadDurationP95Ms": null
+      },
+      "advisory": {
+        "perMove": {
+          "scriptPerMoveMs": {
+            "median": 7.81,
+            "p95": 8.28,
+            "samples": [
+              8.28,
+              7.81
+            ]
+          },
+          "layoutPerMove": {
+            "median": 7.92,
+            "p95": 8.37,
+            "samples": [
+              8.37,
+              7.92
+            ]
+          }
+        },
+        "dragOverPan": {
+          "scriptRatio": {
+            "median": null,
+            "samples": []
+          },
+          "layoutRatio": {
+            "median": null,
+            "samples": []
+          }
+        },
+        "actionLatency": {
+          "samples": [
+            24.699999999254942,
+            14
+          ],
+          "p95Ms": 24.7,
+          "medianMs": 14
+        },
+        "offCanvasRender": {
+          "installed": false,
+          "windows": 0,
+          "totalMax": null,
+          "totalMedian": null,
+          "perComponentMax": {
+            "CategoryTree": null,
+            "AssetLibraryPanel": null,
+            "AssetPicker": null,
+            "TaskCenterButton": null,
+            "TaskCenterPanel": null,
+            "TimelinePreview": null,
+            "PreviewSourcePanel": null,
+            "OnboardingChecklist": null
+          }
+        }
+      },
+      "verdict": {
+        "pass": true,
+        "advisoryOnly": false,
+        "budgetsAdvisory": false,
+        "hardFailures": [],
+        "budgetChecks": [
+          {
+            "metric": "frameGapP95Ms",
+            "actualP95": 11.9,
+            "max": 33,
+            "pass": true,
+            "advisory": false
+          },
+          {
+            "metric": "maxFrameGapMs",
+            "actualP95": 40.4,
+            "max": 100,
+            "pass": true,
+            "advisory": true
+          },
+          {
+            "metric": "maxLoadingImages",
+            "actualP95": 3,
+            "max": 4,
+            "pass": true,
+            "advisory": false
+          },
+          {
+            "metric": "maxLoadingVideos",
+            "actualP95": 1,
+            "max": 1,
+            "pass": true,
+            "advisory": false
+          },
+          {
+            "metric": "maxActiveVideos",
+            "actualP95": 0,
+            "max": 1,
+            "pass": true,
+            "advisory": false
+          }
+        ]
+      }
+    }
+  },
+  "runtimeVersions": {
+    "app": "0.21.0",
+    "electron": "43.4.1",
+    "chrome": "150.0.7871.224",
+    "node": "24.18.1",
+    "v8": "15.0.245.28-electron.0"
+  },
+  "pass": true
+}

--- a/tests/ux/perf-results/canvas-real-hevc-S-lowzoom.json
+++ b/tests/ux/perf-results/canvas-real-hevc-S-lowzoom.json
@@ -1,0 +1,689 @@
+{
+  "label": "real-hevc-S-lowzoom",
+  "commit": "ba753cfa5ec7ad24e7bb3e453e3ef99ccdf64276",
+  "dirty": true,
+  "platform": "darwin",
+  "arch": "arm64",
+  "machine": {
+    "cpu": "Apple M5",
+    "logicalCpus": 10,
+    "totalMemoryGB": 24
+  },
+  "viewport": {
+    "width": 1600,
+    "height": 1000
+  },
+  "viewportOverride": null,
+  "sampleCount": 2,
+  "warmupCount": 0,
+  "scales": [
+    "S"
+  ],
+  "scenarios": [
+    "drag-at-low-zoom"
+  ],
+  "leg": {
+    "devServer": false,
+    "cpuThrottleRate": 1,
+    "kind": "prod"
+  },
+  "results": [
+    {
+      "scale": "S",
+      "scenario": "drag-at-low-zoom",
+      "runIndex": 0,
+      "fixture": {
+        "scale": "S",
+        "imageNodes": 24,
+        "videoNodes": 24,
+        "nodes": 48,
+        "edges": 96,
+        "clips": 12,
+        "imageBytes": [
+          1845636,
+          1804651,
+          1744981,
+          1663390
+        ],
+        "imagePreviewBytes": [
+          73757,
+          43927,
+          45467,
+          41996
+        ],
+        "videoBytes": [
+          1380939031
+        ],
+        "mediaProfile": "real-assets"
+      },
+      "probe": {
+        "elapsedMs": 1044,
+        "frames": 122,
+        "fps": 116.9,
+        "frameGapP50Ms": 8.3,
+        "frameGapP95Ms": 10.9,
+        "maxFrameGapMs": 40.2,
+        "longTasks": 0,
+        "longTaskMs": 0,
+        "longTaskP95Ms": null,
+        "maxLoadingImages": 0,
+        "maxLoadingVideos": 0,
+        "maxActiveVideos": 0,
+        "firstMutationMs": 26.2,
+        "mutations": {
+          "stage": 2,
+          "edges": 350,
+          "labels": 0
+        }
+      },
+      "cdpBefore": {
+        "LayoutCount": 9,
+        "RecalcStyleCount": 18,
+        "ScriptDurationMs": 110.3,
+        "LayoutDurationMs": 1.6,
+        "TaskDurationMs": 146,
+        "JSHeapUsedMB": 28.7,
+        "domNodes": 1284,
+        "domDocuments": 1,
+        "jsEventListeners": 1014
+      },
+      "cdpAfter": {
+        "LayoutCount": 45,
+        "RecalcStyleCount": 101,
+        "ScriptDurationMs": 184.6,
+        "LayoutDurationMs": 5,
+        "TaskDurationMs": 322.2,
+        "JSHeapUsedMB": 29.5,
+        "domNodes": 1343,
+        "domDocuments": 1,
+        "jsEventListeners": 1188
+      },
+      "cdpDelta": {
+        "LayoutCount": 36,
+        "RecalcStyleCount": 83,
+        "ScriptDurationMs": 74.3,
+        "LayoutDurationMs": 3.4,
+        "TaskDurationMs": 176.2,
+        "JSHeapUsedMB": 0.8,
+        "domNodes": 59,
+        "domDocuments": 0,
+        "jsEventListeners": 174
+      },
+      "beforePage": {
+        "domNodes": 987,
+        "canvasNodes": 16,
+        "lightweightCanvasNodes": 16,
+        "lightweightPreviewNodes": 16,
+        "imageElements": 16,
+        "videoElements": 0,
+        "visibleMedia": 16,
+        "loadedImages": 16,
+        "loadedVideos": 0,
+        "visibleMediaNodes": 16,
+        "visibleMediaPending": 0,
+        "visibleMediaFailures": 0,
+        "activeVideos": 0,
+        "resourceCount": 0,
+        "jsHeapUsedMB": 37.8,
+        "transform": {
+          "x": 225.325,
+          "y": 247.349,
+          "zoom": 0.435275
+        }
+      },
+      "page": {
+        "domNodes": 1141,
+        "canvasNodes": 16,
+        "lightweightCanvasNodes": 15,
+        "lightweightPreviewNodes": 15,
+        "imageElements": 17,
+        "videoElements": 0,
+        "visibleMedia": 16,
+        "loadedImages": 17,
+        "loadedVideos": 0,
+        "visibleMediaNodes": 16,
+        "visibleMediaPending": 0,
+        "visibleMediaFailures": 0,
+        "activeVideos": 0,
+        "resourceCount": 0,
+        "jsHeapUsedMB": 37.8,
+        "transform": {
+          "x": 225.325,
+          "y": 247.349,
+          "zoom": 0.435275
+        }
+      },
+      "actionDetails": {
+        "zoom": 0.435,
+        "lightweightMounted": 16,
+        "lightweightActive": true,
+        "moves": 22,
+        "firstFeedbackMs": 26.199999999254942,
+        "nodeId": "canvas-perf-image-0"
+      },
+      "offCanvasRender": null,
+      "nodeIdentity": {
+        "before": 16,
+        "after": 16,
+        "common": 16,
+        "tracked": 16,
+        "preserved": 16,
+        "virtualizationChurn": [],
+        "remountedInPlace": [],
+        "commonIdentityPreserved": true,
+        "targetNodeId": "canvas-perf-image-0",
+        "targetIdentityPreserved": true
+      },
+      "appMetrics": {
+        "rendererWorkingSetMB": 316.4,
+        "gpuWorkingSetMB": 138.5,
+        "processCount": 5,
+        "processes": [
+          {
+            "type": "Browser",
+            "pid": 53560,
+            "workingSetMB": 335.2
+          },
+          {
+            "type": "GPU",
+            "pid": 53583,
+            "workingSetMB": 138.5
+          },
+          {
+            "type": "Utility",
+            "pid": 53584,
+            "workingSetMB": 45.1
+          },
+          {
+            "type": "Tab",
+            "pid": 53598,
+            "workingSetMB": 316.4
+          },
+          {
+            "type": "Utility",
+            "pid": 53605,
+            "workingSetMB": 45.1
+          }
+        ]
+      },
+      "runtimeVersions": {
+        "app": "0.21.0",
+        "electron": "43.4.1",
+        "chrome": "150.0.7871.224",
+        "node": "24.18.1",
+        "v8": "15.0.245.28-electron.0"
+      },
+      "pageErrors": [],
+      "consoleErrors": [],
+      "elapsedMs": 20876
+    },
+    {
+      "scale": "S",
+      "scenario": "drag-at-low-zoom",
+      "runIndex": 1,
+      "fixture": {
+        "scale": "S",
+        "imageNodes": 24,
+        "videoNodes": 24,
+        "nodes": 48,
+        "edges": 96,
+        "clips": 12,
+        "imageBytes": [
+          1845636,
+          1804651,
+          1744981,
+          1663390
+        ],
+        "imagePreviewBytes": [
+          73757,
+          43927,
+          45467,
+          41996
+        ],
+        "videoBytes": [
+          1380939031
+        ],
+        "mediaProfile": "real-assets"
+      },
+      "probe": {
+        "elapsedMs": 1047,
+        "frames": 122,
+        "fps": 116.6,
+        "frameGapP50Ms": 8.3,
+        "frameGapP95Ms": 11,
+        "maxFrameGapMs": 41.7,
+        "longTasks": 0,
+        "longTaskMs": 0,
+        "longTaskP95Ms": null,
+        "maxLoadingImages": 0,
+        "maxLoadingVideos": 0,
+        "maxActiveVideos": 0,
+        "firstMutationMs": 26.6,
+        "mutations": {
+          "stage": 2,
+          "edges": 350,
+          "labels": 0
+        }
+      },
+      "cdpBefore": {
+        "LayoutCount": 9,
+        "RecalcStyleCount": 18,
+        "ScriptDurationMs": 120,
+        "LayoutDurationMs": 1.6,
+        "TaskDurationMs": 145.2,
+        "JSHeapUsedMB": 33.2,
+        "domNodes": 4560,
+        "domDocuments": 1,
+        "jsEventListeners": 1194
+      },
+      "cdpAfter": {
+        "LayoutCount": 44,
+        "RecalcStyleCount": 101,
+        "ScriptDurationMs": 197.8,
+        "LayoutDurationMs": 5,
+        "TaskDurationMs": 334.7,
+        "JSHeapUsedMB": 29.5,
+        "domNodes": 1343,
+        "domDocuments": 1,
+        "jsEventListeners": 1188
+      },
+      "cdpDelta": {
+        "LayoutCount": 35,
+        "RecalcStyleCount": 83,
+        "ScriptDurationMs": 77.8,
+        "LayoutDurationMs": 3.4,
+        "TaskDurationMs": 189.5,
+        "JSHeapUsedMB": -3.7,
+        "domNodes": -3217,
+        "domDocuments": 0,
+        "jsEventListeners": -6
+      },
+      "beforePage": {
+        "domNodes": 987,
+        "canvasNodes": 16,
+        "lightweightCanvasNodes": 16,
+        "lightweightPreviewNodes": 16,
+        "imageElements": 16,
+        "videoElements": 0,
+        "visibleMedia": 16,
+        "loadedImages": 16,
+        "loadedVideos": 0,
+        "visibleMediaNodes": 16,
+        "visibleMediaPending": 0,
+        "visibleMediaFailures": 0,
+        "activeVideos": 0,
+        "resourceCount": 0,
+        "jsHeapUsedMB": 48.1,
+        "transform": {
+          "x": 225.325,
+          "y": 247.349,
+          "zoom": 0.435275
+        }
+      },
+      "page": {
+        "domNodes": 1141,
+        "canvasNodes": 16,
+        "lightweightCanvasNodes": 15,
+        "lightweightPreviewNodes": 15,
+        "imageElements": 17,
+        "videoElements": 0,
+        "visibleMedia": 16,
+        "loadedImages": 17,
+        "loadedVideos": 0,
+        "visibleMediaNodes": 16,
+        "visibleMediaPending": 0,
+        "visibleMediaFailures": 0,
+        "activeVideos": 0,
+        "resourceCount": 0,
+        "jsHeapUsedMB": 48.1,
+        "transform": {
+          "x": 225.325,
+          "y": 247.349,
+          "zoom": 0.435275
+        }
+      },
+      "actionDetails": {
+        "zoom": 0.435,
+        "lightweightMounted": 16,
+        "lightweightActive": true,
+        "moves": 22,
+        "firstFeedbackMs": 26.600000001490116,
+        "nodeId": "canvas-perf-image-0"
+      },
+      "offCanvasRender": null,
+      "nodeIdentity": {
+        "before": 16,
+        "after": 16,
+        "common": 16,
+        "tracked": 16,
+        "preserved": 16,
+        "virtualizationChurn": [],
+        "remountedInPlace": [],
+        "commonIdentityPreserved": true,
+        "targetNodeId": "canvas-perf-image-0",
+        "targetIdentityPreserved": true
+      },
+      "appMetrics": {
+        "rendererWorkingSetMB": 326,
+        "gpuWorkingSetMB": 141.3,
+        "processCount": 5,
+        "processes": [
+          {
+            "type": "Browser",
+            "pid": 53772,
+            "workingSetMB": 333.9
+          },
+          {
+            "type": "GPU",
+            "pid": 53775,
+            "workingSetMB": 141.3
+          },
+          {
+            "type": "Utility",
+            "pid": 53776,
+            "workingSetMB": 45
+          },
+          {
+            "type": "Tab",
+            "pid": 53777,
+            "workingSetMB": 326
+          },
+          {
+            "type": "Utility",
+            "pid": 53780,
+            "workingSetMB": 45
+          }
+        ]
+      },
+      "runtimeVersions": {
+        "app": "0.21.0",
+        "electron": "43.4.1",
+        "chrome": "150.0.7871.224",
+        "node": "24.18.1",
+        "v8": "15.0.245.28-electron.0"
+      },
+      "pageErrors": [],
+      "consoleErrors": [],
+      "elapsedMs": 20407
+    }
+  ],
+  "warmupFailures": [],
+  "summary": {
+    "S/drag-at-low-zoom": {
+      "samples": 2,
+      "errors": 0,
+      "metrics": {
+        "coldFirstCanvasMs": null,
+        "coldMediaSettledMs": null,
+        "fps": {
+          "median": 116.6,
+          "p95": 116.9,
+          "samples": [
+            116.6,
+            116.9
+          ]
+        },
+        "frameGapP95Ms": {
+          "median": 10.9,
+          "p95": 11,
+          "samples": [
+            10.9,
+            11
+          ]
+        },
+        "maxFrameGapMs": {
+          "median": 40.2,
+          "p95": 41.7,
+          "samples": [
+            40.2,
+            41.7
+          ]
+        },
+        "longTaskMs": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "longTaskP95Ms": null,
+        "maxLoadingImages": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "maxLoadingVideos": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "maxActiveVideos": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "layoutCount": {
+          "median": 35,
+          "p95": 36,
+          "samples": [
+            35,
+            36
+          ]
+        },
+        "recalcStyleCount": {
+          "median": 83,
+          "p95": 83,
+          "samples": [
+            83,
+            83
+          ]
+        },
+        "scriptDurationMs": {
+          "median": 74.3,
+          "p95": 77.8,
+          "samples": [
+            74.3,
+            77.8
+          ]
+        },
+        "layoutDurationMs": {
+          "median": 3.4,
+          "p95": 3.4,
+          "samples": [
+            3.4,
+            3.4
+          ]
+        },
+        "jsHeapUsedMB": {
+          "median": 37.8,
+          "p95": 48.1,
+          "samples": [
+            37.8,
+            48.1
+          ]
+        },
+        "visibleMedia": {
+          "median": 16,
+          "p95": 16,
+          "samples": [
+            16,
+            16
+          ]
+        },
+        "visibleMediaNodes": {
+          "median": 16,
+          "p95": 16,
+          "samples": [
+            16,
+            16
+          ]
+        },
+        "visibleMediaPending": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "visibleMediaFailures": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "loadedImages": {
+          "median": 17,
+          "p95": 17,
+          "samples": [
+            17,
+            17
+          ]
+        },
+        "loadedVideos": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "activeVideos": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "rendererWorkingSetMB": {
+          "median": 316.4,
+          "p95": 326,
+          "samples": [
+            316.4,
+            326
+          ]
+        },
+        "reloadHeapDeltaMB": null,
+        "reloadDurationP95Ms": null
+      },
+      "advisory": {
+        "perMove": {
+          "scriptPerMoveMs": {
+            "median": 3.38,
+            "p95": 3.54,
+            "samples": [
+              3.38,
+              3.54
+            ]
+          },
+          "layoutPerMove": {
+            "median": 1.59,
+            "p95": 1.64,
+            "samples": [
+              1.64,
+              1.59
+            ]
+          }
+        },
+        "dragOverPan": {
+          "scriptRatio": {
+            "median": null,
+            "samples": []
+          },
+          "layoutRatio": {
+            "median": null,
+            "samples": []
+          }
+        },
+        "actionLatency": {
+          "samples": [
+            26.199999999254942,
+            26.600000001490116
+          ],
+          "p95Ms": 26.6,
+          "medianMs": 26.2
+        },
+        "offCanvasRender": {
+          "installed": false,
+          "windows": 0,
+          "totalMax": null,
+          "totalMedian": null,
+          "perComponentMax": {
+            "CategoryTree": null,
+            "AssetLibraryPanel": null,
+            "AssetPicker": null,
+            "TaskCenterButton": null,
+            "TaskCenterPanel": null,
+            "TimelinePreview": null,
+            "PreviewSourcePanel": null,
+            "OnboardingChecklist": null
+          }
+        }
+      },
+      "verdict": {
+        "pass": true,
+        "advisoryOnly": true,
+        "budgetsAdvisory": false,
+        "hardFailures": [],
+        "budgetChecks": [
+          {
+            "metric": "frameGapP95Ms",
+            "actualP95": 11,
+            "max": 33,
+            "pass": true,
+            "advisory": false
+          },
+          {
+            "metric": "maxFrameGapMs",
+            "actualP95": 41.7,
+            "max": 100,
+            "pass": true,
+            "advisory": true
+          },
+          {
+            "metric": "maxLoadingImages",
+            "actualP95": 0,
+            "max": 4,
+            "pass": true,
+            "advisory": false
+          },
+          {
+            "metric": "maxLoadingVideos",
+            "actualP95": 0,
+            "max": 1,
+            "pass": true,
+            "advisory": false
+          },
+          {
+            "metric": "maxActiveVideos",
+            "actualP95": 0,
+            "max": 1,
+            "pass": true,
+            "advisory": false
+          }
+        ]
+      }
+    }
+  },
+  "runtimeVersions": {
+    "app": "0.21.0",
+    "electron": "43.4.1",
+    "chrome": "150.0.7871.224",
+    "node": "24.18.1",
+    "v8": "15.0.245.28-electron.0"
+  },
+  "pass": true
+}

--- a/tests/ux/perf-results/canvas-real-hevc-S-normal.json
+++ b/tests/ux/perf-results/canvas-real-hevc-S-normal.json
@@ -1,0 +1,691 @@
+{
+  "label": "real-hevc-S-normal",
+  "commit": "ba753cfa5ec7ad24e7bb3e453e3ef99ccdf64276",
+  "dirty": true,
+  "platform": "darwin",
+  "arch": "arm64",
+  "machine": {
+    "cpu": "Apple M5",
+    "logicalCpus": 10,
+    "totalMemoryGB": 24
+  },
+  "viewport": {
+    "width": 1600,
+    "height": 1000
+  },
+  "viewportOverride": null,
+  "sampleCount": 2,
+  "warmupCount": 0,
+  "scales": [
+    "S"
+  ],
+  "scenarios": [
+    "node-drag-video"
+  ],
+  "leg": {
+    "devServer": false,
+    "cpuThrottleRate": 1,
+    "kind": "prod"
+  },
+  "results": [
+    {
+      "scale": "S",
+      "scenario": "node-drag-video",
+      "runIndex": 0,
+      "fixture": {
+        "scale": "S",
+        "imageNodes": 24,
+        "videoNodes": 24,
+        "nodes": 48,
+        "edges": 96,
+        "clips": 12,
+        "imageBytes": [
+          1845636,
+          1804651,
+          1744981,
+          1663390
+        ],
+        "imagePreviewBytes": [
+          73757,
+          43927,
+          45467,
+          41996
+        ],
+        "videoBytes": [
+          1380939031
+        ],
+        "mediaProfile": "real-assets"
+      },
+      "probe": {
+        "elapsedMs": 2018,
+        "frames": 238,
+        "fps": 118,
+        "frameGapP50Ms": 8.3,
+        "frameGapP95Ms": 10.2,
+        "maxFrameGapMs": 41,
+        "longTasks": 0,
+        "longTaskMs": 0,
+        "longTaskP95Ms": null,
+        "maxLoadingImages": 3,
+        "maxLoadingVideos": 1,
+        "maxActiveVideos": 0,
+        "firstMutationMs": 21.7,
+        "mutations": {
+          "stage": 2,
+          "edges": 2537,
+          "labels": 0
+        }
+      },
+      "cdpBefore": {
+        "LayoutCount": 0,
+        "RecalcStyleCount": 0,
+        "ScriptDurationMs": 2.3,
+        "LayoutDurationMs": 0,
+        "TaskDurationMs": 4.3,
+        "JSHeapUsedMB": 30.6,
+        "domNodes": 4056,
+        "domDocuments": 1,
+        "jsEventListeners": 1288
+      },
+      "cdpAfter": {
+        "LayoutCount": 500,
+        "RecalcStyleCount": 520,
+        "ScriptDurationMs": 467.4,
+        "LayoutDurationMs": 27.3,
+        "TaskDurationMs": 815.4,
+        "JSHeapUsedMB": 59.8,
+        "domNodes": 1988,
+        "domDocuments": 1,
+        "jsEventListeners": 1692
+      },
+      "cdpDelta": {
+        "LayoutCount": 500,
+        "RecalcStyleCount": 520,
+        "ScriptDurationMs": 465.1,
+        "LayoutDurationMs": 27.3,
+        "TaskDurationMs": 811.1,
+        "JSHeapUsedMB": 29.2,
+        "domNodes": -2068,
+        "domDocuments": 0,
+        "jsEventListeners": 404
+      },
+      "beforePage": {
+        "domNodes": 875,
+        "canvasNodes": 6,
+        "lightweightCanvasNodes": 0,
+        "lightweightPreviewNodes": 0,
+        "imageElements": 6,
+        "videoElements": 0,
+        "visibleMedia": 6,
+        "loadedImages": 6,
+        "loadedVideos": 0,
+        "visibleMediaNodes": 3,
+        "visibleMediaPending": 0,
+        "visibleMediaFailures": 0,
+        "activeVideos": 0,
+        "resourceCount": 0,
+        "jsHeapUsedMB": 37.8,
+        "transform": {
+          "x": 0,
+          "y": 0,
+          "zoom": 1
+        }
+      },
+      "page": {
+        "domNodes": 1336,
+        "canvasNodes": 9,
+        "lightweightCanvasNodes": 0,
+        "lightweightPreviewNodes": 0,
+        "imageElements": 11,
+        "videoElements": 1,
+        "visibleMedia": 10,
+        "loadedImages": 11,
+        "loadedVideos": 1,
+        "visibleMediaNodes": 4,
+        "visibleMediaPending": 0,
+        "visibleMediaFailures": 0,
+        "activeVideos": 0,
+        "resourceCount": 0,
+        "jsHeapUsedMB": 37.8,
+        "transform": {
+          "x": -651.375,
+          "y": 0,
+          "zoom": 1
+        }
+      },
+      "actionDetails": {
+        "nodeId": "canvas-perf-video-0",
+        "moves": 60,
+        "firstFeedbackMs": 21.699999999254942
+      },
+      "offCanvasRender": null,
+      "nodeIdentity": {
+        "before": 6,
+        "after": 9,
+        "common": 3,
+        "tracked": 3,
+        "preserved": 3,
+        "virtualizationChurn": [
+          "canvas-perf-image-0",
+          "canvas-perf-image-6",
+          "canvas-perf-image-12"
+        ],
+        "remountedInPlace": [],
+        "commonIdentityPreserved": true,
+        "targetNodeId": "canvas-perf-video-0",
+        "targetIdentityPreserved": true
+      },
+      "appMetrics": {
+        "rendererWorkingSetMB": 416.1,
+        "gpuWorkingSetMB": 155.8,
+        "processCount": 5,
+        "processes": [
+          {
+            "type": "Browser",
+            "pid": 54645,
+            "workingSetMB": 358.2
+          },
+          {
+            "type": "GPU",
+            "pid": 54648,
+            "workingSetMB": 155.8
+          },
+          {
+            "type": "Utility",
+            "pid": 54649,
+            "workingSetMB": 45
+          },
+          {
+            "type": "Tab",
+            "pid": 54650,
+            "workingSetMB": 416.1
+          },
+          {
+            "type": "Utility",
+            "pid": 54651,
+            "workingSetMB": 45.3
+          }
+        ]
+      },
+      "runtimeVersions": {
+        "app": "0.21.0",
+        "electron": "43.4.1",
+        "chrome": "150.0.7871.224",
+        "node": "24.18.1",
+        "v8": "15.0.245.28-electron.0"
+      },
+      "pageErrors": [],
+      "consoleErrors": [],
+      "elapsedMs": 20538
+    },
+    {
+      "scale": "S",
+      "scenario": "node-drag-video",
+      "runIndex": 1,
+      "fixture": {
+        "scale": "S",
+        "imageNodes": 24,
+        "videoNodes": 24,
+        "nodes": 48,
+        "edges": 96,
+        "clips": 12,
+        "imageBytes": [
+          1845636,
+          1804651,
+          1744981,
+          1663390
+        ],
+        "imagePreviewBytes": [
+          73757,
+          43927,
+          45467,
+          41996
+        ],
+        "videoBytes": [
+          1380939031
+        ],
+        "mediaProfile": "real-assets"
+      },
+      "probe": {
+        "elapsedMs": 2020,
+        "frames": 237,
+        "fps": 117.3,
+        "frameGapP50Ms": 8.3,
+        "frameGapP95Ms": 11.1,
+        "maxFrameGapMs": 40.3,
+        "longTasks": 0,
+        "longTaskMs": 0,
+        "longTaskP95Ms": null,
+        "maxLoadingImages": 3,
+        "maxLoadingVideos": 1,
+        "maxActiveVideos": 0,
+        "firstMutationMs": 22.4,
+        "mutations": {
+          "stage": 2,
+          "edges": 2537,
+          "labels": 0
+        }
+      },
+      "cdpBefore": {
+        "LayoutCount": 0,
+        "RecalcStyleCount": 0,
+        "ScriptDurationMs": 2.6,
+        "LayoutDurationMs": 0,
+        "TaskDurationMs": 9,
+        "JSHeapUsedMB": 29,
+        "domNodes": 3959,
+        "domDocuments": 1,
+        "jsEventListeners": 1265
+      },
+      "cdpAfter": {
+        "LayoutCount": 509,
+        "RecalcStyleCount": 527,
+        "ScriptDurationMs": 486.1,
+        "LayoutDurationMs": 30.3,
+        "TaskDurationMs": 847.5,
+        "JSHeapUsedMB": 47.4,
+        "domNodes": 2014,
+        "domDocuments": 1,
+        "jsEventListeners": 1890
+      },
+      "cdpDelta": {
+        "LayoutCount": 509,
+        "RecalcStyleCount": 527,
+        "ScriptDurationMs": 483.5,
+        "LayoutDurationMs": 30.3,
+        "TaskDurationMs": 838.5,
+        "JSHeapUsedMB": 18.4,
+        "domNodes": -1945,
+        "domDocuments": 0,
+        "jsEventListeners": 625
+      },
+      "beforePage": {
+        "domNodes": 875,
+        "canvasNodes": 6,
+        "lightweightCanvasNodes": 0,
+        "lightweightPreviewNodes": 0,
+        "imageElements": 6,
+        "videoElements": 0,
+        "visibleMedia": 6,
+        "loadedImages": 6,
+        "loadedVideos": 0,
+        "visibleMediaNodes": 3,
+        "visibleMediaPending": 0,
+        "visibleMediaFailures": 0,
+        "activeVideos": 0,
+        "resourceCount": 0,
+        "jsHeapUsedMB": 48.1,
+        "transform": {
+          "x": 0,
+          "y": 0,
+          "zoom": 1
+        }
+      },
+      "page": {
+        "domNodes": 1336,
+        "canvasNodes": 9,
+        "lightweightCanvasNodes": 0,
+        "lightweightPreviewNodes": 0,
+        "imageElements": 11,
+        "videoElements": 1,
+        "visibleMedia": 10,
+        "loadedImages": 11,
+        "loadedVideos": 1,
+        "visibleMediaNodes": 4,
+        "visibleMediaPending": 0,
+        "visibleMediaFailures": 0,
+        "activeVideos": 0,
+        "resourceCount": 0,
+        "jsHeapUsedMB": 48.1,
+        "transform": {
+          "x": -687.375,
+          "y": 0,
+          "zoom": 1
+        }
+      },
+      "actionDetails": {
+        "nodeId": "canvas-perf-video-0",
+        "moves": 60,
+        "firstFeedbackMs": 22.399999998509884
+      },
+      "offCanvasRender": null,
+      "nodeIdentity": {
+        "before": 6,
+        "after": 9,
+        "common": 3,
+        "tracked": 3,
+        "preserved": 3,
+        "virtualizationChurn": [
+          "canvas-perf-image-0",
+          "canvas-perf-image-6",
+          "canvas-perf-image-12"
+        ],
+        "remountedInPlace": [],
+        "commonIdentityPreserved": true,
+        "targetNodeId": "canvas-perf-video-0",
+        "targetIdentityPreserved": true
+      },
+      "appMetrics": {
+        "rendererWorkingSetMB": 414.5,
+        "gpuWorkingSetMB": 145.7,
+        "processCount": 5,
+        "processes": [
+          {
+            "type": "Browser",
+            "pid": 54685,
+            "workingSetMB": 354.2
+          },
+          {
+            "type": "GPU",
+            "pid": 54688,
+            "workingSetMB": 145.7
+          },
+          {
+            "type": "Utility",
+            "pid": 54689,
+            "workingSetMB": 45
+          },
+          {
+            "type": "Tab",
+            "pid": 54690,
+            "workingSetMB": 414.5
+          },
+          {
+            "type": "Utility",
+            "pid": 54693,
+            "workingSetMB": 45.3
+          }
+        ]
+      },
+      "runtimeVersions": {
+        "app": "0.21.0",
+        "electron": "43.4.1",
+        "chrome": "150.0.7871.224",
+        "node": "24.18.1",
+        "v8": "15.0.245.28-electron.0"
+      },
+      "pageErrors": [],
+      "consoleErrors": [],
+      "elapsedMs": 20188
+    }
+  ],
+  "warmupFailures": [],
+  "summary": {
+    "S/node-drag-video": {
+      "samples": 2,
+      "errors": 0,
+      "metrics": {
+        "coldFirstCanvasMs": null,
+        "coldMediaSettledMs": null,
+        "fps": {
+          "median": 117.3,
+          "p95": 118,
+          "samples": [
+            117.3,
+            118
+          ]
+        },
+        "frameGapP95Ms": {
+          "median": 10.2,
+          "p95": 11.1,
+          "samples": [
+            10.2,
+            11.1
+          ]
+        },
+        "maxFrameGapMs": {
+          "median": 40.3,
+          "p95": 41,
+          "samples": [
+            40.3,
+            41
+          ]
+        },
+        "longTaskMs": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "longTaskP95Ms": null,
+        "maxLoadingImages": {
+          "median": 3,
+          "p95": 3,
+          "samples": [
+            3,
+            3
+          ]
+        },
+        "maxLoadingVideos": {
+          "median": 1,
+          "p95": 1,
+          "samples": [
+            1,
+            1
+          ]
+        },
+        "maxActiveVideos": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "layoutCount": {
+          "median": 500,
+          "p95": 509,
+          "samples": [
+            500,
+            509
+          ]
+        },
+        "recalcStyleCount": {
+          "median": 520,
+          "p95": 527,
+          "samples": [
+            520,
+            527
+          ]
+        },
+        "scriptDurationMs": {
+          "median": 465.1,
+          "p95": 483.5,
+          "samples": [
+            465.1,
+            483.5
+          ]
+        },
+        "layoutDurationMs": {
+          "median": 27.3,
+          "p95": 30.3,
+          "samples": [
+            27.3,
+            30.3
+          ]
+        },
+        "jsHeapUsedMB": {
+          "median": 37.8,
+          "p95": 48.1,
+          "samples": [
+            37.8,
+            48.1
+          ]
+        },
+        "visibleMedia": {
+          "median": 10,
+          "p95": 10,
+          "samples": [
+            10,
+            10
+          ]
+        },
+        "visibleMediaNodes": {
+          "median": 4,
+          "p95": 4,
+          "samples": [
+            4,
+            4
+          ]
+        },
+        "visibleMediaPending": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "visibleMediaFailures": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "loadedImages": {
+          "median": 11,
+          "p95": 11,
+          "samples": [
+            11,
+            11
+          ]
+        },
+        "loadedVideos": {
+          "median": 1,
+          "p95": 1,
+          "samples": [
+            1,
+            1
+          ]
+        },
+        "activeVideos": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "rendererWorkingSetMB": {
+          "median": 414.5,
+          "p95": 416.1,
+          "samples": [
+            414.5,
+            416.1
+          ]
+        },
+        "reloadHeapDeltaMB": null,
+        "reloadDurationP95Ms": null
+      },
+      "advisory": {
+        "perMove": {
+          "scriptPerMoveMs": {
+            "median": 7.75,
+            "p95": 8.06,
+            "samples": [
+              7.75,
+              8.06
+            ]
+          },
+          "layoutPerMove": {
+            "median": 8.33,
+            "p95": 8.48,
+            "samples": [
+              8.33,
+              8.48
+            ]
+          }
+        },
+        "dragOverPan": {
+          "scriptRatio": {
+            "median": null,
+            "samples": []
+          },
+          "layoutRatio": {
+            "median": null,
+            "samples": []
+          }
+        },
+        "actionLatency": {
+          "samples": [
+            21.699999999254942,
+            22.399999998509884
+          ],
+          "p95Ms": 22.4,
+          "medianMs": 21.7
+        },
+        "offCanvasRender": {
+          "installed": false,
+          "windows": 0,
+          "totalMax": null,
+          "totalMedian": null,
+          "perComponentMax": {
+            "CategoryTree": null,
+            "AssetLibraryPanel": null,
+            "AssetPicker": null,
+            "TaskCenterButton": null,
+            "TaskCenterPanel": null,
+            "TimelinePreview": null,
+            "PreviewSourcePanel": null,
+            "OnboardingChecklist": null
+          }
+        }
+      },
+      "verdict": {
+        "pass": true,
+        "advisoryOnly": false,
+        "budgetsAdvisory": false,
+        "hardFailures": [],
+        "budgetChecks": [
+          {
+            "metric": "frameGapP95Ms",
+            "actualP95": 11.1,
+            "max": 33,
+            "pass": true,
+            "advisory": false
+          },
+          {
+            "metric": "maxFrameGapMs",
+            "actualP95": 41,
+            "max": 100,
+            "pass": true,
+            "advisory": true
+          },
+          {
+            "metric": "maxLoadingImages",
+            "actualP95": 3,
+            "max": 4,
+            "pass": true,
+            "advisory": false
+          },
+          {
+            "metric": "maxLoadingVideos",
+            "actualP95": 1,
+            "max": 1,
+            "pass": true,
+            "advisory": false
+          },
+          {
+            "metric": "maxActiveVideos",
+            "actualP95": 0,
+            "max": 1,
+            "pass": true,
+            "advisory": false
+          }
+        ]
+      }
+    }
+  },
+  "runtimeVersions": {
+    "app": "0.21.0",
+    "electron": "43.4.1",
+    "chrome": "150.0.7871.224",
+    "node": "24.18.1",
+    "v8": "15.0.245.28-electron.0"
+  },
+  "pass": true
+}

--- a/tests/ux/perf-results/canvas-real-hevc-XL-lowzoom.json
+++ b/tests/ux/perf-results/canvas-real-hevc-XL-lowzoom.json
@@ -1,0 +1,689 @@
+{
+  "label": "real-hevc-XL-lowzoom",
+  "commit": "ba753cfa5ec7ad24e7bb3e453e3ef99ccdf64276",
+  "dirty": true,
+  "platform": "darwin",
+  "arch": "arm64",
+  "machine": {
+    "cpu": "Apple M5",
+    "logicalCpus": 10,
+    "totalMemoryGB": 24
+  },
+  "viewport": {
+    "width": 1600,
+    "height": 1000
+  },
+  "viewportOverride": null,
+  "sampleCount": 2,
+  "warmupCount": 0,
+  "scales": [
+    "XL"
+  ],
+  "scenarios": [
+    "drag-at-low-zoom"
+  ],
+  "leg": {
+    "devServer": false,
+    "cpuThrottleRate": 1,
+    "kind": "prod"
+  },
+  "results": [
+    {
+      "scale": "XL",
+      "scenario": "drag-at-low-zoom",
+      "runIndex": 0,
+      "fixture": {
+        "scale": "XL",
+        "imageNodes": 160,
+        "videoNodes": 160,
+        "nodes": 320,
+        "edges": 640,
+        "clips": 80,
+        "imageBytes": [
+          1845636,
+          1804651,
+          1744981,
+          1663390
+        ],
+        "imagePreviewBytes": [
+          73757,
+          43927,
+          45467,
+          41996
+        ],
+        "videoBytes": [
+          1380939031
+        ],
+        "mediaProfile": "real-assets"
+      },
+      "probe": {
+        "elapsedMs": 1082,
+        "frames": 124,
+        "fps": 114.6,
+        "frameGapP50Ms": 8.3,
+        "frameGapP95Ms": 11.4,
+        "maxFrameGapMs": 45.8,
+        "longTasks": 0,
+        "longTaskMs": 0,
+        "longTaskP95Ms": null,
+        "maxLoadingImages": 0,
+        "maxLoadingVideos": 0,
+        "maxActiveVideos": 0,
+        "firstMutationMs": 44.6,
+        "mutations": {
+          "stage": 2,
+          "edges": 350,
+          "labels": 0
+        }
+      },
+      "cdpBefore": {
+        "LayoutCount": 10,
+        "RecalcStyleCount": 20,
+        "ScriptDurationMs": 147.5,
+        "LayoutDurationMs": 1.9,
+        "TaskDurationMs": 197.9,
+        "JSHeapUsedMB": 35.4,
+        "domNodes": 1852,
+        "domDocuments": 1,
+        "jsEventListeners": 1098
+      },
+      "cdpAfter": {
+        "LayoutCount": 45,
+        "RecalcStyleCount": 103,
+        "ScriptDurationMs": 265,
+        "LayoutDurationMs": 6.9,
+        "TaskDurationMs": 448.6,
+        "JSHeapUsedMB": 53,
+        "domNodes": 2112,
+        "domDocuments": 1,
+        "jsEventListeners": 1458
+      },
+      "cdpDelta": {
+        "LayoutCount": 35,
+        "RecalcStyleCount": 83,
+        "ScriptDurationMs": 117.5,
+        "LayoutDurationMs": 5,
+        "TaskDurationMs": 250.7,
+        "JSHeapUsedMB": 17.6,
+        "domNodes": 260,
+        "domDocuments": 0,
+        "jsEventListeners": 360
+      },
+      "beforePage": {
+        "domNodes": 1543,
+        "canvasNodes": 20,
+        "lightweightCanvasNodes": 20,
+        "lightweightPreviewNodes": 20,
+        "imageElements": 20,
+        "videoElements": 0,
+        "visibleMedia": 20,
+        "loadedImages": 20,
+        "loadedVideos": 0,
+        "visibleMediaNodes": 20,
+        "visibleMediaPending": 0,
+        "visibleMediaFailures": 0,
+        "activeVideos": 0,
+        "resourceCount": 0,
+        "jsHeapUsedMB": 48.1,
+        "transform": {
+          "x": 225.325,
+          "y": 247.349,
+          "zoom": 0.435275
+        }
+      },
+      "page": {
+        "domNodes": 1697,
+        "canvasNodes": 20,
+        "lightweightCanvasNodes": 19,
+        "lightweightPreviewNodes": 19,
+        "imageElements": 21,
+        "videoElements": 0,
+        "visibleMedia": 20,
+        "loadedImages": 21,
+        "loadedVideos": 0,
+        "visibleMediaNodes": 20,
+        "visibleMediaPending": 0,
+        "visibleMediaFailures": 0,
+        "activeVideos": 0,
+        "resourceCount": 0,
+        "jsHeapUsedMB": 48.1,
+        "transform": {
+          "x": 225.325,
+          "y": 247.349,
+          "zoom": 0.435275
+        }
+      },
+      "actionDetails": {
+        "zoom": 0.435,
+        "lightweightMounted": 20,
+        "lightweightActive": true,
+        "moves": 22,
+        "firstFeedbackMs": 44.600000001490116,
+        "nodeId": "canvas-perf-image-0"
+      },
+      "offCanvasRender": null,
+      "nodeIdentity": {
+        "before": 20,
+        "after": 20,
+        "common": 20,
+        "tracked": 20,
+        "preserved": 20,
+        "virtualizationChurn": [],
+        "remountedInPlace": [],
+        "commonIdentityPreserved": true,
+        "targetNodeId": "canvas-perf-image-0",
+        "targetIdentityPreserved": true
+      },
+      "appMetrics": {
+        "rendererWorkingSetMB": 368.8,
+        "gpuWorkingSetMB": 146.8,
+        "processCount": 5,
+        "processes": [
+          {
+            "type": "Browser",
+            "pid": 54298,
+            "workingSetMB": 346.9
+          },
+          {
+            "type": "GPU",
+            "pid": 54301,
+            "workingSetMB": 146.8
+          },
+          {
+            "type": "Utility",
+            "pid": 54302,
+            "workingSetMB": 45
+          },
+          {
+            "type": "Tab",
+            "pid": 54303,
+            "workingSetMB": 368.8
+          },
+          {
+            "type": "Utility",
+            "pid": 54304,
+            "workingSetMB": 45
+          }
+        ]
+      },
+      "runtimeVersions": {
+        "app": "0.21.0",
+        "electron": "43.4.1",
+        "chrome": "150.0.7871.224",
+        "node": "24.18.1",
+        "v8": "15.0.245.28-electron.0"
+      },
+      "pageErrors": [],
+      "consoleErrors": [],
+      "elapsedMs": 22527
+    },
+    {
+      "scale": "XL",
+      "scenario": "drag-at-low-zoom",
+      "runIndex": 1,
+      "fixture": {
+        "scale": "XL",
+        "imageNodes": 160,
+        "videoNodes": 160,
+        "nodes": 320,
+        "edges": 640,
+        "clips": 80,
+        "imageBytes": [
+          1845636,
+          1804651,
+          1744981,
+          1663390
+        ],
+        "imagePreviewBytes": [
+          73757,
+          43927,
+          45467,
+          41996
+        ],
+        "videoBytes": [
+          1380939031
+        ],
+        "mediaProfile": "real-assets"
+      },
+      "probe": {
+        "elapsedMs": 1067,
+        "frames": 122,
+        "fps": 114.3,
+        "frameGapP50Ms": 8.3,
+        "frameGapP95Ms": 10.3,
+        "maxFrameGapMs": 41.8,
+        "longTasks": 0,
+        "longTaskMs": 0,
+        "longTaskP95Ms": null,
+        "maxLoadingImages": 1,
+        "maxLoadingVideos": 0,
+        "maxActiveVideos": 0,
+        "firstMutationMs": 44.1,
+        "mutations": {
+          "stage": 2,
+          "edges": 350,
+          "labels": 0
+        }
+      },
+      "cdpBefore": {
+        "LayoutCount": 10,
+        "RecalcStyleCount": 19,
+        "ScriptDurationMs": 153.7,
+        "LayoutDurationMs": 1.8,
+        "TaskDurationMs": 201.3,
+        "JSHeapUsedMB": 29.9,
+        "domNodes": 1852,
+        "domDocuments": 1,
+        "jsEventListeners": 1086
+      },
+      "cdpAfter": {
+        "LayoutCount": 46,
+        "RecalcStyleCount": 101,
+        "ScriptDurationMs": 252.5,
+        "LayoutDurationMs": 5.6,
+        "TaskDurationMs": 421.8,
+        "JSHeapUsedMB": 32.6,
+        "domNodes": 1911,
+        "domDocuments": 1,
+        "jsEventListeners": 1272
+      },
+      "cdpDelta": {
+        "LayoutCount": 36,
+        "RecalcStyleCount": 82,
+        "ScriptDurationMs": 98.8,
+        "LayoutDurationMs": 3.8,
+        "TaskDurationMs": 220.5,
+        "JSHeapUsedMB": 2.7,
+        "domNodes": 59,
+        "domDocuments": 0,
+        "jsEventListeners": 186
+      },
+      "beforePage": {
+        "domNodes": 1543,
+        "canvasNodes": 20,
+        "lightweightCanvasNodes": 20,
+        "lightweightPreviewNodes": 20,
+        "imageElements": 20,
+        "videoElements": 0,
+        "visibleMedia": 20,
+        "loadedImages": 20,
+        "loadedVideos": 0,
+        "visibleMediaNodes": 20,
+        "visibleMediaPending": 0,
+        "visibleMediaFailures": 0,
+        "activeVideos": 0,
+        "resourceCount": 0,
+        "jsHeapUsedMB": 48.1,
+        "transform": {
+          "x": 225.325,
+          "y": 247.349,
+          "zoom": 0.435275
+        }
+      },
+      "page": {
+        "domNodes": 1697,
+        "canvasNodes": 20,
+        "lightweightCanvasNodes": 19,
+        "lightweightPreviewNodes": 19,
+        "imageElements": 21,
+        "videoElements": 0,
+        "visibleMedia": 20,
+        "loadedImages": 21,
+        "loadedVideos": 0,
+        "visibleMediaNodes": 20,
+        "visibleMediaPending": 0,
+        "visibleMediaFailures": 0,
+        "activeVideos": 0,
+        "resourceCount": 0,
+        "jsHeapUsedMB": 48.1,
+        "transform": {
+          "x": 225.325,
+          "y": 247.349,
+          "zoom": 0.435275
+        }
+      },
+      "actionDetails": {
+        "zoom": 0.435,
+        "lightweightMounted": 20,
+        "lightweightActive": true,
+        "moves": 22,
+        "firstFeedbackMs": 44.100000001490116,
+        "nodeId": "canvas-perf-image-0"
+      },
+      "offCanvasRender": null,
+      "nodeIdentity": {
+        "before": 20,
+        "after": 20,
+        "common": 20,
+        "tracked": 20,
+        "preserved": 20,
+        "virtualizationChurn": [],
+        "remountedInPlace": [],
+        "commonIdentityPreserved": true,
+        "targetNodeId": "canvas-perf-image-0",
+        "targetIdentityPreserved": true
+      },
+      "appMetrics": {
+        "rendererWorkingSetMB": 384.5,
+        "gpuWorkingSetMB": 145.4,
+        "processCount": 5,
+        "processes": [
+          {
+            "type": "Browser",
+            "pid": 54427,
+            "workingSetMB": 347.6
+          },
+          {
+            "type": "GPU",
+            "pid": 54430,
+            "workingSetMB": 145.4
+          },
+          {
+            "type": "Utility",
+            "pid": 54431,
+            "workingSetMB": 45.1
+          },
+          {
+            "type": "Tab",
+            "pid": 54432,
+            "workingSetMB": 384.5
+          },
+          {
+            "type": "Utility",
+            "pid": 54435,
+            "workingSetMB": 45
+          }
+        ]
+      },
+      "runtimeVersions": {
+        "app": "0.21.0",
+        "electron": "43.4.1",
+        "chrome": "150.0.7871.224",
+        "node": "24.18.1",
+        "v8": "15.0.245.28-electron.0"
+      },
+      "pageErrors": [],
+      "consoleErrors": [],
+      "elapsedMs": 22335
+    }
+  ],
+  "warmupFailures": [],
+  "summary": {
+    "XL/drag-at-low-zoom": {
+      "samples": 2,
+      "errors": 0,
+      "metrics": {
+        "coldFirstCanvasMs": null,
+        "coldMediaSettledMs": null,
+        "fps": {
+          "median": 114.3,
+          "p95": 114.6,
+          "samples": [
+            114.3,
+            114.6
+          ]
+        },
+        "frameGapP95Ms": {
+          "median": 10.3,
+          "p95": 11.4,
+          "samples": [
+            10.3,
+            11.4
+          ]
+        },
+        "maxFrameGapMs": {
+          "median": 41.8,
+          "p95": 45.8,
+          "samples": [
+            41.8,
+            45.8
+          ]
+        },
+        "longTaskMs": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "longTaskP95Ms": null,
+        "maxLoadingImages": {
+          "median": 0,
+          "p95": 1,
+          "samples": [
+            0,
+            1
+          ]
+        },
+        "maxLoadingVideos": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "maxActiveVideos": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "layoutCount": {
+          "median": 35,
+          "p95": 36,
+          "samples": [
+            35,
+            36
+          ]
+        },
+        "recalcStyleCount": {
+          "median": 82,
+          "p95": 83,
+          "samples": [
+            82,
+            83
+          ]
+        },
+        "scriptDurationMs": {
+          "median": 98.8,
+          "p95": 117.5,
+          "samples": [
+            98.8,
+            117.5
+          ]
+        },
+        "layoutDurationMs": {
+          "median": 3.8,
+          "p95": 5,
+          "samples": [
+            3.8,
+            5
+          ]
+        },
+        "jsHeapUsedMB": {
+          "median": 48.1,
+          "p95": 48.1,
+          "samples": [
+            48.1,
+            48.1
+          ]
+        },
+        "visibleMedia": {
+          "median": 20,
+          "p95": 20,
+          "samples": [
+            20,
+            20
+          ]
+        },
+        "visibleMediaNodes": {
+          "median": 20,
+          "p95": 20,
+          "samples": [
+            20,
+            20
+          ]
+        },
+        "visibleMediaPending": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "visibleMediaFailures": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "loadedImages": {
+          "median": 21,
+          "p95": 21,
+          "samples": [
+            21,
+            21
+          ]
+        },
+        "loadedVideos": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "activeVideos": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "rendererWorkingSetMB": {
+          "median": 368.8,
+          "p95": 384.5,
+          "samples": [
+            368.8,
+            384.5
+          ]
+        },
+        "reloadHeapDeltaMB": null,
+        "reloadDurationP95Ms": null
+      },
+      "advisory": {
+        "perMove": {
+          "scriptPerMoveMs": {
+            "median": 4.49,
+            "p95": 5.34,
+            "samples": [
+              5.34,
+              4.49
+            ]
+          },
+          "layoutPerMove": {
+            "median": 1.59,
+            "p95": 1.64,
+            "samples": [
+              1.59,
+              1.64
+            ]
+          }
+        },
+        "dragOverPan": {
+          "scriptRatio": {
+            "median": null,
+            "samples": []
+          },
+          "layoutRatio": {
+            "median": null,
+            "samples": []
+          }
+        },
+        "actionLatency": {
+          "samples": [
+            44.600000001490116,
+            44.100000001490116
+          ],
+          "p95Ms": 44.6,
+          "medianMs": 44.1
+        },
+        "offCanvasRender": {
+          "installed": false,
+          "windows": 0,
+          "totalMax": null,
+          "totalMedian": null,
+          "perComponentMax": {
+            "CategoryTree": null,
+            "AssetLibraryPanel": null,
+            "AssetPicker": null,
+            "TaskCenterButton": null,
+            "TaskCenterPanel": null,
+            "TimelinePreview": null,
+            "PreviewSourcePanel": null,
+            "OnboardingChecklist": null
+          }
+        }
+      },
+      "verdict": {
+        "pass": true,
+        "advisoryOnly": true,
+        "budgetsAdvisory": false,
+        "hardFailures": [],
+        "budgetChecks": [
+          {
+            "metric": "frameGapP95Ms",
+            "actualP95": 11.4,
+            "max": 33,
+            "pass": true,
+            "advisory": false
+          },
+          {
+            "metric": "maxFrameGapMs",
+            "actualP95": 45.8,
+            "max": 100,
+            "pass": true,
+            "advisory": true
+          },
+          {
+            "metric": "maxLoadingImages",
+            "actualP95": 1,
+            "max": 4,
+            "pass": true,
+            "advisory": false
+          },
+          {
+            "metric": "maxLoadingVideos",
+            "actualP95": 0,
+            "max": 1,
+            "pass": true,
+            "advisory": false
+          },
+          {
+            "metric": "maxActiveVideos",
+            "actualP95": 0,
+            "max": 1,
+            "pass": true,
+            "advisory": false
+          }
+        ]
+      }
+    }
+  },
+  "runtimeVersions": {
+    "app": "0.21.0",
+    "electron": "43.4.1",
+    "chrome": "150.0.7871.224",
+    "node": "24.18.1",
+    "v8": "15.0.245.28-electron.0"
+  },
+  "pass": true
+}

--- a/tests/ux/perf-results/canvas-real-hevc-XL-normal.json
+++ b/tests/ux/perf-results/canvas-real-hevc-XL-normal.json
@@ -1,0 +1,691 @@
+{
+  "label": "real-hevc-XL-normal",
+  "commit": "ba753cfa5ec7ad24e7bb3e453e3ef99ccdf64276",
+  "dirty": true,
+  "platform": "darwin",
+  "arch": "arm64",
+  "machine": {
+    "cpu": "Apple M5",
+    "logicalCpus": 10,
+    "totalMemoryGB": 24
+  },
+  "viewport": {
+    "width": 1600,
+    "height": 1000
+  },
+  "viewportOverride": null,
+  "sampleCount": 2,
+  "warmupCount": 0,
+  "scales": [
+    "XL"
+  ],
+  "scenarios": [
+    "node-drag-video"
+  ],
+  "leg": {
+    "devServer": false,
+    "cpuThrottleRate": 1,
+    "kind": "prod"
+  },
+  "results": [
+    {
+      "scale": "XL",
+      "scenario": "node-drag-video",
+      "runIndex": 0,
+      "fixture": {
+        "scale": "XL",
+        "imageNodes": 160,
+        "videoNodes": 160,
+        "nodes": 320,
+        "edges": 640,
+        "clips": 80,
+        "imageBytes": [
+          1845636,
+          1804651,
+          1744981,
+          1663390
+        ],
+        "imagePreviewBytes": [
+          73757,
+          43927,
+          45467,
+          41996
+        ],
+        "videoBytes": [
+          1380939031
+        ],
+        "mediaProfile": "real-assets"
+      },
+      "probe": {
+        "elapsedMs": 2093,
+        "frames": 245,
+        "fps": 117.1,
+        "frameGapP50Ms": 8.3,
+        "frameGapP95Ms": 10.8,
+        "maxFrameGapMs": 42.3,
+        "longTasks": 0,
+        "longTaskMs": 0,
+        "longTaskP95Ms": null,
+        "maxLoadingImages": 3,
+        "maxLoadingVideos": 1,
+        "maxActiveVideos": 0,
+        "firstMutationMs": 26.7,
+        "mutations": {
+          "stage": 2,
+          "edges": 2615,
+          "labels": 0
+        }
+      },
+      "cdpBefore": {
+        "LayoutCount": 0,
+        "RecalcStyleCount": 0,
+        "ScriptDurationMs": 1.9,
+        "LayoutDurationMs": 0,
+        "TaskDurationMs": 7.8,
+        "JSHeapUsedMB": 46.4,
+        "domNodes": 19979,
+        "domDocuments": 1,
+        "jsEventListeners": 2951
+      },
+      "cdpAfter": {
+        "LayoutCount": 512,
+        "RecalcStyleCount": 531,
+        "ScriptDurationMs": 528.4,
+        "LayoutDurationMs": 33.5,
+        "TaskDurationMs": 921,
+        "JSHeapUsedMB": 51.8,
+        "domNodes": 2325,
+        "domDocuments": 1,
+        "jsEventListeners": 1802
+      },
+      "cdpDelta": {
+        "LayoutCount": 512,
+        "RecalcStyleCount": 531,
+        "ScriptDurationMs": 526.5,
+        "LayoutDurationMs": 33.5,
+        "TaskDurationMs": 913.2,
+        "JSHeapUsedMB": 5.4,
+        "domNodes": -17654,
+        "domDocuments": 0,
+        "jsEventListeners": -1149
+      },
+      "beforePage": {
+        "domNodes": 1189,
+        "canvasNodes": 6,
+        "lightweightCanvasNodes": 0,
+        "lightweightPreviewNodes": 0,
+        "imageElements": 6,
+        "videoElements": 0,
+        "visibleMedia": 6,
+        "loadedImages": 6,
+        "loadedVideos": 0,
+        "visibleMediaNodes": 3,
+        "visibleMediaPending": 0,
+        "visibleMediaFailures": 0,
+        "activeVideos": 0,
+        "resourceCount": 0,
+        "jsHeapUsedMB": 73.1,
+        "transform": {
+          "x": 0,
+          "y": 0,
+          "zoom": 1
+        }
+      },
+      "page": {
+        "domNodes": 1680,
+        "canvasNodes": 9,
+        "lightweightCanvasNodes": 0,
+        "lightweightPreviewNodes": 0,
+        "imageElements": 11,
+        "videoElements": 1,
+        "visibleMedia": 10,
+        "loadedImages": 11,
+        "loadedVideos": 1,
+        "visibleMediaNodes": 4,
+        "visibleMediaPending": 0,
+        "visibleMediaFailures": 0,
+        "activeVideos": 0,
+        "resourceCount": 0,
+        "jsHeapUsedMB": 73.1,
+        "transform": {
+          "x": -657.375,
+          "y": 0,
+          "zoom": 1
+        }
+      },
+      "actionDetails": {
+        "nodeId": "canvas-perf-video-0",
+        "moves": 60,
+        "firstFeedbackMs": 26.699999999254942
+      },
+      "offCanvasRender": null,
+      "nodeIdentity": {
+        "before": 6,
+        "after": 9,
+        "common": 3,
+        "tracked": 3,
+        "preserved": 3,
+        "virtualizationChurn": [
+          "canvas-perf-image-0",
+          "canvas-perf-image-6",
+          "canvas-perf-image-12"
+        ],
+        "remountedInPlace": [],
+        "commonIdentityPreserved": true,
+        "targetNodeId": "canvas-perf-video-0",
+        "targetIdentityPreserved": true
+      },
+      "appMetrics": {
+        "rendererWorkingSetMB": 486.1,
+        "gpuWorkingSetMB": 153.8,
+        "processCount": 5,
+        "processes": [
+          {
+            "type": "Browser",
+            "pid": 55240,
+            "workingSetMB": 367.5
+          },
+          {
+            "type": "GPU",
+            "pid": 55250,
+            "workingSetMB": 153.8
+          },
+          {
+            "type": "Utility",
+            "pid": 55251,
+            "workingSetMB": 45
+          },
+          {
+            "type": "Tab",
+            "pid": 55252,
+            "workingSetMB": 486.1
+          },
+          {
+            "type": "Utility",
+            "pid": 55253,
+            "workingSetMB": 45.2
+          }
+        ]
+      },
+      "runtimeVersions": {
+        "app": "0.21.0",
+        "electron": "43.4.1",
+        "chrome": "150.0.7871.224",
+        "node": "24.18.1",
+        "v8": "15.0.245.28-electron.0"
+      },
+      "pageErrors": [],
+      "consoleErrors": [],
+      "elapsedMs": 22289
+    },
+    {
+      "scale": "XL",
+      "scenario": "node-drag-video",
+      "runIndex": 1,
+      "fixture": {
+        "scale": "XL",
+        "imageNodes": 160,
+        "videoNodes": 160,
+        "nodes": 320,
+        "edges": 640,
+        "clips": 80,
+        "imageBytes": [
+          1845636,
+          1804651,
+          1744981,
+          1663390
+        ],
+        "imagePreviewBytes": [
+          73757,
+          43927,
+          45467,
+          41996
+        ],
+        "videoBytes": [
+          1380939031
+        ],
+        "mediaProfile": "real-assets"
+      },
+      "probe": {
+        "elapsedMs": 2032,
+        "frames": 236,
+        "fps": 116.2,
+        "frameGapP50Ms": 8.2,
+        "frameGapP95Ms": 10.6,
+        "maxFrameGapMs": 42.5,
+        "longTasks": 0,
+        "longTaskMs": 0,
+        "longTaskP95Ms": null,
+        "maxLoadingImages": 3,
+        "maxLoadingVideos": 1,
+        "maxActiveVideos": 0,
+        "firstMutationMs": 21.2,
+        "mutations": {
+          "stage": 2,
+          "edges": 2524,
+          "labels": 0
+        }
+      },
+      "cdpBefore": {
+        "LayoutCount": 0,
+        "RecalcStyleCount": 0,
+        "ScriptDurationMs": 1.2,
+        "LayoutDurationMs": 0,
+        "TaskDurationMs": 2.8,
+        "JSHeapUsedMB": 62.3,
+        "domNodes": 19760,
+        "domDocuments": 1,
+        "jsEventListeners": 2923
+      },
+      "cdpAfter": {
+        "LayoutCount": 493,
+        "RecalcStyleCount": 514,
+        "ScriptDurationMs": 505,
+        "LayoutDurationMs": 33.6,
+        "TaskDurationMs": 886.1,
+        "JSHeapUsedMB": 58.6,
+        "domNodes": 2358,
+        "domDocuments": 1,
+        "jsEventListeners": 1856
+      },
+      "cdpDelta": {
+        "LayoutCount": 493,
+        "RecalcStyleCount": 514,
+        "ScriptDurationMs": 503.8,
+        "LayoutDurationMs": 33.6,
+        "TaskDurationMs": 883.3,
+        "JSHeapUsedMB": -3.7,
+        "domNodes": -17402,
+        "domDocuments": 0,
+        "jsEventListeners": -1067
+      },
+      "beforePage": {
+        "domNodes": 1189,
+        "canvasNodes": 6,
+        "lightweightCanvasNodes": 0,
+        "lightweightPreviewNodes": 0,
+        "imageElements": 6,
+        "videoElements": 0,
+        "visibleMedia": 6,
+        "loadedImages": 6,
+        "loadedVideos": 0,
+        "visibleMediaNodes": 3,
+        "visibleMediaPending": 0,
+        "visibleMediaFailures": 0,
+        "activeVideos": 0,
+        "resourceCount": 0,
+        "jsHeapUsedMB": 68.9,
+        "transform": {
+          "x": 0,
+          "y": 0,
+          "zoom": 1
+        }
+      },
+      "page": {
+        "domNodes": 1680,
+        "canvasNodes": 9,
+        "lightweightCanvasNodes": 0,
+        "lightweightPreviewNodes": 0,
+        "imageElements": 11,
+        "videoElements": 1,
+        "visibleMedia": 10,
+        "loadedImages": 11,
+        "loadedVideos": 1,
+        "visibleMediaNodes": 4,
+        "visibleMediaPending": 0,
+        "visibleMediaFailures": 0,
+        "activeVideos": 0,
+        "resourceCount": 0,
+        "jsHeapUsedMB": 68.9,
+        "transform": {
+          "x": -628.5,
+          "y": 0,
+          "zoom": 1
+        }
+      },
+      "actionDetails": {
+        "nodeId": "canvas-perf-video-0",
+        "moves": 60,
+        "firstFeedbackMs": 21.199999999254942
+      },
+      "offCanvasRender": null,
+      "nodeIdentity": {
+        "before": 6,
+        "after": 9,
+        "common": 3,
+        "tracked": 3,
+        "preserved": 3,
+        "virtualizationChurn": [
+          "canvas-perf-image-0",
+          "canvas-perf-image-6",
+          "canvas-perf-image-12"
+        ],
+        "remountedInPlace": [],
+        "commonIdentityPreserved": true,
+        "targetNodeId": "canvas-perf-video-0",
+        "targetIdentityPreserved": true
+      },
+      "appMetrics": {
+        "rendererWorkingSetMB": 480.2,
+        "gpuWorkingSetMB": 152.8,
+        "processCount": 5,
+        "processes": [
+          {
+            "type": "Browser",
+            "pid": 55297,
+            "workingSetMB": 364.1
+          },
+          {
+            "type": "GPU",
+            "pid": 55300,
+            "workingSetMB": 152.8
+          },
+          {
+            "type": "Utility",
+            "pid": 55301,
+            "workingSetMB": 45
+          },
+          {
+            "type": "Tab",
+            "pid": 55302,
+            "workingSetMB": 480.2
+          },
+          {
+            "type": "Utility",
+            "pid": 55305,
+            "workingSetMB": 45.4
+          }
+        ]
+      },
+      "runtimeVersions": {
+        "app": "0.21.0",
+        "electron": "43.4.1",
+        "chrome": "150.0.7871.224",
+        "node": "24.18.1",
+        "v8": "15.0.245.28-electron.0"
+      },
+      "pageErrors": [],
+      "consoleErrors": [],
+      "elapsedMs": 22115
+    }
+  ],
+  "warmupFailures": [],
+  "summary": {
+    "XL/node-drag-video": {
+      "samples": 2,
+      "errors": 0,
+      "metrics": {
+        "coldFirstCanvasMs": null,
+        "coldMediaSettledMs": null,
+        "fps": {
+          "median": 116.2,
+          "p95": 117.1,
+          "samples": [
+            116.2,
+            117.1
+          ]
+        },
+        "frameGapP95Ms": {
+          "median": 10.6,
+          "p95": 10.8,
+          "samples": [
+            10.6,
+            10.8
+          ]
+        },
+        "maxFrameGapMs": {
+          "median": 42.3,
+          "p95": 42.5,
+          "samples": [
+            42.3,
+            42.5
+          ]
+        },
+        "longTaskMs": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "longTaskP95Ms": null,
+        "maxLoadingImages": {
+          "median": 3,
+          "p95": 3,
+          "samples": [
+            3,
+            3
+          ]
+        },
+        "maxLoadingVideos": {
+          "median": 1,
+          "p95": 1,
+          "samples": [
+            1,
+            1
+          ]
+        },
+        "maxActiveVideos": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "layoutCount": {
+          "median": 493,
+          "p95": 512,
+          "samples": [
+            493,
+            512
+          ]
+        },
+        "recalcStyleCount": {
+          "median": 514,
+          "p95": 531,
+          "samples": [
+            514,
+            531
+          ]
+        },
+        "scriptDurationMs": {
+          "median": 503.8,
+          "p95": 526.5,
+          "samples": [
+            503.8,
+            526.5
+          ]
+        },
+        "layoutDurationMs": {
+          "median": 33.5,
+          "p95": 33.6,
+          "samples": [
+            33.5,
+            33.6
+          ]
+        },
+        "jsHeapUsedMB": {
+          "median": 68.9,
+          "p95": 73.1,
+          "samples": [
+            68.9,
+            73.1
+          ]
+        },
+        "visibleMedia": {
+          "median": 10,
+          "p95": 10,
+          "samples": [
+            10,
+            10
+          ]
+        },
+        "visibleMediaNodes": {
+          "median": 4,
+          "p95": 4,
+          "samples": [
+            4,
+            4
+          ]
+        },
+        "visibleMediaPending": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "visibleMediaFailures": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "loadedImages": {
+          "median": 11,
+          "p95": 11,
+          "samples": [
+            11,
+            11
+          ]
+        },
+        "loadedVideos": {
+          "median": 1,
+          "p95": 1,
+          "samples": [
+            1,
+            1
+          ]
+        },
+        "activeVideos": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "rendererWorkingSetMB": {
+          "median": 480.2,
+          "p95": 486.1,
+          "samples": [
+            480.2,
+            486.1
+          ]
+        },
+        "reloadHeapDeltaMB": null,
+        "reloadDurationP95Ms": null
+      },
+      "advisory": {
+        "perMove": {
+          "scriptPerMoveMs": {
+            "median": 8.4,
+            "p95": 8.78,
+            "samples": [
+              8.78,
+              8.4
+            ]
+          },
+          "layoutPerMove": {
+            "median": 8.22,
+            "p95": 8.53,
+            "samples": [
+              8.53,
+              8.22
+            ]
+          }
+        },
+        "dragOverPan": {
+          "scriptRatio": {
+            "median": null,
+            "samples": []
+          },
+          "layoutRatio": {
+            "median": null,
+            "samples": []
+          }
+        },
+        "actionLatency": {
+          "samples": [
+            26.699999999254942,
+            21.199999999254942
+          ],
+          "p95Ms": 26.7,
+          "medianMs": 21.2
+        },
+        "offCanvasRender": {
+          "installed": false,
+          "windows": 0,
+          "totalMax": null,
+          "totalMedian": null,
+          "perComponentMax": {
+            "CategoryTree": null,
+            "AssetLibraryPanel": null,
+            "AssetPicker": null,
+            "TaskCenterButton": null,
+            "TaskCenterPanel": null,
+            "TimelinePreview": null,
+            "PreviewSourcePanel": null,
+            "OnboardingChecklist": null
+          }
+        }
+      },
+      "verdict": {
+        "pass": true,
+        "advisoryOnly": false,
+        "budgetsAdvisory": false,
+        "hardFailures": [],
+        "budgetChecks": [
+          {
+            "metric": "frameGapP95Ms",
+            "actualP95": 10.8,
+            "max": 33,
+            "pass": true,
+            "advisory": false
+          },
+          {
+            "metric": "maxFrameGapMs",
+            "actualP95": 42.5,
+            "max": 100,
+            "pass": true,
+            "advisory": true
+          },
+          {
+            "metric": "maxLoadingImages",
+            "actualP95": 3,
+            "max": 4,
+            "pass": true,
+            "advisory": false
+          },
+          {
+            "metric": "maxLoadingVideos",
+            "actualP95": 1,
+            "max": 1,
+            "pass": true,
+            "advisory": false
+          },
+          {
+            "metric": "maxActiveVideos",
+            "actualP95": 0,
+            "max": 1,
+            "pass": true,
+            "advisory": false
+          }
+        ]
+      }
+    }
+  },
+  "runtimeVersions": {
+    "app": "0.21.0",
+    "electron": "43.4.1",
+    "chrome": "150.0.7871.224",
+    "node": "24.18.1",
+    "v8": "15.0.245.28-electron.0"
+  },
+  "pass": true
+}

--- a/tests/ux/perf-results/canvas-real-hevc-xl-hover.json
+++ b/tests/ux/perf-results/canvas-real-hevc-xl-hover.json
@@ -1,0 +1,670 @@
+{
+  "label": "real-hevc-xl-hover",
+  "commit": "ba753cfa5ec7ad24e7bb3e453e3ef99ccdf64276",
+  "dirty": true,
+  "platform": "darwin",
+  "arch": "arm64",
+  "machine": {
+    "cpu": "Apple M5",
+    "logicalCpus": 10,
+    "totalMemoryGB": 24
+  },
+  "viewport": {
+    "width": 1600,
+    "height": 1000
+  },
+  "viewportOverride": null,
+  "sampleCount": 2,
+  "warmupCount": 0,
+  "scales": [
+    "XL"
+  ],
+  "scenarios": [
+    "video-hover"
+  ],
+  "leg": {
+    "devServer": false,
+    "cpuThrottleRate": 1,
+    "kind": "prod"
+  },
+  "results": [
+    {
+      "scale": "XL",
+      "scenario": "video-hover",
+      "runIndex": 0,
+      "fixture": {
+        "scale": "XL",
+        "imageNodes": 160,
+        "videoNodes": 160,
+        "nodes": 320,
+        "edges": 640,
+        "clips": 80,
+        "imageBytes": [
+          1845636,
+          1804651,
+          1744981,
+          1663390
+        ],
+        "imagePreviewBytes": [
+          73757,
+          43927,
+          45467,
+          41996
+        ],
+        "videoBytes": [
+          1380939031
+        ],
+        "mediaProfile": "real-assets"
+      },
+      "probe": {
+        "elapsedMs": 828,
+        "frames": 101,
+        "fps": 122,
+        "frameGapP50Ms": 8.2,
+        "frameGapP95Ms": 12.4,
+        "maxFrameGapMs": 19.6,
+        "longTasks": 0,
+        "longTaskMs": 0,
+        "longTaskP95Ms": null,
+        "maxLoadingImages": 0,
+        "maxLoadingVideos": 1,
+        "maxActiveVideos": 1,
+        "firstMutationMs": 11.3,
+        "mutations": {
+          "stage": 0,
+          "edges": 38,
+          "labels": 0
+        }
+      },
+      "cdpBefore": {
+        "LayoutCount": 0,
+        "RecalcStyleCount": 0,
+        "ScriptDurationMs": 0,
+        "LayoutDurationMs": 0,
+        "TaskDurationMs": 0.7,
+        "JSHeapUsedMB": 62.8,
+        "domNodes": 19829,
+        "domDocuments": 1,
+        "jsEventListeners": 2922
+      },
+      "cdpAfter": {
+        "LayoutCount": 33,
+        "RecalcStyleCount": 127,
+        "ScriptDurationMs": 63.4,
+        "LayoutDurationMs": 5.1,
+        "TaskDurationMs": 207.8,
+        "JSHeapUsedMB": 30.5,
+        "domNodes": 2005,
+        "domDocuments": 9,
+        "jsEventListeners": 1025
+      },
+      "cdpDelta": {
+        "LayoutCount": 33,
+        "RecalcStyleCount": 127,
+        "ScriptDurationMs": 63.4,
+        "LayoutDurationMs": 5.1,
+        "TaskDurationMs": 207.1,
+        "JSHeapUsedMB": -32.3,
+        "domNodes": -17824,
+        "domDocuments": 8,
+        "jsEventListeners": -1897
+      },
+      "beforePage": {
+        "domNodes": 1189,
+        "canvasNodes": 6,
+        "lightweightCanvasNodes": 0,
+        "lightweightPreviewNodes": 0,
+        "imageElements": 6,
+        "videoElements": 0,
+        "visibleMedia": 6,
+        "loadedImages": 6,
+        "loadedVideos": 0,
+        "visibleMediaNodes": 3,
+        "visibleMediaPending": 0,
+        "visibleMediaFailures": 0,
+        "activeVideos": 0,
+        "resourceCount": 0,
+        "jsHeapUsedMB": 73.1,
+        "transform": {
+          "x": 0,
+          "y": 0,
+          "zoom": 1
+        }
+      },
+      "page": {
+        "domNodes": 1192,
+        "canvasNodes": 6,
+        "lightweightCanvasNodes": 0,
+        "lightweightPreviewNodes": 0,
+        "imageElements": 3,
+        "videoElements": 3,
+        "visibleMedia": 6,
+        "loadedImages": 3,
+        "loadedVideos": 3,
+        "visibleMediaNodes": 6,
+        "visibleMediaPending": 0,
+        "visibleMediaFailures": 0,
+        "activeVideos": 0,
+        "resourceCount": 0,
+        "jsHeapUsedMB": 73.1,
+        "transform": {
+          "x": 0,
+          "y": 0,
+          "zoom": 1
+        }
+      },
+      "actionDetails": {
+        "hoveredNodes": 3
+      },
+      "offCanvasRender": null,
+      "nodeIdentity": {
+        "before": 6,
+        "after": 6,
+        "common": 6,
+        "tracked": 6,
+        "preserved": 6,
+        "virtualizationChurn": [],
+        "remountedInPlace": [],
+        "commonIdentityPreserved": true,
+        "targetNodeId": null,
+        "targetIdentityPreserved": null
+      },
+      "appMetrics": {
+        "rendererWorkingSetMB": 479,
+        "gpuWorkingSetMB": 148.6,
+        "processCount": 5,
+        "processes": [
+          {
+            "type": "Browser",
+            "pid": 35299,
+            "workingSetMB": 370.4
+          },
+          {
+            "type": "GPU",
+            "pid": 35302,
+            "workingSetMB": 148.6
+          },
+          {
+            "type": "Utility",
+            "pid": 35303,
+            "workingSetMB": 45
+          },
+          {
+            "type": "Tab",
+            "pid": 35307,
+            "workingSetMB": 479
+          },
+          {
+            "type": "Utility",
+            "pid": 35308,
+            "workingSetMB": 45.4
+          }
+        ]
+      },
+      "runtimeVersions": {
+        "app": "0.21.0",
+        "electron": "43.4.1",
+        "chrome": "150.0.7871.224",
+        "node": "24.18.1",
+        "v8": "15.0.245.28-electron.0"
+      },
+      "pageErrors": [],
+      "consoleErrors": [],
+      "elapsedMs": 21926
+    },
+    {
+      "scale": "XL",
+      "scenario": "video-hover",
+      "runIndex": 1,
+      "fixture": {
+        "scale": "XL",
+        "imageNodes": 160,
+        "videoNodes": 160,
+        "nodes": 320,
+        "edges": 640,
+        "clips": 80,
+        "imageBytes": [
+          1845636,
+          1804651,
+          1744981,
+          1663390
+        ],
+        "imagePreviewBytes": [
+          73757,
+          43927,
+          45467,
+          41996
+        ],
+        "videoBytes": [
+          1380939031
+        ],
+        "mediaProfile": "real-assets"
+      },
+      "probe": {
+        "elapsedMs": 837,
+        "frames": 101,
+        "fps": 120.7,
+        "frameGapP50Ms": 8.2,
+        "frameGapP95Ms": 10.4,
+        "maxFrameGapMs": 14.7,
+        "longTasks": 0,
+        "longTaskMs": 0,
+        "longTaskP95Ms": null,
+        "maxLoadingImages": 0,
+        "maxLoadingVideos": 1,
+        "maxActiveVideos": 1,
+        "firstMutationMs": 16.4,
+        "mutations": {
+          "stage": 0,
+          "edges": 38,
+          "labels": 0
+        }
+      },
+      "cdpBefore": {
+        "LayoutCount": 0,
+        "RecalcStyleCount": 0,
+        "ScriptDurationMs": 0,
+        "LayoutDurationMs": 0,
+        "TaskDurationMs": 1.6,
+        "JSHeapUsedMB": 65.1,
+        "domNodes": 19978,
+        "domDocuments": 1,
+        "jsEventListeners": 2943
+      },
+      "cdpAfter": {
+        "LayoutCount": 33,
+        "RecalcStyleCount": 128,
+        "ScriptDurationMs": 53.7,
+        "LayoutDurationMs": 4.8,
+        "TaskDurationMs": 197.7,
+        "JSHeapUsedMB": 30.6,
+        "domNodes": 2005,
+        "domDocuments": 9,
+        "jsEventListeners": 1025
+      },
+      "cdpDelta": {
+        "LayoutCount": 33,
+        "RecalcStyleCount": 128,
+        "ScriptDurationMs": 53.7,
+        "LayoutDurationMs": 4.8,
+        "TaskDurationMs": 196.1,
+        "JSHeapUsedMB": -34.5,
+        "domNodes": -17973,
+        "domDocuments": 8,
+        "jsEventListeners": -1918
+      },
+      "beforePage": {
+        "domNodes": 1189,
+        "canvasNodes": 6,
+        "lightweightCanvasNodes": 0,
+        "lightweightPreviewNodes": 0,
+        "imageElements": 6,
+        "videoElements": 0,
+        "visibleMedia": 6,
+        "loadedImages": 6,
+        "loadedVideos": 0,
+        "visibleMediaNodes": 3,
+        "visibleMediaPending": 0,
+        "visibleMediaFailures": 0,
+        "activeVideos": 0,
+        "resourceCount": 0,
+        "jsHeapUsedMB": 73.1,
+        "transform": {
+          "x": 0,
+          "y": 0,
+          "zoom": 1
+        }
+      },
+      "page": {
+        "domNodes": 1192,
+        "canvasNodes": 6,
+        "lightweightCanvasNodes": 0,
+        "lightweightPreviewNodes": 0,
+        "imageElements": 3,
+        "videoElements": 3,
+        "visibleMedia": 6,
+        "loadedImages": 3,
+        "loadedVideos": 3,
+        "visibleMediaNodes": 6,
+        "visibleMediaPending": 0,
+        "visibleMediaFailures": 0,
+        "activeVideos": 0,
+        "resourceCount": 0,
+        "jsHeapUsedMB": 73.1,
+        "transform": {
+          "x": 0,
+          "y": 0,
+          "zoom": 1
+        }
+      },
+      "actionDetails": {
+        "hoveredNodes": 3
+      },
+      "offCanvasRender": null,
+      "nodeIdentity": {
+        "before": 6,
+        "after": 6,
+        "common": 6,
+        "tracked": 6,
+        "preserved": 6,
+        "virtualizationChurn": [],
+        "remountedInPlace": [],
+        "commonIdentityPreserved": true,
+        "targetNodeId": null,
+        "targetIdentityPreserved": null
+      },
+      "appMetrics": {
+        "rendererWorkingSetMB": 471.7,
+        "gpuWorkingSetMB": 147.5,
+        "processCount": 5,
+        "processes": [
+          {
+            "type": "Browser",
+            "pid": 35839,
+            "workingSetMB": 369.3
+          },
+          {
+            "type": "GPU",
+            "pid": 35843,
+            "workingSetMB": 147.5
+          },
+          {
+            "type": "Utility",
+            "pid": 35844,
+            "workingSetMB": 45
+          },
+          {
+            "type": "Tab",
+            "pid": 35845,
+            "workingSetMB": 471.7
+          },
+          {
+            "type": "Utility",
+            "pid": 35848,
+            "workingSetMB": 45.2
+          }
+        ]
+      },
+      "runtimeVersions": {
+        "app": "0.21.0",
+        "electron": "43.4.1",
+        "chrome": "150.0.7871.224",
+        "node": "24.18.1",
+        "v8": "15.0.245.28-electron.0"
+      },
+      "pageErrors": [],
+      "consoleErrors": [],
+      "elapsedMs": 21561
+    }
+  ],
+  "warmupFailures": [],
+  "summary": {
+    "XL/video-hover": {
+      "samples": 2,
+      "errors": 0,
+      "metrics": {
+        "coldFirstCanvasMs": null,
+        "coldMediaSettledMs": null,
+        "fps": {
+          "median": 120.7,
+          "p95": 122,
+          "samples": [
+            120.7,
+            122
+          ]
+        },
+        "frameGapP95Ms": {
+          "median": 10.4,
+          "p95": 12.4,
+          "samples": [
+            10.4,
+            12.4
+          ]
+        },
+        "maxFrameGapMs": {
+          "median": 14.7,
+          "p95": 19.6,
+          "samples": [
+            14.7,
+            19.6
+          ]
+        },
+        "longTaskMs": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "longTaskP95Ms": null,
+        "maxLoadingImages": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "maxLoadingVideos": {
+          "median": 1,
+          "p95": 1,
+          "samples": [
+            1,
+            1
+          ]
+        },
+        "maxActiveVideos": {
+          "median": 1,
+          "p95": 1,
+          "samples": [
+            1,
+            1
+          ]
+        },
+        "layoutCount": {
+          "median": 33,
+          "p95": 33,
+          "samples": [
+            33,
+            33
+          ]
+        },
+        "recalcStyleCount": {
+          "median": 127,
+          "p95": 128,
+          "samples": [
+            127,
+            128
+          ]
+        },
+        "scriptDurationMs": {
+          "median": 53.7,
+          "p95": 63.4,
+          "samples": [
+            53.7,
+            63.4
+          ]
+        },
+        "layoutDurationMs": {
+          "median": 4.8,
+          "p95": 5.1,
+          "samples": [
+            4.8,
+            5.1
+          ]
+        },
+        "jsHeapUsedMB": {
+          "median": 73.1,
+          "p95": 73.1,
+          "samples": [
+            73.1,
+            73.1
+          ]
+        },
+        "visibleMedia": {
+          "median": 6,
+          "p95": 6,
+          "samples": [
+            6,
+            6
+          ]
+        },
+        "visibleMediaNodes": {
+          "median": 6,
+          "p95": 6,
+          "samples": [
+            6,
+            6
+          ]
+        },
+        "visibleMediaPending": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "visibleMediaFailures": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "loadedImages": {
+          "median": 3,
+          "p95": 3,
+          "samples": [
+            3,
+            3
+          ]
+        },
+        "loadedVideos": {
+          "median": 3,
+          "p95": 3,
+          "samples": [
+            3,
+            3
+          ]
+        },
+        "activeVideos": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "rendererWorkingSetMB": {
+          "median": 471.7,
+          "p95": 479,
+          "samples": [
+            471.7,
+            479
+          ]
+        },
+        "reloadHeapDeltaMB": null,
+        "reloadDurationP95Ms": null
+      },
+      "advisory": {
+        "perMove": {
+          "scriptPerMoveMs": {
+            "median": null,
+            "p95": null,
+            "samples": []
+          },
+          "layoutPerMove": {
+            "median": null,
+            "p95": null,
+            "samples": []
+          }
+        },
+        "dragOverPan": {
+          "scriptRatio": {
+            "median": null,
+            "samples": []
+          },
+          "layoutRatio": {
+            "median": null,
+            "samples": []
+          }
+        },
+        "actionLatency": {
+          "samples": [],
+          "p95Ms": null,
+          "medianMs": null
+        },
+        "offCanvasRender": {
+          "installed": false,
+          "windows": 0,
+          "totalMax": null,
+          "totalMedian": null,
+          "perComponentMax": {
+            "CategoryTree": null,
+            "AssetLibraryPanel": null,
+            "AssetPicker": null,
+            "TaskCenterButton": null,
+            "TaskCenterPanel": null,
+            "TimelinePreview": null,
+            "PreviewSourcePanel": null,
+            "OnboardingChecklist": null
+          }
+        }
+      },
+      "verdict": {
+        "pass": true,
+        "advisoryOnly": false,
+        "budgetsAdvisory": false,
+        "hardFailures": [],
+        "budgetChecks": [
+          {
+            "metric": "frameGapP95Ms",
+            "actualP95": 12.4,
+            "max": 33,
+            "pass": true,
+            "advisory": false
+          },
+          {
+            "metric": "maxFrameGapMs",
+            "actualP95": 19.6,
+            "max": 100,
+            "pass": true,
+            "advisory": true
+          },
+          {
+            "metric": "maxLoadingImages",
+            "actualP95": 0,
+            "max": 4,
+            "pass": true,
+            "advisory": false
+          },
+          {
+            "metric": "maxLoadingVideos",
+            "actualP95": 1,
+            "max": 1,
+            "pass": true,
+            "advisory": false
+          },
+          {
+            "metric": "maxActiveVideos",
+            "actualP95": 1,
+            "max": 1,
+            "pass": true,
+            "advisory": false
+          }
+        ]
+      }
+    }
+  },
+  "runtimeVersions": {
+    "app": "0.21.0",
+    "electron": "43.4.1",
+    "chrome": "150.0.7871.224",
+    "node": "24.18.1",
+    "v8": "15.0.245.28-electron.0"
+  },
+  "pass": true
+}

--- a/tests/ux/perf-results/canvas-real-hevc-xl-media-error.json
+++ b/tests/ux/perf-results/canvas-real-hevc-xl-media-error.json
@@ -1,0 +1,678 @@
+{
+  "label": "real-hevc-xl-media-error",
+  "commit": "ba753cfa5ec7ad24e7bb3e453e3ef99ccdf64276",
+  "dirty": true,
+  "platform": "darwin",
+  "arch": "arm64",
+  "machine": {
+    "cpu": "Apple M5",
+    "logicalCpus": 10,
+    "totalMemoryGB": 24
+  },
+  "viewport": {
+    "width": 1600,
+    "height": 1000
+  },
+  "viewportOverride": null,
+  "sampleCount": 2,
+  "warmupCount": 0,
+  "scales": [
+    "XL"
+  ],
+  "scenarios": [
+    "media-error"
+  ],
+  "leg": {
+    "devServer": false,
+    "cpuThrottleRate": 1,
+    "kind": "prod"
+  },
+  "results": [
+    {
+      "scale": "XL",
+      "scenario": "media-error",
+      "runIndex": 0,
+      "fixture": {
+        "scale": "XL",
+        "imageNodes": 160,
+        "videoNodes": 160,
+        "nodes": 320,
+        "edges": 640,
+        "clips": 80,
+        "imageBytes": [
+          1845636,
+          1804651,
+          1744981,
+          1663390
+        ],
+        "imagePreviewBytes": [
+          73757,
+          43927,
+          45467,
+          41996
+        ],
+        "videoBytes": [
+          1380939031
+        ],
+        "mediaProfile": "real-assets"
+      },
+      "probe": {
+        "elapsedMs": 364,
+        "frames": 43,
+        "fps": 118.2,
+        "frameGapP50Ms": 8.3,
+        "frameGapP95Ms": 9,
+        "maxFrameGapMs": 13.5,
+        "longTasks": 0,
+        "longTaskMs": 0,
+        "longTaskP95Ms": null,
+        "maxLoadingImages": 0,
+        "maxLoadingVideos": 0,
+        "maxActiveVideos": 0,
+        "firstMutationMs": 5.7,
+        "mutations": {
+          "stage": 0,
+          "edges": 8,
+          "labels": 0
+        }
+      },
+      "cdpBefore": {
+        "LayoutCount": 0,
+        "RecalcStyleCount": 0,
+        "ScriptDurationMs": 2.4,
+        "LayoutDurationMs": 0,
+        "TaskDurationMs": 3.8,
+        "JSHeapUsedMB": 43,
+        "domNodes": 10213,
+        "domDocuments": 1,
+        "jsEventListeners": 1285
+      },
+      "cdpAfter": {
+        "LayoutCount": 6,
+        "RecalcStyleCount": 38,
+        "ScriptDurationMs": 9.8,
+        "LayoutDurationMs": 0.5,
+        "TaskDurationMs": 39,
+        "JSHeapUsedMB": 44.2,
+        "domNodes": 10269,
+        "domDocuments": 1,
+        "jsEventListeners": 1307
+      },
+      "cdpDelta": {
+        "LayoutCount": 6,
+        "RecalcStyleCount": 38,
+        "ScriptDurationMs": 7.4,
+        "LayoutDurationMs": 0.5,
+        "TaskDurationMs": 35.2,
+        "JSHeapUsedMB": 1.2,
+        "domNodes": 56,
+        "domDocuments": 0,
+        "jsEventListeners": 22
+      },
+      "beforePage": {
+        "domNodes": 1189,
+        "canvasNodes": 6,
+        "lightweightCanvasNodes": 0,
+        "lightweightPreviewNodes": 0,
+        "imageElements": 6,
+        "videoElements": 0,
+        "visibleMedia": 6,
+        "loadedImages": 6,
+        "loadedVideos": 0,
+        "visibleMediaNodes": 3,
+        "visibleMediaPending": 0,
+        "visibleMediaFailures": 0,
+        "activeVideos": 0,
+        "resourceCount": 0,
+        "jsHeapUsedMB": 51,
+        "transform": {
+          "x": 0,
+          "y": 0,
+          "zoom": 1
+        }
+      },
+      "page": {
+        "domNodes": 1189,
+        "canvasNodes": 6,
+        "lightweightCanvasNodes": 0,
+        "lightweightPreviewNodes": 0,
+        "imageElements": 6,
+        "videoElements": 0,
+        "visibleMedia": 6,
+        "loadedImages": 6,
+        "loadedVideos": 0,
+        "visibleMediaNodes": 3,
+        "visibleMediaPending": 0,
+        "visibleMediaFailures": 0,
+        "activeVideos": 0,
+        "resourceCount": 0,
+        "jsHeapUsedMB": 51,
+        "transform": {
+          "x": 0,
+          "y": 0,
+          "zoom": 1
+        }
+      },
+      "actionDetails": {
+        "explicitFailures": 2,
+        "initialFailure": true,
+        "retryFailure": true,
+        "recoverySuccess": true,
+        "retryCompleted": true
+      },
+      "offCanvasRender": null,
+      "nodeIdentity": {
+        "before": 6,
+        "after": 6,
+        "common": 6,
+        "tracked": 6,
+        "preserved": 6,
+        "virtualizationChurn": [],
+        "remountedInPlace": [],
+        "commonIdentityPreserved": true,
+        "targetNodeId": null,
+        "targetIdentityPreserved": null
+      },
+      "appMetrics": {
+        "rendererWorkingSetMB": 358.8,
+        "gpuWorkingSetMB": 137.6,
+        "processCount": 5,
+        "processes": [
+          {
+            "type": "Browser",
+            "pid": 55519,
+            "workingSetMB": 343.3
+          },
+          {
+            "type": "GPU",
+            "pid": 55522,
+            "workingSetMB": 137.6
+          },
+          {
+            "type": "Utility",
+            "pid": 55523,
+            "workingSetMB": 45.1
+          },
+          {
+            "type": "Tab",
+            "pid": 55524,
+            "workingSetMB": 358.8
+          },
+          {
+            "type": "Utility",
+            "pid": 55525,
+            "workingSetMB": 45.1
+          }
+        ]
+      },
+      "runtimeVersions": {
+        "app": "0.21.0",
+        "electron": "43.4.1",
+        "chrome": "150.0.7871.224",
+        "node": "24.18.1",
+        "v8": "15.0.245.28-electron.0"
+      },
+      "pageErrors": [],
+      "consoleErrors": [],
+      "elapsedMs": 20869
+    },
+    {
+      "scale": "XL",
+      "scenario": "media-error",
+      "runIndex": 1,
+      "fixture": {
+        "scale": "XL",
+        "imageNodes": 160,
+        "videoNodes": 160,
+        "nodes": 320,
+        "edges": 640,
+        "clips": 80,
+        "imageBytes": [
+          1845636,
+          1804651,
+          1744981,
+          1663390
+        ],
+        "imagePreviewBytes": [
+          73757,
+          43927,
+          45467,
+          41996
+        ],
+        "videoBytes": [
+          1380939031
+        ],
+        "mediaProfile": "real-assets"
+      },
+      "probe": {
+        "elapsedMs": 360,
+        "frames": 44,
+        "fps": 122.2,
+        "frameGapP50Ms": 8.4,
+        "frameGapP95Ms": 9.5,
+        "maxFrameGapMs": 9.8,
+        "longTasks": 0,
+        "longTaskMs": 0,
+        "longTaskP95Ms": null,
+        "maxLoadingImages": 0,
+        "maxLoadingVideos": 0,
+        "maxActiveVideos": 0,
+        "firstMutationMs": 3.7,
+        "mutations": {
+          "stage": 0,
+          "edges": 8,
+          "labels": 0
+        }
+      },
+      "cdpBefore": {
+        "LayoutCount": 0,
+        "RecalcStyleCount": 0,
+        "ScriptDurationMs": 2.3,
+        "LayoutDurationMs": 0,
+        "TaskDurationMs": 3.6,
+        "JSHeapUsedMB": 39.3,
+        "domNodes": 1483,
+        "domDocuments": 1,
+        "jsEventListeners": 959
+      },
+      "cdpAfter": {
+        "LayoutCount": 6,
+        "RecalcStyleCount": 39,
+        "ScriptDurationMs": 8.5,
+        "LayoutDurationMs": 0.5,
+        "TaskDurationMs": 33.6,
+        "JSHeapUsedMB": 40.5,
+        "domNodes": 1539,
+        "domDocuments": 1,
+        "jsEventListeners": 981
+      },
+      "cdpDelta": {
+        "LayoutCount": 6,
+        "RecalcStyleCount": 39,
+        "ScriptDurationMs": 6.2,
+        "LayoutDurationMs": 0.5,
+        "TaskDurationMs": 30,
+        "JSHeapUsedMB": 1.2,
+        "domNodes": 56,
+        "domDocuments": 0,
+        "jsEventListeners": 22
+      },
+      "beforePage": {
+        "domNodes": 1189,
+        "canvasNodes": 6,
+        "lightweightCanvasNodes": 0,
+        "lightweightPreviewNodes": 0,
+        "imageElements": 6,
+        "videoElements": 0,
+        "visibleMedia": 6,
+        "loadedImages": 6,
+        "loadedVideos": 0,
+        "visibleMediaNodes": 3,
+        "visibleMediaPending": 0,
+        "visibleMediaFailures": 0,
+        "activeVideos": 0,
+        "resourceCount": 0,
+        "jsHeapUsedMB": 48.1,
+        "transform": {
+          "x": 0,
+          "y": 0,
+          "zoom": 1
+        }
+      },
+      "page": {
+        "domNodes": 1189,
+        "canvasNodes": 6,
+        "lightweightCanvasNodes": 0,
+        "lightweightPreviewNodes": 0,
+        "imageElements": 6,
+        "videoElements": 0,
+        "visibleMedia": 6,
+        "loadedImages": 6,
+        "loadedVideos": 0,
+        "visibleMediaNodes": 3,
+        "visibleMediaPending": 0,
+        "visibleMediaFailures": 0,
+        "activeVideos": 0,
+        "resourceCount": 0,
+        "jsHeapUsedMB": 48.1,
+        "transform": {
+          "x": 0,
+          "y": 0,
+          "zoom": 1
+        }
+      },
+      "actionDetails": {
+        "explicitFailures": 2,
+        "initialFailure": true,
+        "retryFailure": true,
+        "recoverySuccess": true,
+        "retryCompleted": true
+      },
+      "offCanvasRender": null,
+      "nodeIdentity": {
+        "before": 6,
+        "after": 6,
+        "common": 6,
+        "tracked": 6,
+        "preserved": 6,
+        "virtualizationChurn": [],
+        "remountedInPlace": [],
+        "commonIdentityPreserved": true,
+        "targetNodeId": null,
+        "targetIdentityPreserved": null
+      },
+      "appMetrics": {
+        "rendererWorkingSetMB": 357.3,
+        "gpuWorkingSetMB": 130.6,
+        "processCount": 5,
+        "processes": [
+          {
+            "type": "Browser",
+            "pid": 55576,
+            "workingSetMB": 352.3
+          },
+          {
+            "type": "GPU",
+            "pid": 55579,
+            "workingSetMB": 130.6
+          },
+          {
+            "type": "Utility",
+            "pid": 55580,
+            "workingSetMB": 45.1
+          },
+          {
+            "type": "Tab",
+            "pid": 55581,
+            "workingSetMB": 357.3
+          },
+          {
+            "type": "Utility",
+            "pid": 55582,
+            "workingSetMB": 45.1
+          }
+        ]
+      },
+      "runtimeVersions": {
+        "app": "0.21.0",
+        "electron": "43.4.1",
+        "chrome": "150.0.7871.224",
+        "node": "24.18.1",
+        "v8": "15.0.245.28-electron.0"
+      },
+      "pageErrors": [],
+      "consoleErrors": [],
+      "elapsedMs": 20456
+    }
+  ],
+  "warmupFailures": [],
+  "summary": {
+    "XL/media-error": {
+      "samples": 2,
+      "errors": 0,
+      "metrics": {
+        "coldFirstCanvasMs": null,
+        "coldMediaSettledMs": null,
+        "fps": {
+          "median": 118.2,
+          "p95": 122.2,
+          "samples": [
+            118.2,
+            122.2
+          ]
+        },
+        "frameGapP95Ms": {
+          "median": 9,
+          "p95": 9.5,
+          "samples": [
+            9,
+            9.5
+          ]
+        },
+        "maxFrameGapMs": {
+          "median": 9.8,
+          "p95": 13.5,
+          "samples": [
+            9.8,
+            13.5
+          ]
+        },
+        "longTaskMs": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "longTaskP95Ms": null,
+        "maxLoadingImages": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "maxLoadingVideos": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "maxActiveVideos": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "layoutCount": {
+          "median": 6,
+          "p95": 6,
+          "samples": [
+            6,
+            6
+          ]
+        },
+        "recalcStyleCount": {
+          "median": 38,
+          "p95": 39,
+          "samples": [
+            38,
+            39
+          ]
+        },
+        "scriptDurationMs": {
+          "median": 6.2,
+          "p95": 7.4,
+          "samples": [
+            6.2,
+            7.4
+          ]
+        },
+        "layoutDurationMs": {
+          "median": 0.5,
+          "p95": 0.5,
+          "samples": [
+            0.5,
+            0.5
+          ]
+        },
+        "jsHeapUsedMB": {
+          "median": 48.1,
+          "p95": 51,
+          "samples": [
+            48.1,
+            51
+          ]
+        },
+        "visibleMedia": {
+          "median": 6,
+          "p95": 6,
+          "samples": [
+            6,
+            6
+          ]
+        },
+        "visibleMediaNodes": {
+          "median": 3,
+          "p95": 3,
+          "samples": [
+            3,
+            3
+          ]
+        },
+        "visibleMediaPending": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "visibleMediaFailures": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "loadedImages": {
+          "median": 6,
+          "p95": 6,
+          "samples": [
+            6,
+            6
+          ]
+        },
+        "loadedVideos": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "activeVideos": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "rendererWorkingSetMB": {
+          "median": 357.3,
+          "p95": 358.8,
+          "samples": [
+            357.3,
+            358.8
+          ]
+        },
+        "reloadHeapDeltaMB": null,
+        "reloadDurationP95Ms": null
+      },
+      "advisory": {
+        "perMove": {
+          "scriptPerMoveMs": {
+            "median": null,
+            "p95": null,
+            "samples": []
+          },
+          "layoutPerMove": {
+            "median": null,
+            "p95": null,
+            "samples": []
+          }
+        },
+        "dragOverPan": {
+          "scriptRatio": {
+            "median": null,
+            "samples": []
+          },
+          "layoutRatio": {
+            "median": null,
+            "samples": []
+          }
+        },
+        "actionLatency": {
+          "samples": [],
+          "p95Ms": null,
+          "medianMs": null
+        },
+        "offCanvasRender": {
+          "installed": false,
+          "windows": 0,
+          "totalMax": null,
+          "totalMedian": null,
+          "perComponentMax": {
+            "CategoryTree": null,
+            "AssetLibraryPanel": null,
+            "AssetPicker": null,
+            "TaskCenterButton": null,
+            "TaskCenterPanel": null,
+            "TimelinePreview": null,
+            "PreviewSourcePanel": null,
+            "OnboardingChecklist": null
+          }
+        }
+      },
+      "verdict": {
+        "pass": true,
+        "advisoryOnly": false,
+        "budgetsAdvisory": false,
+        "hardFailures": [],
+        "budgetChecks": [
+          {
+            "metric": "frameGapP95Ms",
+            "actualP95": 9.5,
+            "max": 33,
+            "pass": true,
+            "advisory": false
+          },
+          {
+            "metric": "maxFrameGapMs",
+            "actualP95": 13.5,
+            "max": 100,
+            "pass": true,
+            "advisory": true
+          },
+          {
+            "metric": "maxLoadingImages",
+            "actualP95": 0,
+            "max": 4,
+            "pass": true,
+            "advisory": false
+          },
+          {
+            "metric": "maxLoadingVideos",
+            "actualP95": 0,
+            "max": 1,
+            "pass": true,
+            "advisory": false
+          },
+          {
+            "metric": "maxActiveVideos",
+            "actualP95": 0,
+            "max": 1,
+            "pass": true,
+            "advisory": false
+          }
+        ]
+      }
+    }
+  },
+  "runtimeVersions": {
+    "app": "0.21.0",
+    "electron": "43.4.1",
+    "chrome": "150.0.7871.224",
+    "node": "24.18.1",
+    "v8": "15.0.245.28-electron.0"
+  },
+  "pass": true
+}

--- a/tests/ux/perf-results/canvas-real-images-xl-post-dim-fix.json
+++ b/tests/ux/perf-results/canvas-real-images-xl-post-dim-fix.json
@@ -1,0 +1,698 @@
+{
+  "label": "real-images-xl-post-dim-fix",
+  "commit": "ba753cfa5ec7ad24e7bb3e453e3ef99ccdf64276",
+  "dirty": true,
+  "platform": "darwin",
+  "arch": "arm64",
+  "machine": {
+    "cpu": "Apple M5",
+    "logicalCpus": 10,
+    "totalMemoryGB": 24
+  },
+  "viewport": {
+    "width": 1600,
+    "height": 1000
+  },
+  "viewportOverride": null,
+  "sampleCount": 2,
+  "warmupCount": 0,
+  "scales": [
+    "XLIMG"
+  ],
+  "scenarios": [
+    "drag-at-low-zoom"
+  ],
+  "leg": {
+    "devServer": false,
+    "cpuThrottleRate": 1,
+    "kind": "prod"
+  },
+  "results": [
+    {
+      "scale": "XLIMG",
+      "scenario": "drag-at-low-zoom",
+      "runIndex": 0,
+      "fixture": {
+        "scale": "XLIMG",
+        "imageNodes": 320,
+        "videoNodes": 0,
+        "nodes": 320,
+        "edges": 0,
+        "clips": 0,
+        "imageBytes": [
+          1845636,
+          1804651,
+          1744981,
+          1663390
+        ],
+        "imagePreviewBytes": [
+          73757,
+          43927,
+          45467,
+          41996
+        ],
+        "videoBytes": [],
+        "mediaProfile": "real-assets"
+      },
+      "probe": {
+        "elapsedMs": 1052,
+        "frames": 122,
+        "fps": 116,
+        "frameGapP50Ms": 8.3,
+        "frameGapP95Ms": 10.7,
+        "maxFrameGapMs": 41.3,
+        "longTasks": 0,
+        "longTaskMs": 0,
+        "longTaskP95Ms": null,
+        "maxLoadingImages": 1,
+        "maxLoadingVideos": 0,
+        "maxActiveVideos": 0,
+        "firstMutationMs": 29.3,
+        "mutations": {
+          "stage": 2,
+          "edges": 5,
+          "labels": 0
+        }
+      },
+      "cdpBefore": {
+        "LayoutCount": 7,
+        "RecalcStyleCount": 16,
+        "ScriptDurationMs": 122,
+        "LayoutDurationMs": 1.5,
+        "TaskDurationMs": 158.9,
+        "JSHeapUsedMB": 29.9,
+        "domNodes": 1369,
+        "domDocuments": 1,
+        "jsEventListeners": 960
+      },
+      "cdpAfter": {
+        "LayoutCount": 20,
+        "RecalcStyleCount": 86,
+        "ScriptDurationMs": 209.2,
+        "LayoutDurationMs": 3,
+        "TaskDurationMs": 354.8,
+        "JSHeapUsedMB": 30.4,
+        "domNodes": 1472,
+        "domDocuments": 1,
+        "jsEventListeners": 1012
+      },
+      "cdpDelta": {
+        "LayoutCount": 13,
+        "RecalcStyleCount": 70,
+        "ScriptDurationMs": 87.2,
+        "LayoutDurationMs": 1.5,
+        "TaskDurationMs": 195.9,
+        "JSHeapUsedMB": 0.5,
+        "domNodes": 103,
+        "domDocuments": 0,
+        "jsEventListeners": 52
+      },
+      "beforePage": {
+        "domNodes": 1060,
+        "canvasNodes": 20,
+        "lightweightCanvasNodes": 20,
+        "lightweightPreviewNodes": 20,
+        "imageElements": 20,
+        "videoElements": 0,
+        "visibleMedia": 20,
+        "loadedImages": 20,
+        "loadedVideos": 0,
+        "visibleMediaNodes": 20,
+        "visibleMediaPending": 0,
+        "visibleMediaFailures": 0,
+        "activeVideos": 0,
+        "resourceCount": 0,
+        "jsHeapUsedMB": 42.6,
+        "transform": {
+          "x": 225.325,
+          "y": 247.349,
+          "zoom": 0.435275
+        }
+      },
+      "page": {
+        "domNodes": 1242,
+        "canvasNodes": 20,
+        "lightweightCanvasNodes": 19,
+        "lightweightPreviewNodes": 19,
+        "imageElements": 21,
+        "videoElements": 0,
+        "visibleMedia": 20,
+        "loadedImages": 21,
+        "loadedVideos": 0,
+        "visibleMediaNodes": 20,
+        "visibleMediaPending": 0,
+        "visibleMediaFailures": 0,
+        "activeVideos": 0,
+        "resourceCount": 0,
+        "jsHeapUsedMB": 42.6,
+        "transform": {
+          "x": 225.325,
+          "y": 247.349,
+          "zoom": 0.435275
+        }
+      },
+      "actionDetails": {
+        "zoom": 0.435,
+        "lightweightMounted": 20,
+        "lightweightActive": true,
+        "moves": 22,
+        "firstFeedbackMs": 29.300000000745058,
+        "nodeId": "canvas-perf-image-0"
+      },
+      "offCanvasRender": null,
+      "nodeIdentity": {
+        "before": 20,
+        "after": 20,
+        "common": 20,
+        "tracked": 20,
+        "preserved": 20,
+        "virtualizationChurn": [],
+        "remountedInPlace": [],
+        "commonIdentityPreserved": true,
+        "targetNodeId": "canvas-perf-image-0",
+        "targetIdentityPreserved": true
+      },
+      "appMetrics": {
+        "rendererWorkingSetMB": 351.1,
+        "gpuWorkingSetMB": 143,
+        "processCount": 5,
+        "processes": [
+          {
+            "type": "Browser",
+            "pid": 4731,
+            "workingSetMB": 344.8
+          },
+          {
+            "type": "GPU",
+            "pid": 4734,
+            "workingSetMB": 143
+          },
+          {
+            "type": "Utility",
+            "pid": 4735,
+            "workingSetMB": 45.1
+          },
+          {
+            "type": "Tab",
+            "pid": 4736,
+            "workingSetMB": 351.1
+          },
+          {
+            "type": "Utility",
+            "pid": 4737,
+            "workingSetMB": 45.1
+          }
+        ]
+      },
+      "runtimeVersions": {
+        "app": "0.21.0",
+        "electron": "43.4.1",
+        "chrome": "150.0.7871.224",
+        "node": "24.18.1",
+        "v8": "15.0.245.28-electron.0"
+      },
+      "pageErrors": [],
+      "consoleErrors": [],
+      "elapsedMs": 23278
+    },
+    {
+      "scale": "XLIMG",
+      "scenario": "drag-at-low-zoom",
+      "runIndex": 1,
+      "fixture": {
+        "scale": "XLIMG",
+        "imageNodes": 320,
+        "videoNodes": 0,
+        "nodes": 320,
+        "edges": 0,
+        "clips": 0,
+        "imageBytes": [
+          1845636,
+          1804651,
+          1744981,
+          1663390
+        ],
+        "imagePreviewBytes": [
+          73757,
+          43927,
+          45467,
+          41996
+        ],
+        "videoBytes": [],
+        "mediaProfile": "real-assets"
+      },
+      "probe": {
+        "elapsedMs": 1035,
+        "frames": 119,
+        "fps": 115,
+        "frameGapP50Ms": 8.3,
+        "frameGapP95Ms": 9.5,
+        "maxFrameGapMs": 56.6,
+        "longTasks": 1,
+        "longTaskMs": 55,
+        "longTaskP95Ms": 55,
+        "maxLoadingImages": 1,
+        "maxLoadingVideos": 0,
+        "maxActiveVideos": 0,
+        "firstMutationMs": 22.5,
+        "mutations": {
+          "stage": 2,
+          "edges": 5,
+          "labels": 0
+        }
+      },
+      "cdpBefore": {
+        "LayoutCount": 8,
+        "RecalcStyleCount": 18,
+        "ScriptDurationMs": 122.8,
+        "LayoutDurationMs": 1.5,
+        "TaskDurationMs": 145.3,
+        "JSHeapUsedMB": 47.8,
+        "domNodes": 2114,
+        "domDocuments": 1,
+        "jsEventListeners": 1039
+      },
+      "cdpAfter": {
+        "LayoutCount": 21,
+        "RecalcStyleCount": 88,
+        "ScriptDurationMs": 187.6,
+        "LayoutDurationMs": 2.8,
+        "TaskDurationMs": 317.8,
+        "JSHeapUsedMB": 44.3,
+        "domNodes": 1617,
+        "domDocuments": 1,
+        "jsEventListeners": 1168
+      },
+      "cdpDelta": {
+        "LayoutCount": 13,
+        "RecalcStyleCount": 70,
+        "ScriptDurationMs": 64.8,
+        "LayoutDurationMs": 1.3,
+        "TaskDurationMs": 172.5,
+        "JSHeapUsedMB": -3.5,
+        "domNodes": -497,
+        "domDocuments": 0,
+        "jsEventListeners": 129
+      },
+      "beforePage": {
+        "domNodes": 1060,
+        "canvasNodes": 20,
+        "lightweightCanvasNodes": 20,
+        "lightweightPreviewNodes": 20,
+        "imageElements": 20,
+        "videoElements": 0,
+        "visibleMedia": 20,
+        "loadedImages": 20,
+        "loadedVideos": 0,
+        "visibleMediaNodes": 20,
+        "visibleMediaPending": 0,
+        "visibleMediaFailures": 0,
+        "activeVideos": 0,
+        "resourceCount": 0,
+        "jsHeapUsedMB": 45.2,
+        "transform": {
+          "x": 225.325,
+          "y": 247.349,
+          "zoom": 0.435275
+        }
+      },
+      "page": {
+        "domNodes": 1242,
+        "canvasNodes": 20,
+        "lightweightCanvasNodes": 19,
+        "lightweightPreviewNodes": 19,
+        "imageElements": 21,
+        "videoElements": 0,
+        "visibleMedia": 20,
+        "loadedImages": 21,
+        "loadedVideos": 0,
+        "visibleMediaNodes": 20,
+        "visibleMediaPending": 0,
+        "visibleMediaFailures": 0,
+        "activeVideos": 0,
+        "resourceCount": 0,
+        "jsHeapUsedMB": 45.2,
+        "transform": {
+          "x": 225.325,
+          "y": 247.349,
+          "zoom": 0.435275
+        }
+      },
+      "actionDetails": {
+        "zoom": 0.435,
+        "lightweightMounted": 20,
+        "lightweightActive": true,
+        "moves": 22,
+        "firstFeedbackMs": 22.5,
+        "nodeId": "canvas-perf-image-0"
+      },
+      "offCanvasRender": null,
+      "nodeIdentity": {
+        "before": 20,
+        "after": 20,
+        "common": 20,
+        "tracked": 20,
+        "preserved": 20,
+        "virtualizationChurn": [],
+        "remountedInPlace": [],
+        "commonIdentityPreserved": true,
+        "targetNodeId": "canvas-perf-image-0",
+        "targetIdentityPreserved": true
+      },
+      "appMetrics": {
+        "rendererWorkingSetMB": 364.5,
+        "gpuWorkingSetMB": 139.4,
+        "processCount": 5,
+        "processes": [
+          {
+            "type": "Browser",
+            "pid": 4834,
+            "workingSetMB": 342.4
+          },
+          {
+            "type": "GPU",
+            "pid": 4837,
+            "workingSetMB": 139.4
+          },
+          {
+            "type": "Utility",
+            "pid": 4838,
+            "workingSetMB": 45
+          },
+          {
+            "type": "Tab",
+            "pid": 4839,
+            "workingSetMB": 364.5
+          },
+          {
+            "type": "Utility",
+            "pid": 4840,
+            "workingSetMB": 45
+          }
+        ]
+      },
+      "runtimeVersions": {
+        "app": "0.21.0",
+        "electron": "43.4.1",
+        "chrome": "150.0.7871.224",
+        "node": "24.18.1",
+        "v8": "15.0.245.28-electron.0"
+      },
+      "pageErrors": [],
+      "consoleErrors": [],
+      "elapsedMs": 22695
+    }
+  ],
+  "warmupFailures": [],
+  "summary": {
+    "XLIMG/drag-at-low-zoom": {
+      "samples": 2,
+      "errors": 0,
+      "metrics": {
+        "coldFirstCanvasMs": null,
+        "coldMediaSettledMs": null,
+        "fps": {
+          "median": 115,
+          "p95": 116,
+          "samples": [
+            115,
+            116
+          ]
+        },
+        "frameGapP95Ms": {
+          "median": 9.5,
+          "p95": 10.7,
+          "samples": [
+            9.5,
+            10.7
+          ]
+        },
+        "maxFrameGapMs": {
+          "median": 41.3,
+          "p95": 56.6,
+          "samples": [
+            41.3,
+            56.6
+          ]
+        },
+        "longTaskMs": {
+          "median": 0,
+          "p95": 55,
+          "samples": [
+            0,
+            55
+          ]
+        },
+        "longTaskP95Ms": {
+          "median": 55,
+          "p95": 55,
+          "samples": [
+            55
+          ]
+        },
+        "maxLoadingImages": {
+          "median": 1,
+          "p95": 1,
+          "samples": [
+            1,
+            1
+          ]
+        },
+        "maxLoadingVideos": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "maxActiveVideos": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "layoutCount": {
+          "median": 13,
+          "p95": 13,
+          "samples": [
+            13,
+            13
+          ]
+        },
+        "recalcStyleCount": {
+          "median": 70,
+          "p95": 70,
+          "samples": [
+            70,
+            70
+          ]
+        },
+        "scriptDurationMs": {
+          "median": 64.8,
+          "p95": 87.2,
+          "samples": [
+            64.8,
+            87.2
+          ]
+        },
+        "layoutDurationMs": {
+          "median": 1.3,
+          "p95": 1.5,
+          "samples": [
+            1.3,
+            1.5
+          ]
+        },
+        "jsHeapUsedMB": {
+          "median": 42.6,
+          "p95": 45.2,
+          "samples": [
+            42.6,
+            45.2
+          ]
+        },
+        "visibleMedia": {
+          "median": 20,
+          "p95": 20,
+          "samples": [
+            20,
+            20
+          ]
+        },
+        "visibleMediaNodes": {
+          "median": 20,
+          "p95": 20,
+          "samples": [
+            20,
+            20
+          ]
+        },
+        "visibleMediaPending": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "visibleMediaFailures": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "loadedImages": {
+          "median": 21,
+          "p95": 21,
+          "samples": [
+            21,
+            21
+          ]
+        },
+        "loadedVideos": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "activeVideos": {
+          "median": 0,
+          "p95": 0,
+          "samples": [
+            0,
+            0
+          ]
+        },
+        "rendererWorkingSetMB": {
+          "median": 351.1,
+          "p95": 364.5,
+          "samples": [
+            351.1,
+            364.5
+          ]
+        },
+        "reloadHeapDeltaMB": null,
+        "reloadDurationP95Ms": null
+      },
+      "advisory": {
+        "perMove": {
+          "scriptPerMoveMs": {
+            "median": 2.95,
+            "p95": 3.96,
+            "samples": [
+              3.96,
+              2.95
+            ]
+          },
+          "layoutPerMove": {
+            "median": 0.59,
+            "p95": 0.59,
+            "samples": [
+              0.59,
+              0.59
+            ]
+          }
+        },
+        "dragOverPan": {
+          "scriptRatio": {
+            "median": null,
+            "samples": []
+          },
+          "layoutRatio": {
+            "median": null,
+            "samples": []
+          }
+        },
+        "actionLatency": {
+          "samples": [
+            29.300000000745058,
+            22.5
+          ],
+          "p95Ms": 29.3,
+          "medianMs": 22.5
+        },
+        "offCanvasRender": {
+          "installed": false,
+          "windows": 0,
+          "totalMax": null,
+          "totalMedian": null,
+          "perComponentMax": {
+            "CategoryTree": null,
+            "AssetLibraryPanel": null,
+            "AssetPicker": null,
+            "TaskCenterButton": null,
+            "TaskCenterPanel": null,
+            "TimelinePreview": null,
+            "PreviewSourcePanel": null,
+            "OnboardingChecklist": null
+          }
+        }
+      },
+      "verdict": {
+        "pass": true,
+        "advisoryOnly": true,
+        "budgetsAdvisory": false,
+        "hardFailures": [],
+        "budgetChecks": [
+          {
+            "metric": "frameGapP95Ms",
+            "actualP95": 10.7,
+            "max": 33,
+            "pass": true,
+            "advisory": false
+          },
+          {
+            "metric": "maxFrameGapMs",
+            "actualP95": 56.6,
+            "max": 100,
+            "pass": true,
+            "advisory": true
+          },
+          {
+            "metric": "longTaskP95Ms",
+            "actualP95": 55,
+            "max": 80,
+            "pass": true,
+            "advisory": false
+          },
+          {
+            "metric": "maxLoadingImages",
+            "actualP95": 1,
+            "max": 4,
+            "pass": true,
+            "advisory": false
+          },
+          {
+            "metric": "maxLoadingVideos",
+            "actualP95": 0,
+            "max": 1,
+            "pass": true,
+            "advisory": false
+          },
+          {
+            "metric": "maxActiveVideos",
+            "actualP95": 0,
+            "max": 1,
+            "pass": true,
+            "advisory": false
+          }
+        ]
+      }
+    }
+  },
+  "runtimeVersions": {
+    "app": "0.21.0",
+    "electron": "43.4.1",
+    "chrome": "150.0.7871.224",
+    "node": "24.18.1",
+    "v8": "15.0.245.28-electron.0"
+  },
+  "pass": true
+}


### PR DESCRIPTION
## Problem
High-resolution canvas media could make the canvas pay the full media cost before the user interacted, and a persisted preview could overwrite the source dimensions used for node geometry.

## What changed
- Keep canonical image/video URLs for viewing/export while using persisted image previews and video posters for the canvas.
- Prevent preview natural dimensions from replacing canonical source dimensions.
- Add modal semantics and a real Electron image preview/rename/reload journey.
- Add Windows real-device validation runbook and record real-media performance receipts.

## Evidence
- Real 3840x2160 10-bit HEVC video: S/M/L/XL, normal and low-zoom drag, 2 samples per scale.
- Real 3840x2160 PNG images, 9.3–12.0MB each: S/M/L/XL, normal and low-zoom drag, 2 samples per scale.
- XL media reveal and media-error/recovery receipts.
- Contracts, root-cause, test-waits, prior-art, typecheck, build, and focused Electron journey passed.
- Ponytail review passed on every pushed batch.

## Verification boundary
macOS arm64 was verified in real Electron. Windows W-NVIDIA/W-IGPU/W-SW remain UNVERIFIED because no Windows device or VM was available on the test host. The runbook explicitly requires fresh Windows receipts and forbids reusing macOS JSON.

## Risks / follow-up
The repository still contains historical Ponytail deferred records on the original task branch; this clean delivery branch was pushed in review-sized batches and each outgoing batch passed Ponytail review. Windows hardware validation remains required before calling the cross-platform goal complete.
